### PR TITLE
chore(deps): update axios and qs dependencies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.9",
+        "axios": "^1.15.0",
         "bcrypt": "^5.1.1",
         "better-sqlite3": "^12.6.2",
         "bottleneck": "^2.19.5",
@@ -216,14 +216,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1936,10 +1936,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "^1.15.0",
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^12.6.2",
     "bottleneck": "^2.19.5",

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -1,6 +1,7 @@
 import { libraryManager } from "../../../services/libraryManager.js";
 import { playlistManager } from "../../../services/weeklyFlowPlaylistManager.js";
 import { dbOps } from "../../../config/db-helpers.js";
+import { hasPermission } from "../../../middleware/auth.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import {
   requireAuth,
@@ -119,21 +120,32 @@ export default function registerAlbums(router) {
   router.put(
     "/albums/:id",
     requireAuth,
-    requirePermission("changeMonitoring"),
-    async (req, res) => {
-    try {
-      const { id } = req.params;
-      const album = await libraryManager.updateAlbum(id, req.body);
-      if (album?.error) {
-        return res.status(503).json({ error: album.error });
+    (req, res, next) => {
+      if (
+        hasPermission(req.user, "changeMonitoring") ||
+        hasPermission(req.user, "addAlbum")
+      ) {
+        return next();
       }
-      res.json(album);
-    } catch (error) {
-      res.status(500).json({
-        error: "Failed to update album",
-        message: error.message,
+      return res.status(403).json({
+        error: "Forbidden",
+        message: "Permission required: changeMonitoring or addAlbum",
       });
-    }
+    },
+    async (req, res) => {
+      try {
+        const { id } = req.params;
+        const album = await libraryManager.updateAlbum(id, req.body);
+        if (album?.error) {
+          return res.status(503).json({ error: album.error });
+        }
+        res.json(album);
+      } catch (error) {
+        res.status(500).json({
+          error: "Failed to update album",
+          message: error.message,
+        });
+      }
     },
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aurral",
-  "version": "1.42.2",
+  "version": "1.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aurral",
-      "version": "1.42.2",
+      "version": "1.44.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",
@@ -6922,9 +6922,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
Update axios from ^1.7.9 to ^1.15.0 and qs from 6.14.1 to 6.14.2 to benefit from security patches and bug fixes. Also bump project version to 1.44.0.

Additionally, modify album update endpoint to allow users with either changeMonitoring or addAlbum permissions, enhancing access control flexibility.

closes #234 and #235 