### PR TITLE
fix(weeklyflow): prevent race conditions when enabling/disabling flows

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -15,6 +15,7 @@ router.use(requireAuth);
 router.use(requirePermission("accessFlow"));
 const DEFAULT_LIMIT = 30;
 const QUEUE_LIMIT = 50;
+const flowEnableMutationVersion = new Map();
 
 router.post("/start/:flowId", async (req, res) => {
   try {
@@ -211,6 +212,8 @@ router.put("/flows/:flowId/enabled", async (req, res) => {
     }
 
     if (enabled) {
+      const mutationVersion = (flowEnableMutationVersion.get(flowId) || 0) + 1;
+      flowEnableMutationVersion.set(flowId, mutationVersion);
       if (!soulseekClient.isConfigured()) {
         return res.status(400).json({
           error: "Soulseek credentials not configured",
@@ -237,7 +240,21 @@ router.put("/flows/:flowId/enabled", async (req, res) => {
 
       (async () => {
         try {
-          const tracks = await playlistSource.getTracksForFlow(flow);
+          if (
+            flowEnableMutationVersion.get(flowId) !== mutationVersion ||
+            !flowPlaylistConfig.isEnabled(flowId)
+          ) {
+            return;
+          }
+          const latestFlow = flowPlaylistConfig.getFlow(flowId);
+          if (!latestFlow) return;
+          const tracks = await playlistSource.getTracksForFlow(latestFlow);
+          if (
+            flowEnableMutationVersion.get(flowId) !== mutationVersion ||
+            !flowPlaylistConfig.isEnabled(flowId)
+          ) {
+            return;
+          }
           if (tracks.length === 0) return;
           downloadTracker.addJobs(tracks, flowId);
           if (!weeklyFlowWorker.running) {
@@ -251,6 +268,8 @@ router.put("/flows/:flowId/enabled", async (req, res) => {
         }
       })();
     } else {
+      const mutationVersion = (flowEnableMutationVersion.get(flowId) || 0) + 1;
+      flowEnableMutationVersion.set(flowId, mutationVersion);
       weeklyFlowWorker.stop();
       playlistManager.updateConfig();
       await playlistManager.weeklyReset([flowId]);

--- a/frontend/src/pages/RequestsPage.jsx
+++ b/frontend/src/pages/RequestsPage.jsx
@@ -24,7 +24,7 @@ function RequestsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [downloadStatuses, setDownloadStatuses] = useState({});
-  const [reSearchingAlbumId, setReSearchingAlbumId] = useState(null);
+  const [reSearchingAlbumIds, setReSearchingAlbumIds] = useState({});
   const navigate = useNavigate();
   const { showError, showSuccess } = useToast();
   const activeAlbumIdsRef = useRef([]);
@@ -97,6 +97,7 @@ function RequestsPage() {
   }, []);
 
   const fetchActiveDownloadStatus = useCallback(async (albumIds) => {
+    const hasExplicitAlbumIds = Array.isArray(albumIds);
     const ids = Array.isArray(albumIds)
       ? albumIds
       : activeAlbumIdsRef.current;
@@ -106,7 +107,15 @@ function RequestsPage() {
     }
     try {
       const statuses = await getDownloadStatus(ids);
-      setDownloadStatuses(statuses || {});
+      setDownloadStatuses((prev) => {
+        if (hasExplicitAlbumIds) {
+          return {
+            ...prev,
+            ...(statuses || {}),
+          };
+        }
+        return statuses || {};
+      });
     } catch {}
   }, []);
 
@@ -194,7 +203,10 @@ function RequestsPage() {
   const handleReSearchRequest = async (request) => {
     if (!request?.albumId) return;
     const albumId = String(request.albumId);
-    setReSearchingAlbumId(albumId);
+    setReSearchingAlbumIds((prev) => ({
+      ...prev,
+      [albumId]: true,
+    }));
     try {
       setDownloadStatuses((prev) => ({
         ...prev,
@@ -210,7 +222,11 @@ function RequestsPage() {
         }`,
       );
     } finally {
-      setReSearchingAlbumId(null);
+      setReSearchingAlbumIds((prev) => {
+        const next = { ...prev };
+        delete next[albumId];
+        return next;
+      });
     }
   };
 
@@ -411,7 +427,7 @@ function RequestsPage() {
               (!statusValue && request.status === "failed");
             const isReSearching =
               request.albumId &&
-              String(request.albumId) === reSearchingAlbumId;
+              !!reSearchingAlbumIds[String(request.albumId)];
 
             return (
               <div


### PR DESCRIPTION
Add mutation version tracking to ensure async flow enable/disable operations are canceled when the flow state changes concurrently. This prevents stale flow configurations from being processed after a user toggles a flow off/on rapidly.

Also fix frontend download status updates to properly merge statuses when fetching for specific albums.