### PR TITLE
Improve Docker setup with deprecation fixes and security hardening

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache su-exec
 
 COPY package*.json ./
 
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 COPY . .
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend:
     build:
@@ -13,6 +11,7 @@ services:
       - PORT=3001
       - LIDARR_URL=${LIDARR_URL:-http://lidarr:8686}
       - LIDARR_API_KEY=${LIDARR_API_KEY}
+      - LASTFM_API_KEY=${LASTFM_API_KEY}
       - CONTACT_EMAIL=${CONTACT_EMAIL:-user@example.com}
       - DEBUG=${DEBUG:-true}
       - AUTH_PASSWORD=${AUTH_PASSWORD}
@@ -20,18 +19,10 @@ services:
       - ./backend/data:/app/data
     networks:
       - aurral-network-dev
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://localhost:3001/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
   frontend:
     build:
@@ -45,19 +36,10 @@ services:
       - backend
     networks:
       - aurral-network-dev
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1:80",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
 networks:
   aurral-network-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend:
     image: ghcr.io/lklynet/aurral-backend:latest
@@ -19,18 +17,10 @@ services:
       - ./backend/data:/app/data
     networks:
       - aurral-network
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://127.0.0.1:3001/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
   frontend:
     image: ghcr.io/lklynet/aurral-frontend:latest
@@ -42,19 +32,10 @@ services:
       - backend
     networks:
       - aurral-network
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1:80",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
 networks:
   aurral-network:


### PR DESCRIPTION
## Summary

A few small improvements for the Docker setup - fixing deprecated syntax, reducing duplication, and adding security hardening.

## Changes

### Deprecation fixes
- **Dockerfile**: Replace deprecated `npm ci --only=production` with `npm ci --omit=dev` (npm 8+)
- **Compose files**: Remove deprecated top-level `version` field ([reference](https://docs.docker.com/reference/compose-file/version-and-name/))

### Cleanup
- **Remove redundant healthchecks** from compose files - when both Dockerfile and compose define healthchecks, compose overrides entirely, so Dockerfiles should be the single source of truth
- **Add missing `LASTFM_API_KEY`** to `docker-compose.dev.yml` (was already in production compose)

### Security hardening
- **`no-new-privileges`**: Prevents processes from gaining additional privileges via setuid/setgid binaries
- **`cap_drop: ALL`**: Neither container requires special Linux capabilities

## Test plan
- [ ] `docker-compose up -d` starts successfully
- [ ] `docker-compose -f docker-compose.dev.yml up --build` builds and starts successfully
- [ ] Healthchecks pass (from Dockerfile definitions)
- [ ] Application functions normally

🤖 Generated with [Claude Code](https://claude.ai/code)