### PR TITLE
Improve Docker setup with deprecation fixes and security hardening

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache su-exec
 
 COPY package*.json ./
 
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 COPY . .
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend:
     build:
@@ -13,6 +11,7 @@ services:
       - PORT=3001
       - LIDARR_URL=${LIDARR_URL:-http://lidarr:8686}
       - LIDARR_API_KEY=${LIDARR_API_KEY}
+      - LASTFM_API_KEY=${LASTFM_API_KEY}
       - CONTACT_EMAIL=${CONTACT_EMAIL:-user@example.com}
       - DEBUG=${DEBUG:-true}
       - AUTH_PASSWORD=${AUTH_PASSWORD}
@@ -20,18 +19,13 @@ services:
       - ./backend/data:/app/data
     networks:
       - aurral-network-dev
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://localhost:3001/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
 
   frontend:
     build:
@@ -45,19 +39,14 @@ services:
       - backend
     networks:
       - aurral-network-dev
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1:80",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
 
 networks:
   aurral-network-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend:
     image: ghcr.io/lklynet/aurral-backend:latest
@@ -19,18 +17,13 @@ services:
       - ./backend/data:/app/data
     networks:
       - aurral-network
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://127.0.0.1:3001/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
 
   frontend:
     image: ghcr.io/lklynet/aurral-frontend:latest
@@ -42,19 +35,14 @@ services:
       - backend
     networks:
       - aurral-network
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1:80",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
 
 networks:
   aurral-network:


### PR DESCRIPTION
Addresses #7

- Replace deprecated `npm ci --only=production` with `npm ci --omit=dev`
- Remove deprecated top-level `version` field from compose files
- Remove redundant healthcheck definitions (Dockerfiles are source of truth)
- Add missing LASTFM_API_KEY to docker-compose.dev.yml
- Add security hardening: no-new-privileges and cap_drop ALL

## Capabilities Explanation

We use `cap_drop: ALL` to remove all Linux capabilities, then add back only what's required:

| Container | Capabilities | Reason |
|-----------|--------------|--------|
| Backend | `SETUID`, `SETGID` | `su-exec` drops from root to `nodejs` user at runtime |
| Frontend | `CHOWN`, `SETUID`, `SETGID` | nginx entrypoint sets up cache directories and spawns workers |

### Why this is still a security win

Default Docker containers have ~14 capabilities. With this change:

**Removed** (no longer available to containers):
- `NET_RAW` - Raw packet crafting
- `SYS_CHROOT` - Chroot jail creation
- `MKNOD` - Device node creation
- `AUDIT_WRITE` - Kernel audit log writes
- `DAC_OVERRIDE` - Bypass file permission checks
- `FOWNER` - Bypass ownership checks
- `FSETID` - Set file SUID/SGID bits
- `KILL` - Send signals to any process
- `NET_BIND_SERVICE` - Bind to privileged ports
- `SETFCAP` - Set file capabilities
- `SETPCAP` - Modify process capabilities

**Retained** (minimum required):
- `SETUID`/`SETGID` - User switching (both containers)
- `CHOWN` - Ownership changes (frontend only)