### PR TITLE
fix(discover): infinite render loop on discover page

### DIFF
--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -807,11 +807,11 @@ function DiscoverPage() {
 
   const discoverArtistIds = useMemo(() => {
     const ids = new Set();
-    for (const artist of recommendations) {
+    for (const artist of data?.recommendations || []) {
       const id = getArtistId(artist);
       if (id) ids.add(id);
     }
-    for (const artist of globalTop) {
+    for (const artist of data?.globalTop || []) {
       const id = getArtistId(artist);
       if (id) ids.add(id);
     }
@@ -826,11 +826,16 @@ function DiscoverPage() {
       if (id) ids.add(id);
     }
     return [...ids];
-  }, [recommendations, globalTop, genreSections, recentlyAdded]);
+  }, [data, genreSections, recentlyAdded]);
+
+  const discoverArtistIdsKey = discoverArtistIds.join(",");
 
   useEffect(() => {
+    if (discoverArtistIds.length === 0) return;
     const cached = readLibraryLookupCache(discoverArtistIds);
-    setLibraryLookup(cached);
+    if (Object.keys(cached).length > 0) {
+      setLibraryLookup((prev) => ({ ...prev, ...cached }));
+    }
     const missing = discoverArtistIds.filter((id) => cached[id] === undefined);
     if (missing.length === 0) return;
     let cancelled = false;
@@ -840,17 +845,14 @@ function DiscoverPage() {
         if (!cancelled && lookup) {
           setLibraryLookup((prev) => ({ ...prev, ...lookup }));
         }
-      } catch {
-        if (!cancelled) {
-          setLibraryLookup((prev) => ({ ...prev }));
-        }
-      }
+      } catch {}
     };
     fetchLookup();
     return () => {
       cancelled = true;
     };
-  }, [discoverArtistIds]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [discoverArtistIdsKey]);
 
   const openDiscoverModal = () => {
     setDraftSections(discoverSections.map((item) => ({ ...item })));


### PR DESCRIPTION
## Context
- Fresh browser sessions on my production reverse-proxied deployment were firing ~5000 `POST /api/library/lookup/batch` calls within seconds of loading the home page, crashing the tab and eventually hitting the backend's 5000/15min rate limiter.
- Triggered on cold loads (fresh session, empty in-memory cache) when the backend's `/discovery` call was slow to resolve, most often "after not having logged in for a while."
- Intermittent ("sometimes, not always") because it depends on the timing gap between `getRecentlyAdded()` (fast) and `getDiscovery()` (slow on cold backend).
- Diagnostic build with a batch-call counter and stack trace confirmed: same `len=20`, same first id, `cacheSize=0` across 300+ calls, all originating from `DiscoverPage`'s library-lookup `useEffect`.

## Description
- Root cause: `DiscoverPage` destructures `const { recommendations = [], globalTop = [] } = data || {};` - when data is null, both defaults produce a brand new `[]` literal on every render. `discoverArtistIds` memoed those unstable refs, so it recomputed every render and returned a new array. The effect keyed on `discoverArtistIds` identity and called `setLibraryLookup(cached)` unconditionally with a fresh `{}`, closing a render→effect→render loop that POSTed the same 20 `recentlyAdded` ids at render speed.
- Stabilized memo deps: moved `|| []` fallbacks inline inside the memo body; memo now depends on data itself, so one stable data ref produces one stable `discoverArtistIds`.
- Content-keyed effect: replaced the array-identity dep with `discoverArtistIds.join(",")`, so identical id sets no longer re-fire the effect.
- Removed self-triggered re-renders: `setLibraryLookup` only fires when there's actually something to merge; dropped the no-op `setLibraryLookup((prev) => ({ ...prev }))` in the catch branch.

### Before:
https://cleanshot.com/share/gXMG46JD

### After:
https://cleanshot.com/share/SDMtjktz

> [!WARNING] 
> This was mostly researched and fixed by AI. I was interacting with it the whole time and ensuring it was targeting the right places to find and fix issues alongside providing debugging and thorough testing, but the root cause was identified by and fixed by AI.