### PR TITLE
feat: support last.fm per user

### DIFF
--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -386,23 +386,26 @@ export const dbOps = {
     updateFn();
   },
 
-  getDiscoveryCache() {
+  getDiscoveryCache(userId = null) {
+    const prefix = userId ? `user:${userId}:` : "";
     const recommendations = dbHelpers.parseJSON(
-      getDiscoveryCacheStmt.get("recommendations")?.value
+      getDiscoveryCacheStmt.get(`${prefix}recommendations`)?.value
     );
     const globalTop = dbHelpers.parseJSON(
-      getDiscoveryCacheStmt.get("globalTop")?.value
+      getDiscoveryCacheStmt.get(`${prefix}globalTop`)?.value
     );
     const basedOn = dbHelpers.parseJSON(
-      getDiscoveryCacheStmt.get("basedOn")?.value
+      getDiscoveryCacheStmt.get(`${prefix}basedOn`)?.value
     );
     const topTags = dbHelpers.parseJSON(
-      getDiscoveryCacheStmt.get("topTags")?.value
+      getDiscoveryCacheStmt.get(`${prefix}topTags`)?.value
     );
     const topGenres = dbHelpers.parseJSON(
-      getDiscoveryCacheStmt.get("topGenres")?.value
+      getDiscoveryCacheStmt.get(`${prefix}topGenres`)?.value
     );
-    const lastUpdated = getDiscoveryCacheLastUpdatedStmt.get()?.last_updated;
+    const lastUpdated = userId
+      ? getDiscoveryCacheStmt.get(`${prefix}lastUpdated`)?.value || null
+      : getDiscoveryCacheLastUpdatedStmt.get()?.last_updated;
 
     return {
       recommendations: recommendations || [],
@@ -414,41 +417,49 @@ export const dbOps = {
     };
   },
 
-  updateDiscoveryCache(discovery) {
+  updateDiscoveryCache(discovery, userId = null) {
     const now = new Date().toISOString();
+    const prefix = userId ? `user:${userId}:` : "";
     const updateFn = db.transaction(() => {
       if (discovery.recommendations) {
         upsertDiscoveryCacheStmt.run(
-          "recommendations",
+          `${prefix}recommendations`,
           dbHelpers.stringifyJSON(discovery.recommendations),
           now
         );
       }
       if (discovery.globalTop) {
         upsertDiscoveryCacheStmt.run(
-          "globalTop",
+          `${prefix}globalTop`,
           dbHelpers.stringifyJSON(discovery.globalTop),
           now
         );
       }
       if (discovery.basedOn) {
         upsertDiscoveryCacheStmt.run(
-          "basedOn",
+          `${prefix}basedOn`,
           dbHelpers.stringifyJSON(discovery.basedOn),
           now
         );
       }
       if (discovery.topTags) {
         upsertDiscoveryCacheStmt.run(
-          "topTags",
+          `${prefix}topTags`,
           dbHelpers.stringifyJSON(discovery.topTags),
           now
         );
       }
       if (discovery.topGenres) {
         upsertDiscoveryCacheStmt.run(
-          "topGenres",
+          `${prefix}topGenres`,
           dbHelpers.stringifyJSON(discovery.topGenres),
+          now
+        );
+      }
+      if (userId) {
+        upsertDiscoveryCacheStmt.run(
+          `${prefix}lastUpdated`,
+          now,
           now
         );
       }

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -386,8 +386,8 @@ export const dbOps = {
     updateFn();
   },
 
-  getDiscoveryCache(userId = null) {
-    const prefix = userId ? `user:${userId}:` : "";
+  getDiscoveryCache(lastfmUsername = null) {
+    const prefix = lastfmUsername ? `lfm:${lastfmUsername}:` : "";
     const recommendations = dbHelpers.parseJSON(
       getDiscoveryCacheStmt.get(`${prefix}recommendations`)?.value
     );
@@ -403,7 +403,7 @@ export const dbOps = {
     const topGenres = dbHelpers.parseJSON(
       getDiscoveryCacheStmt.get(`${prefix}topGenres`)?.value
     );
-    const lastUpdated = userId
+    const lastUpdated = lastfmUsername
       ? getDiscoveryCacheStmt.get(`${prefix}lastUpdated`)?.value || null
       : getDiscoveryCacheLastUpdatedStmt.get()?.last_updated;
 
@@ -417,9 +417,9 @@ export const dbOps = {
     };
   },
 
-  updateDiscoveryCache(discovery, userId = null) {
+  updateDiscoveryCache(discovery, lastfmUsername = null) {
     const now = new Date().toISOString();
-    const prefix = userId ? `user:${userId}:` : "";
+    const prefix = lastfmUsername ? `lfm:${lastfmUsername}:` : "";
     const updateFn = db.transaction(() => {
       if (discovery.recommendations) {
         upsertDiscoveryCacheStmt.run(
@@ -456,7 +456,7 @@ export const dbOps = {
           now
         );
       }
-      if (userId) {
+      if (lastfmUsername) {
         upsertDiscoveryCacheStmt.run(
           `${prefix}lastUpdated`,
           now,

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -467,6 +467,12 @@ export const dbOps = {
     updateFn();
   },
 
+  deleteDiscoveryCacheByPrefix(prefix) {
+    return db.prepare("DELETE FROM discovery_cache WHERE key LIKE ?").run(
+      `${prefix}%`
+    );
+  },
+
   getImage(mbid) {
     const row = getImageStmt.get(mbid);
     if (!row) return null;

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -62,16 +62,19 @@ const getUserByUsernameStmt = db.prepare(
   "SELECT * FROM users WHERE username = ?"
 );
 const getAllUsersStmt = db.prepare(
-  "SELECT id, username, role, permissions FROM users ORDER BY username"
+  "SELECT id, username, role, permissions, lastfm_username FROM users ORDER BY username"
 );
 const getUserByIdStmt = db.prepare("SELECT * FROM users WHERE id = ?");
 const insertUserStmt = db.prepare(
   "INSERT INTO users (username, password_hash, role, permissions) VALUES (?, ?, ?, ?)"
 );
 const updateUserStmt = db.prepare(
-  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ? WHERE id = ?"
+  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ? WHERE id = ?"
 );
 const deleteUserStmt = db.prepare("DELETE FROM users WHERE id = ?");
+const getAllLastfmUsersStmt = db.prepare(
+  "SELECT id, username, lastfm_username FROM users WHERE lastfm_username IS NOT NULL AND lastfm_username != ''"
+);
 
 const DEFAULT_PERMISSIONS = {
   addArtist: true,
@@ -98,6 +101,7 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(row.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lastfmUsername: row.lastfm_username || null,
     };
   },
   getUserById(id) {
@@ -111,6 +115,7 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(row.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lastfmUsername: row.lastfm_username || null,
     };
   },
   getAllUsers() {
@@ -122,6 +127,7 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(r.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lastfmUsername: r.lastfm_username || null,
     }));
   },
   createUser(username, passwordHash, role = "user", permissions = null) {
@@ -163,15 +169,20 @@ export const userOps = {
       data.permissions !== undefined
         ? { ...DEFAULT_PERMISSIONS, ...data.permissions }
         : existing.permissions;
+    const lastfmUsername =
+      data.lastfmUsername !== undefined
+        ? (data.lastfmUsername ? String(data.lastfmUsername).trim() : null)
+        : existing.lastfmUsername;
     try {
       updateUserStmt.run(
         username.toLowerCase(),
         passwordHash,
         role,
         dbHelpers.stringifyJSON(permissions),
+        lastfmUsername,
         parseInt(id, 10)
       );
-      return { id: parseInt(id, 10), username, role, permissions };
+      return { id: parseInt(id, 10), username, role, permissions, lastfmUsername };
     } catch (e) {
       return null;
     }
@@ -183,6 +194,13 @@ export const userOps = {
     } catch (e) {
       return false;
     }
+  },
+  getAllLastfmUsers() {
+    return getAllLastfmUsersStmt.all().map((r) => ({
+      id: r.id,
+      username: r.username,
+      lastfmUsername: r.lastfm_username,
+    }));
   },
 };
 

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -120,6 +120,15 @@ if (!tableColumns.includes("artist_mbid")) {
   db.exec("ALTER TABLE weekly_flow_jobs ADD COLUMN artist_mbid TEXT");
 }
 
+const userColumns = db
+  .prepare("PRAGMA table_info(users)")
+  .all()
+  .map((column) => column.name);
+
+if (!userColumns.includes("lastfm_username")) {
+  db.exec("ALTER TABLE users ADD COLUMN lastfm_username TEXT");
+}
+
 export const dbHelpers = {
   parseJSON: (text) => {
     if (!text) return null;

--- a/backend/config/encryption.js
+++ b/backend/config/encryption.js
@@ -47,6 +47,7 @@ const SENSITIVE_PATHS = [
   ["lidarr", "apiKey"],
   ["slskd", "apiKey"],
   ["gotify", "token"],
+  ["lastfm", "apiKey"],
 ];
 
 function getAt(obj, path) {

--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -111,7 +111,7 @@ router.get("/", requireAuth, async (req, res) => {
       isUpdating: false,
     });
 
-    res.set("Cache-Control", "public, max-age=300");
+    res.set("Cache-Control", "private, max-age=300");
     return res.json({
       recommendations: [],
       globalTop: [],
@@ -196,11 +196,11 @@ router.get("/", requireAuth, async (req, res) => {
   }
 
   if (recommendations.length > 0 || globalTop.length > 0) {
-    res.set("Cache-Control", "public, max-age=120, stale-while-revalidate=300");
+    res.set("Cache-Control", "private, max-age=120, stale-while-revalidate=300");
   } else if (isUpdating) {
     res.set("Cache-Control", "no-cache, no-store, must-revalidate");
   } else {
-    res.set("Cache-Control", "public, max-age=30, stale-while-revalidate=120");
+    res.set("Cache-Control", "private, max-age=30, stale-while-revalidate=120");
   }
 
   res.json({

--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -2,6 +2,8 @@ import express from "express";
 import {
   getDiscoveryCache,
   updateDiscoveryCache,
+  updateUserDiscoveryCache,
+  getUserDiscoveryCacheStaleness,
 } from "../services/discoveryService.js";
 import {
   lastfmRequest,
@@ -10,7 +12,7 @@ import {
   clearApiCaches,
 } from "../services/apiClients.js";
 import { libraryManager } from "../services/libraryManager.js";
-import { dbOps } from "../config/db-helpers.js";
+import { dbOps, userOps } from "../config/db-helpers.js";
 import { imagePrefetchService } from "../services/imagePrefetchService.js";
 import { defaultDiscoveryPreferences } from "../config/constants.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
@@ -74,11 +76,11 @@ router.post("/clear-discovery", requireAuth, requireAdmin, async (req, res) => {
 
 router.get("/", requireAuth, async (req, res) => {
   const hasLastfmKey = !!getLastfmApiKey();
-  const settings = dbOps.getSettings();
-  const lastfmUsername = settings.integrations?.lastfm?.username || null;
-  const hasLastfmUser = hasLastfmKey && lastfmUsername;
   const libraryArtists = await libraryManager.getAllArtists();
   const hasArtists = libraryArtists.length > 0;
+
+  const reqUser = userOps.getUserById(req.user.id);
+  const userLastfmUsername = reqUser?.lastfmUsername || null;
 
   if (!hasLastfmKey && !hasArtists) {
     const dbData = dbOps.getDiscoveryCache();
@@ -122,13 +124,21 @@ router.get("/", requireAuth, async (req, res) => {
     });
   }
 
-  const discoveryCache = getDiscoveryCache();
-  const dbData = dbOps.getDiscoveryCache();
+  if (userLastfmUsername && hasLastfmKey) {
+    const staleness = getUserDiscoveryCacheStaleness(userLastfmUsername);
+    if (staleness > DISCOVERY_STALE_MS) {
+      updateUserDiscoveryCache(userLastfmUsername).catch((err) => {
+        console.error(
+          `[Discover] On-demand refresh for ${userLastfmUsername} failed:`,
+          err.message,
+        );
+      });
+    }
+  }
+
+  const discoveryCache = getDiscoveryCache(userLastfmUsername);
 
   const hasData =
-    dbData.recommendations?.length > 0 ||
-    dbData.globalTop?.length > 0 ||
-    dbData.topGenres?.length > 0 ||
     discoveryCache.recommendations?.length > 0 ||
     discoveryCache.globalTop?.length > 0 ||
     discoveryCache.topGenres?.length > 0;
@@ -143,39 +153,8 @@ router.get("/", requireAuth, async (req, res) => {
     isUpdating = true;
   }
 
-  const dbHasData =
-    dbData.recommendations?.length > 0 ||
-    dbData.globalTop?.length > 0 ||
-    dbData.topGenres?.length > 0;
-  const cacheHasData =
-    discoveryCache.recommendations?.length > 0 ||
-    discoveryCache.globalTop?.length > 0 ||
-    discoveryCache.topGenres?.length > 0;
-
-  let recommendations, globalTop, basedOn, topTags, topGenres, lastUpdated;
-
-  if (dbHasData) {
-    recommendations = dbData.recommendations || [];
-    globalTop = dbData.globalTop || [];
-    basedOn = dbData.basedOn || [];
-    topTags = dbData.topTags || [];
-    topGenres = dbData.topGenres || [];
-    lastUpdated = dbData.lastUpdated || null;
-  } else if (cacheHasData) {
-    recommendations = discoveryCache.recommendations || [];
-    globalTop = discoveryCache.globalTop || [];
-    basedOn = discoveryCache.basedOn || [];
-    topTags = discoveryCache.topTags || [];
-    topGenres = discoveryCache.topGenres || [];
-    lastUpdated = discoveryCache.lastUpdated || null;
-  } else {
-    recommendations = [];
-    globalTop = [];
-    basedOn = [];
-    topTags = [];
-    topGenres = [];
-    lastUpdated = null;
-  }
+  let { recommendations, globalTop, basedOn, topTags, topGenres, lastUpdated } =
+    discoveryCache;
 
   const existingArtistIds = new Set(
     libraryArtists
@@ -188,22 +167,6 @@ router.get("/", requireAuth, async (req, res) => {
   );
   globalTop = globalTop.filter((artist) => !existingArtistIds.has(artist.id));
 
-  if (
-    recommendations.length > 0 ||
-    globalTop.length > 0 ||
-    topGenres.length > 0
-  ) {
-    Object.assign(discoveryCache, {
-      recommendations,
-      globalTop,
-      basedOn,
-      topTags,
-      topGenres,
-      lastUpdated,
-      isUpdating: false,
-    });
-  }
-
   const parsedLastUpdated = lastUpdated ? new Date(lastUpdated).getTime() : 0;
   const isStale =
     Number.isFinite(parsedLastUpdated) &&
@@ -213,6 +176,7 @@ router.get("/", requireAuth, async (req, res) => {
   if (
     isStale &&
     !isUpdating &&
+    !userLastfmUsername &&
     Date.now() - lastDiscoveryRevalidateAt > DISCOVERY_REVALIDATE_COOLDOWN_MS
   ) {
     lastDiscoveryRevalidateAt = Date.now();

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,6 +1,6 @@
 import express from "express";
 import bcrypt from "bcrypt";
-import { userOps } from "../config/db-helpers.js";
+import { userOps, dbOps } from "../config/db-helpers.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
 import { requirePasswordStrength } from "../middleware/validation.js";
 import { deleteSessionsByUserId } from "../config/session-helpers.js";
@@ -66,6 +66,18 @@ router.patch("/:id", requireAuth, (req, res) => {
       return res.status(404).json({ error: "User not found" });
     }
     const { password, permissions, role, lastfmUsername } = req.body;
+    if (
+      lastfmUsername !== undefined &&
+      existing.lastfmUsername &&
+      lastfmUsername !== existing.lastfmUsername
+    ) {
+      const otherUsers = userOps.getAllLastfmUsers().filter(
+        (u) => u.lastfmUsername === existing.lastfmUsername && u.id !== id
+      );
+      if (otherUsers.length === 0) {
+        dbOps.deleteDiscoveryCacheByPrefix(`lfm:${existing.lastfmUsername}:`);
+      }
+    }
     if (isSelf && !isAdmin) {
       if (permissions !== undefined || role !== undefined) {
         return res.status(403).json({ error: "Forbidden" });

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -65,28 +65,44 @@ router.patch("/:id", requireAuth, (req, res) => {
     if (!existing) {
       return res.status(404).json({ error: "User not found" });
     }
-    const { password, permissions, role } = req.body;
+    const { password, permissions, role, lastfmUsername } = req.body;
     if (isSelf && !isAdmin) {
       if (permissions !== undefined || role !== undefined) {
         return res.status(403).json({ error: "Forbidden" });
       }
-      const { currentPassword } = req.body;
-      if (!password || !currentPassword) {
-        return res
-          .status(400)
-          .json({ error: "currentPassword and password required" });
+      const updates = {};
+      if (lastfmUsername !== undefined) {
+        updates.lastfmUsername = lastfmUsername;
       }
-      if (!bcrypt.compareSync(currentPassword, existing.passwordHash)) {
-        return res.status(401).json({ error: "Current password is incorrect" });
+      if (password) {
+        const { currentPassword } = req.body;
+        if (!currentPassword) {
+          return res
+            .status(400)
+            .json({ error: "currentPassword required to change password" });
+        }
+        if (!bcrypt.compareSync(currentPassword, existing.passwordHash)) {
+          return res.status(401).json({ error: "Current password is incorrect" });
+        }
+        const passwordValidation = requirePasswordStrength(password);
+        if (!passwordValidation.valid) {
+          return res.status(400).json({ error: passwordValidation.error });
+        }
+        updates.passwordHash = bcrypt.hashSync(password, 10);
       }
-      const passwordValidation = requirePasswordStrength(password);
-      if (!passwordValidation.valid) {
-        return res.status(400).json({ error: passwordValidation.error });
+      if (Object.keys(updates).length === 0) {
+        return res.json({
+          id,
+          username: existing.username,
+          role: existing.role,
+          lastfmUsername: existing.lastfmUsername,
+        });
       }
-      const hash = bcrypt.hashSync(password, 10);
-      userOps.updateUser(id, { passwordHash: hash });
-      deleteSessionsByUserId(id);
-      return res.json({ id, username: existing.username, role: existing.role });
+      const updated = userOps.updateUser(id, updates);
+      if (updates.passwordHash) {
+        deleteSessionsByUserId(id);
+      }
+      return res.json(updated);
     }
     const updates = {};
     if (password) {
@@ -98,12 +114,14 @@ router.patch("/:id", requireAuth, (req, res) => {
     }
     if (permissions !== undefined) updates.permissions = permissions;
     if (role !== undefined) updates.role = role;
+    if (lastfmUsername !== undefined) updates.lastfmUsername = lastfmUsername;
     if (Object.keys(updates).length === 0) {
       return res.json({
         id: existing.id,
         username: existing.username,
         role: existing.role,
         permissions: existing.permissions,
+        lastfmUsername: existing.lastfmUsername,
       });
     }
     const updated = userOps.updateUser(id, updates);
@@ -112,6 +130,18 @@ router.patch("/:id", requireAuth, (req, res) => {
     res
       .status(500)
       .json({ error: "Failed to update user", message: e.message });
+  }
+});
+
+router.get("/me/lastfm", requireAuth, (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.json({ lastfmUsername: user.lastfmUsername });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to get Last.fm settings", message: e.message });
   }
 });
 

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -7,11 +7,7 @@ import {
   musicbrainzGetCachedArtistMbidByName,
 } from "./apiClients.js";
 import { websocketService } from "./websocketService.js";
-
-const getLastfmUsername = () => {
-  const settings = dbOps.getSettings();
-  return settings.integrations?.lastfm?.username || null;
-};
+import {libraryManager} from "./libraryManager.js";
 
 const LASTFM_PERIODS = [
   "none",
@@ -89,7 +85,7 @@ const emitDiscoveryProgress = (
   });
 };
 
-let discoveryCache = {
+const EMPTY_CACHE = {
   recommendations: [],
   globalTop: [],
   basedOn: [],
@@ -98,6 +94,8 @@ let discoveryCache = {
   lastUpdated: null,
   isUpdating: false,
 };
+
+let discoveryCache = { ...EMPTY_CACHE };
 
 const dbData = dbOps.getDiscoveryCache();
 if (
@@ -116,7 +114,25 @@ if (
   };
 }
 
-export const getDiscoveryCache = () => {
+export const getDiscoveryCache = (lastfmUsername = null) => {
+  if (lastfmUsername) {
+    const userDbData = dbOps.getDiscoveryCache(lastfmUsername);
+    const hasUserData =
+      userDbData.recommendations?.length > 0 ||
+      userDbData.basedOn?.length > 0;
+    if (hasUserData) {
+      return {
+        recommendations: userDbData.recommendations || [],
+        globalTop: discoveryCache.globalTop || [],
+        basedOn: userDbData.basedOn || [],
+        topTags: userDbData.topTags?.length > 0 ? userDbData.topTags : discoveryCache.topTags || [],
+        topGenres: userDbData.topGenres?.length > 0 ? userDbData.topGenres : discoveryCache.topGenres || [],
+        lastUpdated: userDbData.lastUpdated || discoveryCache.lastUpdated || null,
+        isUpdating: discoveryCache.isUpdating,
+      };
+    }
+  }
+
   const dbData = dbOps.getDiscoveryCache();
   if (
     (dbData.recommendations?.length > 0 &&
@@ -173,14 +189,6 @@ export const updateDiscoveryCache = async () => {
 
     const hasLastfmKey = !!getLastfmApiKey();
     const lastfmHealth = createLastfmHealth();
-    const lastfmUsername = getLastfmUsername();
-    const hasLastfmUser = hasLastfmKey && lastfmUsername;
-
-    if (hasLastfmKey && !lastfmUsername) {
-      console.log(
-        "Last.fm API key configured but username not set. User-specific recommendations will not be available.",
-      );
-    }
 
     if (allLibraryArtists.length === 0 && !hasLastfmKey) {
       console.log(
@@ -218,96 +226,17 @@ export const updateDiscoveryCache = async () => {
       return;
     }
 
-    let lastfmArtists = [];
     emitDiscoveryProgress(
       "collecting_seeds",
       "Collecting recommendation seed artists",
       20,
     );
-    if (hasLastfmUser) {
-      const discoveryPeriod = getLastfmDiscoveryPeriod();
-      if (discoveryPeriod === "none") {
-        console.log(
-          "Last.fm discovery period set to 'none', skipping Last.fm user top artists.",
-        );
-      } else {
-        console.log(
-          `Fetching Last.fm user top artists for ${lastfmUsername} (period: ${discoveryPeriod})...`,
-        );
-        try {
-          const userTopArtists = await lastfmRequest("user.getTopArtists", {
-            user: lastfmUsername,
-            limit: 50,
-            period: discoveryPeriod,
-          });
-          recordLastfmResult(lastfmHealth, userTopArtists);
 
-          if (!userTopArtists) {
-            console.warn(
-              "Last.fm user.getTopArtists returned null - check API key and username",
-            );
-          } else if (userTopArtists.error) {
-            console.error(
-              `Last.fm API error: ${
-                userTopArtists.message || userTopArtists.error
-              }`,
-            );
-          } else if (userTopArtists?.topartists?.artist) {
-            const artists = Array.isArray(userTopArtists.topartists.artist)
-              ? userTopArtists.topartists.artist
-              : [userTopArtists.topartists.artist];
-
-            const artistsWithMbids = [];
-            const artistsWithoutMbids = [];
-
-            for (const artist of artists) {
-              if (artist.mbid) {
-                artistsWithMbids.push(artist);
-              } else if (artist.name) {
-                artistsWithoutMbids.push(artist);
-              }
-            }
-
-            for (const artist of artistsWithMbids) {
-              lastfmArtists.push({
-                mbid: artist.mbid,
-                artistName: artist.name,
-                playcount: parseInt(artist.playcount || 0),
-              });
-            }
-
-            console.log(
-              `Found ${lastfmArtists.length} Last.fm artists with MBIDs.`,
-            );
-          } else {
-            console.warn(
-              `Last.fm user.getTopArtists response missing expected data structure. Response:`,
-              JSON.stringify(userTopArtists).substring(0, 200),
-            );
-          }
-        } catch (e) {
-          console.error(`Failed to fetch Last.fm user artists: ${e.message}`);
-          console.error(`Stack trace:`, e.stack);
-        }
-      }
-    } else if (hasLastfmKey) {
-      console.log(
-        "Last.fm API key is configured but username is missing. Set Last.fm username in Settings to enable user-specific recommendations.",
-      );
-    }
-
-    const allSourceArtists = [
-      ...libraryArtists.map((a) => ({
-        mbid: a.mbid,
-        artistName: a.artistName,
-        source: "library",
-      })),
-      ...lastfmArtists.map((a) => ({
-        mbid: a.mbid,
-        artistName: a.artistName,
-        source: "lastfm",
-      })),
-    ];
+    const allSourceArtists = libraryArtists.map((a) => ({
+      mbid: a.mbid,
+      artistName: a.artistName,
+      source: "library",
+    }));
 
     const uniqueArtists = [];
     const seenMbids = new Set();
@@ -333,7 +262,7 @@ export const updateDiscoveryCache = async () => {
       .slice(0, profileSampleLimit);
 
     console.log(
-      `Sampling tags/genres from ${profileSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`,
+      `Sampling tags/genres from ${profileSample.length} artists (${libraryArtists.length} library)...`,
     );
     emitDiscoveryProgress(
       "building_genres",
@@ -525,7 +454,7 @@ export const updateDiscoveryCache = async () => {
     const recommendations = new Map();
 
     console.log(
-      `Generating recommendations based on ${recSample.length} artists (${libraryArtists.length} library, ${lastfmArtists.length} Last.fm)...`,
+      `Generating recommendations based on ${recSample.length} library artists...`,
     );
     emitDiscoveryProgress(
       "generating_recommendations",
@@ -743,4 +672,261 @@ export const updateDiscoveryCache = async () => {
   } finally {
     discoveryCache.isUpdating = false;
   }
+};
+
+const userDiscoveryLocks = new Set();
+
+export const updateUserDiscoveryCache = async (lastfmUsername) => {
+  if (!lastfmUsername) return null;
+  if (!getLastfmApiKey()) return null;
+  if (userDiscoveryLocks.has(lastfmUsername)) return null;
+
+  userDiscoveryLocks.add(lastfmUsername);
+  console.log(
+    `[Discovery] Starting per-user refresh for Last.fm user ${lastfmUsername}...`,
+  );
+
+  try {
+    const allLibraryArtistsRaw = await libraryManager.getAllArtists();
+    const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
+      ? allLibraryArtistsRaw
+      : [];
+    const existingArtistIds = new Set(
+      allLibraryArtists
+        .map((a) => a.mbid || a.foreignArtistId || a.id)
+        .filter(Boolean),
+    );
+
+    const lastfmHealth = createLastfmHealth();
+    const discoveryPeriod = getLastfmDiscoveryPeriod();
+    const lastfmArtists = [];
+
+    if (discoveryPeriod !== "none") {
+      console.log(
+        `[Discovery] Fetching Last.fm top artists for ${lastfmUsername} (period: ${discoveryPeriod})...`,
+      );
+      try {
+        const userTopArtists = await lastfmRequest("user.getTopArtists", {
+          user: lastfmUsername,
+          limit: 50,
+          period: discoveryPeriod,
+        });
+        recordLastfmResult(lastfmHealth, userTopArtists);
+
+        if (userTopArtists?.topartists?.artist) {
+          const artists = Array.isArray(userTopArtists.topartists.artist)
+            ? userTopArtists.topartists.artist
+            : [userTopArtists.topartists.artist];
+          for (const artist of artists) {
+            if (artist.mbid) {
+              lastfmArtists.push({
+                mbid: artist.mbid,
+                artistName: artist.name,
+                playcount: parseInt(artist.playcount || 0),
+              });
+            }
+          }
+          console.log(
+            `[Discovery] Found ${lastfmArtists.length} Last.fm artists for ${lastfmUsername}.`,
+          );
+        }
+      } catch (e) {
+        console.error(
+          `[Discovery] Failed to fetch Last.fm artists for ${lastfmUsername}: ${e.message}`,
+        );
+      }
+    }
+
+    const allSourceArtists = [
+      ...allLibraryArtists.slice(0, 25).map((a) => ({
+        mbid: a.mbid,
+        artistName: a.artistName,
+        source: "library",
+      })),
+      ...lastfmArtists.map((a) => ({
+        mbid: a.mbid,
+        artistName: a.artistName,
+        source: "lastfm",
+      })),
+    ];
+
+    const uniqueArtists = [];
+    const seenMbids = new Set();
+    for (const artist of allSourceArtists) {
+      if (artist.mbid && !seenMbids.has(artist.mbid)) {
+        seenMbids.add(artist.mbid);
+        uniqueArtists.push(artist);
+      }
+    }
+
+    // Build per-user tag/genre profile
+    const tagCounts = new Map();
+    const genreCounts = new Map();
+    const profileSample = [...uniqueArtists]
+      .sort(() => 0.5 - Math.random())
+      .slice(0, 20);
+
+    await Promise.all(
+      profileSample.map(async (artist) => {
+        try {
+          const data = await lastfmRequest("artist.getTopTags", {
+            mbid: artist.mbid,
+          });
+          recordLastfmResult(lastfmHealth, data);
+          if (data?.toptags?.tag) {
+            const tags = Array.isArray(data.toptags.tag)
+              ? data.toptags.tag
+              : [data.toptags.tag];
+            tags.slice(0, 15).forEach((t) => {
+              tagCounts.set(
+                t.name,
+                (tagCounts.get(t.name) || 0) + (parseInt(t.count) || 1),
+              );
+              const l = t.name.toLowerCase();
+              if (GENRE_KEYWORDS.some((g) => l.includes(g)))
+                genreCounts.set(t.name, (genreCounts.get(t.name) || 0) + 1);
+            });
+          }
+        } catch (e) {
+          console.warn(
+            `[Discovery] Failed to get tags for ${artist.artistName}: ${e.message}`,
+          );
+        }
+      }),
+    );
+
+    const topTags = Array.from(tagCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)
+      .map((t) => t[0]);
+    const topGenres = Array.from(genreCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 24)
+      .map((t) => t[0]);
+
+    // Generate per-user recommendations
+    const recSample = [...uniqueArtists]
+      .sort(() => 0.5 - Math.random())
+      .slice(0, 20);
+    const recommendations = new Map();
+
+    await Promise.all(
+      recSample.map(async (artist) => {
+        try {
+          let sourceTags = [];
+          const tagData = await lastfmRequest("artist.getTopTags", {
+            mbid: artist.mbid,
+          });
+          recordLastfmResult(lastfmHealth, tagData);
+          if (tagData?.toptags?.tag) {
+            const allTags = Array.isArray(tagData.toptags.tag)
+              ? tagData.toptags.tag
+              : [tagData.toptags.tag];
+            sourceTags = allTags.slice(0, 15).map((t) => t.name);
+          }
+
+          const similar = await lastfmRequest("artist.getSimilar", {
+            mbid: artist.mbid,
+            limit: 20,
+          });
+          recordLastfmResult(lastfmHealth, similar);
+          if (similar?.similarartists?.artist) {
+            const list = Array.isArray(similar.similarartists.artist)
+              ? similar.similarartists.artist
+              : [similar.similarartists.artist];
+            for (const s of list) {
+              if (
+                s.mbid &&
+                !existingArtistIds.has(s.mbid) &&
+                !recommendations.has(s.mbid)
+              ) {
+                let img = null;
+                if (s.image && Array.isArray(s.image)) {
+                  const i =
+                    s.image.find((im) => im.size === "extralarge") ||
+                    s.image.find((im) => im.size === "large");
+                  if (
+                    i &&
+                    i["#text"] &&
+                    !i["#text"].includes("2a96cbd8b46e442fc41c2b86b821562f")
+                  )
+                    img = i["#text"];
+                }
+                recommendations.set(s.mbid, {
+                  id: s.mbid,
+                  name: s.name,
+                  type: "Artist",
+                  sourceArtist: artist.artistName,
+                  sourceType: artist.source || "library",
+                  tags: sourceTags,
+                  score: Math.round((s.match || 0) * 100),
+                  image: img,
+                });
+              }
+            }
+          }
+        } catch (e) {
+          console.warn(
+            `[Discovery] Error getting similar for ${artist.artistName}: ${e.message}`,
+          );
+        }
+      }),
+    );
+
+    const recommendationsPerRefresh = getDiscoveryRecommendationsPerRefresh();
+    const recommendationsArray = Array.from(recommendations.values())
+      .sort((a, b) => (b.score || 0) - (a.score || 0))
+      .slice(0, recommendationsPerRefresh);
+
+    // Hydrate images
+    const toHydrate = recommendationsArray.filter((a) => !a.image);
+    const batchSize = 10;
+    for (let i = 0; i < toHydrate.length; i += batchSize) {
+      const batch = toHydrate.slice(i, i + batchSize);
+      await Promise.all(
+        batch.map(async (item) => {
+          try {
+            const artistName = item.name || item.artistName;
+            if (artistName) {
+              const deezer = await deezerSearchArtist(artistName);
+              if (deezer?.imageUrl) item.image = deezer.imageUrl;
+            }
+          } catch {}
+        }),
+      );
+      if (i + batchSize < toHydrate.length) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+
+    const userData = {
+      recommendations: recommendationsArray,
+      basedOn: recSample.map((a) => ({
+        name: a.artistName,
+        id: a.mbid,
+        source: a.source || "library",
+      })),
+      topTags,
+      topGenres,
+    };
+
+    dbOps.updateDiscoveryCache(userData, lastfmUsername);
+    console.log(
+      `[Discovery] ${lastfmUsername} refresh complete: ${recommendationsArray.length} recommendations, ${topGenres.length} genres.`,
+    );
+    return userData;
+  } catch (error) {
+    console.error(
+      `[Discovery] Failed to update cache for ${lastfmUsername}: ${error.message}`,
+    );
+    return null;
+  } finally {
+    userDiscoveryLocks.delete(lastfmUsername);
+  }
+};
+
+export const getUserDiscoveryCacheStaleness = (lastfmUsername) => {
+  const data = dbOps.getDiscoveryCache(lastfmUsername);
+  if (!data.lastUpdated) return Infinity;
+  return Date.now() - new Date(data.lastUpdated).getTime();
 };

--- a/frontend/src/components/LastfmBanner.jsx
+++ b/frontend/src/components/LastfmBanner.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getMyLastfm } from "../utils/api";
+
+const DISMISS_KEY = "lastfm_banner_dismissed";
+
+const LastfmBanner = () => {
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem(DISMISS_KEY) === "1",
+  );
+  const [lastfmUsername, setLastfmUsername] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (dismissed) return;
+    getMyLastfm()
+      .then((d) => setLastfmUsername(d.lastfmUsername || ""))
+      .catch(() => {});
+  }, [dismissed]);
+
+  if (dismissed || lastfmUsername === null || lastfmUsername !== "") {
+    return null;
+  }
+
+  return (
+    <div className="mb-6 bg-[#211f27] px-5 py-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <p className="text-sm uppercase tracking-wide">
+            Personalize your discovery
+          </p>
+          <p className="text-xs text-[#c1c1c3]">
+            Recommendations are based on the admin&apos;s Last.fm account by
+            default. Connect your own for personalized results.
+          </p>
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <button
+            type="button"
+            className="btn btn-secondary bg-gray-700/50 hover:bg-gray-700/70 btn-sm w-full sm:w-auto"
+            onClick={() => navigate("/settings")}
+          >
+            Connect Last.fm
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm hover:bg-gray-700/50 w-full sm:w-auto"
+            onClick={() => {
+              setDismissed(true);
+              sessionStorage.setItem(DISMISS_KEY, "1");
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LastfmBanner;

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -27,6 +27,7 @@ import {
 } from "../utils/api";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
 import ArtistImage from "../components/ArtistImage";
+import LastfmBanner from "../components/LastfmBanner";
 
 const TAG_COLORS = [
   "#845336",
@@ -474,6 +475,7 @@ function DiscoverPage() {
   const requestedArtistCoversRef = useRef(new Set());
   const lastDiscoveryWsMessageAtRef = useRef(0);
   const navigate = useNavigate();
+
 
   const { isConnected: isDiscoverySocketConnected } = useWebSocketChannel(
     "discovery",
@@ -1450,6 +1452,7 @@ function DiscoverPage() {
 
   return (
     <div className="space-y-10 pb-12">
+      <LastfmBanner />
       <section
         className="relative overflow-hidden"
         style={{
@@ -1477,7 +1480,7 @@ function DiscoverPage() {
                 Your daily mix, curated from your library.
               </p>
             </div>
-            
+
             <button
               type="button"
               onClick={openDiscoverModal}

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -26,6 +26,7 @@ import {
   readLibraryLookupCache,
 } from "../utils/api";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
+import { useAuth } from "../contexts/AuthContext";
 import ArtistImage from "../components/ArtistImage";
 import LastfmBanner from "../components/LastfmBanner";
 
@@ -475,6 +476,7 @@ function DiscoverPage() {
   const requestedArtistCoversRef = useRef(new Set());
   const lastDiscoveryWsMessageAtRef = useRef(0);
   const navigate = useNavigate();
+  const { user: authUser } = useAuth();
 
 
   const { isConnected: isDiscoverySocketConnected } = useWebSocketChannel(
@@ -548,7 +550,7 @@ function DiscoverPage() {
   }, [data, data?.isUpdating, data?.stale]);
 
   useEffect(() => {
-    getDiscovery()
+    getDiscovery(true)
       .then((discoveryData) => {
         setData(discoveryData);
         setError(null);
@@ -578,7 +580,7 @@ function DiscoverPage() {
       .then(setRecentReleases)
       .catch(() => {});
 
-  }, []);
+  }, [authUser?.id]);
 
   useEffect(() => {
     try {

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -12,12 +12,15 @@ import { SettingsMetadataTab } from "./components/SettingsMetadataTab";
 import { SettingsDiscoverTab } from "./components/SettingsDiscoverTab";
 import { SettingsNotificationsTab } from "./components/SettingsNotificationsTab";
 import { SettingsUsersTab } from "./components/SettingsUsersTab";
+import { SettingsAccountTab } from "./components/SettingsAccountTab";
+import { useAccountSettings } from "./hooks/useAccountSettings";
 
 function SettingsPage() {
   const { showSuccess, showError, showInfo } = useToast();
   const { user: authUser } = useAuth();
 
   const data = useSettingsData(showSuccess, showError, showInfo);
+  const account = useAccountSettings(authUser, showSuccess, showError);
   const guard = useUnsavedGuard(data.hasUnsavedChanges, data.setHasUnsavedChanges);
   const tabs = useSettingsTabs(authUser);
   const users = useSettingsUsers(
@@ -104,6 +107,17 @@ function SettingsPage() {
             setTestingGotify={data.setTestingGotify}
             showSuccess={showSuccess}
             showError={showError}
+          />
+        );
+      case "account":
+        return (
+          <SettingsAccountTab
+            lastfmUsername={account.lastfmUsername}
+            setLastfmUsername={account.setLastfmUsername}
+            hasUnsavedChanges={account.hasUnsavedChanges}
+            loading={account.loading}
+            saving={account.saving}
+            handleSave={account.handleSave}
           />
         );
       case "users":

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Pencil } from "lucide-react";
+import FlipSaveButton from "../../../components/FlipSaveButton";
+
+export function SettingsAccountTab({
+  lastfmUsername,
+  setLastfmUsername,
+  hasUnsavedChanges,
+  loading,
+  saving,
+  handleSave,
+}) {
+  const [editing, setEditing] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="card animate-fade-in">
+        <p style={{ color: "#c1c1c3" }}>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card animate-fade-in">
+      <div className="flex items-center justify-between mb-6">
+        <h2
+          className="text-2xl font-bold flex items-center"
+          style={{ color: "#fff" }}
+        >
+          My Account
+        </h2>
+        <FlipSaveButton
+          saving={saving}
+          disabled={!hasUnsavedChanges}
+          onClick={handleSave}
+        />
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSave();
+        }}
+        className="space-y-6"
+        autoComplete="off"
+      >
+        <div
+          className="p-6 rounded-lg space-y-4"
+          style={{
+            backgroundColor: "#1a1a1e",
+            border: "1px solid #2a2a2e",
+          }}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <h3
+              className="text-lg font-medium flex items-center"
+              style={{ color: "#fff" }}
+            >
+              Last.fm
+            </h3>
+            <div className="flex items-center gap-2">
+              {lastfmUsername && !editing && (
+                <span className="text-sm" style={{ color: "#c1c1c3" }}>
+                  {lastfmUsername}
+                </span>
+              )}
+              <button
+                type="button"
+                className={`btn ${
+                  editing ? "btn-primary" : "btn-secondary"
+                } px-2 py-1`}
+                onClick={() => setEditing((v) => !v)}
+                aria-label={
+                  editing
+                    ? "Lock Last.fm settings"
+                    : "Edit Last.fm settings"
+                }
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+          <fieldset
+            disabled={!editing}
+            className={`space-y-4 ${editing ? "" : "opacity-60"}`}
+          >
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Username
+              </label>
+              <input
+                type="text"
+                className="input"
+                placeholder="Your Last.fm username"
+                autoComplete="off"
+                value={lastfmUsername}
+                onChange={(e) => setLastfmUsername(e.target.value)}
+              />
+              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
+                Connect your Last.fm account for personalized discovery
+                recommendations based on your listening history.
+              </p>
+            </div>
+          </fieldset>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
@@ -199,8 +199,8 @@ export function SettingsMetadataTab({
                 }
               />
               <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Your Last.fm username for personalized recommendations based on
-                your listening history.
+                Default Last.fm username for users who haven&apos;t set their own
+                in their Account settings.
               </p>
             </div>
             <div>
@@ -242,8 +242,8 @@ export function SettingsMetadataTab({
             </div>
             <p className="text-xs" style={{ color: "#c1c1c3" }}>
               API key is required for high-quality images, better recommendations,
-              and weekly flow. Username enables personalized recommendations from
-              your Last.fm listening history.
+              and weekly flow. Username serves as the default for users who
+              haven&apos;t configured their own in Account settings.
             </p>
           </fieldset>
         </div>

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -209,6 +209,15 @@ export function SettingsUsersTab({
                       >
                         {u.role}
                       </span>
+                      {u.lastfmUsername && (
+                        <span
+                          className="text-xs truncate"
+                          style={{ color: "#8a8a8f" }}
+                          title={`Last.fm: ${u.lastfmUsername}`}
+                        >
+                          Last.fm: {u.lastfmUsername}
+                        </span>
+                      )}
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       <button

--- a/frontend/src/pages/Settings/hooks/useAccountSettings.js
+++ b/frontend/src/pages/Settings/hooks/useAccountSettings.js
@@ -1,0 +1,54 @@
+import { useState, useEffect, useCallback } from "react";
+import { getMyLastfm, updateMyLastfm } from "../../../utils/api";
+
+export function useAccountSettings(authUser, showSuccess, showError) {
+  const [lastfmUsername, setLastfmUsername] = useState("");
+  const [savedLastfmUsername, setSavedLastfmUsername] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const hasUnsavedChanges = lastfmUsername !== savedLastfmUsername;
+
+  const fetchLastfm = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getMyLastfm();
+      const val = data.lastfmUsername || "";
+      setLastfmUsername(val);
+      setSavedLastfmUsername(val);
+    } catch {
+      showError("Failed to load Last.fm settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [showError]);
+
+  useEffect(() => {
+    fetchLastfm();
+  }, [fetchLastfm]);
+
+  const handleSave = useCallback(async () => {
+    if (!authUser?.id) return;
+    try {
+      setSaving(true);
+      await updateMyLastfm(authUser.id, lastfmUsername.trim() || null);
+      const trimmed = lastfmUsername.trim();
+      setSavedLastfmUsername(trimmed);
+      setLastfmUsername(trimmed);
+      showSuccess("Last.fm username saved");
+    } catch {
+      showError("Failed to save Last.fm username");
+    } finally {
+      setSaving(false);
+    }
+  }, [authUser?.id, lastfmUsername, showSuccess, showError]);
+
+  return {
+    lastfmUsername,
+    setLastfmUsername,
+    hasUnsavedChanges,
+    loading,
+    saving,
+    handleSave,
+  };
+}

--- a/frontend/src/pages/Settings/hooks/useSettingsTabs.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsTabs.js
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { Server, TrendingUp, Compass, Bell, Users } from "lucide-react";
+import { Server, TrendingUp, Compass, Bell, Users, User } from "lucide-react";
 
 export function useSettingsTabs(authUser) {
-  const [activeTab, setActiveTab] = useState("integrations");
+  const isAdmin = authUser?.role === "admin";
+  const [activeTab, setActiveTab] = useState(isAdmin ? "integrations" : "account");
   const [hoveredTabIndex, setHoveredTabIndex] = useState(null);
   const tabsRef = useRef(null);
   const activeBubbleRef = useRef(null);
@@ -10,17 +11,20 @@ export function useSettingsTabs(authUser) {
   const tabRefs = useRef({});
 
   const tabs = useMemo(() => {
-    const all = [
+    const adminTabs = [
       { id: "integrations", label: "Integrations", icon: Server },
       { id: "metadata", label: "Metadata", icon: TrendingUp },
       { id: "discover", label: "Discover", icon: Compass },
       { id: "notifications", label: "Notifications", icon: Bell },
       { id: "users", label: "Users", icon: Users },
     ];
+    const userTabs = [
+      { id: "account", label: "Account", icon: User },
+    ];
     if (authUser?.role !== "admin") {
-      return all.filter((t) => t.id === "users");
+      return userTabs;
     }
-    return all;
+    return [...adminTabs, ...userTabs];
   }, [authUser?.role]);
 
   useEffect(() => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -573,6 +573,16 @@ export const changeMyPassword = async (currentPassword, newPassword) => {
   await api.post("/users/me/password", { currentPassword, newPassword });
 };
 
+export const getMyLastfm = async () => {
+  const response = await api.get("/users/me/lastfm");
+  return response.data;
+};
+
+export const updateMyLastfm = async (userId, lastfmUsername) => {
+  const response = await api.patch(`/users/${userId}`, { lastfmUsername });
+  return response.data;
+};
+
 export const getAppSettings = async () => {
   const response = await api.get("/settings");
   return response.data;


### PR DESCRIPTION
Addresses #101 

## Context
Right now, only discovery is supported based on the account the Last.fm API key comes from, making multi-user support not fully fleshed out.

## Description
- Add new account section for users to input Last.fm username
  - We are using username instead of multiple API keys because one API key can support multiple users, so all they need to do is input the username to get recommendations from instead of managing a ton of API keys. [Example user request from their API docs](https://www.last.fm/api/show/user.getRecentTracks), takes a user field we can dynamically set.
- Add banner to discover page to let users know they need to add it or else they will get default recommendations
- Add cache per user for discovery
- Cache on page render as opposed to relying on background cache
  - Background cache will still run for the default user, but it would have been too expensive imo to run this cache on background for all users' discovery pages, so cache when they visit and the cache is empty.
- Personalize discovery based by passing in user's username as opposed to default one

## Images
### Account page for user
<img width="3424" height="1760" alt="CleanShot 2026-04-14 at 16 12 03@2x" src="https://github.com/user-attachments/assets/37405be9-76dd-493f-87fd-2afee09d52d8" />

### Banner on disovery if Last.fm username missing
<img width="3424" height="1760" alt="CleanShot 2026-04-14 at 16 13 00@2x" src="https://github.com/user-attachments/assets/d05247f0-3dd1-44ab-bee8-9564ca513df3" />

### Discovery between two different accounts demo
[https://cleanshot.com/share/NkJczCHG](https://cleanshot.com/share/NkJczCHG)