### PR TITLE
feat(discovery): add dedicated discover tab with configurable refresh settings

### DIFF
--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -163,7 +163,13 @@ export const defaultData = {
     ],
     integrations: {
       navidrome: { url: "", username: "", password: "" },
-      lastfm: { username: "", discoveryPeriod: "1month" },
+      lastfm: {
+        apiKey: "",
+        username: "",
+        discoveryPeriod: "1month",
+        discoveryAutoRefreshHours: 168,
+        discoveryRecommendationsPerRefresh: 100,
+      },
       slskd: { url: "", apiKey: "" },
       soulseek: { username: "", password: "" },
       lidarr: {

--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -39,8 +39,12 @@ router.post("/refresh", (req, res) => {
 });
 
 router.post("/clear", async (req, res) => {
-  const { clearImages = true } = req.body;
+  dbOps.clearImages();
+  clearApiCaches();
+  res.json({ message: "Image cache cleared" });
+});
 
+router.post("/clear-discovery", async (req, res) => {
   dbOps.updateDiscoveryCache({
     recommendations: [],
     globalTop: [],
@@ -49,7 +53,6 @@ router.post("/clear", async (req, res) => {
     topGenres: [],
     lastUpdated: null,
   });
-
   const discoveryCache = getDiscoveryCache();
   Object.assign(discoveryCache, {
     recommendations: [],
@@ -60,22 +63,10 @@ router.post("/clear", async (req, res) => {
     lastUpdated: null,
     isUpdating: false,
   });
-
-  clearApiCaches();
-
-  if (clearImages) {
-    dbOps.clearImages();
-  }
-
   pendingTagRequests.clear();
   pendingTagSuggestRequest.promise = null;
   pendingTagSuggestRequest.expiry = 0;
-
-  res.json({
-    message: clearImages
-      ? "Discovery and image caches cleared"
-      : "Discovery cache cleared",
-  });
+  res.json({ message: "Discovery cache cleared" });
 });
 
 router.get("/", async (req, res) => {

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -28,6 +28,32 @@ const getLastfmDiscoveryPeriod = () => {
   return p && LASTFM_PERIODS.includes(p) ? p : "1month";
 };
 
+const clampInt = (value, fallback, min, max) => {
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+};
+
+export const getDiscoveryAutoRefreshHours = () => {
+  const settings = dbOps.getSettings();
+  return clampInt(
+    settings.integrations?.lastfm?.discoveryAutoRefreshHours,
+    168,
+    1,
+    168,
+  );
+};
+
+export const getDiscoveryRecommendationsPerRefresh = () => {
+  const settings = dbOps.getSettings();
+  return clampInt(
+    settings.integrations?.lastfm?.discoveryRecommendationsPerRefresh,
+    100,
+    10,
+    500,
+  );
+};
+
 const createLastfmHealth = () => ({
   success: 0,
   failure: 0,
@@ -45,6 +71,22 @@ const recordLastfmResult = (health, payload) => {
   } else {
     health.failure += 1;
   }
+};
+
+const emitDiscoveryProgress = (
+  phase,
+  progressMessage,
+  progress,
+  extra = {},
+) => {
+  websocketService.emitDiscoveryUpdate({
+    phase,
+    progress,
+    progressMessage,
+    isUpdating: true,
+    configured: true,
+    ...extra,
+  });
 };
 
 let discoveryCache = {
@@ -105,9 +147,11 @@ export const updateDiscoveryCache = async () => {
   }
   discoveryCache.isUpdating = true;
   console.log("Starting background update of discovery recommendations...");
+  emitDiscoveryProgress("starting", "Preparing discovery refresh", 5);
 
   try {
     const { libraryManager } = await import("./libraryManager.js");
+    emitDiscoveryProgress("loading_sources", "Loading library artists", 12);
     const [recentLibraryArtists, allLibraryArtistsRaw] = await Promise.all([
       libraryManager.getRecentArtists(25),
       libraryManager.getAllArtists(),
@@ -134,13 +178,13 @@ export const updateDiscoveryCache = async () => {
 
     if (hasLastfmKey && !lastfmUsername) {
       console.log(
-        "Last.fm API key configured but username not set. User-specific recommendations will not be available."
+        "Last.fm API key configured but username not set. User-specific recommendations will not be available.",
       );
     }
 
     if (allLibraryArtists.length === 0 && !hasLastfmKey) {
       console.log(
-        "No artists in library and no Last.fm key. Skipping discovery and clearing cache."
+        "No artists in library and no Last.fm key. Skipping discovery and clearing cache.",
       );
       discoveryCache.recommendations = [];
       discoveryCache.globalTop = [];
@@ -158,17 +202,37 @@ export const updateDiscoveryCache = async () => {
         topGenres: [],
         lastUpdated: null,
       });
+      websocketService.emitDiscoveryUpdate({
+        recommendations: [],
+        globalTop: [],
+        basedOn: [],
+        topTags: [],
+        topGenres: [],
+        lastUpdated: null,
+        isUpdating: false,
+        configured: false,
+        phase: "completed",
+        progress: 100,
+        progressMessage: "Discovery refresh completed",
+      });
       return;
     }
 
     let lastfmArtists = [];
+    emitDiscoveryProgress(
+      "collecting_seeds",
+      "Collecting recommendation seed artists",
+      20,
+    );
     if (hasLastfmUser) {
       const discoveryPeriod = getLastfmDiscoveryPeriod();
       if (discoveryPeriod === "none") {
-        console.log("Last.fm discovery period set to 'none', skipping Last.fm user top artists.");
+        console.log(
+          "Last.fm discovery period set to 'none', skipping Last.fm user top artists.",
+        );
       } else {
         console.log(
-          `Fetching Last.fm user top artists for ${lastfmUsername} (period: ${discoveryPeriod})...`
+          `Fetching Last.fm user top artists for ${lastfmUsername} (period: ${discoveryPeriod})...`,
         );
         try {
           const userTopArtists = await lastfmRequest("user.getTopArtists", {
@@ -180,13 +244,13 @@ export const updateDiscoveryCache = async () => {
 
           if (!userTopArtists) {
             console.warn(
-              "Last.fm user.getTopArtists returned null - check API key and username"
+              "Last.fm user.getTopArtists returned null - check API key and username",
             );
           } else if (userTopArtists.error) {
             console.error(
               `Last.fm API error: ${
                 userTopArtists.message || userTopArtists.error
-              }`
+              }`,
             );
           } else if (userTopArtists?.topartists?.artist) {
             const artists = Array.isArray(userTopArtists.topartists.artist)
@@ -213,12 +277,12 @@ export const updateDiscoveryCache = async () => {
             }
 
             console.log(
-              `Found ${lastfmArtists.length} Last.fm artists with MBIDs.`
+              `Found ${lastfmArtists.length} Last.fm artists with MBIDs.`,
             );
           } else {
             console.warn(
               `Last.fm user.getTopArtists response missing expected data structure. Response:`,
-              JSON.stringify(userTopArtists).substring(0, 200)
+              JSON.stringify(userTopArtists).substring(0, 200),
             );
           }
         } catch (e) {
@@ -228,7 +292,7 @@ export const updateDiscoveryCache = async () => {
       }
     } else if (hasLastfmKey) {
       console.log(
-        "Last.fm API key is configured but username is missing. Set Last.fm username in Settings to enable user-specific recommendations."
+        "Last.fm API key is configured but username is missing. Set Last.fm username in Settings to enable user-specific recommendations.",
       );
     }
 
@@ -269,7 +333,12 @@ export const updateDiscoveryCache = async () => {
       .slice(0, profileSampleLimit);
 
     console.log(
-      `Sampling tags/genres from ${profileSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`
+      `Sampling tags/genres from ${profileSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`,
+    );
+    emitDiscoveryProgress(
+      "building_genres",
+      "Building genre and tag profile",
+      35,
     );
 
     let tagsFound = 0;
@@ -289,7 +358,7 @@ export const updateDiscoveryCache = async () => {
               tags.slice(0, 15).forEach((t) => {
                 tagCounts.set(
                   t.name,
-                  (tagCounts.get(t.name) || 0) + (parseInt(t.count) || 1)
+                  (tagCounts.get(t.name) || 0) + (parseInt(t.count) || 1),
                 );
                 const l = t.name.toLowerCase();
                 if (GENRE_KEYWORDS.some((g) => l.includes(g)))
@@ -300,14 +369,14 @@ export const updateDiscoveryCache = async () => {
             }
           } catch (e) {
             console.warn(
-              `Failed to get Last.fm tags for ${artist.artistName}: ${e.message}`
+              `Failed to get Last.fm tags for ${artist.artistName}: ${e.message}`,
             );
           }
         }
-      })
+      }),
     );
     console.log(
-      `Found tags for ${tagsFound} out of ${profileSample.length} artists`
+      `Found tags for ${tagsFound} out of ${profileSample.length} artists`,
     );
 
     discoveryCache.topTags = Array.from(tagCounts.entries())
@@ -320,11 +389,16 @@ export const updateDiscoveryCache = async () => {
       .map((t) => t[0]);
 
     console.log(
-      `Identified Top Genres: ${discoveryCache.topGenres.join(", ")}`
+      `Identified Top Genres: ${discoveryCache.topGenres.join(", ")}`,
     );
 
     if (getLastfmApiKey()) {
       console.log("Fetching Global Trending (real-time style) from Last.fm...");
+      emitDiscoveryProgress(
+        "fetching_trending",
+        "Fetching global trending artists",
+        50,
+      );
       try {
         const trackData = await lastfmRequest("chart.getTopTracks", {
           limit: getLastfmFailureRatio(lastfmHealth) >= 0.3 ? 60 : 100,
@@ -400,7 +474,7 @@ export const updateDiscoveryCache = async () => {
               })
               .filter((a) => a.id && !existingArtistIds.has(a.id));
             const fillMbids = new Set(
-              globalTop.map((a) => a.id).filter(Boolean)
+              globalTop.map((a) => a.id).filter(Boolean),
             );
             for (const a of fromArtists) {
               if (globalTop.length >= 32) break;
@@ -430,7 +504,7 @@ export const updateDiscoveryCache = async () => {
 
         discoveryCache.globalTop = globalTop;
         console.log(
-          `Found ${discoveryCache.globalTop.length} trending artists (from top tracks).`
+          `Found ${discoveryCache.globalTop.length} trending artists (from top tracks).`,
         );
       } catch (e) {
         console.error(`Failed to fetch Global Top: ${e.message}`);
@@ -451,7 +525,12 @@ export const updateDiscoveryCache = async () => {
     const recommendations = new Map();
 
     console.log(
-      `Generating recommendations based on ${recSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`
+      `Generating recommendations based on ${recSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`,
+    );
+    emitDiscoveryProgress(
+      "generating_recommendations",
+      "Generating personalized recommendations",
+      65,
     );
 
     if (getLastfmApiKey()) {
@@ -518,21 +597,22 @@ export const updateDiscoveryCache = async () => {
           } catch (e) {
             errorCount++;
             console.warn(
-              `Error getting similar artists for ${artist.artistName}: ${e.message}`
+              `Error getting similar artists for ${artist.artistName}: ${e.message}`,
             );
           }
-        })
+        }),
       );
       console.log(
-        `Recommendation generation: ${successCount} succeeded, ${errorCount} failed`
+        `Recommendation generation: ${successCount} succeeded, ${errorCount} failed`,
       );
     } else {
       console.warn("Last.fm API key required for similar artist discovery.");
     }
 
+    const recommendationsPerRefresh = getDiscoveryRecommendationsPerRefresh();
     const recommendationsArray = Array.from(recommendations.values())
       .sort((a, b) => (b.score || 0) - (a.score || 0))
-      .slice(0, 100);
+      .slice(0, recommendationsPerRefresh);
 
     const recommendationFailureRatio = getLastfmFailureRatio(lastfmHealth);
     const maxResolve =
@@ -555,7 +635,7 @@ export const updateDiscoveryCache = async () => {
     }
 
     console.log(
-      `Generated ${recommendationsArray.length} total recommendations.`
+      `Generated ${recommendationsArray.length} total recommendations.`,
     );
 
     const discoveryData = {
@@ -573,12 +653,17 @@ export const updateDiscoveryCache = async () => {
 
     Object.assign(discoveryCache, discoveryData);
     dbOps.updateDiscoveryCache(discoveryData);
+    emitDiscoveryProgress(
+      "saving_results",
+      "Saving refreshed discovery cache",
+      82,
+    );
     const { notifyDiscoveryUpdated } = await import("./notificationService.js");
     notifyDiscoveryUpdated().catch((err) =>
-      console.warn("[Discovery] Gotify notification failed:", err.message)
+      console.warn("[Discovery] Gotify notification failed:", err.message),
     );
     console.log(
-      `Discovery data written to database: ${discoveryData.recommendations.length} recommendations, ${discoveryData.topGenres.length} genres, ${discoveryData.globalTop.length} trending`
+      `Discovery data written to database: ${discoveryData.recommendations.length} recommendations, ${discoveryData.topGenres.length} genres, ${discoveryData.globalTop.length} trending`,
     );
 
     const allToHydrate = [
@@ -586,6 +671,7 @@ export const updateDiscoveryCache = async () => {
       ...recommendationsArray,
     ].filter((a) => !a.image);
     console.log(`Hydrating images for ${allToHydrate.length} artists...`);
+    emitDiscoveryProgress("hydrating_images", "Hydrating artist images", 90);
 
     const batchSize = 10;
     for (let i = 0; i < allToHydrate.length; i += batchSize) {
@@ -606,7 +692,7 @@ export const updateDiscoveryCache = async () => {
               }
             } catch (e) {}
           } catch (e) {}
-        })
+        }),
       );
 
       if (i + batchSize < allToHydrate.length) {
@@ -616,7 +702,7 @@ export const updateDiscoveryCache = async () => {
 
     console.log("Discovery cache updated successfully.");
     console.log(
-      `Summary: ${recommendationsArray.length} recommendations, ${discoveryCache.topGenres.length} genres, ${discoveryCache.globalTop.length} trending artists`
+      `Summary: ${recommendationsArray.length} recommendations, ${discoveryCache.topGenres.length} genres, ${discoveryCache.globalTop.length} trending artists`,
     );
     websocketService.emitDiscoveryUpdate({
       recommendations: discoveryData.recommendations,
@@ -627,13 +713,16 @@ export const updateDiscoveryCache = async () => {
       lastUpdated: discoveryData.lastUpdated,
       isUpdating: false,
       configured: true,
+      phase: "completed",
+      progress: 100,
+      progressMessage: "Discovery refresh completed",
     });
 
     try {
       const cleaned = dbOps.cleanOldImageCache(30);
       if (cleaned?.changes > 0) {
         console.log(
-          `[Discovery] Cleaned ${cleaned.changes} old image cache entries`
+          `[Discovery] Cleaned ${cleaned.changes} old image cache entries`,
         );
       }
       dbOps.cleanOldMusicbrainzArtistMbidCache(90);
@@ -643,6 +732,14 @@ export const updateDiscoveryCache = async () => {
   } catch (error) {
     console.error("Failed to update discovery cache:", error.message);
     console.error("Stack trace:", error.stack);
+    websocketService.emitDiscoveryUpdate({
+      isUpdating: false,
+      configured: true,
+      phase: "error",
+      progress: 100,
+      progressMessage: "Discovery refresh failed",
+      error: error.message,
+    });
   } finally {
     discoveryCache.isUpdating = false;
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,17 +4,18 @@ import {
   Route,
   Navigate,
 } from "react-router-dom";
-import { useState, useEffect, Suspense, lazy } from "react";
+import { useState, useEffect, Suspense, lazy, useRef } from "react";
 import PropTypes from "prop-types";
 import Layout from "./components/Layout";
 import Login from "./pages/Login";
 import Onboarding from "./pages/Onboarding";
 import { checkHealth } from "./utils/api";
 import { ThemeProvider } from "./contexts/ThemeContext";
-import { ToastProvider } from "./contexts/ToastContext";
+import { ToastProvider, useToast } from "./contexts/ToastContext";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import ReloadPrompt from "./components/ReloadPrompt";
 import UpdateBanner from "./components/UpdateBanner";
+import { useWebSocketChannel } from "./hooks/useWebSocket";
 
 const SearchResultsPage = lazy(() => import("./pages/SearchResultsPage"));
 const DiscoverPage = lazy(() => import("./pages/DiscoverPage"));
@@ -23,6 +24,7 @@ const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const ArtistDetailsPage = lazy(() => import("./pages/ArtistDetailsPage"));
 const RequestsPage = lazy(() => import("./pages/RequestsPage"));
 const FlowPage = lazy(() => import("./pages/FlowPage"));
+const DISCOVERY_MANUAL_REFRESH_KEY = "aurral.discovery.manualRefreshPending";
 
 const normalizeBasePath = (baseUrl) => {
   const raw = (baseUrl || "/").trim();
@@ -92,7 +94,38 @@ function AppContent() {
   const [isHealthy, setIsHealthy] = useState(null);
   const [rootFolderConfigured, setRootFolderConfigured] = useState(false);
   const [appVersion, setAppVersion] = useState(null);
+  const discoveryToastShownRef = useRef(false);
   const { isAuthenticated } = useAuth();
+  const { showSuccess, showError } = useToast();
+
+  useWebSocketChannel("discovery", (msg) => {
+    if (msg.type !== "discovery_update") return;
+
+    const hasPendingManualRefresh =
+      localStorage.getItem(DISCOVERY_MANUAL_REFRESH_KEY) === "1";
+    if (!hasPendingManualRefresh) return;
+
+    if (msg.phase === "error") {
+      localStorage.removeItem(DISCOVERY_MANUAL_REFRESH_KEY);
+      discoveryToastShownRef.current = false;
+      showError(
+        msg.error
+          ? `Discovery refresh failed: ${msg.error}`
+          : "Discovery refresh failed",
+      );
+      return;
+    }
+
+    if (msg.phase === "completed" || Array.isArray(msg.recommendations)) {
+      if (discoveryToastShownRef.current) return;
+      discoveryToastShownRef.current = true;
+      localStorage.removeItem(DISCOVERY_MANUAL_REFRESH_KEY);
+      showSuccess("Discovery refresh completed. Recommendations are now updated.");
+      setTimeout(() => {
+        discoveryToastShownRef.current = false;
+      }, 1000);
+    }
+  });
 
   useEffect(() => {
     const checkApiHealth = async () => {

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -9,6 +9,7 @@ import { UnsavedModal } from "./components/UnsavedModal";
 import { CommunityGuideModal } from "./components/CommunityGuideModal";
 import { SettingsIntegrationsTab } from "./components/SettingsIntegrationsTab";
 import { SettingsMetadataTab } from "./components/SettingsMetadataTab";
+import { SettingsDiscoverTab } from "./components/SettingsDiscoverTab";
 import { SettingsNotificationsTab } from "./components/SettingsNotificationsTab";
 import { SettingsUsersTab } from "./components/SettingsUsersTab";
 
@@ -27,7 +28,7 @@ function SettingsPage() {
   );
 
   useEffect(() => {
-    if (tabs.activeTab === "metadata") {
+    if (tabs.activeTab === "metadata" || tabs.activeTab === "discover") {
       data.refreshHealth();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when switching to metadata tab
@@ -73,7 +74,19 @@ function SettingsPage() {
             hasUnsavedChanges={data.hasUnsavedChanges}
             saving={data.saving}
             handleSaveSettings={data.handleSaveSettings}
+          />
+        );
+      case "discover":
+        return (
+          <SettingsDiscoverTab
+            settings={data.settings}
+            updateSettings={data.updateSettings}
+            health={data.health}
+            hasUnsavedChanges={data.hasUnsavedChanges}
+            saving={data.saving}
+            handleSaveSettings={data.handleSaveSettings}
             refreshingDiscovery={data.refreshingDiscovery}
+            discoveryProgressMessage={data.discoveryProgressMessage}
             clearingCache={data.clearingCache}
             handleRefreshDiscovery={data.handleRefreshDiscovery}
             handleClearCache={data.handleClearCache}

--- a/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import { RefreshCw, Trash2, Compass, Pencil } from "lucide-react";
+import FlipSaveButton from "../../../components/FlipSaveButton";
+
+const AUTO_REFRESH_OPTIONS = [
+  { value: 1, label: "Every hour" },
+  { value: 3, label: "Every 3 hours" },
+  { value: 6, label: "Every 6 hours" },
+  { value: 12, label: "Every 12 hours" },
+  { value: 24, label: "Every 24 hours" },
+  { value: 48, label: "Every 48 hours" },
+  { value: 72, label: "Every 72 hours" },
+  { value: 168, label: "Weekly" },
+];
+
+const RECOMMENDATION_OPTIONS = [25, 50, 75, 100, 150, 200];
+
+export function SettingsDiscoverTab({
+  settings,
+  updateSettings,
+  health,
+  hasUnsavedChanges,
+  saving,
+  handleSaveSettings,
+  refreshingDiscovery,
+  discoveryProgressMessage,
+  clearingCache,
+  handleRefreshDiscovery,
+  handleClearCache,
+}) {
+  const [discoverEditing, setDiscoverEditing] = useState(false);
+  const autoRefreshHours =
+    settings.integrations?.lastfm?.discoveryAutoRefreshHours || 168;
+  const recommendationsPerRefresh =
+    settings.integrations?.lastfm?.discoveryRecommendationsPerRefresh || 100;
+
+  return (
+    <div className="card animate-fade-in">
+      <div className="flex items-center justify-between mb-6">
+        <h2
+          className="text-2xl font-bold flex items-center gap-2"
+          style={{ color: "#fff" }}
+        >
+          <Compass className="w-6 h-6" />
+          Discover
+        </h2>
+        <FlipSaveButton
+          saving={saving}
+          disabled={!hasUnsavedChanges}
+          onClick={handleSaveSettings}
+        />
+      </div>
+
+      <form
+        onSubmit={handleSaveSettings}
+        className="space-y-6"
+        autoComplete="off"
+      >
+        <div
+          className="p-6 rounded-lg space-y-4"
+          style={{
+            backgroundColor: "#1a1a1e",
+            border: "1px solid #2a2a2e",
+          }}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-lg font-medium" style={{ color: "#fff" }}>
+              Discovery behavior
+            </h3>
+            <button
+              type="button"
+              className={`btn ${
+                discoverEditing ? "btn-primary" : "btn-secondary"
+              } px-2 py-1`}
+              onClick={() => setDiscoverEditing((value) => !value)}
+              aria-label={
+                discoverEditing
+                  ? "Lock discovery settings"
+                  : "Edit discovery settings"
+              }
+            >
+              <Pencil className="w-4 h-4" />
+            </button>
+          </div>
+          <fieldset
+            disabled={!discoverEditing}
+            className={`space-y-4 ${discoverEditing ? "" : "opacity-60"}`}
+          >
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Auto-refresh frequency
+              </label>
+              <select
+                className="input"
+                value={String(autoRefreshHours)}
+                onChange={(e) =>
+                  updateSettings({
+                    ...settings,
+                    integrations: {
+                      ...settings.integrations,
+                      lastfm: {
+                        ...(settings.integrations?.lastfm || {}),
+                        discoveryAutoRefreshHours: parseInt(
+                          e.target.value,
+                          10,
+                        ),
+                      },
+                    },
+                  })
+                }
+              >
+                {AUTO_REFRESH_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Recommendations per refresh
+              </label>
+              <select
+                className="input"
+                value={String(recommendationsPerRefresh)}
+                onChange={(e) =>
+                  updateSettings({
+                    ...settings,
+                    integrations: {
+                      ...settings.integrations,
+                      lastfm: {
+                        ...(settings.integrations?.lastfm || {}),
+                        discoveryRecommendationsPerRefresh: parseInt(
+                          e.target.value,
+                          10,
+                        ),
+                      },
+                    },
+                  })
+                }
+              >
+                {RECOMMENDATION_OPTIONS.map((count) => (
+                  <option key={count} value={count}>
+                    {count}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </fieldset>
+        </div>
+
+        <div
+          className="p-6 rounded-lg space-y-4"
+          style={{
+            backgroundColor: "#1a1a1e",
+            border: "1px solid #2a2a2e",
+          }}
+        >
+          <h3
+            className="text-lg font-medium flex items-center"
+            style={{ color: "#fff" }}
+          >
+            Cache status
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 items-start">
+            <div className="space-y-3 min-w-0">
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt style={{ color: "#c1c1c3" }}>Last updated</dt>
+                  <dd style={{ color: "#fff" }}>
+                    {health?.discovery?.lastUpdated
+                      ? new Date(
+                          health.discovery.lastUpdated,
+                        ).toLocaleString()
+                      : "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt style={{ color: "#c1c1c3" }}>Recommendations</dt>
+                  <dd style={{ color: "#fff" }}>
+                    {health?.discovery?.recommendationsCount ?? "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt style={{ color: "#c1c1c3" }}>Global trending</dt>
+                  <dd style={{ color: "#fff" }}>
+                    {health?.discovery?.globalTopCount ?? "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt style={{ color: "#c1c1c3" }}>Cached images</dt>
+                  <dd style={{ color: "#fff" }}>
+                    {health?.discovery?.cachedImagesCount ?? "—"}
+                  </dd>
+                </div>
+              </dl>
+              {(health?.discovery?.isUpdating || refreshingDiscovery) && (
+                <p
+                  className="text-sm flex items-center gap-2"
+                  style={{ color: "#c1c1c3" }}
+                >
+                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  {discoveryProgressMessage || "Refreshing discovery"}
+                </p>
+              )}
+              {!refreshingDiscovery &&
+                !health?.discovery?.isUpdating &&
+                discoveryProgressMessage && (
+                  <p className="text-sm" style={{ color: "#8ec07c" }}>
+                    {discoveryProgressMessage}
+                  </p>
+                )}
+            </div>
+            <div className="flex flex-col gap-3 w-full md:w-auto md:min-w-[220px]">
+              <div
+                className="rounded-md p-3 space-y-2"
+                style={{ border: "1px solid #2a2a2e", backgroundColor: "#141418" }}
+              >
+                <p className="text-xs uppercase tracking-wide" style={{ color: "#c1c1c3" }}>
+                  Discovery data
+                </p>
+                <button
+                  type="button"
+                  onClick={handleRefreshDiscovery}
+                  disabled={refreshingDiscovery}
+                  className="btn btn-primary w-full flex items-center justify-center gap-2 py-2.5 px-4 font-medium shadow-md hover:opacity-90"
+                >
+                  <RefreshCw
+                    className={`w-4 h-4 flex-shrink-0 ${
+                      refreshingDiscovery ? "animate-spin" : ""
+                    }`}
+                  />
+                  {refreshingDiscovery ? "Refreshing..." : "Refresh Discovery"}
+                </button>
+              </div>
+              <div
+                className="rounded-md p-3 space-y-2"
+                style={{ border: "1px solid #2a2a2e", backgroundColor: "#141418" }}
+              >
+                <p className="text-xs uppercase tracking-wide" style={{ color: "#c1c1c3" }}>
+                  Image cache
+                </p>
+                <button
+                  type="button"
+                  onClick={handleClearCache}
+                  disabled={clearingCache}
+                  className="btn btn-secondary w-full flex items-center justify-center gap-2 py-2.5 px-4 font-medium shadow-md"
+                >
+                  <Trash2
+                    className={`w-4 h-4 flex-shrink-0 ${
+                      clearingCache ? "animate-spin" : ""
+                    }`}
+                  />
+                  {clearingCache ? "Clearing..." : "Clear Image Cache"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CheckCircle, Pencil, RefreshCw, Trash2 } from "lucide-react";
+import { CheckCircle, Pencil } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 
 export function SettingsMetadataTab({
@@ -9,10 +9,6 @@ export function SettingsMetadataTab({
   hasUnsavedChanges,
   saving,
   handleSaveSettings,
-  refreshingDiscovery,
-  clearingCache,
-  handleRefreshDiscovery,
-  handleClearCache,
 }) {
   const [musicbrainzEditing, setMusicbrainzEditing] = useState(false);
   const [lastfmEditing, setLastfmEditing] = useState(false);
@@ -250,93 +246,6 @@ export function SettingsMetadataTab({
               your Last.fm listening history.
             </p>
           </fieldset>
-        </div>
-        <div
-          className="p-6 rounded-lg space-y-4"
-          style={{
-            backgroundColor: "#1a1a1e",
-            border: "1px solid #2a2a2e",
-          }}
-        >
-          <h3
-            className="text-lg font-medium flex items-center"
-            style={{ color: "#fff" }}
-          >
-            Cache status
-          </h3>
-          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 items-start">
-            <div className="space-y-3 min-w-0">
-              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                <div>
-                  <dt style={{ color: "#c1c1c3" }}>Last updated</dt>
-                  <dd style={{ color: "#fff" }}>
-                    {health?.discovery?.lastUpdated
-                      ? new Date(
-                          health.discovery.lastUpdated
-                        ).toLocaleString()
-                      : "—"}
-                  </dd>
-                </div>
-                <div>
-                  <dt style={{ color: "#c1c1c3" }}>Recommendations</dt>
-                  <dd style={{ color: "#fff" }}>
-                    {health?.discovery?.recommendationsCount ?? "—"}
-                  </dd>
-                </div>
-                <div>
-                  <dt style={{ color: "#c1c1c3" }}>Global trending</dt>
-                  <dd style={{ color: "#fff" }}>
-                    {health?.discovery?.globalTopCount ?? "—"}
-                  </dd>
-                </div>
-                <div>
-                  <dt style={{ color: "#c1c1c3" }}>Cached images</dt>
-                  <dd style={{ color: "#fff" }}>
-                    {health?.discovery?.cachedImagesCount ?? "—"}
-                  </dd>
-                </div>
-              </dl>
-              {health?.discovery?.isUpdating && (
-                <p
-                  className="text-sm flex items-center gap-2"
-                  style={{ color: "#c1c1c3" }}
-                >
-                  <RefreshCw className="w-4 h-4 animate-spin" />
-                  Updating…
-                </p>
-              )}
-            </div>
-            <div className="flex flex-col gap-2 w-full md:w-auto md:min-w-[180px]">
-              <button
-                type="button"
-                onClick={handleRefreshDiscovery}
-                disabled={refreshingDiscovery}
-                className="btn btn-primary flex items-center justify-center gap-2 py-2.5 px-4 font-medium shadow-md hover:opacity-90"
-              >
-                <RefreshCw
-                  className={`w-4 h-4 flex-shrink-0 ${
-                    refreshingDiscovery ? "animate-spin" : ""
-                  }`}
-                />
-                {refreshingDiscovery
-                  ? "Refreshing..."
-                  : "Refresh Discovery"}
-              </button>
-              <button
-                type="button"
-                onClick={handleClearCache}
-                disabled={clearingCache}
-                className="btn btn-secondary flex items-center justify-center gap-2 py-2.5 px-4 font-medium shadow-md"
-              >
-                <Trash2
-                  className={`w-4 h-4 flex-shrink-0 ${
-                    clearingCache ? "animate-spin" : ""
-                  }`}
-                />
-                {clearingCache ? "Clearing..." : "Clear Cache"}
-              </button>
-            </div>
-          </div>
         </div>
       </form>
     </div>

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -9,8 +9,11 @@ import api, {
   testGotifyConnection,
   applyLidarrCommunityGuide,
 } from "../../../utils/api";
+import { useWebSocketChannel } from "../../../hooks/useWebSocket";
 import { allReleaseTypes } from "../constants";
 import { normalizeSettings, checkForChanges } from "../utils";
+
+const DISCOVERY_MANUAL_REFRESH_KEY = "aurral.discovery.manualRefreshPending";
 
 const defaultSettings = {
   rootFolderPath: "",
@@ -18,7 +21,13 @@ const defaultSettings = {
   releaseTypes: allReleaseTypes,
   integrations: {
     navidrome: { url: "", username: "", password: "" },
-    lastfm: { username: "" },
+    lastfm: {
+      apiKey: "",
+      username: "",
+      discoveryPeriod: "1month",
+      discoveryAutoRefreshHours: 168,
+      discoveryRecommendationsPerRefresh: 100,
+    },
     slskd: { url: "", apiKey: "" },
     lidarr: {
       url: "",
@@ -46,6 +55,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [saving, setSaving] = useState(false);
   const [refreshingDiscovery, setRefreshingDiscovery] = useState(false);
+  const [discoveryProgressMessage, setDiscoveryProgressMessage] = useState("");
   const [clearingCache, setClearingCache] = useState(false);
   const [lidarrProfiles, setLidarrProfiles] = useState([]);
   const [loadingLidarrProfiles, setLoadingLidarrProfiles] = useState(false);
@@ -58,6 +68,51 @@ export function useSettingsData(showSuccess, showError, showInfo) {
   const [showCommunityGuideModal, setShowCommunityGuideModal] = useState(false);
   const comparisonEnabledRef = useRef(false);
 
+  const applyHealthUpdate = useCallback((healthData) => {
+    setHealth(healthData);
+    if (healthData?.discovery?.isUpdating) {
+      setRefreshingDiscovery(true);
+      setDiscoveryProgressMessage(
+        (current) => current || "Discovery refresh is running",
+      );
+    } else {
+      setRefreshingDiscovery(false);
+    }
+  }, []);
+
+  useWebSocketChannel("discovery", (msg) => {
+    if (msg.type !== "discovery_update") return;
+
+    if (msg.phase === "error") {
+      setRefreshingDiscovery(false);
+      setDiscoveryProgressMessage(
+        msg.progressMessage || "Discovery refresh failed",
+      );
+      return;
+    }
+
+    if (msg.isUpdating) {
+      setRefreshingDiscovery(true);
+      setDiscoveryProgressMessage(
+        msg.progressMessage || "Discovery refresh is running",
+      );
+      return;
+    }
+
+    if (msg.phase === "completed" || Array.isArray(msg.recommendations)) {
+      setRefreshingDiscovery(false);
+      setDiscoveryProgressMessage(
+        msg.progressMessage || "Discovery refresh completed",
+      );
+      checkHealth()
+        .then((healthData) => {
+          applyHealthUpdate(healthData);
+        })
+        .catch(() => {});
+      return;
+    }
+  });
+
   const fetchSettings = useCallback(async () => {
     comparisonEnabledRef.current = false;
     try {
@@ -65,7 +120,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
         checkHealth(),
         getAppSettings(),
       ]);
-      setHealth(healthData);
+      applyHealthUpdate(healthData);
       const updatedSettings = normalizeSettings(savedSettings);
       setSettingsState(updatedSettings);
       setOriginalSettings(JSON.parse(JSON.stringify(updatedSettings)));
@@ -92,11 +147,31 @@ export function useSettingsData(showSuccess, showError, showInfo) {
         }
       }
     } catch {}
-  }, []);
+  }, [applyHealthUpdate]);
 
   useEffect(() => {
     fetchSettings();
   }, [fetchSettings]);
+
+  useEffect(() => {
+    if (!refreshingDiscovery) return;
+
+    const pollHealth = async () => {
+      try {
+        const healthData = await checkHealth();
+        applyHealthUpdate(healthData);
+        if (!healthData?.discovery?.isUpdating) {
+          setDiscoveryProgressMessage(
+            (current) => current || "Discovery refresh completed",
+          );
+        }
+      } catch {}
+    };
+
+    pollHealth();
+    const intervalId = setInterval(pollHealth, 8000);
+    return () => clearInterval(intervalId);
+  }, [refreshingDiscovery, applyHealthUpdate]);
 
   const updateSettings = useCallback(
     (newSettings) => {
@@ -105,7 +180,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
         setHasUnsavedChanges(checkForChanges(newSettings, originalSettings));
       }
     },
-    [originalSettings]
+    [originalSettings],
   );
 
   const handleSaveSettings = useCallback(
@@ -123,51 +198,57 @@ export function useSettingsData(showSuccess, showError, showInfo) {
         setSaving(false);
       }
     },
-    [settings, showSuccess, showError]
+    [settings, showSuccess, showError],
   );
 
   const handleRefreshDiscovery = useCallback(async () => {
     if (refreshingDiscovery) return;
     setRefreshingDiscovery(true);
+    setDiscoveryProgressMessage("Submitting discovery refresh request");
     try {
       await api.post("/discover/refresh");
+      localStorage.setItem(DISCOVERY_MANUAL_REFRESH_KEY, "1");
       showInfo(
-        "Discovery refresh started in background. This may take a few minutes to fully hydrate images."
+        "Discovery refresh started in background. This may take a few minutes to fully hydrate images.",
       );
       const healthData = await checkHealth();
-      setHealth(healthData);
+      applyHealthUpdate(healthData);
     } catch (err) {
+      setRefreshingDiscovery(false);
+      setDiscoveryProgressMessage("");
       showError(
         "Failed to start refresh: " +
-          (err.response?.data?.message || err.response?.data?.error || err.message)
+          (err.response?.data?.message ||
+            err.response?.data?.error ||
+            err.message),
       );
-    } finally {
-      setRefreshingDiscovery(false);
     }
-  }, [refreshingDiscovery, showInfo, showError]);
+  }, [refreshingDiscovery, showInfo, showError, applyHealthUpdate]);
 
   const handleClearCache = useCallback(async () => {
     if (
       !window.confirm(
-        "Are you sure you want to clear the discovery and image cache? This will reset all recommendations until the next refresh."
+        "Are you sure you want to clear the image cache? Discovery recommendations will stay intact.",
       )
     )
       return;
     setClearingCache(true);
     try {
       await api.post("/discover/clear");
-      showSuccess("Cache cleared successfully.");
+      showSuccess("Image cache cleared successfully.");
       const healthData = await checkHealth();
-      setHealth(healthData);
+      applyHealthUpdate(healthData);
     } catch (err) {
       showError(
         "Failed to clear cache: " +
-          (err.response?.data?.message || err.response?.data?.error || err.message)
+          (err.response?.data?.message ||
+            err.response?.data?.error ||
+            err.message),
       );
     } finally {
       setClearingCache(false);
     }
-  }, [showSuccess, showError]);
+  }, [showSuccess, showError, applyHealthUpdate]);
 
   const handleApplyCommunityGuide = useCallback(async () => {
     setShowCommunityGuideModal(false);
@@ -195,7 +276,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
               },
             });
             showInfo(
-              `Default quality profile set to '${result.results.qualityProfile.name}'`
+              `Default quality profile set to '${result.results.qualityProfile.name}'`,
             );
           }
         } catch {
@@ -222,7 +303,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
               },
             });
             showInfo(
-              `Default metadata profile set to '${result.results.metadataProfile.name}'`
+              `Default metadata profile set to '${result.results.metadataProfile.name}'`,
             );
           }
         } catch {
@@ -242,9 +323,9 @@ export function useSettingsData(showSuccess, showError, showInfo) {
   const refreshHealth = useCallback(async () => {
     try {
       const healthData = await checkHealth();
-      setHealth(healthData);
+      applyHealthUpdate(healthData);
     } catch {}
-  }, []);
+  }, [applyHealthUpdate]);
 
   return {
     health,
@@ -258,6 +339,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
     fetchSettings,
     refreshHealth,
     refreshingDiscovery,
+    discoveryProgressMessage,
     clearingCache,
     handleRefreshDiscovery,
     handleClearCache,

--- a/frontend/src/pages/Settings/hooks/useSettingsTabs.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsTabs.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { Server, TrendingUp, Bell, Users } from "lucide-react";
+import { Server, TrendingUp, Compass, Bell, Users } from "lucide-react";
 
 export function useSettingsTabs(authUser) {
   const [activeTab, setActiveTab] = useState("integrations");
@@ -13,6 +13,7 @@ export function useSettingsTabs(authUser) {
     const all = [
       { id: "integrations", label: "Integrations", icon: Server },
       { id: "metadata", label: "Metadata", icon: TrendingUp },
+      { id: "discover", label: "Discover", icon: Compass },
       { id: "notifications", label: "Notifications", icon: Bell },
       { id: "users", label: "Users", icon: Users },
     ];

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -2,6 +2,15 @@ import { allReleaseTypes } from "./constants";
 
 export const normalizeSettings = (savedSettings) => {
   const lidarr = savedSettings.integrations?.lidarr || {};
+  const lastfm = savedSettings.integrations?.lastfm || {};
+  const parsedAutoRefreshHours = parseInt(
+    lastfm.discoveryAutoRefreshHours,
+    10,
+  );
+  const parsedRecommendationLimit = parseInt(
+    lastfm.discoveryRecommendationsPerRefresh,
+    10,
+  );
   return {
     ...savedSettings,
     releaseTypes: savedSettings.releaseTypes || allReleaseTypes,
@@ -29,8 +38,19 @@ export const normalizeSettings = (savedSettings) => {
         ...(savedSettings.integrations?.navidrome || {}),
       },
       lastfm: {
+        apiKey: "",
         username: "",
-        ...(savedSettings.integrations?.lastfm || {}),
+        discoveryPeriod: "1month",
+        discoveryAutoRefreshHours:
+          Number.isFinite(parsedAutoRefreshHours) && parsedAutoRefreshHours > 0
+            ? parsedAutoRefreshHours
+            : 168,
+        discoveryRecommendationsPerRefresh:
+          Number.isFinite(parsedRecommendationLimit) &&
+          parsedRecommendationLimit > 0
+            ? parsedRecommendationLimit
+            : 100,
+        ...lastfm,
       },
       slskd: {
         url: "",

--- a/server.js
+++ b/server.js
@@ -13,9 +13,11 @@ import { createAuthMiddleware } from "./backend/middleware/auth.js";
 import {
   updateDiscoveryCache,
   getDiscoveryCache,
+  getDiscoveryAutoRefreshHours,
 } from "./backend/services/discoveryService.js";
 import { websocketService } from "./backend/services/websocketService.js";
 import { getAllDownloadStatuses } from "./backend/routes/library/handlers/downloads.js";
+import { dbOps } from "./backend/config/db-helpers.js";
 
 import settingsRouter from "./backend/routes/settings.js";
 import onboardingRouter from "./backend/routes/onboarding.js";
@@ -116,20 +118,28 @@ if (fs.existsSync(frontendDist)) {
   });
 }
 
-setInterval(
-  () => {
-    updateDiscoveryCache().catch((err) => {
-      console.error("Error in scheduled discovery update:", err.message);
-    });
-  },
-  24 * 60 * 60 * 1000,
-);
+setInterval(() => {
+  const discoveryCache = getDiscoveryCache();
+  const lastUpdated = discoveryCache?.lastUpdated;
+  const refreshHours = getDiscoveryAutoRefreshHours();
+  const refreshIntervalMs = refreshHours * 60 * 60 * 1000;
+  const parsedLastUpdated = lastUpdated ? new Date(lastUpdated).getTime() : 0;
+  const needsUpdate =
+    !Number.isFinite(parsedLastUpdated) ||
+    parsedLastUpdated <= 0 ||
+    Date.now() - parsedLastUpdated >= refreshIntervalMs;
+
+  if (!needsUpdate) return;
+
+  updateDiscoveryCache().catch((err) => {
+    console.error("Error in scheduled discovery update:", err.message);
+  });
+}, 15 * 60 * 1000);
 
 setTimeout(async () => {
   const { getLastfmApiKey } = await import("./backend/services/apiClients.js");
   const { libraryManager } =
     await import("./backend/services/libraryManager.js");
-  const { dbOps } = await import("./backend/config/db-helpers.js");
 
   const hasLastfm = !!getLastfmApiKey();
   const libraryArtists = await libraryManager.getAllArtists();
@@ -161,10 +171,11 @@ setTimeout(async () => {
   const hasGenres =
     discoveryCache.topGenres && discoveryCache.topGenres.length > 0;
 
-  const twentyFourHoursAgo = Date.now() - 24 * 60 * 60 * 1000;
+  const refreshHours = getDiscoveryAutoRefreshHours();
+  const staleCutoff = Date.now() - refreshHours * 60 * 60 * 1000;
   const needsUpdate =
     !lastUpdated ||
-    new Date(lastUpdated).getTime() < twentyFourHoursAgo ||
+    new Date(lastUpdated).getTime() < staleCutoff ||
     !hasRecommendations ||
     !hasGenres;
 


### PR DESCRIPTION
- Introduce new Discover settings tab with configurable auto-refresh frequency and recommendations per refresh
- Separate discovery cache clearing from image cache clearing for better user control
- Add WebSocket progress notifications for manual discovery refreshes with user feedback
- Implement configurable auto-refresh interval (1-168 hours) instead of fixed 24-hour schedule
- Allow customization of recommendation count per refresh (10-500)
- Move discovery-related UI controls from Metadata tab to new Discover tab
- Improve discovery service with progress emission and better error handling