### PR TITLE
feat(discovery): implement stale-while-revalidate with WebSocket fallback

### DIFF
--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -17,6 +17,9 @@ const router = express.Router();
 
 const pendingTagRequests = new Map();
 const pendingTagSuggestRequest = { promise: null, expiry: 0 };
+const DISCOVERY_STALE_MS = 6 * 60 * 60 * 1000;
+const DISCOVERY_REVALIDATE_COOLDOWN_MS = 60 * 1000;
+let lastDiscoveryRevalidateAt = 0;
 
 let discoveryPreferences = { ...defaultDiscoveryPreferences };
 
@@ -139,6 +142,7 @@ router.get("/", async (req, res) => {
   let isUpdating = discoveryCache.isUpdating || false;
 
   if (!hasData && !isUpdating) {
+    lastDiscoveryRevalidateAt = Date.now();
     updateDiscoveryCache().catch((err) => {
       console.error("[Discover] Lazy discovery refresh failed:", err.message);
     });
@@ -202,6 +206,24 @@ router.get("/", async (req, res) => {
     });
   }
 
+  const parsedLastUpdated = lastUpdated ? new Date(lastUpdated).getTime() : 0;
+  const isStale =
+    Number.isFinite(parsedLastUpdated) &&
+    parsedLastUpdated > 0 &&
+    Date.now() - parsedLastUpdated > DISCOVERY_STALE_MS;
+
+  if (
+    isStale &&
+    !isUpdating &&
+    Date.now() - lastDiscoveryRevalidateAt > DISCOVERY_REVALIDATE_COOLDOWN_MS
+  ) {
+    lastDiscoveryRevalidateAt = Date.now();
+    updateDiscoveryCache().catch((err) => {
+      console.error("[Discover] SWR revalidation failed:", err.message);
+    });
+    isUpdating = true;
+  }
+
   if (recommendations.length > 0 || globalTop.length > 0) {
     imagePrefetchService
       .prefetchDiscoveryImages({
@@ -212,11 +234,11 @@ router.get("/", async (req, res) => {
   }
 
   if (recommendations.length > 0 || globalTop.length > 0) {
-    res.set("Cache-Control", "public, max-age=300");
+    res.set("Cache-Control", "public, max-age=120, stale-while-revalidate=300");
   } else if (isUpdating) {
     res.set("Cache-Control", "no-cache, no-store, must-revalidate");
   } else {
-    res.set("Cache-Control", "public, max-age=30");
+    res.set("Cache-Control", "public, max-age=30, stale-while-revalidate=120");
   }
 
   res.json({
@@ -227,6 +249,7 @@ router.get("/", async (req, res) => {
     topGenres,
     lastUpdated,
     isUpdating,
+    stale: isStale,
     configured: true,
   });
 });

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function getWsUrl() {
   const apiUrl = import.meta.env.VITE_API_URL;
@@ -15,16 +15,19 @@ function getWsUrl() {
 export function useWebSocketChannel(channel, onMessage) {
   const wsRef = useRef(null);
   const onMessageRef = useRef(onMessage);
+  const [isConnected, setIsConnected] = useState(false);
   onMessageRef.current = onMessage;
 
   useEffect(() => {
     const url = getWsUrl();
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
+    let ws = null;
+    let reconnectTimer = null;
+    let reconnectAttempts = 0;
+    let closed = false;
 
-    ws.onopen = () => {
+    const subscribe = () => {
       try {
-        if (ws.readyState === WebSocket.OPEN) {
+        if (ws?.readyState === WebSocket.OPEN) {
           ws.send(
             JSON.stringify({
               type: "subscribe",
@@ -35,28 +38,68 @@ export function useWebSocketChannel(channel, onMessage) {
       } catch {}
     };
 
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data);
-        if (msg.channel === channel && msg.type && onMessageRef.current) {
-          onMessageRef.current(msg);
-        }
-      } catch {}
+    const scheduleReconnect = () => {
+      if (closed) return;
+      const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), 15000);
+      reconnectAttempts += 1;
+      reconnectTimer = setTimeout(() => {
+        connect();
+      }, delay);
     };
 
+    const connect = () => {
+      ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        reconnectAttempts = 0;
+        setIsConnected(true);
+        subscribe();
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+          if (msg.channel === channel && msg.type && onMessageRef.current) {
+            onMessageRef.current(msg);
+          }
+        } catch {}
+      };
+
+      ws.onclose = () => {
+        setIsConnected(false);
+        scheduleReconnect();
+      };
+
+      ws.onerror = () => {
+        setIsConnected(false);
+      };
+    };
+
+    connect();
+
     return () => {
+      closed = true;
+      setIsConnected(false);
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
       try {
-        if (ws.readyState === WebSocket.OPEN) {
+        if (ws?.readyState === WebSocket.OPEN) {
           ws.send(
             JSON.stringify({
               type: "unsubscribe",
               channels: [channel],
             }),
           );
-          ws.close();
         }
+      } catch {}
+      try {
+        ws?.close();
       } catch {}
       wsRef.current = null;
     };
   }, [channel]);
+
+  return { isConnected };
 }

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -275,22 +275,78 @@ function DiscoverPage() {
   const [error, setError] = useState(null);
   const requestedReleaseCoversRef = useRef(new Set());
   const requestedArtistCoversRef = useRef(new Set());
+  const lastDiscoveryWsMessageAtRef = useRef(0);
   const navigate = useNavigate();
 
-  useWebSocketChannel("discovery", (msg) => {
-    if (msg.type === "discovery_update" && msg.recommendations) {
-      setData({
-        recommendations: msg.recommendations || [],
-        globalTop: msg.globalTop || [],
-        basedOn: msg.basedOn || [],
-        topTags: msg.topTags || [],
-        topGenres: msg.topGenres || [],
-        lastUpdated: msg.lastUpdated || null,
-        isUpdating: false,
-        configured: true,
-      });
+  const { isConnected: isDiscoverySocketConnected } = useWebSocketChannel(
+    "discovery",
+    (msg) => {
+      if (msg.type === "discovery_update" && msg.recommendations) {
+        lastDiscoveryWsMessageAtRef.current = Date.now();
+        setData({
+          recommendations: msg.recommendations || [],
+          globalTop: msg.globalTop || [],
+          basedOn: msg.basedOn || [],
+          topTags: msg.topTags || [],
+          topGenres: msg.topGenres || [],
+          lastUpdated: msg.lastUpdated || null,
+          isUpdating: false,
+          stale: false,
+          configured: true,
+        });
+      }
+    },
+  );
+
+  useEffect(() => {
+    if (!isDiscoverySocketConnected) return;
+    if (!data?.isUpdating && !data?.stale) return;
+    getDiscovery()
+      .then((discoveryData) => {
+        setData(discoveryData);
+        setError(null);
+      })
+      .catch(() => {});
+  }, [isDiscoverySocketConnected, data?.isUpdating, data?.stale]);
+
+  useEffect(() => {
+    if (!data?.isUpdating) return;
+    const hasRecentWsUpdate =
+      Date.now() - lastDiscoveryWsMessageAtRef.current < 20000;
+    if (isDiscoverySocketConnected && hasRecentWsUpdate) return;
+    const pollDiscovery = () => {
+      getDiscovery(true)
+        .then((next) => {
+          setData(next);
+          setError(null);
+        })
+        .catch(() => {});
+    };
+    pollDiscovery();
+    const id = setInterval(pollDiscovery, 10000);
+    return () => clearInterval(id);
+  }, [data?.isUpdating, isDiscoverySocketConnected]);
+
+  useEffect(() => {
+    if (!data?.stale || data?.isUpdating) return;
+    if (isDiscoverySocketConnected) return;
+    const id = setTimeout(() => {
+      getDiscovery(true)
+        .then((next) => {
+          setData(next);
+          setError(null);
+        })
+        .catch(() => {});
+    }, 15000);
+    return () => clearTimeout(id);
+  }, [data?.stale, data?.isUpdating, isDiscoverySocketConnected]);
+
+  useEffect(() => {
+    if (!data) return;
+    if (data.isUpdating && !data.stale) {
+      lastDiscoveryWsMessageAtRef.current = 0;
     }
-  });
+  }, [data, data?.isUpdating, data?.stale]);
 
   useEffect(() => {
     getDiscovery()
@@ -310,6 +366,7 @@ function DiscoverPage() {
           topGenres: [],
           lastUpdated: null,
           isUpdating: false,
+          stale: false,
           configured: false,
         });
       });
@@ -404,23 +461,6 @@ function DiscoverPage() {
         });
     });
   }, [recentReleases, releaseCovers, artistCovers]);
-
-  const hasDataForPoll =
-    data &&
-    ((data.recommendations && data.recommendations.length > 0) ||
-      (data.globalTop && data.globalTop.length > 0) ||
-      (data.topGenres && data.topGenres.length > 0));
-
-  useEffect(() => {
-    if (!data?.isUpdating || hasDataForPoll) return;
-    const pollDiscovery = () => {
-      getDiscovery(true)
-        .then(setData)
-        .catch(() => {});
-    };
-    const id = setInterval(pollDiscovery, 8000);
-    return () => clearInterval(id);
-  }, [data?.isUpdating, hasDataForPoll]);
 
   const getLibraryArtistImage = (artist) => {
     if (artist.images && artist.images.length > 0) {


### PR DESCRIPTION
Add SWR caching headers to discovery endpoint and improve client-side revalidation logic. Introduce WebSocket reconnection with exponential backoff and polling fallbacks when WebSocket is disconnected or stale data is detected. This ensures users see fresh discovery data while maintaining responsiveness.

- Set Cache-Control with stale-while-revalidate on backend responses
- Add WebSocket auto-reconnect with backoff strategy
- Implement polling fallback when WebSocket is unavailable
- Add stale state detection to trigger background updates
- Maintain existing UI behavior while improving data freshness