### PR TITLE
feat: add incremental job stats and query params to flow endpoints

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -68,28 +68,40 @@ router.post("/start/:flowId", async (req, res) => {
 router.get("/status", (req, res) => {
   const workerStatus = weeklyFlowWorker.getStatus();
   const stats = downloadTracker.getStats();
-  const allJobs = downloadTracker.getAll();
   const flows = flowPlaylistConfig.getFlows();
+  const flowIds = flows.map((flow) => flow.id);
+  const flowStats = downloadTracker.getStatsByPlaylistType(flowIds);
+
+  const includeJobs =
+    req.query.includeJobs === "1" || req.query.includeJobs === "true";
+  const flowId = req.query.flowId ? String(req.query.flowId) : null;
+  const parsedLimit = Number(req.query.jobsLimit);
+  const jobsLimit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(Math.floor(parsedLimit), 500)
+      : null;
+
+  let jobs;
+  if (includeJobs) {
+    const sourceJobs = flowId
+      ? downloadTracker.getByPlaylistType(flowId)
+      : downloadTracker.getAll();
+    jobs = jobsLimit ? sourceJobs.slice(0, jobsLimit) : sourceJobs;
+  }
 
   res.json({
     worker: workerStatus,
     stats,
-    jobs: allJobs,
+    flowStats,
+    jobs,
     flows,
   });
 });
 
 router.post("/flows", async (req, res) => {
   try {
-    const {
-      name,
-      mix,
-      size,
-      deepDive,
-      recipe,
-      tags,
-      relatedArtists,
-    } = req.body || {};
+    const { name, mix, size, deepDive, recipe, tags, relatedArtists } =
+      req.body || {};
     if (!name || !String(name).trim()) {
       return res.status(400).json({ error: "name is required" });
     }
@@ -115,15 +127,8 @@ router.post("/flows", async (req, res) => {
 router.put("/flows/:flowId", async (req, res) => {
   try {
     const { flowId } = req.params;
-    const {
-      name,
-      mix,
-      size,
-      deepDive,
-      recipe,
-      tags,
-      relatedArtists,
-    } = req.body || {};
+    const { name, mix, size, deepDive, recipe, tags, relatedArtists } =
+      req.body || {};
     const updated = flowPlaylistConfig.updateFlow(flowId, {
       name,
       mix,
@@ -255,7 +260,12 @@ router.put("/flows/:flowId/enabled", async (req, res) => {
 
 router.get("/jobs/:flowId", (req, res) => {
   const { flowId } = req.params;
-  const jobs = downloadTracker.getByPlaylistType(flowId);
+  const parsedLimit = Number(req.query.limit);
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(Math.floor(parsedLimit), 500)
+      : 200;
+  const jobs = downloadTracker.getByPlaylistType(flowId).slice(0, limit);
   res.json(jobs);
 });
 

--- a/backend/services/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlowDownloadTracker.js
@@ -256,6 +256,36 @@ export class WeeklyFlowDownloadTracker {
     return stats;
   }
 
+  getStatsByPlaylistType(playlistTypes = []) {
+    const statsByType = {};
+    const ensure = (playlistType) => {
+      if (!playlistType) return null;
+      if (!statsByType[playlistType]) {
+        statsByType[playlistType] = {
+          total: 0,
+          pending: 0,
+          downloading: 0,
+          done: 0,
+          failed: 0,
+        };
+      }
+      return statsByType[playlistType];
+    };
+
+    for (const playlistType of playlistTypes) {
+      ensure(playlistType);
+    }
+
+    for (const job of this.jobs.values()) {
+      const stats = ensure(job.playlistType);
+      if (!stats) continue;
+      stats.total += 1;
+      stats[job.status] = (stats[job.status] || 0) + 1;
+    }
+
+    return statsByType;
+  }
+
   clearCompleted() {
     const toDelete = [];
     for (const [id, job] of this.jobs.entries()) {

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import {
   getFlowStatus,
+  getFlowJobs,
   createFlow,
   updateFlow,
   deleteFlow,
@@ -401,6 +402,26 @@ const isFlowDirty = (flow, draft) => {
   return JSON.stringify(base) !== JSON.stringify(next);
 };
 
+const EMPTY_FLOW_STATS = {
+  total: 0,
+  done: 0,
+  failed: 0,
+  pending: 0,
+  downloading: 0,
+};
+
+const buildFlowStatsFromJobs = (jobs) => {
+  const stats = { ...EMPTY_FLOW_STATS };
+  if (!Array.isArray(jobs)) return stats;
+  stats.total = jobs.length;
+  for (const job of jobs) {
+    if (job?.status) {
+      stats[job.status] = (stats[job.status] || 0) + 1;
+    }
+  }
+  return stats;
+};
+
 function FlowPage() {
   const [status, setStatus] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -414,6 +435,7 @@ function FlowPage() {
   const [simpleDrafts, setSimpleDrafts] = useState({});
   const [simpleErrors, setSimpleErrors] = useState({});
   const [applyingFlowId, setApplyingFlowId] = useState(null);
+  const [flowStatsById, setFlowStatsById] = useState({});
   const { showSuccess, showError } = useToast();
 
   const fetchStatus = async () => {
@@ -438,6 +460,63 @@ function FlowPage() {
   }, [status?.worker?.running]);
 
   useEffect(() => {
+    if (!status?.worker?.running || !status?.flows?.length) return;
+    const activeFlowIds = status.flows
+      .filter((flow) => {
+        const stats = status.flowStats?.[flow.id];
+        return (stats?.pending || 0) > 0 || (stats?.downloading || 0) > 0;
+      })
+      .map((flow) => flow.id);
+    if (!activeFlowIds.length) return;
+
+    let cancelled = false;
+    const fetchIncrementalJobs = async () => {
+      try {
+        const results = await Promise.all(
+          activeFlowIds.map((flowId) =>
+            getFlowJobs(flowId).then((jobs) => ({
+              flowId,
+              stats: buildFlowStatsFromJobs(jobs),
+            })),
+          ),
+        );
+        if (cancelled) return;
+        setFlowStatsById((prev) => {
+          const next = { ...prev };
+          for (const result of results) {
+            next[result.flowId] = result.stats;
+          }
+          return next;
+        });
+      } catch {}
+    };
+
+    fetchIncrementalJobs();
+    const interval = setInterval(fetchIncrementalJobs, 15000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [status?.worker?.running, status?.flows, status?.flowStats]);
+
+  useEffect(() => {
+    if (!status?.flows?.length) {
+      setFlowStatsById({});
+      return;
+    }
+    const flowIds = new Set(status.flows.map((flow) => flow.id));
+    setFlowStatsById((prev) => {
+      const next = {};
+      for (const [flowId, stats] of Object.entries(prev)) {
+        if (flowIds.has(flowId)) {
+          next[flowId] = stats;
+        }
+      }
+      return next;
+    });
+  }, [status?.flows]);
+
+  useEffect(() => {
     if (!status?.flows?.length) return;
     setSimpleDrafts((prev) => {
       const next = { ...prev };
@@ -460,16 +539,11 @@ function FlowPage() {
   }, [status?.flows]);
 
   const getPlaylistStats = (flowId) => {
-    if (!status?.jobs)
-      return { total: 0, done: 0, failed: 0, pending: 0, downloading: 0 };
-    const jobs = status.jobs.filter((j) => j.playlistType === flowId);
-    return {
-      total: jobs.length,
-      done: jobs.filter((j) => j.status === "done").length,
-      failed: jobs.filter((j) => j.status === "failed").length,
-      pending: jobs.filter((j) => j.status === "pending").length,
-      downloading: jobs.filter((j) => j.status === "downloading").length,
-    };
+    return (
+      flowStatsById[flowId] ||
+      status?.flowStats?.[flowId] ||
+      EMPTY_FLOW_STATS
+    );
   };
 
   const getPlaylistState = (flowId) => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -524,13 +524,29 @@ export const applyLidarrCommunityGuide = async () => {
   return response.data;
 };
 
-export const getFlowStatus = async () => {
-  const response = await api.get("/weekly-flow/status");
+export const getFlowStatus = async ({
+  includeJobs = false,
+  flowId,
+  jobsLimit,
+} = {}) => {
+  const params = {};
+  if (includeJobs) {
+    params.includeJobs = "1";
+  }
+  if (flowId) {
+    params.flowId = flowId;
+  }
+  if (jobsLimit != null) {
+    params.jobsLimit = jobsLimit;
+  }
+  const response = await api.get("/weekly-flow/status", { params });
   return response.data;
 };
 
-export const getFlowJobs = async (flowId) => {
-  const response = await api.get(`/weekly-flow/jobs/${flowId}`);
+export const getFlowJobs = async (flowId, limit = 200) => {
+  const response = await api.get(`/weekly-flow/jobs/${flowId}`, {
+    params: { limit },
+  });
   return response.data;
 };
 


### PR DESCRIPTION
- Add optional query parameters to /weekly-flow/status endpoint (includeJobs, flowId, jobsLimit) and /weekly-flow/jobs/:flowId (limit) for better control over returned data
- Implement getStatsByPlaylistType method in WeeklyFlowDownloadTracker to provide per-flow statistics
- Add incremental job fetching in frontend for active flows to update stats without full refresh
- Add pagination support to job listings with default limit of 200 and maximum of 500
- Refactor status endpoint to return flowStats instead of all jobs by default, improving performance