### PR TITLE
fix(discovery): limit library artist queries to recent 25 artists

### DIFF
--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -80,7 +80,7 @@ router.get("/", async (req, res) => {
   const settings = dbOps.getSettings();
   const lastfmUsername = settings.integrations?.lastfm?.username || null;
   const hasLastfmUser = hasLastfmKey && lastfmUsername;
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = await libraryManager.getRecentArtists(25);
   const hasArtists = libraryArtists.length > 0;
 
   if (!hasLastfmKey && !hasArtists) {
@@ -182,7 +182,7 @@ router.get("/", async (req, res) => {
   const existingArtistIds = new Set(libraryArtists.map((a) => a.mbid));
 
   recommendations = recommendations.filter(
-    (artist) => !existingArtistIds.has(artist.id)
+    (artist) => !existingArtistIds.has(artist.id),
   );
   globalTop = globalTop.filter((artist) => !existingArtistIds.has(artist.id));
 
@@ -384,10 +384,12 @@ router.get("/by-tag", async (req, res) => {
     } else {
       const discoveryCache = getDiscoveryCache();
       const tagLower = String(tag).trim().toLowerCase();
-      const matches = (discoveryCache.recommendations || []).filter((artist) => {
-        const tags = Array.isArray(artist.tags) ? artist.tags : [];
-        return tags.some((t) => String(t).toLowerCase() === tagLower);
-      });
+      const matches = (discoveryCache.recommendations || []).filter(
+        (artist) => {
+          const tags = Array.isArray(artist.tags) ? artist.tags : [];
+          return tags.some((t) => String(t).toLowerCase() === tagLower);
+        },
+      );
       recommendations = matches.slice(offsetInt, offsetInt + limitInt);
       return res.json({
         recommendations,
@@ -472,7 +474,7 @@ router.delete("/preferences/exclude-genre/:genre", (req, res) => {
     const { genre } = req.params;
     discoveryPreferences.excludedGenres =
       discoveryPreferences.excludedGenres.filter(
-        (g) => g !== genre.toLowerCase()
+        (g) => g !== genre.toLowerCase(),
       );
 
     res.json({
@@ -517,7 +519,7 @@ router.delete("/preferences/exclude-artist/:artistId", (req, res) => {
     const { artistId } = req.params;
     discoveryPreferences.excludedArtists =
       discoveryPreferences.excludedArtists.filter(
-        (a) => a.artistId !== artistId
+        (a) => a.artistId !== artistId,
       );
 
     res.json({
@@ -538,17 +540,17 @@ router.get("/filtered", async (req, res) => {
     let recommendations = discoveryCache.recommendations || [];
     let globalTop = discoveryCache.globalTop || [];
 
-    const libraryArtists = await libraryManager.getAllArtists();
+    const libraryArtists = await libraryManager.getRecentArtists(25);
     const existingArtistIds = new Set(libraryArtists.map((a) => a.mbid));
 
     recommendations = recommendations.filter(
-      (artist) => !existingArtistIds.has(artist.id)
+      (artist) => !existingArtistIds.has(artist.id),
     );
     globalTop = globalTop.filter((artist) => !existingArtistIds.has(artist.id));
 
     if (discoveryPreferences.excludedGenres.length > 0) {
       const excludedGenresLower = discoveryPreferences.excludedGenres.map((g) =>
-        g.toLowerCase()
+        g.toLowerCase(),
       );
 
       recommendations = recommendations.filter((artist) => {
@@ -564,10 +566,10 @@ router.get("/filtered", async (req, res) => {
 
     if (discoveryPreferences.excludedArtists.length > 0) {
       const excludedIds = new Set(
-        discoveryPreferences.excludedArtists.map((a) => a.artistId)
+        discoveryPreferences.excludedArtists.map((a) => a.artistId),
       );
       recommendations = recommendations.filter(
-        (artist) => !excludedIds.has(artist.id)
+        (artist) => !excludedIds.has(artist.id),
       );
       globalTop = globalTop.filter((artist) => !excludedIds.has(artist.id));
     }
@@ -575,7 +577,7 @@ router.get("/filtered", async (req, res) => {
     if (discoveryPreferences.maxRecommendations > 0) {
       recommendations = recommendations.slice(
         0,
-        discoveryPreferences.maxRecommendations
+        discoveryPreferences.maxRecommendations,
       );
     }
 

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -89,7 +89,7 @@ export const updateDiscoveryCache = async () => {
 
   try {
     const { libraryManager } = await import("./libraryManager.js");
-    const libraryArtists = await libraryManager.getAllArtists();
+    const libraryArtists = await libraryManager.getRecentArtists(25);
     console.log(`Found ${libraryArtists.length} artists in library.`);
 
     const existingArtistIds = new Set(libraryArtists.map((a) => a.mbid));

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -8,6 +8,7 @@ import {
 } from "./apiClients.js";
 
 const LIDARR_RETRY_MS = 60000;
+const FULL_LIST_FALLBACK_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 const TRACKS_CACHE_TTL_MS = 120000;
 const TRACKS_CACHE_MAX = 300;
 
@@ -15,6 +16,7 @@ let lidarrClient = null;
 let _cachedArtists = [];
 let _lastLidarrFailureAt = 0;
 let _retryTimeoutId = null;
+let _lastFullArtistFetchAt = 0;
 const _tracksCache = new Map();
 
 async function getLidarrClient() {
@@ -90,8 +92,7 @@ export class LibraryManager {
             const profiles = await lidarr.getMetadataProfiles();
             const profile = Array.isArray(profiles)
               ? profiles.find(
-                  (item) =>
-                    String(item?.id) === String(metadataProfileId),
+                  (item) => String(item?.id) === String(metadataProfileId),
                 )
               : null;
             if (profile?.primaryAlbumTypes) {
@@ -275,6 +276,96 @@ export class LibraryManager {
       }
     } catch (_) {
       return _cachedArtists;
+    }
+  }
+
+  async getRecentArtists(limit = 25, poolSize = 100) {
+    try {
+      const lidarr = await getLidarrClient();
+      if (!lidarr || !lidarr.isConfigured()) {
+        return Array.isArray(_cachedArtists)
+          ? _cachedArtists.slice(0, limit)
+          : [];
+      }
+      if (
+        _lastLidarrFailureAt &&
+        Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS
+      ) {
+        scheduleLidarrRetry(this);
+        return Array.isArray(_cachedArtists)
+          ? _cachedArtists.slice(0, limit)
+          : [];
+      }
+      const normalizedLimit = Math.max(0, limit);
+      const normalizedPool = Math.max(normalizedLimit, poolSize);
+      const pageSize = Math.max(normalizedPool * 2, normalizedPool);
+      const history = await lidarr.getHistory(
+        1,
+        pageSize,
+        "date",
+        "descending",
+      );
+      const records = Array.isArray(history) ? history : history?.records || [];
+      const artistIds = [];
+      const seen = new Set();
+      for (const record of records) {
+        const id = record?.artistId ?? record?.artist?.id;
+        if (id === undefined || id === null) continue;
+        const key = String(id);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        artistIds.push(key);
+        if (artistIds.length >= normalizedPool) break;
+      }
+      if (artistIds.length === 0) {
+        if (
+          (!Array.isArray(_cachedArtists) || _cachedArtists.length === 0) &&
+          Date.now() - _lastFullArtistFetchAt > FULL_LIST_FALLBACK_COOLDOWN_MS
+        ) {
+          try {
+            const lidarrArtists = await lidarr.request("/artist");
+            if (Array.isArray(lidarrArtists)) {
+              _cachedArtists = lidarrArtists.map((a) =>
+                this.mapLidarrArtist(a),
+              );
+              _lastFullArtistFetchAt = Date.now();
+            }
+          } catch {}
+        }
+        return Array.isArray(_cachedArtists)
+          ? _cachedArtists.slice(0, normalizedLimit)
+          : [];
+      }
+      const picked = artistIds
+        .sort(() => 0.5 - Math.random())
+        .slice(0, normalizedLimit);
+      const artists = await Promise.all(
+        picked.map((id) => lidarr.getArtist(id).catch(() => null)),
+      );
+      const mapped = artists
+        .filter(Boolean)
+        .map((artist) => this.mapLidarrArtist(artist));
+      if (mapped.length >= normalizedLimit) return mapped;
+      if (Array.isArray(_cachedArtists) && _cachedArtists.length > 0) {
+        const existing = new Set(
+          mapped.map(
+            (artist) => artist.mbid || artist.foreignArtistId || artist.id,
+          ),
+        );
+        const fallback = _cachedArtists.filter(
+          (artist) =>
+            !existing.has(artist.mbid || artist.foreignArtistId || artist.id),
+        );
+        const extra = fallback
+          .sort(() => 0.5 - Math.random())
+          .slice(0, Math.max(0, normalizedLimit - mapped.length));
+        return [...mapped, ...extra];
+      }
+      return mapped;
+    } catch (_) {
+      return Array.isArray(_cachedArtists)
+        ? _cachedArtists.slice(0, limit)
+        : [];
     }
   }
 


### PR DESCRIPTION
Replace getAllArtists with getRecentArtists in discovery endpoints to improve performance. The new method fetches recent artists from history with fallback to cached data, reducing load on Lidarr API while maintaining discovery functionality.