### PR TITLE
fix: make first-click album add reliable and harden Last.fm requests

### DIFF
--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -46,6 +46,11 @@ const lastfmLimiter = new Bottleneck({
 });
 
 let musicbrainzLast503Log = 0;
+const lastfmInflightRequests = new Map();
+const lastfmErrorLogAt = new Map();
+
+const LASTFM_TIMEOUT_MS = 6000;
+const LASTFM_MAX_RETRIES = 2;
 
 const musicbrainzRequestWithRetry = async (
   endpoint,
@@ -153,36 +158,78 @@ export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {
   const cacheKey = `lfm:${method}:${JSON.stringify(params)}`;
   const cached = lastfmCache.get(cacheKey);
   if (cached) return cached;
+  const inflight = lastfmInflightRequests.get(cacheKey);
+  if (inflight) return inflight;
 
-  try {
-    const response = await axios.get(LASTFM_API, {
-      params: {
-        method,
-        api_key: apiKey,
-        format: "json",
-        ...params,
-      },
-      timeout: 3000,
-    });
-    lastfmCache.set(cacheKey, response.data);
-    return response.data;
-  } catch (error) {
-    const status = error.response?.status || null;
+  const requestPromise = (async () => {
+    const isRetryable = (error) => {
+      const status = error.response?.status;
+      const code = error.code;
+      return (
+        code === "ECONNABORTED" ||
+        code === "ETIMEDOUT" ||
+        code === "ECONNRESET" ||
+        code === "ENOTFOUND" ||
+        code === "EAI_AGAIN" ||
+        [408, 425, 429, 500, 502, 503, 504].includes(status)
+      );
+    };
+    const getLogKey = (details) =>
+      `${details.method}:${details.status || "none"}:${details.code || "none"}`;
+    const logError = (message, details) => {
+      const key = getLogKey(details);
+      const now = Date.now();
+      const last = lastfmErrorLogAt.get(key) || 0;
+      if (now - last < 15000) return;
+      lastfmErrorLogAt.set(key, now);
+      console.error(message, details);
+    };
+    let lastError = null;
+    for (let retryCount = 0; retryCount <= LASTFM_MAX_RETRIES; retryCount++) {
+      try {
+        const response = await axios.get(LASTFM_API, {
+          params: {
+            method,
+            api_key: apiKey,
+            format: "json",
+            ...params,
+          },
+          timeout: LASTFM_TIMEOUT_MS,
+        });
+        lastfmCache.set(cacheKey, response.data);
+        return response.data;
+      } catch (error) {
+        lastError = error;
+        if (retryCount < LASTFM_MAX_RETRIES && isRetryable(error)) {
+          const backoffMs = 300 * Math.pow(2, retryCount) + retryCount * 200;
+          await new Promise((resolve) => setTimeout(resolve, backoffMs));
+          continue;
+        }
+        break;
+      }
+    }
+    const status = lastError?.response?.status || null;
     const payloadError =
-      error.response?.data?.message || error.response?.data?.error || null;
+      lastError?.response?.data?.message || lastError?.response?.data?.error || null;
     const details = {
       method,
       status,
-      code: error.code || null,
-      message: error.message,
+      code: lastError?.code || null,
+      message: lastError?.message || "Unknown Last.fm error",
       error: payloadError,
     };
-    if (error.code === "ECONNABORTED") {
-      console.error(`Last.fm API timeout (${method})`, details);
+    if (details.code === "ECONNABORTED") {
+      logError(`Last.fm API timeout (${method})`, details);
     } else {
-      console.error(`Last.fm API error (${method})`, details);
+      logError(`Last.fm API error (${method})`, details);
     }
     return null;
+  })();
+  lastfmInflightRequests.set(cacheKey, requestPromise);
+  try {
+    return await requestPromise;
+  } finally {
+    lastfmInflightRequests.delete(cacheKey);
   }
 });
 

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -19,6 +19,32 @@ let _retryTimeoutId = null;
 let _lastFullArtistFetchAt = 0;
 const _tracksCache = new Map();
 
+function findCachedArtistByMbid(mbid) {
+  if (!mbid || !Array.isArray(_cachedArtists) || _cachedArtists.length === 0) {
+    return null;
+  }
+  return (
+    _cachedArtists.find(
+      (artist) =>
+        artist?.mbid === mbid || artist?.foreignArtistId === mbid,
+    ) || null
+  );
+}
+
+function upsertCachedArtist(mappedArtist) {
+  if (!mappedArtist) return;
+  const mbid = mappedArtist.mbid || mappedArtist.foreignArtistId;
+  if (!mbid) return;
+  const existingIndex = _cachedArtists.findIndex(
+    (artist) => artist?.mbid === mbid || artist?.foreignArtistId === mbid,
+  );
+  if (existingIndex >= 0) {
+    _cachedArtists[existingIndex] = mappedArtist;
+    return;
+  }
+  _cachedArtists.unshift(mappedArtist);
+}
+
 async function getLidarrClient() {
   if (!lidarrClient) {
     try {
@@ -68,13 +94,15 @@ export class LibraryManager {
           lidarrSettings.integrations?.lidarr?.metadataProfileId,
       });
       console.log(`[LibraryManager] Added artist "${artistName}" to Lidarr`);
-      return this.mapLidarrArtist(lidarrArtist);
+      const mappedArtist = this.mapLidarrArtist(lidarrArtist);
+      upsertCachedArtist(mappedArtist);
+      return mappedArtist;
     } catch (error) {
       if (isArtistAlreadyAddedError(error)) {
         try {
-          const existing = await lidarr.getArtistByMbid(mbid);
+          const existing = await this.getArtist(mbid);
           if (existing) {
-            return this.mapLidarrArtist(existing);
+            return existing;
           }
         } catch {}
       }
@@ -228,10 +256,16 @@ export class LibraryManager {
     if (!lidarr || !lidarr.isConfigured()) {
       return null;
     }
+    const cachedArtist = findCachedArtistByMbid(mbid);
+    if (cachedArtist) {
+      return cachedArtist;
+    }
     try {
       const lidarrArtist = await lidarr.getArtistByMbid(mbid);
       if (!lidarrArtist) return null;
-      return this.mapLidarrArtist(lidarrArtist);
+      const mappedArtist = this.mapLidarrArtist(lidarrArtist);
+      upsertCachedArtist(mappedArtist);
+      return mappedArtist;
     } catch {
       return null;
     }
@@ -504,6 +538,36 @@ export class LibraryManager {
         );
       };
       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const artistIdString = String(artistId);
+      const artistNumericId = Number.parseInt(artistId, 10);
+      const isSameArtist = (album) => {
+        if (!album) return false;
+        if (String(album.artistId) === artistIdString) return true;
+        if (
+          Number.isFinite(artistNumericId) &&
+          Number.isFinite(Number(album.artistId))
+        ) {
+          return Number(album.artistId) === artistNumericId;
+        }
+        return false;
+      };
+      const findExistingAlbumForArtist = async ({
+        attempts = 1,
+        delayMs = 0,
+      } = {}) => {
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+          const existingAlbum = await lidarr
+            .getAlbumByMbid(releaseGroupMbid)
+            .catch(() => null);
+          if (isSameArtist(existingAlbum)) {
+            return existingAlbum;
+          }
+          if (attempt < attempts && delayMs > 0) {
+            await sleep(delayMs);
+          }
+        }
+        return null;
+      };
       const settings = getSettings();
       const searchOnAdd = settings.integrations?.lidarr?.searchOnAdd ?? false;
       const shouldTriggerSearch =
@@ -512,7 +576,23 @@ export class LibraryManager {
       const mapExistingAlbum = async (existingAlbum, fallbackArtist = null) => {
         if (!existingAlbum) return null;
         if (!existingAlbum.monitored) {
-          await lidarr.monitorAlbum(existingAlbum.id, true);
+          const monitorAttempts = 3;
+          const monitorDelayMs = 600;
+          for (let attempt = 1; attempt <= monitorAttempts; attempt++) {
+            try {
+              await lidarr.monitorAlbum(existingAlbum.id, true);
+              break;
+            } catch (monitorError) {
+              if (
+                attempt < monitorAttempts &&
+                isArtistNotReadyError(monitorError)
+              ) {
+                await sleep(monitorDelayMs);
+                continue;
+              }
+              throw monitorError;
+            }
+          }
         }
         if (shouldTriggerSearch) {
           await lidarr.triggerAlbumSearch(existingAlbum.id);
@@ -551,13 +631,10 @@ export class LibraryManager {
           .getArtist(artistId)
           .catch(() => lidarrArtist);
       }
-      const existing = await lidarr.getAlbumByMbid(releaseGroupMbid);
-      const artistNumericId = parseInt(artistId, 10);
-      const sameArtistExisting =
-        existing && existing.artistId === artistNumericId ? existing : null;
-      if (sameArtistExisting) {
+      const existing = await findExistingAlbumForArtist();
+      if (existing) {
         const mappedExisting = await mapExistingAlbum(
-          sameArtistExisting,
+          existing,
           lidarrArtist,
         );
         if (mappedExisting) return mappedExisting;
@@ -582,20 +659,20 @@ export class LibraryManager {
           break;
         } catch (error) {
           if (isAlbumAlreadyAddedError(error)) {
-            const existingAfterConflict = await lidarr
-              .getAlbumByMbid(releaseGroupMbid)
-              .catch(() => null);
-            const sameArtistAfterConflict =
-              existingAfterConflict &&
-              existingAfterConflict.artistId === artistNumericId
-                ? existingAfterConflict
-                : null;
-            if (sameArtistAfterConflict) {
+            const existingAfterConflict = await findExistingAlbumForArtist({
+              attempts: 8,
+              delayMs: 450,
+            });
+            if (existingAfterConflict) {
               const mappedConflictAlbum = await mapExistingAlbum(
-                sameArtistAfterConflict,
+                existingAfterConflict,
                 lidarrArtist,
               );
               if (mappedConflictAlbum) return mappedConflictAlbum;
+            }
+            if (attempt < addAlbumAttempts) {
+              await sleep(addAlbumDelayMs);
+              continue;
             }
           }
           if (attempt < addAlbumAttempts && isArtistNotReadyError(error)) {
@@ -616,7 +693,8 @@ export class LibraryManager {
             .filter(
               (a) =>
                 a.artistId === parseInt(artistId) &&
-                a.foreignAlbumId !== releaseGroupMbid,
+                a.foreignAlbumId !== releaseGroupMbid &&
+                a.monitored === true,
             )
             .map((a) => a.id)
         : [];


### PR DESCRIPTION
- improve artist lookup/add album sequencing to avoid first-attempt Lidarr conflicts
- add Last.fm request retries/backoff, in-flight dedupe, and timeout/log-throttle improvements