### PR TITLE
fix: optimize download status polling and caching

### DIFF
--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -22,6 +22,7 @@ const upsertImageStmt = db.prepare(
   "INSERT OR REPLACE INTO images_cache (mbid, image_url, cache_age, created_at) VALUES (?, ?, ?, ?)"
 );
 const getAllImagesStmt = db.prepare("SELECT * FROM images_cache");
+const countImagesStmt = db.prepare("SELECT COUNT(*) as count FROM images_cache");
 const deleteImageStmt = db.prepare("DELETE FROM images_cache WHERE mbid = ?");
 const clearImagesStmt = db.prepare("DELETE FROM images_cache");
 const cleanOldImagesStmt = db.prepare(
@@ -407,6 +408,11 @@ export const dbOps = {
       images[row.mbid] = row.image_url;
     }
     return images;
+  },
+
+  countImages() {
+    const row = countImagesStmt.get();
+    return Number(row?.count || 0);
   },
 
   deleteImage(mbid) {

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -65,9 +65,7 @@ router.get("/", noCache, async (req, res) => {
         isUpdating: !!discoveryCache?.isUpdating,
         recommendationsCount: discoveryCache?.recommendations?.length || 0,
         globalTopCount: discoveryCache?.globalTop?.length || 0,
-        cachedImagesCount: dbOps.getAllImages()
-          ? Object.keys(dbOps.getAllImages()).length
-          : 0,
+        cachedImagesCount: dbOps.countImages(),
       },
       websocket: {
         clients: wsStats.totalClients,

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -8,6 +8,12 @@ import {
 import { hasPermission } from "../../../middleware/auth.js";
 
 const STALE_GRABBED_MS = 15 * 60 * 1000;
+const DOWNLOAD_STATUS_CACHE_MS = 5000;
+let allDownloadStatusesCache = {
+  at: 0,
+  statuses: null,
+  pending: null,
+};
 
 export const getDownloadStatusesForAlbumIds = async (albumIdArrayInput) => {
   const albumIdArray = Array.isArray(albumIdArrayInput)
@@ -214,7 +220,7 @@ export const getDownloadStatusesForAlbumIds = async (albumIdArrayInput) => {
   return statuses;
 };
 
-export const getAllDownloadStatuses = async () => {
+const computeAllDownloadStatuses = async () => {
   const allStatuses = {};
   const { lidarrClient } = await import("../../../services/lidarrClient.js");
 
@@ -428,6 +434,38 @@ export const getAllDownloadStatuses = async () => {
   return allStatuses;
 };
 
+export const invalidateAllDownloadStatusesCache = () => {
+  allDownloadStatusesCache.at = 0;
+  allDownloadStatusesCache.statuses = null;
+  allDownloadStatusesCache.pending = null;
+};
+
+export const getAllDownloadStatuses = async () => {
+  const now = Date.now();
+  if (
+    allDownloadStatusesCache.statuses &&
+    now - allDownloadStatusesCache.at < DOWNLOAD_STATUS_CACHE_MS
+  ) {
+    return allDownloadStatusesCache.statuses;
+  }
+
+  if (allDownloadStatusesCache.pending) {
+    return allDownloadStatusesCache.pending;
+  }
+
+  allDownloadStatusesCache.pending = computeAllDownloadStatuses()
+    .then((statuses) => {
+      allDownloadStatusesCache.statuses = statuses;
+      allDownloadStatusesCache.at = Date.now();
+      return statuses;
+    })
+    .finally(() => {
+      allDownloadStatusesCache.pending = null;
+    });
+
+  return allDownloadStatusesCache.pending;
+};
+
 export default function registerDownloads(router) {
   router.post(
     "/downloads/album",
@@ -508,6 +546,7 @@ export default function registerDownloads(router) {
               albumIds: [parseInt(albumId, 10)],
             });
           }
+          invalidateAllDownloadStatusesCache();
 
           res.json({
             success: true,
@@ -566,6 +605,7 @@ export default function registerDownloads(router) {
           name: "AlbumSearch",
           albumIds: [parseInt(albumId, 10)],
         });
+        invalidateAllDownloadStatusesCache();
 
         res.json({
           success: true,
@@ -624,229 +664,15 @@ export default function registerDownloads(router) {
   router.get("/downloads/status", noCache, async (req, res) => {
     try {
       const { albumIds } = req.query;
-
       if (!albumIds) {
         return res
           .status(400)
           .json({ error: "albumIds query parameter is required" });
       }
-
       const albumIdArray = Array.isArray(albumIds)
         ? albumIds
         : albumIds.split(",");
       const statuses = await getDownloadStatusesForAlbumIds(albumIdArray);
-      res.json(statuses);
-      return;
-
-      const { lidarrClient } =
-        await import("../../../services/lidarrClient.js");
-
-      if (lidarrClient.isConfigured()) {
-        try {
-          const [queue, history, commands] = await Promise.all([
-            lidarrClient.getQueue(),
-            lidarrClient.getHistory(1, 200),
-            lidarrClient.request("/command").catch(() => []),
-          ]);
-          const queueItems = Array.isArray(queue) ? queue : queue.records || [];
-          const historyItems = Array.isArray(history)
-            ? history
-            : history.records || [];
-          const commandItems = Array.isArray(commands)
-            ? commands
-            : commands?.records || [];
-          const searchingAlbumIds = new Set();
-          for (const command of commandItems) {
-            const name = String(command?.name || command?.commandName || "")
-              .toLowerCase()
-              .trim();
-            if (!name.includes("albumsearch")) continue;
-            const status = String(command?.status || "")
-              .toLowerCase()
-              .trim();
-            if (
-              status === "completed" ||
-              status === "failed" ||
-              status === "aborted" ||
-              status === "canceled" ||
-              status === "cancelled"
-            ) {
-              continue;
-            }
-            const albumIds = Array.isArray(command?.body?.albumIds)
-              ? command.body.albumIds
-              : Array.isArray(command?.albumIds)
-                ? command.albumIds
-                : [];
-            for (const id of albumIds) {
-              if (id != null) searchingAlbumIds.add(id);
-            }
-          }
-
-          const latestHistoryByAlbumId = new Map();
-          for (const h of historyItems) {
-            if (h?.albumId == null) continue;
-            const historyTime = new Date(
-              h?.date || h?.eventDate || 0,
-            ).getTime();
-            const existing = latestHistoryByAlbumId.get(h.albumId);
-            if (!existing || historyTime > existing.historyTime) {
-              latestHistoryByAlbumId.set(h.albumId, {
-                history: h,
-                historyTime,
-              });
-            }
-          }
-
-          for (const albumId of albumIdArray) {
-            if (!albumId || albumId === "undefined" || albumId === "null")
-              continue;
-            const lidarrAlbumId = parseInt(albumId, 10);
-            if (isNaN(lidarrAlbumId)) continue;
-
-            const queueItem = queueItems.find((q) => {
-              const qAlbumId = q?.albumId ?? q?.album?.id;
-              return qAlbumId != null && qAlbumId === lidarrAlbumId;
-            });
-
-            if (queueItem) {
-              const queueStatus = String(queueItem.status || "").toLowerCase();
-              const title = String(queueItem.title || "").toLowerCase();
-              const trackedDownloadState = String(
-                queueItem.trackedDownloadState || "",
-              ).toLowerCase();
-              const trackedDownloadStatus = String(
-                queueItem.trackedDownloadStatus || "",
-              ).toLowerCase();
-              const errorMessage = String(
-                queueItem.errorMessage || "",
-              ).toLowerCase();
-              const statusMessages = Array.isArray(queueItem.statusMessages)
-                ? queueItem.statusMessages
-                    .map((m) => String(m || "").toLowerCase())
-                    .join(" ")
-                : "";
-
-              const size = Number(queueItem.size || 0);
-              const sizeLeft = Number(queueItem.sizeleft || 0);
-              const hasActiveDownload = size > 0 && sizeLeft < size;
-              const isDownloadingState =
-                hasActiveDownload ||
-                queueStatus.includes("downloading") ||
-                queueStatus.includes("queued") ||
-                queueStatus.includes("processing");
-              const isExplicitFailure =
-                trackedDownloadState === "importfailed" ||
-                trackedDownloadState === "importFailed" ||
-                trackedDownloadState.includes("importfailed") ||
-                queueStatus.includes("failed") ||
-                queueStatus.includes("import fail") ||
-                title.includes("import fail") ||
-                trackedDownloadState.includes("fail") ||
-                trackedDownloadStatus.includes("fail") ||
-                (trackedDownloadStatus === "warning" && !isDownloadingState) ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("retrying") ||
-                statusMessages.includes("unmatched");
-
-              if (isDownloadingState) {
-                const progress = size
-                  ? Math.round((1 - sizeLeft / size) * 100)
-                  : 0;
-                statuses[albumId] = {
-                  status: "downloading",
-                  progress: progress,
-                  updatedAt: new Date().toISOString(),
-                };
-              } else if (isExplicitFailure) {
-                statuses[albumId] = {
-                  status: "failed",
-                  updatedAt: new Date().toISOString(),
-                };
-              } else {
-                const progress = size
-                  ? Math.round((1 - sizeLeft / size) * 100)
-                  : 0;
-                statuses[albumId] = {
-                  status: "downloading",
-                  progress: progress,
-                  updatedAt: new Date().toISOString(),
-                };
-              }
-              continue;
-            }
-
-            if (searchingAlbumIds.has(lidarrAlbumId)) {
-              statuses[albumId] = {
-                status: "searching",
-                updatedAt: new Date().toISOString(),
-              };
-              continue;
-            }
-
-            const historyEntry = latestHistoryByAlbumId.get(lidarrAlbumId);
-            const recentHistory = historyEntry?.history;
-            const historyTime = historyEntry?.historyTime ?? 0;
-
-            if (recentHistory) {
-              const eventType = String(
-                recentHistory.eventType || "",
-              ).toLowerCase();
-              const data = recentHistory?.data || {};
-              const statusMessages = Array.isArray(data?.statusMessages)
-                ? data.statusMessages
-                    .map((m) => String(m || "").toLowerCase())
-                    .join(" ")
-                : String(data?.statusMessages?.[0] || "").toLowerCase();
-              const errorMessage = String(
-                data?.errorMessage || "",
-              ).toLowerCase();
-              const sourceTitle = String(
-                recentHistory?.sourceTitle || "",
-              ).toLowerCase();
-              const dataString = JSON.stringify(data).toLowerCase();
-              const isGrabbed =
-                eventType.includes("grabbed") ||
-                sourceTitle.includes("grabbed") ||
-                dataString.includes("grabbed");
-              const isFailedDownload =
-                eventType.includes("fail") ||
-                statusMessages.includes("fail") ||
-                statusMessages.includes("error") ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("error") ||
-                sourceTitle.includes("fail") ||
-                dataString.includes("fail");
-              const isFailedImport =
-                eventType === "albumimportincomplete" ||
-                eventType.includes("incomplete") ||
-                statusMessages.includes("fail") ||
-                statusMessages.includes("error") ||
-                statusMessages.includes("incomplete") ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("error");
-              const isComplete =
-                eventType.includes("import") &&
-                !isFailedImport &&
-                eventType !== "albumimportincomplete";
-              const isStaleGrabbed =
-                isGrabbed && Date.now() - historyTime > STALE_GRABBED_MS;
-              statuses[albumId] = {
-                status: isComplete
-                  ? "added"
-                  : isFailedImport || isFailedDownload || isStaleGrabbed
-                    ? "failed"
-                    : "processing",
-                updatedAt: new Date().toISOString(),
-              };
-              continue;
-            }
-          }
-        } catch (error) {
-          console.warn("Failed to fetch Lidarr status:", error.message);
-        }
-      }
-
       res.json(statuses);
     } catch (error) {
       res.status(500).json({
@@ -858,231 +684,8 @@ export default function registerDownloads(router) {
 
   router.get("/downloads/status/all", noCache, async (req, res) => {
     try {
-      const computedStatuses = await getAllDownloadStatuses();
-      res.json(computedStatuses);
-      return;
-      const { lidarrClient } =
-        await import("../../../services/lidarrClient.js");
-      const allStatuses = {};
-
-      if (lidarrClient.isConfigured()) {
-        try {
-          const [queue, history, albums, commands] = await Promise.all([
-            lidarrClient.getQueue(),
-            lidarrClient.getHistory(1, 200),
-            lidarrClient.request("/album"),
-            lidarrClient.request("/command").catch(() => []),
-          ]);
-
-          const queueItems = Array.isArray(queue) ? queue : queue.records || [];
-          const historyItems = Array.isArray(history)
-            ? history
-            : history.records || [];
-          const allAlbums = Array.isArray(albums) ? albums : [];
-          const commandItems = Array.isArray(commands)
-            ? commands
-            : commands?.records || [];
-          const searchingAlbumIds = new Set();
-          for (const command of commandItems) {
-            const name = String(command?.name || command?.commandName || "")
-              .toLowerCase()
-              .trim();
-            if (!name.includes("albumsearch")) continue;
-            const status = String(command?.status || "")
-              .toLowerCase()
-              .trim();
-            if (
-              status === "completed" ||
-              status === "failed" ||
-              status === "aborted" ||
-              status === "canceled" ||
-              status === "cancelled"
-            ) {
-              continue;
-            }
-            const albumIds = Array.isArray(command?.body?.albumIds)
-              ? command.body.albumIds
-              : Array.isArray(command?.albumIds)
-                ? command.albumIds
-                : [];
-            for (const id of albumIds) {
-              if (id != null) searchingAlbumIds.add(id);
-            }
-          }
-
-          const queueByAlbumId = new Map();
-          for (const q of queueItems) {
-            const qAlbumId = q?.albumId ?? q?.album?.id;
-            if (qAlbumId == null) continue;
-            queueByAlbumId.set(qAlbumId, q);
-          }
-
-          const historyByAlbumId = new Map();
-          for (const h of historyItems) {
-            if (h?.albumId == null) continue;
-            const historyTime = new Date(
-              h?.date || h?.eventDate || 0,
-            ).getTime();
-            const existing = historyByAlbumId.get(h.albumId);
-            if (!existing || historyTime > existing.historyTime) {
-              historyByAlbumId.set(h.albumId, {
-                history: h,
-                historyTime,
-              });
-            }
-          }
-
-          for (const album of allAlbums) {
-            const lidarrAlbumId = album?.id;
-            if (lidarrAlbumId == null) continue;
-            const queueItem = queueByAlbumId.get(lidarrAlbumId);
-
-            if (queueItem) {
-              const queueStatus = String(queueItem.status || "").toLowerCase();
-              const title = String(queueItem.title || "").toLowerCase();
-              const trackedDownloadState = String(
-                queueItem.trackedDownloadState || "",
-              ).toLowerCase();
-              const trackedDownloadStatus = String(
-                queueItem.trackedDownloadStatus || "",
-              ).toLowerCase();
-              const errorMessage = String(
-                queueItem.errorMessage || "",
-              ).toLowerCase();
-              const statusMessages = Array.isArray(queueItem.statusMessages)
-                ? queueItem.statusMessages
-                    .map((m) => String(m || "").toLowerCase())
-                    .join(" ")
-                : "";
-
-              const size = Number(queueItem.size || 0);
-              const sizeLeft = Number(queueItem.sizeleft || 0);
-              const hasActiveDownload = size > 0 && sizeLeft < size;
-              const isDownloadingState =
-                hasActiveDownload ||
-                queueStatus.includes("downloading") ||
-                queueStatus.includes("queued") ||
-                queueStatus.includes("processing");
-              const isExplicitFailure =
-                trackedDownloadState === "importfailed" ||
-                trackedDownloadState === "importFailed" ||
-                trackedDownloadState.includes("importfailed") ||
-                queueStatus.includes("failed") ||
-                queueStatus.includes("import fail") ||
-                title.includes("import fail") ||
-                trackedDownloadState.includes("fail") ||
-                trackedDownloadStatus.includes("fail") ||
-                (trackedDownloadStatus === "warning" && !isDownloadingState) ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("retrying") ||
-                statusMessages.includes("unmatched");
-
-              if (isDownloadingState) {
-                const progress = size
-                  ? Math.round((1 - sizeLeft / size) * 100)
-                  : 0;
-                allStatuses[String(lidarrAlbumId)] = {
-                  status: "downloading",
-                  progress: progress,
-                  updatedAt: new Date().toISOString(),
-                };
-              } else if (isExplicitFailure) {
-                allStatuses[String(lidarrAlbumId)] = {
-                  status: "failed",
-                  updatedAt: new Date().toISOString(),
-                };
-              } else {
-                const progress = size
-                  ? Math.round((1 - sizeLeft / size) * 100)
-                  : 0;
-                allStatuses[String(lidarrAlbumId)] = {
-                  status: "downloading",
-                  progress: progress,
-                  updatedAt: new Date().toISOString(),
-                };
-              }
-              continue;
-            }
-
-            if (searchingAlbumIds.has(lidarrAlbumId)) {
-              allStatuses[String(lidarrAlbumId)] = {
-                status: "searching",
-                updatedAt: new Date().toISOString(),
-              };
-              continue;
-            }
-
-            const historyEntry = historyByAlbumId.get(lidarrAlbumId);
-            const recentHistory = historyEntry?.history;
-            const historyTime = historyEntry?.historyTime ?? 0;
-
-            if (recentHistory) {
-              const eventType = String(
-                recentHistory.eventType || "",
-              ).toLowerCase();
-              const data = recentHistory?.data || {};
-              const statusMessages = Array.isArray(data?.statusMessages)
-                ? data.statusMessages
-                    .map((m) => String(m || "").toLowerCase())
-                    .join(" ")
-                : String(data?.statusMessages?.[0] || "").toLowerCase();
-              const errorMessage = String(
-                data?.errorMessage || "",
-              ).toLowerCase();
-              const sourceTitle = String(
-                recentHistory?.sourceTitle || "",
-              ).toLowerCase();
-              const dataString = JSON.stringify(data).toLowerCase();
-              const isGrabbed =
-                eventType.includes("grabbed") ||
-                sourceTitle.includes("grabbed") ||
-                dataString.includes("grabbed");
-              const isFailedDownload =
-                eventType.includes("fail") ||
-                statusMessages.includes("fail") ||
-                statusMessages.includes("error") ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("error") ||
-                sourceTitle.includes("fail") ||
-                dataString.includes("fail");
-              const isFailedImport =
-                eventType === "albumimportincomplete" ||
-                eventType.includes("incomplete") ||
-                statusMessages.includes("fail") ||
-                statusMessages.includes("error") ||
-                statusMessages.includes("incomplete") ||
-                errorMessage.includes("fail") ||
-                errorMessage.includes("error");
-              const isComplete =
-                eventType.includes("import") &&
-                !isFailedImport &&
-                eventType !== "albumimportincomplete";
-              const isStaleGrabbed =
-                isGrabbed && Date.now() - historyTime > STALE_GRABBED_MS;
-              const historyDate = new Date(
-                recentHistory.date || recentHistory.eventDate || 0,
-              );
-              const oneHourAgo = Date.now() - 60 * 60 * 1000;
-
-              if (historyDate.getTime() > oneHourAgo) {
-                allStatuses[String(lidarrAlbumId)] = {
-                  status: isComplete
-                    ? "added"
-                    : isFailedImport || isFailedDownload || isStaleGrabbed
-                      ? "failed"
-                      : "processing",
-                  updatedAt: new Date().toISOString(),
-                };
-                continue;
-              }
-            }
-          }
-        } catch (error) {
-          console.warn("Failed to fetch Lidarr status:", error.message);
-        }
-      }
-
-      res.json(allStatuses);
+      const statuses = await getAllDownloadStatuses();
+      res.json(statuses);
     } catch (error) {
       res.status(500).json({
         error: "Failed to fetch download status",

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -1,13 +1,35 @@
 import express from "express";
 import { UUID_REGEX } from "../config/constants.js";
 import { noCache } from "../middleware/cache.js";
+import { invalidateAllDownloadStatusesCache } from "./library/handlers/downloads.js";
 
 const router = express.Router();
-const dismissedAlbumIds = new Set();
+const dismissedAlbumIds = new Map();
+const DISMISSED_ALBUM_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_DISMISSED_ALBUMS = 1000;
 const REQUESTS_CACHE_MS = 15000;
 const STALE_GRABBED_MS = 15 * 60 * 1000;
 let lastRequestsResponse = null;
 let lastRequestsAt = 0;
+
+const pruneDismissedAlbumIds = () => {
+  const now = Date.now();
+  for (const [albumId, dismissedAt] of dismissedAlbumIds.entries()) {
+    if (now - dismissedAt > DISMISSED_ALBUM_TTL_MS) {
+      dismissedAlbumIds.delete(albumId);
+    }
+  }
+  if (dismissedAlbumIds.size <= MAX_DISMISSED_ALBUMS) {
+    return;
+  }
+  const entries = Array.from(dismissedAlbumIds.entries()).sort(
+    (a, b) => a[1] - b[1],
+  );
+  const removeCount = dismissedAlbumIds.size - MAX_DISMISSED_ALBUMS;
+  for (let i = 0; i < removeCount; i++) {
+    dismissedAlbumIds.delete(entries[i][0]);
+  }
+};
 
 const toIso = (value) => {
   if (!value) return new Date().toISOString();
@@ -21,6 +43,7 @@ const toIso = (value) => {
 
 router.get("/", noCache, async (req, res) => {
   try {
+    pruneDismissedAlbumIds();
     const { lidarrClient } = await import("../services/lidarrClient.js");
 
     if (!lidarrClient?.isConfigured()) {
@@ -53,24 +76,30 @@ router.get("/", noCache, async (req, res) => {
 
       const albumName = item?.album?.title || item?.title || "Album";
       const artistName = item?.artist?.artistName || "Artist";
-      
+
       let artistMbid = null;
-      
+
       artistMbid = item?.artist?.foreignArtistId || null;
 
       const queueStatus = String(item.status || "").toLowerCase();
       const title = String(item.title || "").toLowerCase();
-      const trackedDownloadState = String(item.trackedDownloadState || "").toLowerCase();
-      const trackedDownloadStatus = String(item.trackedDownloadStatus || "").toLowerCase();
+      const trackedDownloadState = String(
+        item.trackedDownloadState || "",
+      ).toLowerCase();
+      const trackedDownloadStatus = String(
+        item.trackedDownloadStatus || "",
+      ).toLowerCase();
       const errorMessage = String(item.errorMessage || "").toLowerCase();
-      const statusMessages = Array.isArray(item.statusMessages) 
-        ? item.statusMessages.map(m => String(m || "").toLowerCase()).join(" ")
+      const statusMessages = Array.isArray(item.statusMessages)
+        ? item.statusMessages
+            .map((m) => String(m || "").toLowerCase())
+            .join(" ")
         : "";
-      
+
       const isFailed =
         trackedDownloadState === "importfailed" ||
         trackedDownloadState === "importFailed" ||
-        queueStatus.includes("fail") || 
+        queueStatus.includes("fail") ||
         queueStatus.includes("import fail") ||
         title.includes("import fail") ||
         title.includes("downloaded - import fail") ||
@@ -81,7 +110,7 @@ router.get("/", noCache, async (req, res) => {
         errorMessage.includes("retrying") ||
         statusMessages.includes("fail") ||
         statusMessages.includes("unmatched");
-      
+
       const status = isFailed ? "failed" : "processing";
 
       requestsByAlbumId.set(String(albumId), {
@@ -130,15 +159,17 @@ router.get("/", noCache, async (req, res) => {
 
       const albumName = record?.album?.title || record?.sourceTitle || "Album";
       const artistName = record?.artist?.artistName || "Artist";
-      
+
       let artistMbid = null;
-      
+
       artistMbid = record?.artist?.foreignArtistId || null;
 
       const eventType = String(record?.eventType || "").toLowerCase();
       const data = record?.data || {};
-      const statusMessages = Array.isArray(data?.statusMessages) 
-        ? data.statusMessages.map(m => String(m || "").toLowerCase()).join(" ")
+      const statusMessages = Array.isArray(data?.statusMessages)
+        ? data.statusMessages
+            .map((m) => String(m || "").toLowerCase())
+            .join(" ")
         : String(data?.statusMessages?.[0] || "").toLowerCase();
       const errorMessage = String(data?.errorMessage || "").toLowerCase();
       const sourceTitle = String(record?.sourceTitle || "").toLowerCase();
@@ -156,11 +187,11 @@ router.get("/", noCache, async (req, res) => {
         errorMessage.includes("error") ||
         sourceTitle.includes("fail") ||
         dataString.includes("fail");
-      
+
       const isFailedImport =
         eventType === "albumimportincomplete" ||
         eventType.includes("incomplete") ||
-        statusMessages.includes("fail") || 
+        statusMessages.includes("fail") ||
         statusMessages.includes("error") ||
         statusMessages.includes("import fail") ||
         statusMessages.includes("incomplete") ||
@@ -168,8 +199,11 @@ router.get("/", noCache, async (req, res) => {
         errorMessage.includes("error") ||
         sourceTitle.includes("import fail") ||
         dataString.includes("import fail");
-      
-      const isSuccessfulImport = eventType.includes("import") && !isFailedImport && eventType !== "albumimportincomplete";
+
+      const isSuccessfulImport =
+        eventType.includes("import") &&
+        !isFailedImport &&
+        eventType !== "albumimportincomplete";
       const isStaleGrabbed =
         isGrabbed && !hasQueue && Date.now() - recordTime > STALE_GRABBED_MS;
       const status = hasQueue
@@ -269,7 +303,10 @@ router.get("/", noCache, async (req, res) => {
     if (albumDetailsById.size > 0 || artistDetailsById.size > 0) {
       sorted = sorted.map((request) => {
         const enriched = { ...request };
-        if (enriched.albumId && albumDetailsById.has(String(enriched.albumId))) {
+        if (
+          enriched.albumId &&
+          albumDetailsById.has(String(enriched.albumId))
+        ) {
           const album = albumDetailsById.get(String(enriched.albumId));
           if (album) {
             if (!enriched.albumMbid && album.foreignAlbumId) {
@@ -284,10 +321,16 @@ router.get("/", noCache, async (req, res) => {
             }
           }
         }
-        if (enriched.artistId && artistDetailsById.has(String(enriched.artistId))) {
+        if (
+          enriched.artistId &&
+          artistDetailsById.has(String(enriched.artistId))
+        ) {
           const artist = artistDetailsById.get(String(enriched.artistId));
           if (artist) {
-            if (isPlaceholder(enriched.artistName, "Artist") && artist.artistName) {
+            if (
+              isPlaceholder(enriched.artistName, "Artist") &&
+              artist.artistName
+            ) {
               enriched.artistName = artist.artistName;
             }
             if (!enriched.artistMbid && artist.foreignArtistId) {
@@ -312,7 +355,8 @@ router.delete("/album/:albumId", async (req, res) => {
   const { albumId } = req.params;
   if (!albumId) return res.status(400).json({ error: "albumId is required" });
 
-  dismissedAlbumIds.add(String(albumId));
+  dismissedAlbumIds.set(String(albumId), Date.now());
+  pruneDismissedAlbumIds();
 
   try {
     const { lidarrClient } = await import("../services/lidarrClient.js");
@@ -332,6 +376,7 @@ router.delete("/album/:albumId", async (req, res) => {
         }
       }
     }
+    invalidateAllDownloadStatusesCache();
 
     res.json({ success: true });
   } catch {
@@ -367,6 +412,7 @@ router.delete("/:mbid", async (req, res) => {
           .catch(() => null);
       }
     }
+    invalidateAllDownloadStatusesCache();
 
     res.json({ success: true });
   } catch {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -36,6 +36,13 @@ export class LidarrClient {
       maxFreeSockets: 2,
       timeout: 60000,
     });
+    this._httpsInsecureAgent = new https.Agent({
+      rejectUnauthorized: false,
+      keepAlive: true,
+      maxSockets: LIDARR_MAX_CONCURRENT,
+      maxFreeSockets: 2,
+      timeout: 60000,
+    });
     this.updateConfig();
   }
 
@@ -234,13 +241,7 @@ export class LidarrClient {
             httpAgent: this._httpAgent,
             httpsAgent:
               isHttps && this.config.insecure
-                ? new https.Agent({
-                    rejectUnauthorized: false,
-                    keepAlive: true,
-                    maxSockets: LIDARR_MAX_CONCURRENT,
-                    maxFreeSockets: 2,
-                    timeout: 60000,
-                  })
+                ? this._httpsInsecureAgent
                 : this._httpsAgent,
             validateStatus: function (status) {
               return status < 500;

--- a/backend/services/websocketService.js
+++ b/backend/services/websocketService.js
@@ -5,9 +5,11 @@ class WebSocketService {
     this.wss = null;
     this.clients = new Set();
     this.subscriptions = new Map();
+    this.startTime = Date.now();
   }
 
   initialize(server) {
+    this.startTime = Date.now();
     this.wss = new WebSocketServer({ 
       server,
       path: '/ws',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -96,6 +96,9 @@ function AppContent() {
 
   useEffect(() => {
     const checkApiHealth = async () => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
       try {
         const health = await checkHealth();
         setIsHealthy(health.status === "ok");
@@ -109,7 +112,16 @@ function AppContent() {
 
     checkApiHealth();
     const interval = setInterval(checkApiHealth, 30000);
-    return () => clearInterval(interval);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkApiHealth();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [isAuthenticated]);
 
   return (

--- a/frontend/src/components/UpdateBanner.jsx
+++ b/frontend/src/components/UpdateBanner.jsx
@@ -12,6 +12,13 @@ const UpdateBanner = ({ currentVersion }) => {
       }`,
     [],
   );
+  const checkMetaKey = useMemo(
+    () =>
+      `aurral:updateCheckMeta:${
+        import.meta.env.VITE_GITHUB_REPO || "lklynet/aurral"
+      }`,
+    [],
+  );
 
   useEffect(() => {
     const currentVersion = resolvedVersion;
@@ -24,15 +31,35 @@ const UpdateBanner = ({ currentVersion }) => {
     }
     const currentIsSha = isSha(currentVersion);
     const currentLabel = normalizeVersion(currentVersion);
+    const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
     let active = true;
     const checkForUpdate = async () => {
       try {
+        const now = Date.now();
+        let checkMeta = null;
+        try {
+          checkMeta = JSON.parse(localStorage.getItem(checkMetaKey) || "null");
+        } catch {}
+        if (
+          checkMeta?.lastCheckedAt &&
+          now - Number(checkMeta.lastCheckedAt) < CHECK_INTERVAL_MS
+        ) {
+          return;
+        }
         const endpoint = `https://api.github.com/repos/${repo}/releases/latest`;
         const res = await fetch(endpoint);
         if (!res.ok) {
+          localStorage.setItem(
+            checkMetaKey,
+            JSON.stringify({ lastCheckedAt: Date.now() }),
+          );
           return;
         }
         const data = await res.json();
+        localStorage.setItem(
+          checkMetaKey,
+          JSON.stringify({ lastCheckedAt: Date.now() }),
+        );
         const latestSha = (data.target_commitish || "").trim();
         const latestLabel = normalizeVersion(data.tag_name || "");
         const releaseUrl =
@@ -71,12 +98,12 @@ const UpdateBanner = ({ currentVersion }) => {
       } catch {}
     };
     checkForUpdate();
-    const intervalId = setInterval(checkForUpdate, 60 * 60 * 1000);
+    const intervalId = setInterval(checkForUpdate, CHECK_INTERVAL_MS);
     return () => {
       active = false;
       clearInterval(intervalId);
     };
-  }, [dismissKey, resolvedVersion]);
+  }, [checkMetaKey, dismissKey, resolvedVersion]);
 
   const dismissUpdate = () => {
     if (!updateInfo?.latestKey) {

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -14,7 +14,6 @@ import {
 import {
   getDiscovery,
   getRecentlyAdded,
-  getAllDownloadStatus,
   getRecentReleases,
   getReleaseGroupCover,
   getArtistCover,
@@ -274,7 +273,6 @@ function DiscoverPage() {
   const [draggingId, setDraggingId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
   const [error, setError] = useState(null);
-  const downloadStatusesRef = useRef({});
   const requestedReleaseCoversRef = useRef(new Set());
   const requestedArtistCoversRef = useRef(new Set());
   const navigate = useNavigate();
@@ -324,36 +322,6 @@ function DiscoverPage() {
       .then(setRecentReleases)
       .catch(() => {});
 
-    const pollDownloadStatus = async () => {
-      try {
-        const statuses = await getAllDownloadStatus();
-        const prev = downloadStatusesRef.current;
-        const prevKeys = Object.keys(prev).sort().join(",");
-        const newKeys = Object.keys(statuses).sort().join(",");
-
-        if (prevKeys !== newKeys) {
-          downloadStatusesRef.current = statuses;
-          return;
-        }
-
-        let hasChanges = false;
-        for (const key in statuses) {
-          if (prev[key] !== statuses[key]) {
-            hasChanges = true;
-            break;
-          }
-        }
-
-        if (hasChanges) {
-          downloadStatusesRef.current = statuses;
-        }
-      } catch {}
-    };
-
-    pollDownloadStatus();
-    const interval = setInterval(pollDownloadStatus, 15000);
-
-    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/RequestsPage.jsx
+++ b/frontend/src/pages/RequestsPage.jsx
@@ -28,8 +28,10 @@ function RequestsPage() {
   const navigate = useNavigate();
   const { showError, showSuccess } = useToast();
   const activeAlbumIdsRef = useRef([]);
+  const lastDownloadWsAtRef = useRef(0);
   const handleDownloadStatusMessage = useCallback((msg) => {
     if (msg?.type !== "download_statuses") return;
+    lastDownloadWsAtRef.current = Date.now();
     const activeIds = activeAlbumIdsRef.current;
     if (!activeIds.length) return;
     const incoming = msg.statuses || {};
@@ -145,6 +147,9 @@ function RequestsPage() {
 
     let cancelled = false;
     const pollDownloadStatus = async () => {
+      if (Date.now() - lastDownloadWsAtRef.current < 20000) {
+        return;
+      }
       try {
         const statuses = await getDownloadStatus(albumIds);
         if (!cancelled) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -29,6 +29,21 @@ const api = axios.create({
 });
 
 const libraryLookupCache = new Map();
+const MAX_LIBRARY_LOOKUP_CACHE_SIZE = 1000;
+
+const setLibraryLookupCacheEntry = (id, value) => {
+  if (id == null) return;
+  if (libraryLookupCache.has(id)) {
+    libraryLookupCache.delete(id);
+  }
+  libraryLookupCache.set(id, value);
+  if (libraryLookupCache.size > MAX_LIBRARY_LOOKUP_CACHE_SIZE) {
+    const oldestKey = libraryLookupCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      libraryLookupCache.delete(oldestKey);
+    }
+  }
+};
 
 api.interceptors.request.use(
   (config) => {
@@ -213,7 +228,7 @@ export const readLibraryLookupCache = (mbids) => {
 export const writeLibraryLookupCache = (lookup) => {
   if (!lookup || typeof lookup !== "object") return;
   Object.entries(lookup).forEach(([id, value]) => {
-    libraryLookupCache.set(id, value);
+    setLibraryLookupCacheEntry(id, value);
   });
 };
 


### PR DESCRIPTION
- Cache all download statuses for 5 seconds to reduce backend load
- Invalidate cache on album dismissal and search commands
- Limit frontend polling to avoid redundant requests when WebSocket updates are recent
- Remove unused polling from Discover page
- Add TTL and size limit to dismissed albums set
- Reuse HTTPS agent for insecure Lidarr connections
- Implement LRU eviction for library lookup cache
- Skip health checks when page is hidden
- Add startup time tracking to WebSocket service
- Optimize image count query with dedicated SQL statement