### PR TITLE
fix(weekly-flow): improve worker lifecycle and playlist source effici…

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -108,8 +108,14 @@ const queueFlowEnableRefresh = (flowId, mutationVersion) => {
         return;
       }
 
-      weeklyFlowWorker.stop();
-      playlistManager.updateConfig();
+      const flowStats = downloadTracker.getPlaylistTypeStats(flowId);
+      const shouldStopWorker =
+        weeklyFlowWorker.running &&
+        (flowStats.pending > 0 || flowStats.downloading > 0);
+      if (shouldStopWorker) {
+        weeklyFlowWorker.stop();
+      }
+      playlistManager.updateConfig(false);
       await playlistManager.weeklyReset([flowId]);
       downloadTracker.clearByPlaylistType(flowId);
 
@@ -117,6 +123,12 @@ const queueFlowEnableRefresh = (flowId, mutationVersion) => {
         flowEnableMutationVersion.get(flowId) !== mutationVersion ||
         !flowPlaylistConfig.isEnabled(flowId)
       ) {
+        if (shouldStopWorker) {
+          const stillPending = downloadTracker.getNextPending();
+          if (stillPending && !weeklyFlowWorker.running) {
+            await weeklyFlowWorker.start();
+          }
+        }
         return;
       }
 
@@ -131,7 +143,15 @@ const queueFlowEnableRefresh = (flowId, mutationVersion) => {
         return;
       }
 
-      if (tracks.length === 0) return;
+      if (tracks.length === 0) {
+        if (shouldStopWorker) {
+          const stillPending = downloadTracker.getNextPending();
+          if (stillPending && !weeklyFlowWorker.running) {
+            await weeklyFlowWorker.start();
+          }
+        }
+        return;
+      }
       downloadTracker.addJobs(tracks, flowId);
       if (!weeklyFlowWorker.running) {
         await weeklyFlowWorker.start();
@@ -152,8 +172,14 @@ const queueFlowDisableCleanup = (flowId, mutationVersion) => {
         return;
       }
 
-      weeklyFlowWorker.stop();
-      playlistManager.updateConfig();
+      const flowStats = downloadTracker.getPlaylistTypeStats(flowId);
+      const shouldStopWorker =
+        weeklyFlowWorker.running &&
+        (flowStats.pending > 0 || flowStats.downloading > 0);
+      if (shouldStopWorker) {
+        weeklyFlowWorker.stop();
+      }
+      playlistManager.updateConfig(false);
       await playlistManager.weeklyReset([flowId]);
       downloadTracker.clearByPlaylistType(flowId);
 
@@ -324,7 +350,7 @@ router.delete("/flows/:flowId", async (req, res) => {
           return false;
         }
         weeklyFlowWorker.stop();
-        playlistManager.updateConfig();
+        playlistManager.updateConfig(false);
         await playlistManager.weeklyReset([flowId]);
         downloadTracker.clearByPlaylistType(flowId);
         const didDelete = flowPlaylistConfig.deleteFlow(flowId);
@@ -461,7 +487,7 @@ router.post("/reset", async (req, res) => {
 
     await weeklyFlowOperationQueue.enqueue("reset:manual", async () => {
       weeklyFlowWorker.stop();
-      playlistManager.updateConfig();
+      playlistManager.updateConfig(false);
       await playlistManager.weeklyReset(types);
     });
 
@@ -479,7 +505,7 @@ router.post("/reset", async (req, res) => {
 
 router.post("/playlist/:playlistType/create", async (req, res) => {
   try {
-    playlistManager.updateConfig();
+    playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
     res.json({
       success: true,

--- a/backend/services/simpleSoulseekClient.js
+++ b/backend/services/simpleSoulseekClient.js
@@ -48,7 +48,6 @@ export class SimpleSoulseekClient {
   }
 
   isConfigured() {
-    this.ensureCredentials();
     this.updateConfig();
     return !!(this.config.username && this.config.password);
   }
@@ -188,7 +187,10 @@ export class SimpleSoulseekClient {
     if (!Array.isArray(results) || results.length === 0) {
       return [];
     }
-    const trackNameLower = String(trackName || "").toLowerCase().trim();
+    const max = Number.isFinite(Number(limit)) ? Math.max(1, Number(limit)) : 5;
+    const trackNameLower = String(trackName || "")
+      .toLowerCase()
+      .trim();
     const qualityOrder = { ".flac": 0, ".mp3": 1, ".m4a": 2, ".ogg": 3 };
     const score = (item) => {
       const file = String(item?.file || "").toLowerCase();
@@ -197,7 +199,8 @@ export class SimpleSoulseekClient {
       const hasTrack = trackNameLower ? file.includes(trackNameLower) : false;
       const hasSlots = item?.slots ? 0 : 1;
       const fileSize = Number(item?.size || 0);
-      const sizePenalty = fileSize > 0 ? Math.max(0, 500000 - fileSize) : 500000;
+      const sizePenalty =
+        fileSize > 0 ? Math.max(0, 500000 - fileSize) : 500000;
       return {
         hasTrack: hasTrack ? 0 : 1,
         quality,
@@ -205,17 +208,34 @@ export class SimpleSoulseekClient {
         sizePenalty,
       };
     };
-    const ranked = [...results].sort((a, b) => {
-      const sa = score(a);
-      const sb = score(b);
+    const compareScore = (sa, sb) => {
       if (sa.hasTrack !== sb.hasTrack) return sa.hasTrack - sb.hasTrack;
       if (sa.quality !== sb.quality) return sa.quality - sb.quality;
       if (sa.hasSlots !== sb.hasSlots) return sa.hasSlots - sb.hasSlots;
-      if (sa.sizePenalty !== sb.sizePenalty) return sa.sizePenalty - sb.sizePenalty;
+      if (sa.sizePenalty !== sb.sizePenalty)
+        return sa.sizePenalty - sb.sizePenalty;
       return 0;
-    });
-    const max = Number.isFinite(Number(limit)) ? Math.max(1, Number(limit)) : 5;
-    return ranked.slice(0, max);
+    };
+    const top = [];
+    const topScores = [];
+    for (const item of results) {
+      const itemScore = score(item);
+      let insertAt = top.length;
+      for (let i = 0; i < top.length; i += 1) {
+        if (compareScore(itemScore, topScores[i]) < 0) {
+          insertAt = i;
+          break;
+        }
+      }
+      if (insertAt >= max && top.length >= max) continue;
+      top.splice(insertAt, 0, item);
+      topScores.splice(insertAt, 0, itemScore);
+      if (top.length > max) {
+        top.pop();
+        topScores.pop();
+      }
+    }
+    return top;
   }
 
   async download(result, destinationPath) {

--- a/backend/services/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlowDownloadTracker.js
@@ -48,7 +48,61 @@ const sortByCreatedAt = (jobs) =>
 export class WeeklyFlowDownloadTracker {
   constructor() {
     this.jobs = new Map();
+    this.statsByPlaylistType = new Map();
     this._load();
+  }
+
+  _emptyStats() {
+    return {
+      total: 0,
+      pending: 0,
+      downloading: 0,
+      done: 0,
+      failed: 0,
+    };
+  }
+
+  _cloneStats(stats) {
+    return {
+      total: Number(stats?.total || 0),
+      pending: Number(stats?.pending || 0),
+      downloading: Number(stats?.downloading || 0),
+      done: Number(stats?.done || 0),
+      failed: Number(stats?.failed || 0),
+    };
+  }
+
+  _getOrCreatePlaylistStats(playlistType) {
+    const key = String(playlistType || "");
+    let stats = this.statsByPlaylistType.get(key);
+    if (!stats) {
+      stats = this._emptyStats();
+      this.statsByPlaylistType.set(key, stats);
+    }
+    return stats;
+  }
+
+  _applyStatusDelta(playlistType, fromStatus, toStatus) {
+    if (!playlistType) return;
+    const stats = this._getOrCreatePlaylistStats(playlistType);
+    if (fromStatus && stats[fromStatus] > 0) {
+      stats[fromStatus] -= 1;
+      stats.total = Math.max(0, stats.total - 1);
+    }
+    if (toStatus) {
+      stats[toStatus] = (stats[toStatus] || 0) + 1;
+      stats.total += 1;
+    }
+    if (stats.total <= 0) {
+      this.statsByPlaylistType.delete(String(playlistType));
+    }
+  }
+
+  _rebuildStatsByPlaylistType() {
+    this.statsByPlaylistType.clear();
+    for (const job of this.jobs.values()) {
+      this._applyStatusDelta(job.playlistType, null, job.status);
+    }
   }
 
   _load() {
@@ -86,6 +140,7 @@ export class WeeklyFlowDownloadTracker {
       }
       this.jobs.set(job.id, job);
     }
+    this._rebuildStatsByPlaylistType();
   }
 
   _insert(job) {
@@ -147,6 +202,7 @@ export class WeeklyFlowDownloadTracker {
     };
     this.jobs.set(id, job);
     this._insert(job);
+    this._applyStatusDelta(playlistType, null, job.status);
     return id;
   }
 
@@ -186,18 +242,21 @@ export class WeeklyFlowDownloadTracker {
   setDownloading(id, stagingPath = null) {
     const job = this.jobs.get(id);
     if (!job) return false;
+    const previousStatus = job.status;
     job.status = "downloading";
     job.startedAt = Date.now();
     if (stagingPath) {
       job.stagingPath = stagingPath;
     }
     this._update(job);
+    this._applyStatusDelta(job.playlistType, previousStatus, job.status);
     return true;
   }
 
   setDone(id, finalPath, albumName = null) {
     const job = this.jobs.get(id);
     if (!job) return false;
+    const previousStatus = job.status;
     job.status = "done";
     job.completedAt = Date.now();
     job.finalPath = finalPath;
@@ -208,17 +267,20 @@ export class WeeklyFlowDownloadTracker {
       job.albumName = null;
     }
     this._update(job);
+    this._applyStatusDelta(job.playlistType, previousStatus, job.status);
     return true;
   }
 
   setFailed(id, error) {
     const job = this.jobs.get(id);
     if (!job) return false;
+    const previousStatus = job.status;
     job.status = "failed";
     job.completedAt = Date.now();
     job.error =
       typeof error === "string" ? error : (error && error.message) || null;
     this._update(job);
+    this._applyStatusDelta(job.playlistType, previousStatus, job.status);
     return true;
   }
 
@@ -254,6 +316,7 @@ export class WeeklyFlowDownloadTracker {
         }
       }
     }
+    this._rebuildStatsByPlaylistType();
     return count;
   }
 
@@ -261,10 +324,12 @@ export class WeeklyFlowDownloadTracker {
     let count = 0;
     for (const job of this.jobs.values()) {
       if (job.status === "downloading") {
+        const previousStatus = job.status;
         job.status = "pending";
         job.startedAt = null;
         job.stagingPath = null;
         this._update(job);
+        this._applyStatusDelta(job.playlistType, previousStatus, job.status);
         count++;
       }
     }
@@ -291,32 +356,24 @@ export class WeeklyFlowDownloadTracker {
 
   getStatsByPlaylistType(playlistTypes = []) {
     const statsByType = {};
-    const ensure = (playlistType) => {
-      if (!playlistType) return null;
-      if (!statsByType[playlistType]) {
-        statsByType[playlistType] = {
-          total: 0,
-          pending: 0,
-          downloading: 0,
-          done: 0,
-          failed: 0,
-        };
+    if (Array.isArray(playlistTypes) && playlistTypes.length > 0) {
+      for (const playlistType of playlistTypes) {
+        statsByType[playlistType] = this._cloneStats(
+          this.statsByPlaylistType.get(String(playlistType)) || this._emptyStats(),
+        );
       }
-      return statsByType[playlistType];
-    };
-
-    for (const playlistType of playlistTypes) {
-      ensure(playlistType);
+      return statsByType;
     }
-
-    for (const job of this.jobs.values()) {
-      const stats = ensure(job.playlistType);
-      if (!stats) continue;
-      stats.total += 1;
-      stats[job.status] = (stats[job.status] || 0) + 1;
+    for (const [playlistType, stats] of this.statsByPlaylistType.entries()) {
+      statsByType[playlistType] = this._cloneStats(stats);
     }
-
     return statsByType;
+  }
+
+  getPlaylistTypeStats(playlistType) {
+    return this._cloneStats(
+      this.statsByPlaylistType.get(String(playlistType)) || this._emptyStats(),
+    );
   }
 
   clearCompleted() {
@@ -329,6 +386,9 @@ export class WeeklyFlowDownloadTracker {
     for (const id of toDelete) {
       this.jobs.delete(id);
       deleteStmt.run(id);
+    }
+    if (toDelete.length > 0) {
+      this._rebuildStatsByPlaylistType();
     }
     return toDelete.length;
   }
@@ -344,12 +404,16 @@ export class WeeklyFlowDownloadTracker {
       this.jobs.delete(id);
       deleteStmt.run(id);
     }
+    if (toDelete.length > 0) {
+      this._rebuildStatsByPlaylistType();
+    }
     return toDelete.length;
   }
 
   clearAll() {
     const count = this.jobs.size;
     this.jobs.clear();
+    this.statsByPlaylistType.clear();
     deleteAllStmt.run();
     return count;
   }

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -14,23 +14,34 @@ export class WeeklyFlowPlaylistManager {
       : path.resolve(process.cwd(), weeklyFlowRoot);
     this.libraryRoot = path.join(this.weeklyFlowRoot, "aurral-weekly-flow");
     this.navidromeClient = null;
+    this._navidromeConfigKey = "";
+    this._ensureInFlight = null;
     this.updateConfig();
   }
 
   updateConfig(triggerEnsurePlaylists = true) {
     const settings = dbOps.getSettings();
     const navidromeConfig = settings.integrations?.navidrome || {};
+    const nextConfigKey = JSON.stringify({
+      url: navidromeConfig.url || "",
+      username: navidromeConfig.username || "",
+      password: navidromeConfig.password || "",
+    });
+    const configChanged = this._navidromeConfigKey !== nextConfigKey;
+    this._navidromeConfigKey = nextConfigKey;
 
     if (
       navidromeConfig.url &&
       navidromeConfig.username &&
       navidromeConfig.password
     ) {
-      this.navidromeClient = new NavidromeClient(
-        navidromeConfig.url,
-        navidromeConfig.username,
-        navidromeConfig.password
-      );
+      if (!this.navidromeClient || configChanged) {
+        this.navidromeClient = new NavidromeClient(
+          navidromeConfig.url,
+          navidromeConfig.username,
+          navidromeConfig.password
+        );
+      }
     } else {
       this.navidromeClient = null;
     }
@@ -57,6 +68,18 @@ export class WeeklyFlowPlaylistManager {
   }
 
   async ensureSmartPlaylists() {
+    if (this._ensureInFlight) {
+      return this._ensureInFlight;
+    }
+    this._ensureInFlight = this._ensureSmartPlaylistsInternal();
+    try {
+      return await this._ensureInFlight;
+    } finally {
+      this._ensureInFlight = null;
+    }
+  }
+
+  async _ensureSmartPlaylistsInternal() {
     const flows = flowPlaylistConfig.getFlows();
     let libraryId = null;
     let playlists = null;

--- a/backend/services/weeklyFlowPlaylistSource.js
+++ b/backend/services/weeklyFlowPlaylistSource.js
@@ -605,25 +605,33 @@ export class WeeklyFlowPlaylistSource {
       recipeCounts?.discover != null
         ? recipeCounts
         : this._buildCounts(limit, flow?.mix);
-    const perTypeLimit = totalTarget > 0 ? Math.max(totalTarget, 50) : 0;
+    const perTypeLimit = totalTarget > 0 ? Math.max(totalTarget, 30) : 0;
+    const sourceNeed = {
+      discover: Number(counts?.discover || 0) > 0,
+      mix: Number(counts?.mix || 0) > 0,
+      trending: Number(counts?.trending || 0) > 0,
+    };
 
-    const [discoverTracks, mixTracks, trendingTracks] =
-      perTypeLimit > 0
-        ? await Promise.all([
-            this.getDiscoverTracks(perTypeLimit, {
-              deepDive: flow?.deepDive === true,
-              reason: "From discovery recommendations",
-            }).catch(() => []),
-            this.getMixTracks(perTypeLimit, {
-              deepDive: flow?.deepDive === true,
-              reason: "From your library mix",
-            }).catch(() => []),
-            this.getTrendingTracks(perTypeLimit, {
-              deepDive: flow?.deepDive === true,
-              reason: "From trending artists",
-            }).catch(() => []),
-          ])
-        : [[], [], []];
+    const [discoverTracks, mixTracks, trendingTracks] = await Promise.all([
+      sourceNeed.discover && perTypeLimit > 0
+        ? this.getDiscoverTracks(perTypeLimit, {
+            deepDive: flow?.deepDive === true,
+            reason: "From discovery recommendations",
+          }).catch(() => [])
+        : [],
+      sourceNeed.mix && perTypeLimit > 0
+        ? this.getMixTracks(perTypeLimit, {
+            deepDive: flow?.deepDive === true,
+            reason: "From your library mix",
+          }).catch(() => [])
+        : [],
+      sourceNeed.trending && perTypeLimit > 0
+        ? this.getTrendingTracks(perTypeLimit, {
+            deepDive: flow?.deepDive === true,
+            reason: "From trending artists",
+          }).catch(() => [])
+        : [],
+    ]);
 
     const tagSources = await Promise.all(
       Object.entries(tags).map(async ([tag, count]) => ({

--- a/backend/services/weeklyFlowScheduler.js
+++ b/backend/services/weeklyFlowScheduler.js
@@ -6,8 +6,6 @@ import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 import { soulseekClient } from "./simpleSoulseekClient.js";
 import { weeklyFlowOperationQueue } from "./weeklyFlowOperationQueue.js";
 
-const QUEUE_LIMIT = 50;
-
 export async function runScheduledRefresh() {
   if (!soulseekClient.isConfigured()) return;
 
@@ -20,19 +18,28 @@ export async function runScheduledRefresh() {
         `scheduled:${flow.id}`,
         async () => {
           if (!flowPlaylistConfig.isEnabled(flow.id)) return;
-          weeklyFlowWorker.stop();
-          playlistManager.updateConfig();
+          const flowStats = downloadTracker.getPlaylistTypeStats(flow.id);
+          const shouldStopWorker =
+            weeklyFlowWorker.running &&
+            (flowStats.pending > 0 || flowStats.downloading > 0);
+          if (shouldStopWorker) {
+            weeklyFlowWorker.stop();
+          }
+          playlistManager.updateConfig(false);
           await playlistManager.weeklyReset([flow.id]);
           downloadTracker.clearByPlaylistType(flow.id);
 
           const latestFlow = flowPlaylistConfig.getFlow(flow.id);
           if (!latestFlow || !latestFlow.enabled) return;
-          const tracks = await playlistSource.getTracksForFlow(
-            latestFlow,
-            Math.max(latestFlow.size || QUEUE_LIMIT, QUEUE_LIMIT),
-          );
+          const tracks = await playlistSource.getTracksForFlow(latestFlow);
           if (tracks.length === 0) {
             flowPlaylistConfig.scheduleNextRun(flow.id);
+            if (shouldStopWorker) {
+              const stillPending = downloadTracker.getNextPending();
+              if (stillPending && !weeklyFlowWorker.running) {
+                await weeklyFlowWorker.start();
+              }
+            }
             return;
           }
 

--- a/backend/services/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlowStatusSnapshot.js
@@ -9,7 +9,7 @@ export function getWeeklyFlowStatusSnapshot({
   jobsLimit = null,
 } = {}) {
   const workerStatus = weeklyFlowWorker.getStatus();
-  const stats = downloadTracker.getStats();
+  const stats = workerStatus.stats || downloadTracker.getStats();
   const flows = flowPlaylistConfig.getFlows();
   const flowIds = flows.map((flow) => flow.id);
   const flowStats = downloadTracker.getStatsByPlaylistType(flowIds);

--- a/backend/services/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlowWorker.js
@@ -22,17 +22,33 @@ const MAX_MATCH_CANDIDATES =
     ? Math.min(Math.floor(parsedCandidateCount), 8)
     : 4;
 const FALLBACK_MP3_REGEX = /^[^/\\]+-[a-f0-9]{8}\.mp3$/i;
+const parsedFallbackSweepInterval = Number(
+  process.env.WEEKLY_FLOW_FALLBACK_SWEEP_MS,
+);
+const FALLBACK_SWEEP_INTERVAL_MS =
+  Number.isFinite(parsedFallbackSweepInterval) &&
+  parsedFallbackSweepInterval >= 1000
+    ? parsedFallbackSweepInterval
+    : 60000;
 
 export class WeeklyFlowWorker {
-  constructor(weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER || "/app/downloads") {
+  constructor(
+    weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER || "/app/downloads",
+  ) {
     this.weeklyFlowRoot = path.isAbsolute(weeklyFlowRoot)
       ? weeklyFlowRoot
       : path.resolve(process.cwd(), weeklyFlowRoot);
     this.running = false;
     this.activeCount = 0;
+    this.lastFallbackSweepAt = 0;
   }
 
-  async moveFallbackMp3sToDir() {
+  async moveFallbackMp3sToDir(force = false) {
+    const now = Date.now();
+    if (!force && now - this.lastFallbackSweepAt < FALLBACK_SWEEP_INTERVAL_MS) {
+      return;
+    }
+    this.lastFallbackSweepAt = now;
     const cwd = process.cwd();
     if (path.resolve(cwd) === path.resolve(this.weeklyFlowRoot)) return;
     const fallbackDir = path.join(this.weeklyFlowRoot, "_fallback");
@@ -63,7 +79,7 @@ export class WeeklyFlowWorker {
 
     this.running = true;
     console.log("[WeeklyFlowWorker] Starting worker...");
-    await this.moveFallbackMp3sToDir();
+    await this.moveFallbackMp3sToDir(true);
 
     const processLoop = () => {
       if (!this.running) return;
@@ -84,7 +100,7 @@ export class WeeklyFlowWorker {
           })
           .finally(() => {
             this.activeCount--;
-            this.moveFallbackMp3sToDir().catch(() => {});
+            this.moveFallbackMp3sToDir(false).catch(() => {});
             if (this.running) setTimeout(processLoop, JOB_COOLDOWN_MS);
           });
       }
@@ -105,7 +121,9 @@ export class WeeklyFlowWorker {
   }
 
   _normalizeAlbumName(value) {
-    const text = String(value || "").replace(/\u0000/g, "").trim();
+    const text = String(value || "")
+      .replace(/\u0000/g, "")
+      .trim();
     return text || null;
   }
 
@@ -367,8 +385,6 @@ export class WeeklyFlowWorker {
 
       await fs.rm(stagingDir, { recursive: true, force: true });
 
-      playlistManager.updateConfig(false);
-
       downloadTracker.setDone(job.id, finalPath, resolvedAlbum);
       console.log(`[WeeklyFlowWorker] Job ${job.id} completed: ${finalPath}`);
 
@@ -386,11 +402,10 @@ export class WeeklyFlowWorker {
   }
 
   async checkPlaylistComplete(playlistType) {
-    const jobs = downloadTracker.getByPlaylistType(playlistType);
-    const allDone = jobs.every(
-      (j) => j.status === "done" || j.status === "failed",
-    );
-    const hasDone = jobs.some((j) => j.status === "done");
+    const stats = downloadTracker.getPlaylistTypeStats(playlistType);
+    const allDone =
+      stats.total > 0 && stats.pending === 0 && stats.downloading === 0;
+    const hasDone = stats.done > 0;
 
     if (allDone && hasDone) {
       console.log(
@@ -415,11 +430,9 @@ export class WeeklyFlowWorker {
           error.message,
         );
       }
-      const completed = jobs.filter((j) => j.status === "done").length;
-      const failed = jobs.filter((j) => j.status === "failed").length;
-      const { notifyWeeklyFlowDone } = await import(
-        "./notificationService.js"
-      );
+      const completed = stats.done;
+      const failed = stats.failed;
+      const { notifyWeeklyFlowDone } = await import("./notificationService.js");
       notifyWeeklyFlowDone(playlistType, { completed, failed }).catch((err) =>
         console.warn(
           "[WeeklyFlowWorker] Gotify notification failed:",


### PR DESCRIPTION
…ency

Prevent unnecessary worker stops during scheduled refreshes and manual triggers by checking pending/downloading jobs. Add stats caching to download tracker for O(1) playlist stats lookups. Reduce fallback sweep frequency to improve performance. Avoid redundant Navidrome client reinitialization and ensure playlist source only fetches needed track types. Fix worker restart logic when no tracks are found.