### PR TITLE
fix(api): fetch all release groups for an artist

### DIFF
--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -604,10 +604,24 @@ const ALLOWED_PRIMARY_TYPES = new Set(["album", "ep", "single"]);
  */
 export async function musicbrainzGetArtistReleaseGroups(mbid) {
   try {
-    const data = await musicbrainzRequest(`/artist/${mbid}`, {
-      inc: "release-groups",
-    });
-    const raw = data["release-groups"] || [];
+    const raw = [];
+    const limit = 100;
+    let offset = 0;
+    let totalCount;
+
+    // Fetch all release-groups for the artist
+    do {
+      const data = await musicbrainzRequest("/release-group", {
+        artist: mbid,
+        limit,
+        offset,
+      });
+      totalCount = data["release-group-count"] || 0;
+      const batch = data["release-groups"] || [];
+      raw.push(...batch);
+      offset += limit;
+    } while (offset < totalCount);
+
     const filtered = raw
       .filter(
         (rg) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aurral",
-  "version": "1.15.0",
+  "version": "1.36.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aurral",
-      "version": "1.15.0",
+      "version": "1.36.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",


### PR DESCRIPTION
First of all, this is an awesome tool, thanks for sharing it!

For context, this is how I use Aurral:
1. Think of a song/artist I want to add to my library
2. Search for the artist
3. Look for the release group I want
4. Add it to my library
5. Let Lidarr handle things

However, while doing this, I noticed that some artists were simply missing release groups that were available on MusicBrainz. After some digging, I found this in the [MusicBrainz wiki](https://wiki.musicbrainz.org/MusicBrainz_API):

> Note that the number of linked entities returned is always limited to 25. If you need the remaining results, you will have to perform a browse request. 

> Browse requests are the only requests which support paging: any browse request supports an 'offset=' argument to get more results. Browse requests also support 'limit=': the default limit is 25, and you can increase that up to 100. 

Ran locally and went on an artist page with more than 25 releases on MusicBrainz, e.g. [King Gnu](https://musicbrainz.org/artist/338f5d97-3133-4bf8-a58e-068ff9b5405d).

Previously, I would only see 25 releases on Aurral. With this PR, I see 31, which matches the MusicBrainz page without introducing any noticeable latency.

Let me know what you think, thanks!