### PR TITLE
fix(auth): implement role-based UI controls and auth persistence

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -95,7 +95,7 @@ function AppContent() {
   const [rootFolderConfigured, setRootFolderConfigured] = useState(false);
   const [appVersion, setAppVersion] = useState(null);
   const discoveryToastShownRef = useRef(false);
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   const { showSuccess, showError } = useToast();
 
   useWebSocketChannel("discovery", (msg) => {
@@ -165,7 +165,10 @@ function AppContent() {
           rootFolderConfigured={rootFolderConfigured}
           appVersion={appVersion}
         >
-          <UpdateBanner currentVersion={appVersion} />
+          <UpdateBanner
+            currentVersion={appVersion}
+            visible={!user || user.role === "admin"}
+          />
           {isHealthy === false && (
             <div className="mb-6 bg-red-500/20 border border-red-500/30 p-4">
               <div className="flex items-center">

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -74,7 +74,6 @@ function Sidebar({ isOpen, onClose, appVersion, mode, onSetMode }) {
         path: "/settings",
         label: "Settings",
         icon: Settings,
-        permission: "accessSettings",
       },
     ];
     return items.filter(

--- a/frontend/src/components/UpdateBanner.jsx
+++ b/frontend/src/components/UpdateBanner.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const UpdateBanner = ({ currentVersion }) => {
+const UpdateBanner = ({ currentVersion, visible = true }) => {
   const [updateInfo, setUpdateInfo] = useState(null);
   const updateNotifiedRef = useRef(null);
   const dismissedUpdateRef = useRef(null);
@@ -26,6 +26,10 @@ const UpdateBanner = ({ currentVersion }) => {
   );
 
   useEffect(() => {
+    if (!visible) {
+      setUpdateInfo(null);
+      return;
+    }
     const currentVersion = resolvedVersion;
     const formatSha = (value) => (value ? value.slice(0, 7) : "");
     const isSha = (value) => /^[0-9a-f]{7,40}$/i.test(value || "");
@@ -122,7 +126,7 @@ const UpdateBanner = ({ currentVersion }) => {
       active = false;
       clearInterval(intervalId);
     };
-  }, [checkMetaKey, dismissKey, releaseChannel, repo, resolvedVersion]);
+  }, [checkMetaKey, dismissKey, releaseChannel, repo, resolvedVersion, visible]);
 
   const dismissUpdate = () => {
     if (!updateInfo?.latestKey) {

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -11,6 +11,21 @@ import {
 } from "../utils/api";
 
 const AuthContext = createContext(null);
+const AUTH_RECOVERY_RELOAD_KEY = "aurral:auth-recovery-reload";
+
+const resetClientCache = async () => {
+  const registrations = globalThis?.navigator?.serviceWorker
+    ? await globalThis.navigator.serviceWorker.getRegistrations()
+    : [];
+  const cacheKeys = globalThis?.caches ? await globalThis.caches.keys() : [];
+
+  await Promise.allSettled(registrations.map((registration) => registration.unregister()));
+  await Promise.allSettled(
+    cacheKeys.map((cacheKey) => globalThis.caches.delete(cacheKey)),
+  );
+
+  return registrations.length > 0 || cacheKeys.length > 0;
+};
 
 export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -81,6 +96,7 @@ export const AuthProvider = ({ children }) => {
       setUser(null);
       setIsAuthenticated(false);
     } finally {
+      globalThis?.sessionStorage?.removeItem(AUTH_RECOVERY_RELOAD_KEY);
       setIsLoading(false);
     }
   };
@@ -90,22 +106,42 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   useEffect(() => {
-    const handleInvalidAuth = () => {
+    let cancelled = false;
+
+    const handleInvalidAuth = async () => {
       setIsAuthenticated(false);
       setUser(null);
-      setIsLoading(false);
+      setIsLoading(true);
+
+      const hadClientCache = await resetClientCache();
+      if (cancelled) return;
+
+      const hasReloaded =
+        globalThis?.sessionStorage?.getItem(AUTH_RECOVERY_RELOAD_KEY) === "1";
+
+      if (hadClientCache && !hasReloaded && typeof window !== "undefined") {
+        globalThis.sessionStorage?.setItem(AUTH_RECOVERY_RELOAD_KEY, "1");
+        window.location.reload();
+        return;
+      }
+
+      globalThis?.sessionStorage?.removeItem(AUTH_RECOVERY_RELOAD_KEY);
+      await checkAuthStatus();
     };
+
     window.addEventListener(AUTH_INVALID_EVENT, handleInvalidAuth);
     return () => {
+      cancelled = true;
       window.removeEventListener(AUTH_INVALID_EVENT, handleInvalidAuth);
     };
   }, []);
 
-  const login = async (password, username = "admin") => {
-    if (!password) return false;
+  const login = async (password, username) => {
+    const normalizedUsername = String(username || "").trim();
+    if (!normalizedUsername || !password) return false;
 
     try {
-      const result = await loginApi(username, password);
+      const result = await loginApi(normalizedUsername, password);
       if (!result?.token) return false;
       setStoredAuth({ token: result.token });
       setUser(result.user || null);

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Loader, Music, ArrowLeft, X } from "lucide-react";
 import { useToast } from "../../contexts/ToastContext";
+import { useAuth } from "../../contexts/AuthContext";
 import { useArtistDetailsStream } from "./hooks/useArtistDetailsStream";
 import { useReleaseTypeFilter } from "./hooks/useReleaseTypeFilter";
 import { usePreviewPlayer } from "./hooks/usePreviewPlayer";
@@ -30,6 +31,7 @@ function ArtistDetailsPage() {
   const navigate = useNavigate();
   const artistNameFromNav = locationState?.artistName;
   const { showSuccess, showError } = useToast();
+  const { hasPermission } = useAuth();
   const similarArtistsScrollRef = useRef(null);
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const [showEditIdsModal, setShowEditIdsModal] = useState(false);
@@ -42,6 +44,12 @@ function ArtistDetailsPage() {
   });
 
   const stream = useArtistDetailsStream(mbid, artistNameFromNav);
+  const canAddArtist = hasPermission("addArtist");
+  const canAddAlbum = hasPermission("addAlbum");
+  const canChangeMonitoring = hasPermission("changeMonitoring");
+  const canDeleteArtist = hasPermission("deleteArtist");
+  const canDeleteAlbum = hasPermission("deleteAlbum");
+  const canBulkAddAlbums = canAddAlbum && canChangeMonitoring;
   const {
     artist,
     coverImages,
@@ -243,11 +251,15 @@ function ArtistDetailsPage() {
         showMonitorOptionMenu={library.showMonitorOptionMenu}
         setShowMonitorOptionMenu={library.setShowMonitorOptionMenu}
         updatingMonitor={library.updatingMonitor}
+        canChangeMonitoring={canChangeMonitoring}
         getCurrentMonitorOption={library.getCurrentMonitorOption}
         handleUpdateMonitorOption={library.handleUpdateMonitorOption}
+        canDeleteArtist={canDeleteArtist}
         handleDeleteClick={library.handleDeleteClick}
+        canAddArtist={canAddArtist}
         handleAddToLibrary={library.handleAddToLibrary}
         addingToLibrary={library.addingToLibrary}
+        canRefreshArtist={canChangeMonitoring}
         handleRefreshArtist={library.handleRefreshArtist}
         refreshingArtist={library.refreshingArtist}
         onNavigate={(path) => navigate(path)}
@@ -277,7 +289,9 @@ function ArtistDetailsPage() {
           albumDropdownOpen={library.albumDropdownOpen}
           setAlbumDropdownOpen={library.setAlbumDropdownOpen}
           handleLibraryAlbumClick={library.handleLibraryAlbumClick}
+          canDeleteAlbum={canDeleteAlbum}
           handleDeleteAlbumClick={library.handleDeleteAlbumClick}
+          canReSearchAlbum={canAddAlbum}
           handleReSearchAlbum={library.handleReSearchAlbum}
         />
       )}
@@ -292,6 +306,7 @@ function ArtistDetailsPage() {
           showFilterDropdown={showFilterDropdown}
           setShowFilterDropdown={setShowFilterDropdown}
           existsInLibrary={existsInLibrary}
+          canBulkAddAlbums={canBulkAddAlbums}
           handleMonitorAll={library.handleMonitorAll}
           processingBulk={library.processingBulk}
           albumCovers={albumCovers}
@@ -302,10 +317,13 @@ function ArtistDetailsPage() {
           albumDropdownOpen={library.albumDropdownOpen}
           setAlbumDropdownOpen={library.setAlbumDropdownOpen}
           handleReleaseGroupAlbumClick={library.handleReleaseGroupAlbumClick}
+          canAddAlbum={canAddAlbum}
           handleRequestAlbum={library.handleRequestAlbum}
+          canDeleteAlbum={canDeleteAlbum}
           handleDeleteAlbumClick={library.handleDeleteAlbumClick}
           requestingAlbum={library.requestingAlbum}
           reSearchingAlbum={library.reSearchingAlbum}
+          canReSearchAlbum={canAddAlbum}
           handleReSearchAlbum={library.handleReSearchAlbum}
           previewVolume={previewVolume}
           setPreviewVolume={setPreviewVolume}

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -32,11 +32,15 @@ export function ArtistDetailsHero({
   showMonitorOptionMenu,
   setShowMonitorOptionMenu,
   updatingMonitor,
+  canChangeMonitoring,
   getCurrentMonitorOption,
   handleUpdateMonitorOption,
+  canDeleteArtist,
   handleDeleteClick,
+  canAddArtist,
   handleAddToLibrary,
   addingToLibrary,
+  canRefreshArtist,
   handleRefreshArtist,
   refreshingArtist,
   onNavigate,
@@ -103,7 +107,7 @@ export function ArtistDetailsHero({
             <h1 className="text-4xl font-bold mb-2" style={{ color: "#fff" }}>
               {artist.name}
             </h1>
-            {existsInLibrary && (
+            {existsInLibrary && canRefreshArtist && (
               <button
                 onClick={handleRefreshArtist}
                 disabled={refreshingArtist}
@@ -199,108 +203,125 @@ export function ArtistDetailsHero({
             ) : existsInLibrary ? (
               <>
                 <div className="relative inline-flex">
-                  <button
-                    type="button"
-                    onClick={() => setShowRemoveDropdown(!showRemoveDropdown)}
-                    className="btn btn-success inline-flex items-center"
-                  >
-                    <CheckCircle className="w-5 h-5 mr-2" />
-                    In Your Library
-                    <ChevronDown
-                      className={`w-4 h-4 ml-2 transition-transform ${
-                        showRemoveDropdown ? "rotate-180" : ""
-                      }`}
-                    />
-                  </button>
-                  {showRemoveDropdown && (
+                  {canChangeMonitoring || canDeleteArtist ? (
                     <>
-                      <div
-                        className="fixed inset-0 z-10"
-                        onClick={() => setShowRemoveDropdown(false)}
-                      />
-                      <div
-                        className="absolute right-0 top-full w-56 z-20 py-1 rounded shadow-lg border border-white/10"
-                        style={{ backgroundColor: "#2a2830" }}
-                        onClick={(e) => e.stopPropagation()}
+                      <button
+                        type="button"
+                        onClick={() => setShowRemoveDropdown(!showRemoveDropdown)}
+                        className="btn btn-success inline-flex items-center"
                       >
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setShowMonitorOptionMenu(!showMonitorOptionMenu);
-                          }}
-                          disabled={updatingMonitor}
-                          className="w-full text-left px-4 py-2 text-sm  hover:bg-gray-900/50 transition-colors flex items-center justify-between"
-                          style={{ color: "#fff" }}
-                        >
-                          <span>Change Monitor Option</span>
-                          <ChevronDown
-                            className={`w-4 h-4 transition-transform ${
-                              showMonitorOptionMenu ? "rotate-180" : ""
-                            }`}
+                        <CheckCircle className="w-5 h-5 mr-2" />
+                        In Your Library
+                        <ChevronDown
+                          className={`w-4 h-4 ml-2 transition-transform ${
+                            showRemoveDropdown ? "rotate-180" : ""
+                          }`}
+                        />
+                      </button>
+                      {showRemoveDropdown && (
+                        <>
+                          <div
+                            className="fixed inset-0 z-10"
+                            onClick={() => setShowRemoveDropdown(false)}
                           />
-                        </button>
-
-                        {showMonitorOptionMenu && (
-                          <>
-                            <div className="my-1" />
-                            {[
-                              { value: "none", label: "None (Artist Only)" },
-                              { value: "all", label: "All Albums" },
-                              { value: "future", label: "Future Albums" },
-                              { value: "missing", label: "Missing Albums" },
-                              { value: "latest", label: "Latest Album" },
-                              { value: "first", label: "First Album" },
-                            ].map((option) => (
+                          <div
+                            className="absolute right-0 top-full w-56 z-20 py-1 rounded shadow-lg border border-white/10"
+                            style={{ backgroundColor: "#2a2830" }}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {canChangeMonitoring && (
                               <button
-                                key={option.value}
                                 type="button"
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  handleUpdateMonitorOption(option.value);
-                                  setShowMonitorOptionMenu(false);
-                                  setShowRemoveDropdown(false);
+                                  setShowMonitorOptionMenu(!showMonitorOptionMenu);
                                 }}
                                 disabled={updatingMonitor}
-                                className="w-full text-left px-4 py-2 text-sm hover:bg-gray-900/50 transition-colors"
-                                style={
-                                  getCurrentMonitorOption() === option.value
-                                    ? {
-                                        backgroundColor: "#211f27",
-                                        color: "#fff",
-                                        fontWeight: "500",
-                                      }
-                                    : { color: "#fff" }
-                                }
+                                className="w-full text-left px-4 py-2 text-sm  hover:bg-gray-900/50 transition-colors flex items-center justify-between"
+                                style={{ color: "#fff" }}
                               >
-                                {option.label}
+                                <span>Change Monitor Option</span>
+                                <ChevronDown
+                                  className={`w-4 h-4 transition-transform ${
+                                    showMonitorOptionMenu ? "rotate-180" : ""
+                                  }`}
+                                />
                               </button>
-                            ))}
-                          </>
-                        )}
+                            )}
 
-                        <div className=" my-1" />
-                        <button
-                          type="button"
-                          onClick={() => {
-                            handleDeleteClick();
-                            setShowRemoveDropdown(false);
-                          }}
-                          className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
-                        >
-                          <Trash2 className="w-4 h-4 mr-2" />
-                          Remove from Library
-                        </button>
-                      </div>
+                            {canChangeMonitoring && showMonitorOptionMenu && (
+                              <>
+                                <div className="my-1" />
+                                {[
+                                  { value: "none", label: "None (Artist Only)" },
+                                  { value: "all", label: "All Albums" },
+                                  { value: "future", label: "Future Albums" },
+                                  { value: "missing", label: "Missing Albums" },
+                                  { value: "latest", label: "Latest Album" },
+                                  { value: "first", label: "First Album" },
+                                ].map((option) => (
+                                  <button
+                                    key={option.value}
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleUpdateMonitorOption(option.value);
+                                      setShowMonitorOptionMenu(false);
+                                      setShowRemoveDropdown(false);
+                                    }}
+                                    disabled={updatingMonitor}
+                                    className="w-full text-left px-4 py-2 text-sm hover:bg-gray-900/50 transition-colors"
+                                    style={
+                                      getCurrentMonitorOption() === option.value
+                                        ? {
+                                            backgroundColor: "#211f27",
+                                            color: "#fff",
+                                            fontWeight: "500",
+                                          }
+                                        : { color: "#fff" }
+                                    }
+                                  >
+                                    {option.label}
+                                  </button>
+                                ))}
+                              </>
+                            )}
+
+                            {canDeleteArtist && (
+                              <>
+                                <div className=" my-1" />
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    handleDeleteClick();
+                                    setShowRemoveDropdown(false);
+                                  }}
+                                  className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
+                                >
+                                  <Trash2 className="w-4 h-4 mr-2" />
+                                  Remove from Library
+                                </button>
+                              </>
+                            )}
+                          </div>
+                        </>
+                      )}
                     </>
+                  ) : (
+                    <div className="btn btn-success inline-flex items-center cursor-default">
+                      <CheckCircle className="w-5 h-5 mr-2" />
+                      In Your Library
+                    </div>
                   )}
                 </div>
               </>
             ) : (
-              <AddToLibraryButton
-                onClick={handleAddToLibrary}
-                isLoading={addingToLibrary}
-              />
+              canAddArtist && (
+                <AddToLibraryButton
+                  onClick={handleAddToLibrary}
+                  isLoading={addingToLibrary}
+                />
+              )
             )}
 
             <button
@@ -583,11 +604,15 @@ ArtistDetailsHero.propTypes = {
   showMonitorOptionMenu: PropTypes.bool,
   setShowMonitorOptionMenu: PropTypes.func,
   updatingMonitor: PropTypes.bool,
+  canChangeMonitoring: PropTypes.bool,
   getCurrentMonitorOption: PropTypes.func,
   handleUpdateMonitorOption: PropTypes.func,
+  canDeleteArtist: PropTypes.bool,
   handleDeleteClick: PropTypes.func,
+  canAddArtist: PropTypes.bool,
   handleAddToLibrary: PropTypes.func,
   addingToLibrary: PropTypes.bool,
+  canRefreshArtist: PropTypes.bool,
   handleRefreshArtist: PropTypes.func,
   refreshingArtist: PropTypes.bool,
   onNavigate: PropTypes.func,

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -29,7 +29,9 @@ export function ArtistDetailsLibraryAlbums({
   albumDropdownOpen,
   setAlbumDropdownOpen,
   handleLibraryAlbumClick,
+  canDeleteAlbum,
   handleDeleteAlbumClick,
+  canReSearchAlbum,
   handleReSearchAlbum,
 }) {
   const [sortMode, setSortMode] = useState("date");
@@ -399,7 +401,7 @@ export function ArtistDetailsLibraryAlbums({
                               <ExternalLink className="w-4 h-4 mr-2" />
                               View on Last.fm
                             </a>
-                            {canReSearch && (
+                            {canReSearch && canReSearchAlbum && (
                               <>
                                 <div className="my-1 border-t border-white/10" />
                                 <button
@@ -427,21 +429,25 @@ export function ArtistDetailsLibraryAlbums({
                                 </button>
                               </>
                             )}
-                            <div className="my-1 border-t border-white/10" />
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteAlbumClick(
-                                  rgId,
-                                  libraryAlbum.albumName
-                                );
-                              }}
-                              className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
-                            >
-                              <Trash2 className="w-4 h-4 mr-2" />
-                              Delete Album
-                            </button>
+                            {canDeleteAlbum && (
+                              <>
+                                <div className="my-1 border-t border-white/10" />
+                                <button
+                                  type="button"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleDeleteAlbumClick(
+                                      rgId,
+                                      libraryAlbum.albumName
+                                    );
+                                  }}
+                                  className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
+                                >
+                                  <Trash2 className="w-4 h-4 mr-2" />
+                                  Delete Album
+                                </button>
+                              </>
+                            )}
                           </div>
                         </>
                       )}
@@ -654,7 +660,9 @@ ArtistDetailsLibraryAlbums.propTypes = {
   albumDropdownOpen: PropTypes.string,
   setAlbumDropdownOpen: PropTypes.func,
   handleLibraryAlbumClick: PropTypes.func,
+  canDeleteAlbum: PropTypes.bool,
   handleDeleteAlbumClick: PropTypes.func,
+  canReSearchAlbum: PropTypes.bool,
   handleReSearchAlbum: PropTypes.func,
   reSearchingAlbum: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -36,6 +36,7 @@ export function ArtistDetailsReleaseGroups({
   showFilterDropdown,
   setShowFilterDropdown,
   existsInLibrary,
+  canBulkAddAlbums,
   handleMonitorAll,
   processingBulk,
   albumCovers,
@@ -46,10 +47,13 @@ export function ArtistDetailsReleaseGroups({
   albumDropdownOpen,
   setAlbumDropdownOpen,
   handleReleaseGroupAlbumClick,
+  canAddAlbum,
   handleRequestAlbum,
+  canDeleteAlbum,
   handleDeleteAlbumClick,
   requestingAlbum,
   reSearchingAlbum,
+  canReSearchAlbum,
   handleReSearchAlbum,
   previewVolume,
   setPreviewVolume,
@@ -367,7 +371,7 @@ export function ArtistDetailsReleaseGroups({
             )}
           </div>
 
-          {existsInLibrary && (
+          {existsInLibrary && canBulkAddAlbums && (
             <button
               onClick={handleMonitorAll}
               disabled={processingBulk}
@@ -448,7 +452,7 @@ export function ArtistDetailsReleaseGroups({
                     <ExternalLink className="w-4 h-4 mr-2" />
                     View on Last.fm
                   </a>
-                  {canReSearch && (
+                  {canReSearch && canReSearchAlbum && (
                     <>
                       <div className="my-1 border-t border-white/10" />
                       <button
@@ -476,21 +480,25 @@ export function ArtistDetailsReleaseGroups({
                       </button>
                     </>
                   )}
-                  <div className="my-1 border-t border-white/10" />
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeleteAlbumClick(
-                        releaseGroup.id,
-                        releaseGroup.title
-                      );
-                    }}
-                    className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
-                  >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Delete Album
-                  </button>
+                  {canDeleteAlbum && (
+                    <>
+                      <div className="my-1 border-t border-white/10" />
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteAlbumClick(
+                            releaseGroup.id,
+                            releaseGroup.title
+                          );
+                        }}
+                        className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors flex items-center"
+                      >
+                        <Trash2 className="w-4 h-4 mr-2" />
+                        Delete Album
+                      </button>
+                    </>
+                  )}
                 </div>
               </>
             );
@@ -776,6 +784,26 @@ export function ArtistDetailsReleaseGroups({
                           </div>
                         </>
                       ) : (
+                        canAddAlbum ? (
+                          <AddAlbumButton
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleRequestAlbum(
+                                releaseGroup.id,
+                                releaseGroup.title
+                              );
+                            }}
+                            isLoading={requestingAlbum === releaseGroup.id}
+                            disabled={requestingAlbum === releaseGroup.id}
+                            style={{
+                              backgroundColor: itemBg,
+                              borderColor: itemBg,
+                            }}
+                          />
+                        ) : null
+                      )
+                    ) : (
+                      canAddAlbum ? (
                         <AddAlbumButton
                           onClick={(e) => {
                             e.stopPropagation();
@@ -791,23 +819,7 @@ export function ArtistDetailsReleaseGroups({
                             borderColor: itemBg,
                           }}
                         />
-                      )
-                    ) : (
-                      <AddAlbumButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRequestAlbum(
-                            releaseGroup.id,
-                            releaseGroup.title
-                          );
-                        }}
-                        isLoading={requestingAlbum === releaseGroup.id}
-                        disabled={requestingAlbum === releaseGroup.id}
-                        style={{
-                          backgroundColor: itemBg,
-                          borderColor: itemBg,
-                        }}
-                      />
+                      ) : null
                     )}
                   </div>
                 </div>
@@ -962,6 +974,7 @@ ArtistDetailsReleaseGroups.propTypes = {
   showFilterDropdown: PropTypes.bool,
   setShowFilterDropdown: PropTypes.func,
   existsInLibrary: PropTypes.bool,
+  canBulkAddAlbums: PropTypes.bool,
   handleMonitorAll: PropTypes.func,
   processingBulk: PropTypes.bool,
   albumCovers: PropTypes.object,
@@ -972,10 +985,13 @@ ArtistDetailsReleaseGroups.propTypes = {
   albumDropdownOpen: PropTypes.string,
   setAlbumDropdownOpen: PropTypes.func,
   handleReleaseGroupAlbumClick: PropTypes.func,
+  canAddAlbum: PropTypes.bool,
   handleRequestAlbum: PropTypes.func,
+  canDeleteAlbum: PropTypes.bool,
   handleDeleteAlbumClick: PropTypes.func,
   requestingAlbum: PropTypes.string,
   reSearchingAlbum: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  canReSearchAlbum: PropTypes.bool,
   handleReSearchAlbum: PropTypes.func,
   previewVolume: PropTypes.number,
   setPreviewVolume: PropTypes.func,

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -3,7 +3,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { Lock } from "lucide-react";
 
 const Login = () => {
-  const [username, setUsername] = useState("admin");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const { login } = useAuth();
@@ -54,6 +54,7 @@ const Login = () => {
                 name="username"
                 type="text"
                 required
+                autoComplete="username"
                 className="appearance-none relative block w-full px-3 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:z-10 sm:text-sm"
                 style={{
                   focusRingColor: "#c1c1c3",
@@ -74,6 +75,7 @@ const Login = () => {
                 name="password"
                 type="password"
                 required
+                autoComplete="current-password"
                 className="appearance-none relative block w-full px-3 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:z-10 sm:text-sm"
                 style={{
                   focusRingColor: "#c1c1c3",

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -1,6 +1,6 @@
 import { UserPlus, Lock, Pencil, Trash2, X } from "lucide-react";
 import { GRANULAR_PERMISSIONS, granularPerms } from "../constants";
-import { getStoredAuth, setStoredAuth } from "../../../utils/api";
+import { loginApi, setStoredAuth } from "../../../utils/api";
 
 export function SettingsUsersTab({
   authUser,
@@ -97,6 +97,10 @@ export function SettingsUsersTab({
               setChangingPassword(true);
               try {
                 await changeMyPassword(changePwCurrent, changePwNew);
+                const result = await loginApi(authUser?.username, changePwNew);
+                if (result?.token) {
+                  setStoredAuth({ token: result.token });
+                }
                 showSuccess("Password changed");
                 setChangePwCurrent("");
                 setChangePwNew("");
@@ -522,8 +526,10 @@ export function SettingsUsersTab({
                           currentPassword: editCurrentPassword,
                           password: editPassword,
                         });
-                        const { username } = getStoredAuth();
-                        setStoredAuth({ username, password: editPassword });
+                        const result = await loginApi(authUser?.username, editPassword);
+                        if (result?.token) {
+                          setStoredAuth({ token: result.token });
+                        }
                         showSuccess("Password changed");
                         setEditUser(null);
                       } catch (err) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -42,27 +42,24 @@ function readAuthFromStorage(storage) {
 }
 
 export const getStoredAuth = () => {
-  const sessionAuth = readAuthFromStorage(globalThis?.sessionStorage);
-  if (sessionAuth.token) return sessionAuth;
   const localAuth = readAuthFromStorage(globalThis?.localStorage);
-  if (localAuth.token && globalThis?.sessionStorage) {
-    globalThis.sessionStorage.setItem(AUTH_TOKEN_KEY, localAuth.token);
-    globalThis.localStorage?.removeItem(AUTH_TOKEN_KEY);
-    globalThis.localStorage?.removeItem(AUTH_USER_KEY);
-    globalThis.localStorage?.removeItem(AUTH_PASSWORD_KEY);
-    return localAuth;
+  if (localAuth.token) return localAuth;
+  const sessionAuth = readAuthFromStorage(globalThis?.sessionStorage);
+  if (sessionAuth.token && globalThis?.localStorage) {
+    globalThis.localStorage.setItem(AUTH_TOKEN_KEY, sessionAuth.token);
+    return sessionAuth;
   }
   return sessionAuth;
 };
 
 export const setStoredAuth = ({ token = "" } = {}) => {
-  if (!globalThis?.sessionStorage) return;
   if (!token) {
-    globalThis.sessionStorage.removeItem(AUTH_TOKEN_KEY);
+    globalThis?.sessionStorage?.removeItem(AUTH_TOKEN_KEY);
+    globalThis?.localStorage?.removeItem(AUTH_TOKEN_KEY);
     return;
   }
-  globalThis.sessionStorage.setItem(AUTH_TOKEN_KEY, token);
-  globalThis.localStorage?.removeItem(AUTH_TOKEN_KEY);
+  globalThis?.sessionStorage?.setItem(AUTH_TOKEN_KEY, token);
+  globalThis?.localStorage?.setItem(AUTH_TOKEN_KEY, token);
   globalThis.localStorage?.removeItem(AUTH_PASSWORD_KEY);
   globalThis.localStorage?.removeItem(AUTH_USER_KEY);
 };
@@ -269,11 +266,9 @@ export const buildStreamUrl = async (path) => {
 
 export const getFlowTrackStreamUrl = (jobId) => {
   const base = import.meta.env.VITE_API_URL || getDefaultApiBaseUrl();
-  const password = localStorage.getItem("auth_password");
-  const username = localStorage.getItem("auth_user") || "admin";
+  const { token } = getStoredAuth();
   let url = `${base}/weekly-flow/stream/${encodeURIComponent(jobId)}`;
-  if (password) {
-    const token = btoa(`${username}:${password}`);
+  if (token) {
     url += `?token=${encodeURIComponent(token)}`;
   }
   return url;
@@ -513,7 +508,7 @@ export const searchArtistsByTag = async (
   return response.data;
 };
 
-export const verifyCredentials = async (password, username = "admin") => {
+export const verifyCredentials = async (password, username) => {
   try {
     const result = await loginApi(username, password);
     return !!result?.token;


### PR DESCRIPTION
- Remove permission check for Settings sidebar item to always show it
- Conditionally show UpdateBanner only for admin users
- Clear username field default and add autocomplete attributes in Login
- Automatically re-login after password change in user settings
- Persist auth token in localStorage for better session recovery
- Add client cache reset and page reload on auth invalidation
- Implement granular permission checks for artist/album operations