### PR TITLE
Exclude OIDC/API/logout from service worker navigation fallback

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -40,6 +40,10 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: "autoUpdate",
         includeAssets: ["arralogo.svg"],
+        workbox: {
+          // SPA fallback must not intercept reverse-proxy auth callbacks or API routes.
+          navigateFallbackDenylist: [/^\/oidc\//, /^\/api\//, /^\/logout$/],
+        },
         manifest: {
           name: "Aurral - Artist Request Manager",
           short_name: "Aurral",


### PR DESCRIPTION
After OIDC session expiry, the frontend app shows `Unable to connect to the backend API. Please check your configuration.` and every API call returns 401.
A single hard refresh (Ctrl+Shift+R) shows the OIDC login page but the app still returns 401s afterward. Only a second hard refresh makes the app work again.

There is no `navigateFallbackDenylist` (https://vite-pwa-org.netlify.app/workbox/generate-sw.html#exclude-routes) for the PWA service worker, so the reverse-proxy OIDC callback (for example `/oidc/callback?code=...`) is intercepted by the SW and answered with cached `index.html`.
The OIDC proxy never sees the callback, no token exchange happens and no session cookie is set.

This setting should also be set for the backend pages to avoid having them cached or intercepted by the worker.

Because this is quite a complex scenario to reproduce in tests, I have only included manual reproduction steps:
1. Deploy behind a reverse-proxy OIDC middleware (like traefik-oidc-auth).
2. Log in, wait for the OIDC session to expire and refresh the page.
3. The application gets stuck with an expired OIDC token and returns 401 for all endpoints.