### PR TITLE
fix(sidebar): add ref to track previous toggle state

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -32,6 +32,11 @@ function Layout({ children, appVersion }) {
       return "full";
     }
   });
+  const prevVisibleMode = useRef(
+    sidebarMode !== "hidden"
+      ? sidebarMode
+      : (() => { try { const s = localStorage.getItem("sidebarVisibleMode"); return s === "full" || s === "icons" ? s : "full"; } catch { return "full"; } })()
+  );
   const [suggestions, setSuggestions] = useState([]);
   const [suggestionMode, setSuggestionMode] = useState(null);
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
@@ -42,9 +47,15 @@ function Layout({ children, appVersion }) {
   const location = useLocation();
 
   const handleSetSidebarMode = useCallback((newMode) => {
+    if (newMode !== "hidden") {
+      prevVisibleMode.current = newMode;
+    }
     setSidebarMode(newMode);
     try {
       localStorage.setItem("sidebarMode", newMode);
+      if (newMode !== "hidden") {
+        localStorage.setItem("sidebarVisibleMode", newMode);
+      }
     } catch {
       // localStorage unavailable
     }
@@ -218,7 +229,7 @@ function Layout({ children, appVersion }) {
             onClick={() => {
               const isDesktop = window.matchMedia("(min-width: 768px)").matches;
               if (isDesktop) {
-                handleSetSidebarMode(sidebarMode === "hidden" ? "full" : "hidden");
+                handleSetSidebarMode(sidebarMode === "hidden" ? prevVisibleMode.current : "hidden");
               } else {
                 setIsSidebarOpen(true);
               }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -30,7 +30,13 @@ function Sidebar({ isOpen, onClose, appVersion, mode, onSetMode }) {
       : true
   );
 
-  const isIcons = mode === "icons" && isDesktop;
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (mode !== "hidden") {
+      prevModeRef.current = mode;
+    }
+  }, [mode]);
+  const isIcons = (mode === "icons" || (mode === "hidden" && prevModeRef.current === "icons")) && isDesktop;
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;


### PR DESCRIPTION
Addresses #202 

- Add previous state to `localStorage` so icon mode can be remembered if collapsed
- Check previous ref to see if icon mode in order to restore to icon mode when uncollapsing
- Use previous ref to determine sidebar width to use when collapsing

https://cleanshot.com/share/vwMKyVhf