### PR TITLE
Add per-user Lidarr add preferences

### DIFF
--- a/.tests/auth/lidarr-preferences.integration.test.js
+++ b/.tests/auth/lidarr-preferences.integration.test.js
@@ -1,0 +1,422 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+import {
+  createIsolatedStateDir,
+  applyIsolatedBackendEnv,
+  cleanupIsolatedState,
+  importFromRepo,
+  resetDatabase,
+  startServerProcess,
+  buildApiUrl,
+} from "../helpers/backendTestHarness.js";
+
+const isolatedState = await createIsolatedStateDir("lidarr-preferences-api");
+applyIsolatedBackendEnv(isolatedState);
+
+const [{ db }, { userOps, dbOps }, bcryptModule] = await Promise.all([
+  importFromRepo("backend/config/db-sqlite.js"),
+  importFromRepo("backend/config/db-helpers.js"),
+  importFromRepo("backend/node_modules/bcrypt/bcrypt.js"),
+]);
+
+const bcrypt = bcryptModule.default;
+const DEFAULT_ROOT_FOLDERS = [
+  { path: "/music/main" },
+  { path: "/music/alt" },
+];
+const DEFAULT_QUALITY_PROFILES = [
+  { id: 7, name: "Lossless" },
+  { id: 9, name: "Compressed" },
+];
+
+function json(res, statusCode, payload) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function startFakeLidarr() {
+  const state = {
+    rootFolders: DEFAULT_ROOT_FOLDERS.map((folder) => ({ ...folder })),
+    qualityProfiles: DEFAULT_QUALITY_PROFILES.map((profile) => ({
+      ...profile,
+    })),
+    metadataProfiles: [{ id: 1, name: "Standard" }],
+    artists: [],
+    postedArtists: [],
+    nextArtistId: 100,
+  };
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || "/", "http://127.0.0.1");
+    if (req.headers["x-api-key"] !== "fake-key") {
+      return json(res, 401, { message: "Invalid API key" });
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/v1/rootFolder") {
+      return json(res, 200, state.rootFolders);
+    }
+    if (req.method === "GET" && url.pathname === "/api/v1/qualityprofile") {
+      return json(res, 200, state.qualityProfiles);
+    }
+    if (req.method === "GET" && url.pathname === "/api/v1/metadataprofile") {
+      return json(res, 200, state.metadataProfiles);
+    }
+    if (req.method === "GET" && url.pathname === "/api/v1/artist") {
+      return json(res, 200, state.artists);
+    }
+    if (
+      req.method === "GET" &&
+      url.pathname.startsWith("/api/v1/artist/") &&
+      url.pathname !== "/api/v1/artist/"
+    ) {
+      const artistId = url.pathname.split("/").pop();
+      const artist = state.artists.find((entry) => String(entry.id) === artistId);
+      if (!artist) {
+        return json(res, 404, { message: "Artist not found" });
+      }
+      return json(res, 200, artist);
+    }
+    if (req.method === "POST" && url.pathname === "/api/v1/artist") {
+      const payload = await readJsonBody(req);
+      state.postedArtists.push(payload);
+      const qualityProfile =
+        state.qualityProfiles.find((profile) => profile.id === payload.qualityProfileId) ||
+        null;
+      const artist = {
+        id: state.nextArtistId++,
+        artistName: payload.artistName,
+        foreignArtistId: payload.foreignArtistId,
+        path: `${payload.rootFolderPath}/${payload.artistName}`,
+        added: new Date().toISOString(),
+        monitored: payload.monitored,
+        monitor: payload.monitor,
+        monitorNewItems: payload.monitorNewItems,
+        addOptions: payload.addOptions,
+        qualityProfile,
+        statistics: {
+          albumCount: 0,
+          trackCount: 0,
+          sizeOnDisk: 0,
+        },
+      };
+      state.artists.push(artist);
+      return json(res, 201, artist);
+    }
+
+    return json(res, 404, { message: "Not found" });
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  return {
+    state,
+    url: `http://127.0.0.1:${port}`,
+    reset() {
+      state.rootFolders = DEFAULT_ROOT_FOLDERS.map((folder) => ({ ...folder }));
+      state.qualityProfiles = DEFAULT_QUALITY_PROFILES.map((profile) => ({
+        ...profile,
+      }));
+      state.metadataProfiles = [{ id: 1, name: "Standard" }];
+      state.artists = [];
+      state.postedArtists = [];
+      state.nextArtistId = 100;
+    },
+    async stop() {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+let server = null;
+let fakeLidarr = null;
+let authToken = "";
+let adminUserId = null;
+
+async function apiFetch(path, options = {}) {
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+    ...(options.body ? { "Content-Type": "application/json" } : {}),
+    ...(options.headers || {}),
+  };
+  const response = await fetch(buildApiUrl(server.port, path), {
+    ...options,
+    headers,
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+  return { response, payload };
+}
+
+async function loginAsAdmin() {
+  const response = await fetch(buildApiUrl(server.port, "/api/auth/login"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      username: "admin",
+      password: "password123",
+    }),
+  });
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  return payload.token;
+}
+
+async function saveLidarrSettings({ apiKey = "fake-key", rootFolderPath = "/music/main", qualityProfileId = 7 } = {}) {
+  const { response, payload } = await apiFetch("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({
+      rootFolderPath,
+      integrations: {
+        lidarr: {
+          url: fakeLidarr.url,
+          apiKey,
+          qualityProfileId,
+        },
+      },
+    }),
+  });
+  assert.equal(response.status, 200, JSON.stringify(payload));
+}
+
+async function waitForPostedArtist(mbid) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const match = fakeLidarr.state.postedArtists.find(
+      (artist) => artist.foreignArtistId === mbid,
+    );
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for fake Lidarr add for ${mbid}`);
+}
+
+test.before(async () => {
+  resetDatabase(db);
+  fakeLidarr = await startFakeLidarr();
+  dbOps.updateSettings({
+    integrations: {
+      lidarr: {
+        url: fakeLidarr.url,
+        apiKey: "fake-key",
+        qualityProfileId: 7,
+      },
+    },
+    rootFolderPath: "/music/main",
+    onboardingComplete: true,
+  });
+  const admin = userOps.createUser(
+    "admin",
+    bcrypt.hashSync("password123", 4),
+    "admin",
+  );
+  adminUserId = admin?.id || null;
+  server = await startServerProcess();
+  authToken = await loginAsAdmin();
+});
+
+test.beforeEach(async () => {
+  fakeLidarr.reset();
+  userOps.updateUser(adminUserId, {
+    lidarrRootFolderPath: null,
+    lidarrQualityProfileId: null,
+  });
+  await saveLidarrSettings();
+});
+
+test.after(async () => {
+  await server?.stop();
+  await fakeLidarr?.stop();
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("GET /users/me/lidarr-preferences returns configured false with empty options when Lidarr is unavailable", async () => {
+  await saveLidarrSettings({ apiKey: "", rootFolderPath: "/music/main" });
+
+  const { response, payload } = await apiFetch("/api/users/me/lidarr-preferences");
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.configured, false);
+  assert.deepEqual(payload.rootFolders, []);
+  assert.deepEqual(payload.qualityProfiles, []);
+  assert.deepEqual(payload.fallbacks, {
+    rootFolderPath: null,
+    qualityProfileId: null,
+  });
+});
+
+test("GET /users/me/lidarr-preferences returns live options plus saved defaults and global fallbacks", async () => {
+  userOps.updateUser(adminUserId, {
+    lidarrRootFolderPath: "/music/alt",
+    lidarrQualityProfileId: 9,
+  });
+
+  const { response, payload } = await apiFetch("/api/users/me/lidarr-preferences");
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.configured, true);
+  assert.deepEqual(payload.rootFolders, DEFAULT_ROOT_FOLDERS);
+  assert.deepEqual(payload.qualityProfiles, DEFAULT_QUALITY_PROFILES);
+  assert.deepEqual(payload.savedDefaults, {
+    rootFolderPath: "/music/alt",
+    qualityProfileId: 9,
+  });
+  assert.deepEqual(payload.fallbacks, {
+    rootFolderPath: "/music/main",
+    qualityProfileId: 7,
+  });
+});
+
+test("PATCH /users/me/lidarr-preferences accepts valid selections and clears them with null", async () => {
+  const saveResult = await apiFetch("/api/users/me/lidarr-preferences", {
+    method: "PATCH",
+    body: JSON.stringify({
+      rootFolderPath: "/music/alt",
+      qualityProfileId: 9,
+    }),
+  });
+
+  assert.equal(saveResult.response.status, 200);
+  assert.deepEqual(saveResult.payload.savedDefaults, {
+    rootFolderPath: "/music/alt",
+    qualityProfileId: 9,
+  });
+
+  const stored = userOps.getUserById(adminUserId);
+  assert.equal(stored?.lidarrRootFolderPath, "/music/alt");
+  assert.equal(stored?.lidarrQualityProfileId, 9);
+
+  const clearResult = await apiFetch("/api/users/me/lidarr-preferences", {
+    method: "PATCH",
+    body: JSON.stringify({
+      rootFolderPath: null,
+      qualityProfileId: null,
+    }),
+  });
+
+  assert.equal(clearResult.response.status, 200);
+  assert.deepEqual(clearResult.payload.savedDefaults, {
+    rootFolderPath: null,
+    qualityProfileId: null,
+  });
+});
+
+test("PATCH /users/me/lidarr-preferences rejects invalid root folders and quality profiles", async () => {
+  const invalidRoot = await apiFetch("/api/users/me/lidarr-preferences", {
+    method: "PATCH",
+    body: JSON.stringify({
+      rootFolderPath: "/music/missing",
+    }),
+  });
+
+  assert.equal(invalidRoot.response.status, 400);
+  assert.equal(invalidRoot.payload.field, "rootFolderPath");
+
+  const invalidQuality = await apiFetch("/api/users/me/lidarr-preferences", {
+    method: "PATCH",
+    body: JSON.stringify({
+      qualityProfileId: 999,
+    }),
+  });
+
+  assert.equal(invalidQuality.response.status, 400);
+  assert.equal(invalidQuality.payload.field, "qualityProfileId");
+});
+
+test("POST /library/artists uses explicit request overrides over saved defaults", async () => {
+  userOps.updateUser(adminUserId, {
+    lidarrRootFolderPath: "/music/main",
+    lidarrQualityProfileId: 7,
+  });
+
+  const mbid = "11111111-1111-1111-1111-111111111111";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Override Artist",
+      rootFolderPath: "/music/alt",
+      qualityProfileId: 9,
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.rootFolderPath, "/music/alt");
+  assert.equal(posted.qualityProfileId, 9);
+});
+
+test("POST /library/artists uses saved per-user defaults when no overrides are provided", async () => {
+  userOps.updateUser(adminUserId, {
+    lidarrRootFolderPath: "/music/alt",
+    lidarrQualityProfileId: 9,
+  });
+
+  const mbid = "22222222-2222-2222-2222-222222222222";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Saved Default Artist",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.rootFolderPath, "/music/alt");
+  assert.equal(posted.qualityProfileId, 9);
+});
+
+test("POST /library/artists falls back to global defaults when the user has no saved defaults", async () => {
+  const mbid = "33333333-3333-3333-3333-333333333333";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Fallback Artist",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.rootFolderPath, "/music/main");
+  assert.equal(posted.qualityProfileId, 7);
+});
+
+test("POST /library/artists returns 409 when saved defaults are stale", async () => {
+  userOps.updateUser(adminUserId, {
+    lidarrRootFolderPath: "/music/stale",
+    lidarrQualityProfileId: 999,
+  });
+
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: "44444444-4444-4444-4444-444444444444",
+      artistName: "Stale Artist",
+    }),
+  });
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.field, "rootFolderPath");
+  assert.match(payload.message, /saved Lidarr root folder/i);
+  assert.equal(fakeLidarr.state.postedArtists.length, 0);
+});

--- a/.tests/auth/lidarr-user-preferences.test.js
+++ b/.tests/auth/lidarr-user-preferences.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createIsolatedStateDir,
+  applyIsolatedBackendEnv,
+  cleanupIsolatedState,
+  importFromRepo,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const isolatedState = await createIsolatedStateDir("lidarr-user-preferences");
+applyIsolatedBackendEnv(isolatedState);
+
+const [{ db }, { userOps }, bcryptModule] = await Promise.all([
+  importFromRepo("backend/config/db-sqlite.js"),
+  importFromRepo("backend/config/db-helpers.js"),
+  importFromRepo("backend/node_modules/bcrypt/bcrypt.js"),
+]);
+
+const bcrypt = bcryptModule.default;
+
+test.beforeEach(() => {
+  resetDatabase(db);
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("new users start with null Lidarr defaults on all user read paths", () => {
+  const hash = bcrypt.hashSync("secret", 4);
+  const user = userOps.createUser("alice", hash, "user");
+
+  assert.equal(user?.lidarrRootFolderPath, null);
+  assert.equal(user?.lidarrQualityProfileId, null);
+
+  const stored = userOps.getUserById(user.id);
+  assert.equal(stored?.lidarrRootFolderPath, null);
+  assert.equal(stored?.lidarrQualityProfileId, null);
+
+  const listed = userOps.getAllUsers();
+  assert.equal(listed[0]?.lidarrRootFolderPath, null);
+  assert.equal(listed[0]?.lidarrQualityProfileId, null);
+});
+
+test("user updates persist Lidarr root folder and quality profile defaults", () => {
+  const hash = bcrypt.hashSync("secret", 4);
+  const user = userOps.createUser("bob", hash, "user");
+
+  const updated = userOps.updateUser(user.id, {
+    lidarrRootFolderPath: "/music/alt",
+    lidarrQualityProfileId: 9,
+  });
+
+  assert.equal(updated?.lidarrRootFolderPath, "/music/alt");
+  assert.equal(updated?.lidarrQualityProfileId, 9);
+
+  const stored = userOps.getUserById(user.id);
+  assert.equal(stored?.lidarrRootFolderPath, "/music/alt");
+  assert.equal(stored?.lidarrQualityProfileId, 9);
+});

--- a/.tests/helpers/normalize-commit-message.test.js
+++ b/.tests/helpers/normalize-commit-message.test.js
@@ -8,7 +8,9 @@ import {
 
 test("infers commit types from supported branch names", () => {
   assert.equal(inferCommitTypeFromBranch("feat/listenbrainz-support"), "feat");
+  assert.equal(inferCommitTypeFromBranch("feature/listenbrainz-support"), "feat");
   assert.equal(inferCommitTypeFromBranch("fix/login-loop"), "fix");
+  assert.equal(inferCommitTypeFromBranch("bugfix/login-loop"), "fix");
   assert.equal(inferCommitTypeFromBranch("hotfix/crash-on-submit"), "fix");
   assert.equal(inferCommitTypeFromBranch("refactor/discovery-cache"), "refactor");
   assert.equal(inferCommitTypeFromBranch("chore/update-deps"), "chore");
@@ -26,6 +28,16 @@ test("normalizes plain commit subjects using the branch type", () => {
 
   assert.equal(
     normalizeCommitMessage(message, "feat/103-listenbrainz-support"),
+    [
+      "feat: Add ListenBrainz listening history support",
+      "",
+      "- Generalize per-user listening history settings",
+      "",
+    ].join("\n"),
+  );
+
+  assert.equal(
+    normalizeCommitMessage(message, "feature/103-listenbrainz-support"),
     [
       "feat: Add ListenBrainz listening history support",
       "",

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -69,14 +69,14 @@ const getUserByUsernameStmt = db.prepare(
   "SELECT * FROM users WHERE username = ?"
 );
 const getAllUsersStmt = db.prepare(
-  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username FROM users ORDER BY username"
+  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username, lidarr_root_folder_path, lidarr_quality_profile_id FROM users ORDER BY username"
 );
 const getUserByIdStmt = db.prepare("SELECT * FROM users WHERE id = ?");
 const insertUserStmt = db.prepare(
-  "INSERT INTO users (username, password_hash, role, permissions) VALUES (?, ?, ?, ?)"
+  "INSERT INTO users (username, password_hash, role, permissions, lidarr_root_folder_path, lidarr_quality_profile_id) VALUES (?, ?, ?, ?, ?, ?)"
 );
 const updateUserStmt = db.prepare(
-  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ? WHERE id = ?"
+  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ?, lidarr_root_folder_path = ?, lidarr_quality_profile_id = ? WHERE id = ?"
 );
 const deleteUserStmt = db.prepare("DELETE FROM users WHERE id = ?");
 const getAllListeningHistoryUsersStmt = db.prepare(
@@ -109,6 +109,11 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(row.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lidarrRootFolderPath: row.lidarr_root_folder_path || null,
+      lidarrQualityProfileId:
+        row.lidarr_quality_profile_id != null
+          ? Number(row.lidarr_quality_profile_id)
+          : null,
       ...history,
     };
   },
@@ -124,6 +129,11 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(row.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lidarrRootFolderPath: row.lidarr_root_folder_path || null,
+      lidarrQualityProfileId:
+        row.lidarr_quality_profile_id != null
+          ? Number(row.lidarr_quality_profile_id)
+          : null,
       ...history,
     };
   },
@@ -137,6 +147,11 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(r.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      lidarrRootFolderPath: r.lidarr_root_folder_path || null,
+      lidarrQualityProfileId:
+        r.lidarr_quality_profile_id != null
+          ? Number(r.lidarr_quality_profile_id)
+          : null,
     }));
   },
   createUser(username, passwordHash, role = "user", permissions = null) {
@@ -150,7 +165,9 @@ export const userOps = {
         un.toLowerCase(),
         passwordHash,
         role,
-        dbHelpers.stringifyJSON(perms)
+        dbHelpers.stringifyJSON(perms),
+        null,
+        null,
       );
       return {
         id: result.lastInsertRowid,
@@ -160,6 +177,8 @@ export const userOps = {
         listenHistoryProvider: DEFAULT_LISTEN_HISTORY_PROVIDER,
         listenHistoryUsername: null,
         lastfmUsername: null,
+        lidarrRootFolderPath: null,
+        lidarrQualityProfileId: null,
       };
     } catch (e) {
       return null;
@@ -197,6 +216,26 @@ export const userOps = {
     );
     const lastfmUsername =
       listenHistoryProvider === "lastfm" ? listenHistoryUsername : null;
+    const lidarrRootFolderPath =
+      data.lidarrRootFolderPath !== undefined
+        ? data.lidarrRootFolderPath
+          ? String(data.lidarrRootFolderPath).trim()
+          : null
+        : existing.lidarrRootFolderPath;
+    const parsedLidarrQualityProfileId =
+      data.lidarrQualityProfileId !== undefined &&
+      data.lidarrQualityProfileId !== null
+        ? Number(data.lidarrQualityProfileId)
+        : data.lidarrQualityProfileId === null
+          ? null
+          : existing.lidarrQualityProfileId;
+    const lidarrQualityProfileId =
+      parsedLidarrQualityProfileId != null &&
+      Number.isFinite(parsedLidarrQualityProfileId)
+        ? Math.trunc(parsedLidarrQualityProfileId)
+        : parsedLidarrQualityProfileId === null
+          ? null
+          : existing.lidarrQualityProfileId;
     try {
       updateUserStmt.run(
         username.toLowerCase(),
@@ -206,6 +245,8 @@ export const userOps = {
         lastfmUsername,
         listenHistoryProvider,
         listenHistoryUsername,
+        lidarrRootFolderPath,
+        lidarrQualityProfileId,
         parseInt(id, 10)
       );
       return {
@@ -216,6 +257,8 @@ export const userOps = {
         listenHistoryProvider,
         listenHistoryUsername,
         lastfmUsername,
+        lidarrRootFolderPath,
+        lidarrQualityProfileId,
       };
     } catch (e) {
       return null;

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -134,6 +134,12 @@ if (!userColumns.includes("listen_history_provider")) {
 if (!userColumns.includes("listen_history_username")) {
   db.exec("ALTER TABLE users ADD COLUMN listen_history_username TEXT");
 }
+if (!userColumns.includes("lidarr_root_folder_path")) {
+  db.exec("ALTER TABLE users ADD COLUMN lidarr_root_folder_path TEXT");
+}
+if (!userColumns.includes("lidarr_quality_profile_id")) {
+  db.exec("ALTER TABLE users ADD COLUMN lidarr_quality_profile_id INTEGER");
+}
 
 db.exec(`
   UPDATE users

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -1,7 +1,7 @@
 import { UUID_REGEX } from "../../../config/constants.js";
 import { libraryManager } from "../../../services/libraryManager.js";
 import { musicbrainzGetArtistReleaseGroups } from "../../../services/apiClients.js";
-import { dbOps } from "../../../config/db-helpers.js";
+import { dbOps, userOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import {
   requireAuth,
@@ -224,6 +224,8 @@ export default function registerArtists(router) {
           artistName,
           quality,
           monitorOption,
+          rootFolderPath,
+          qualityProfileId,
         } = req.body;
 
         if (!mbid || !artistName) {
@@ -260,6 +262,33 @@ export default function registerArtists(router) {
           });
         }
 
+        const currentUser =
+          req.user?.id != null ? userOps.getUserById(req.user.id) : null;
+        let preparedAddOptions = null;
+        try {
+          preparedAddOptions = await lidarrClient.resolveArtistAddConfiguration({
+            requestRootFolderPath: rootFolderPath,
+            requestQualityProfileId: qualityProfileId,
+            savedRootFolderPath: currentUser?.lidarrRootFolderPath,
+            savedQualityProfileId: currentUser?.lidarrQualityProfileId,
+            settings,
+          });
+        } catch (error) {
+          const statusCode =
+            error?.statusCode === 400 || error?.statusCode === 409
+              ? error.statusCode
+              : 500;
+          return res.status(statusCode).json({
+            error:
+              statusCode === 409
+                ? "Saved Lidarr default is no longer valid"
+                : "Failed to validate Lidarr add options",
+            message: error.message,
+            field: error.field || null,
+            code: error.code || null,
+          });
+        }
+
         res.status(202).json({
           queued: true,
           foreignArtistId: mbid,
@@ -274,6 +303,8 @@ export default function registerArtists(router) {
           const artist = await libraryManager.addArtist(mbid, artistName, {
             quality: quality || settings.quality || "standard",
             monitorOption: requestedMonitorOption,
+            rootFolderPath: preparedAddOptions?.resolved?.rootFolderPath,
+            qualityProfileId: preparedAddOptions?.resolved?.qualityProfileId,
           });
           if (artist?.error) {
             console.error(

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -23,7 +23,7 @@ router.get("/", noCache, (req, res) => {
 
 router.post("/", async (req, res) => {
   try {
-    const { quality, releaseTypes, integrations } = req.body;
+    const { quality, releaseTypes, integrations, rootFolderPath } = req.body;
 
     const currentSettings = dbOps.getSettings();
     const lidarrExternalUrl = integrations?.lidarr?.externalUrl;
@@ -110,6 +110,10 @@ router.post("/", async (req, res) => {
       ...currentSettings,
       quality:
         quality !== undefined ? quality : currentSettings.quality || "standard",
+      rootFolderPath:
+        rootFolderPath !== undefined
+          ? rootFolderPath
+          : currentSettings.rootFolderPath || null,
       releaseTypes:
         releaseTypes !== undefined
           ? releaseTypes

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -13,6 +13,22 @@ import {
 
 const router = express.Router();
 
+const normalizeRootFolderPath = (value) => {
+  const normalized = String(value || "").trim();
+  return normalized || null;
+};
+
+const normalizeQualityProfileId = (value) => {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Math.trunc(parsed);
+};
+
 const clearOrphanedDiscoveryCache = (userId, existingProfile, nextProfile) => {
   if (
     !hasListenHistoryProfile(existingProfile) ||
@@ -71,6 +87,8 @@ router.post("/", requireAuth, requireAdmin, (req, res) => {
         username: created.username,
         role: created.role,
         permissions: created.permissions,
+        lidarrRootFolderPath: created.lidarrRootFolderPath,
+        lidarrQualityProfileId: created.lidarrQualityProfileId,
       });
   } catch (e) {
     res
@@ -150,6 +168,8 @@ router.patch("/:id", requireAuth, (req, res) => {
           listenHistoryProvider: existing.listenHistoryProvider,
           listenHistoryUsername: existing.listenHistoryUsername,
           lastfmUsername: existing.lastfmUsername,
+          lidarrRootFolderPath: existing.lidarrRootFolderPath,
+          lidarrQualityProfileId: existing.lidarrQualityProfileId,
         });
       }
       const updated = userOps.updateUser(id, updates);
@@ -187,6 +207,8 @@ router.patch("/:id", requireAuth, (req, res) => {
         listenHistoryProvider: existing.listenHistoryProvider,
         listenHistoryUsername: existing.listenHistoryUsername,
         lastfmUsername: existing.lastfmUsername,
+        lidarrRootFolderPath: existing.lidarrRootFolderPath,
+        lidarrQualityProfileId: existing.lidarrQualityProfileId,
       });
     }
     const updated = userOps.updateUser(id, updates);
@@ -219,6 +241,137 @@ const sendListenHistorySettings = (req, res) => {
 
 router.get("/me/listening-history", requireAuth, sendListenHistorySettings);
 router.get("/me/lastfm", requireAuth, sendListenHistorySettings);
+
+router.get("/me/lidarr-preferences", requireAuth, async (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    const { lidarrClient } = await import("../services/lidarrClient.js");
+    const summary = await lidarrClient.getArtistAddPreferenceSummary(user);
+    res.json(summary);
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to get Lidarr preferences",
+      message: e.message,
+    });
+  }
+});
+
+router.patch("/me/lidarr-preferences", requireAuth, async (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const hasRootFolderPath = Object.hasOwn(req.body, "rootFolderPath");
+    const hasQualityProfileId = Object.hasOwn(req.body, "qualityProfileId");
+
+    const nextRootFolderPath = hasRootFolderPath
+      ? req.body.rootFolderPath === null
+        ? null
+        : normalizeRootFolderPath(req.body.rootFolderPath)
+      : user.lidarrRootFolderPath;
+    const nextQualityProfileId = hasQualityProfileId
+      ? req.body.qualityProfileId === null
+        ? null
+        : normalizeQualityProfileId(req.body.qualityProfileId)
+      : user.lidarrQualityProfileId;
+
+    if (hasRootFolderPath && req.body.rootFolderPath !== null && !nextRootFolderPath) {
+      return res.status(400).json({
+        error: "Invalid Lidarr preferences",
+        message: "rootFolderPath must be a non-empty string or null",
+        field: "rootFolderPath",
+      });
+    }
+
+    if (
+      hasQualityProfileId &&
+      req.body.qualityProfileId !== null &&
+      nextQualityProfileId === null
+    ) {
+      return res.status(400).json({
+        error: "Invalid Lidarr preferences",
+        message: "qualityProfileId must be a numeric id or null",
+        field: "qualityProfileId",
+      });
+    }
+
+    const { lidarrClient } = await import("../services/lidarrClient.js");
+    if (!lidarrClient.isConfigured()) {
+      if (nextRootFolderPath !== null || nextQualityProfileId !== null) {
+        return res.status(503).json({
+          error: "Lidarr is not configured",
+          message: "Configure Lidarr before saving library defaults.",
+        });
+      }
+      const updated = userOps.updateUser(req.user.id, {
+        lidarrRootFolderPath: null,
+        lidarrQualityProfileId: null,
+      });
+      return res.json({
+        configured: false,
+        rootFolders: [],
+        qualityProfiles: [],
+        savedDefaults: {
+          rootFolderPath: updated?.lidarrRootFolderPath || null,
+          qualityProfileId: updated?.lidarrQualityProfileId ?? null,
+        },
+        fallbacks: {
+          rootFolderPath: null,
+          qualityProfileId: null,
+        },
+      });
+    }
+
+    const summary = await lidarrClient.getArtistAddPreferenceSummary(user);
+    if (
+      nextRootFolderPath !== null &&
+      !summary.rootFolders.some((folder) => folder.path === nextRootFolderPath)
+    ) {
+      return res.status(400).json({
+        error: "Invalid Lidarr preferences",
+        message: `Unknown Lidarr root folder: ${nextRootFolderPath}`,
+        field: "rootFolderPath",
+      });
+    }
+    if (
+      nextQualityProfileId !== null &&
+      !summary.qualityProfiles.some(
+        (profile) => profile.id === nextQualityProfileId,
+      )
+    ) {
+      return res.status(400).json({
+        error: "Invalid Lidarr preferences",
+        message: `Unknown Lidarr quality profile: ${nextQualityProfileId}`,
+        field: "qualityProfileId",
+      });
+    }
+
+    const updated = userOps.updateUser(req.user.id, {
+      lidarrRootFolderPath: nextRootFolderPath,
+      lidarrQualityProfileId: nextQualityProfileId,
+    });
+    if (!updated) {
+      return res.status(500).json({
+        error: "Failed to save Lidarr preferences",
+      });
+    }
+
+    const refreshedSummary = await lidarrClient.getArtistAddPreferenceSummary(
+      updated,
+    );
+    res.json(refreshedSummary);
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to save Lidarr preferences",
+      message: e.message,
+    });
+  }
+});
 
 router.post("/me/password", requireAuth, (req, res) => {
   try {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -89,8 +89,12 @@ export class LibraryManager {
       const lidarrArtist = await lidarr.addArtist(mbid, artistName, {
         albumOnly: options.albumOnly === true,
         monitorOption: options.monitorOption || "none",
-        qualityProfileId: lidarrSettings.integrations?.lidarr?.qualityProfileId,
+        rootFolderPath: options.rootFolderPath,
+        savedRootFolderPath: options.savedRootFolderPath,
+        qualityProfileId: options.qualityProfileId,
+        savedQualityProfileId: options.savedQualityProfileId,
         metadataProfileId:
+          options.metadataProfileId ||
           lidarrSettings.integrations?.lidarr?.metadataProfileId,
       });
       console.log(`[LibraryManager] Added artist "${artistName}" to Lidarr`);

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -12,6 +12,71 @@ const LIDARR_RETRY_ATTEMPTS = 2;
 const LIDARR_RETRY_DELAY_MS = 800;
 const LIDARR_STATUS_CACHE_MS = 10000;
 
+function normalizeRootFolderPath(value) {
+  const normalized = String(value || "").trim();
+  return normalized || null;
+}
+
+function normalizeProfileId(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Math.trunc(parsed);
+}
+
+function createPreferenceError(statusCode, field, message, code) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  error.field = field;
+  error.code = code;
+  return error;
+}
+
+function mapRootFolders(rootFolders) {
+  return Array.isArray(rootFolders)
+    ? rootFolders
+        .filter((item) => normalizeRootFolderPath(item?.path))
+        .map((item) => ({
+          ...item,
+          path: normalizeRootFolderPath(item.path),
+        }))
+    : [];
+}
+
+function mapQualityProfiles(qualityProfiles) {
+  return Array.isArray(qualityProfiles)
+    ? qualityProfiles
+        .filter((profile) => normalizeProfileId(profile?.id) !== null)
+        .map((profile) => ({
+          ...profile,
+          id: normalizeProfileId(profile.id),
+        }))
+    : [];
+}
+
+function findRootFolder(rootFolders, rootFolderPath) {
+  const normalizedPath = normalizeRootFolderPath(rootFolderPath);
+  if (!normalizedPath) return null;
+  return (
+    rootFolders.find(
+      (folder) => normalizeRootFolderPath(folder?.path) === normalizedPath,
+    ) || null
+  );
+}
+
+function findQualityProfile(qualityProfiles, qualityProfileId) {
+  const normalizedId = normalizeProfileId(qualityProfileId);
+  if (normalizedId === null) return null;
+  return (
+    qualityProfiles.find((profile) => normalizeProfileId(profile?.id) === normalizedId) ||
+    null
+  );
+}
+
 export class LidarrClient {
   constructor() {
     this.config = null;
@@ -140,6 +205,7 @@ export class LidarrClient {
   }
 
   isConfigured() {
+    this.updateConfig();
     return !!this.config.apiKey;
   }
 
@@ -518,14 +584,183 @@ export class LidarrClient {
     return this.request("/rootFolder");
   }
 
-  async addArtist(mbid, artistName, options = {}) {
-    const rootFolders = await this.getRootFolders();
-    if (!rootFolders || rootFolders.length === 0) {
+  getArtistAddFallbacks({ rootFolders, qualityProfiles, settings } = {}) {
+    const safeRootFolders = mapRootFolders(rootFolders);
+    const safeQualityProfiles = mapQualityProfiles(qualityProfiles);
+    const currentSettings = settings || dbOps.getSettings();
+
+    const legacyRootFolderPath = normalizeRootFolderPath(
+      currentSettings.rootFolderPath,
+    );
+    const legacyQualityProfileId = normalizeProfileId(
+      currentSettings.integrations?.lidarr?.qualityProfileId,
+    );
+
+    const fallbackRootFolder =
+      findRootFolder(safeRootFolders, legacyRootFolderPath) || safeRootFolders[0];
+    const fallbackQualityProfile =
+      findQualityProfile(safeQualityProfiles, legacyQualityProfileId) ||
+      safeQualityProfiles[0];
+
+    return {
+      rootFolderPath: fallbackRootFolder?.path || null,
+      qualityProfileId: fallbackQualityProfile?.id ?? null,
+    };
+  }
+
+  async getArtistAddPreferenceSummary(user = null) {
+    if (!this.isConfigured()) {
+      return {
+        configured: false,
+        rootFolders: [],
+        qualityProfiles: [],
+        savedDefaults: {
+          rootFolderPath: normalizeRootFolderPath(user?.lidarrRootFolderPath),
+          qualityProfileId: normalizeProfileId(user?.lidarrQualityProfileId),
+        },
+        fallbacks: {
+          rootFolderPath: null,
+          qualityProfileId: null,
+        },
+      };
+    }
+
+    const [rootFoldersRaw, qualityProfilesRaw] = await Promise.all([
+      this.getRootFolders(),
+      this.getQualityProfiles(),
+    ]);
+    const rootFolders = mapRootFolders(rootFoldersRaw);
+    const qualityProfiles = mapQualityProfiles(qualityProfilesRaw);
+
+    return {
+      configured: true,
+      rootFolders: rootFolders.map((folder) => ({ path: folder.path })),
+      qualityProfiles: qualityProfiles.map((profile) => ({
+        id: profile.id,
+        name: profile.name || `Profile ${profile.id}`,
+      })),
+      savedDefaults: {
+        rootFolderPath: normalizeRootFolderPath(user?.lidarrRootFolderPath),
+        qualityProfileId: normalizeProfileId(user?.lidarrQualityProfileId),
+      },
+      fallbacks: this.getArtistAddFallbacks({
+        rootFolders,
+        qualityProfiles,
+      }),
+    };
+  }
+
+  async resolveArtistAddConfiguration(options = {}) {
+    const rootFolders = mapRootFolders(
+      options.rootFolders || (await this.getRootFolders()),
+    );
+    if (rootFolders.length === 0) {
       throw new Error("No root folders configured in Lidarr");
     }
 
-    const rootFolder = rootFolders[0];
+    const qualityProfiles = mapQualityProfiles(
+      options.qualityProfiles || (await this.getQualityProfiles()),
+    );
+    if (qualityProfiles.length === 0) {
+      throw new Error("No quality profiles configured in Lidarr");
+    }
+
+    const fallbacks = this.getArtistAddFallbacks({
+      rootFolders,
+      qualityProfiles,
+      settings: options.settings,
+    });
+
+    const requestedRootFolderPath = normalizeRootFolderPath(
+      options.requestRootFolderPath,
+    );
+    const requestedQualityProfileId = normalizeProfileId(
+      options.requestQualityProfileId,
+    );
+    const savedRootFolderPath = normalizeRootFolderPath(
+      options.savedRootFolderPath,
+    );
+    const savedQualityProfileId = normalizeProfileId(
+      options.savedQualityProfileId,
+    );
+
+    let resolvedRootFolderPath = fallbacks.rootFolderPath;
+    let resolvedQualityProfileId = fallbacks.qualityProfileId;
+
+    if (requestedRootFolderPath) {
+      const requestRootFolder = findRootFolder(rootFolders, requestedRootFolderPath);
+      if (!requestRootFolder) {
+        throw createPreferenceError(
+          400,
+          "rootFolderPath",
+          `Unknown Lidarr root folder: ${requestedRootFolderPath}`,
+          "INVALID_ROOT_FOLDER_PATH",
+        );
+      }
+      resolvedRootFolderPath = requestRootFolder.path;
+    } else if (savedRootFolderPath) {
+      const savedRootFolder = findRootFolder(rootFolders, savedRootFolderPath);
+      if (!savedRootFolder) {
+        throw createPreferenceError(
+          409,
+          "rootFolderPath",
+          `Your saved Lidarr root folder no longer exists: ${savedRootFolderPath}. Update your Library Defaults or use Customize.`,
+          "STALE_ROOT_FOLDER_PATH",
+        );
+      }
+      resolvedRootFolderPath = savedRootFolder.path;
+    }
+
+    if (requestedQualityProfileId !== null) {
+      const requestQualityProfile = findQualityProfile(
+        qualityProfiles,
+        requestedQualityProfileId,
+      );
+      if (!requestQualityProfile) {
+        throw createPreferenceError(
+          400,
+          "qualityProfileId",
+          `Unknown Lidarr quality profile: ${requestedQualityProfileId}`,
+          "INVALID_QUALITY_PROFILE_ID",
+        );
+      }
+      resolvedQualityProfileId = requestQualityProfile.id;
+    } else if (savedQualityProfileId !== null) {
+      const savedQualityProfile = findQualityProfile(
+        qualityProfiles,
+        savedQualityProfileId,
+      );
+      if (!savedQualityProfile) {
+        throw createPreferenceError(
+          409,
+          "qualityProfileId",
+          `Your saved Lidarr quality profile no longer exists: ${savedQualityProfileId}. Update your Library Defaults or use Customize.`,
+          "STALE_QUALITY_PROFILE_ID",
+        );
+      }
+      resolvedQualityProfileId = savedQualityProfile.id;
+    }
+
+    return {
+      rootFolders,
+      qualityProfiles,
+      fallbacks,
+      resolved: {
+        rootFolderPath: resolvedRootFolderPath,
+        qualityProfileId: resolvedQualityProfileId,
+      },
+    };
+  }
+
+  async addArtist(mbid, artistName, options = {}) {
     const settings = dbOps.getSettings();
+    const { resolved } = await this.resolveArtistAddConfiguration({
+      requestRootFolderPath: options.rootFolderPath,
+      requestQualityProfileId: options.qualityProfileId,
+      savedRootFolderPath: options.savedRootFolderPath,
+      savedQualityProfileId: options.savedQualityProfileId,
+      settings,
+    });
 
     const albumOnly = options.albumOnly === true;
     const monitorOption = options.monitorOption || options.monitor || "none";
@@ -535,10 +770,7 @@ export class LidarrClient {
     const searchOnAdd = settings.integrations?.lidarr?.searchOnAdd ?? false;
     const monitorNewItems = monitorOption === "none" ? "none" : "all";
 
-    const defaultQualityProfileId =
-      settings.integrations?.lidarr?.qualityProfileId;
-    const qualityProfileId =
-      options.qualityProfileId || defaultQualityProfileId || 1;
+    const qualityProfileId = resolved.qualityProfileId;
     const defaultMetadataProfileId =
       settings.integrations?.lidarr?.metadataProfileId;
     let metadataProfileId =
@@ -556,7 +788,7 @@ export class LidarrClient {
     const lidarrArtist = {
       artistName: artistName,
       foreignArtistId: mbid,
-      rootFolderPath: rootFolder.path,
+      rootFolderPath: resolved.rootFolderPath,
       qualityProfileId: qualityProfileId,
       metadataProfileId: metadataProfileId,
       monitored: artistMonitored,

--- a/frontend/src/components/AddToLibraryButton.css
+++ b/frontend/src/components/AddToLibraryButton.css
@@ -1,3 +1,13 @@
+.add-to-library-button-group {
+  display: inline-flex;
+  align-items: stretch;
+  overflow: hidden;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #302d38 0%, #2a2830 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+}
+
 .add-to-library-button {
   display: block;
   background-color: #2a2830;
@@ -13,6 +23,10 @@
   transition: all 0.25s cubic-bezier(0.310, -0.105, 0.430, 1.400);
   border: none;
   padding: 0;
+}
+
+.add-to-library-button.add-to-library-button--split {
+  border-radius: 0;
 }
 
 .add-to-library-button span,
@@ -35,11 +49,11 @@
 
 .add-to-library-button span:after {
   content: '';
-  background-color: #3a3840; /* Darker separator */
-  width: 2px;
-  height: 70%;
+  background-color: rgba(255, 255, 255, 0.1);
+  width: 1px;
+  height: 58%;
   position: absolute;
-  top: 15%;
+  top: 21%;
   right: -1px;
 }
 
@@ -103,4 +117,46 @@
 
 .add-to-library-button:active {
   opacity: 1;
+}
+
+.add-to-library-button-split-trigger {
+  width: 48px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  position: relative;
+  background: transparent;
+  color: #fff;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.add-to-library-button-split-trigger::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.add-to-library-button-group .add-to-library-button {
+  background: transparent;
+  box-shadow: none;
+}
+
+.add-to-library-button-group .add-to-library-button:hover,
+.add-to-library-button-group .add-to-library-button.success {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.add-to-library-button-split-trigger:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.add-to-library-button-split-trigger:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -13,6 +13,7 @@ import { ArtistDetailsReleaseGroups } from "./components/ArtistDetailsReleaseGro
 import { ArtistDetailsSimilar } from "./components/ArtistDetailsSimilar";
 import { DeleteArtistModal } from "./components/DeleteArtistModal";
 import { DeleteAlbumModal } from "./components/DeleteAlbumModal";
+import { AddArtistCustomizeModal } from "./components/AddArtistCustomizeModal";
 import {
   getArtistCover,
   getArtistDetails,
@@ -258,6 +259,7 @@ function ArtistDetailsPage() {
         handleDeleteClick={library.handleDeleteClick}
         canAddArtist={canAddArtist}
         handleAddToLibrary={library.handleAddToLibrary}
+        handleOpenAddCustomizeModal={library.handleOpenAddCustomizeModal}
         addingToLibrary={library.addingToLibrary}
         canRefreshArtist={canChangeMonitoring}
         handleRefreshArtist={library.handleRefreshArtist}
@@ -363,6 +365,20 @@ function ArtistDetailsPage() {
         onCancel={library.handleDeleteAlbumCancel}
         onConfirm={library.handleDeleteAlbumConfirm}
         removing={library.removingAlbum}
+      />
+
+      <AddArtistCustomizeModal
+        show={library.showAddCustomizeModal}
+        artistName={artist?.name}
+        loading={library.loadingLidarrPreferences}
+        preferences={library.lidarrPreferences}
+        rootFolderPath={library.customizeRootFolderPath}
+        setRootFolderPath={library.setCustomizeRootFolderPath}
+        qualityProfileId={library.customizeQualityProfileId}
+        setQualityProfileId={library.setCustomizeQualityProfileId}
+        onClose={() => library.setShowAddCustomizeModal(false)}
+        onConfirm={library.handleCustomizeAddToLibrary}
+        confirming={library.addingToLibrary}
       />
 
       <EditArtistIdsModal

--- a/frontend/src/pages/ArtistDetails/components/AddArtistCustomizeModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/AddArtistCustomizeModal.jsx
@@ -1,0 +1,163 @@
+import PropTypes from "prop-types";
+import { Loader } from "lucide-react";
+
+export function AddArtistCustomizeModal({
+  show,
+  artistName,
+  loading,
+  preferences,
+  rootFolderPath,
+  setRootFolderPath,
+  qualityProfileId,
+  setQualityProfileId,
+  onClose,
+  onConfirm,
+  confirming,
+}) {
+  if (!show) return null;
+
+  const rootFolders = Array.isArray(preferences?.rootFolders)
+    ? preferences.rootFolders
+    : [];
+  const qualityProfiles = Array.isArray(preferences?.qualityProfiles)
+    ? preferences.qualityProfiles
+    : [];
+  const configured = preferences?.configured === true;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.75)" }}
+      onClick={confirming ? undefined : onClose}
+    >
+      <div
+        className="card max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4">
+          <h3 className="text-xl font-bold mb-2" style={{ color: "#fff" }}>
+            Customize Add
+          </h3>
+          <p style={{ color: "#c1c1c3" }}>
+            Choose where <strong>{artistName}</strong> should go for this add
+            only.
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="py-10 flex items-center justify-center">
+            <Loader
+              className="w-8 h-8 animate-spin"
+              style={{ color: "#c1c1c3" }}
+            />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Root Folder
+              </label>
+              <select
+                className="input"
+                value={rootFolderPath}
+                onChange={(e) => setRootFolderPath(e.target.value)}
+                disabled={!configured || confirming}
+              >
+                <option value="">
+                  {configured
+                    ? "Use automatic default"
+                    : "Lidarr is not configured"}
+                </option>
+                {rootFolders.map((folder) => (
+                  <option key={folder.path} value={folder.path}>
+                    {folder.path}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Quality Profile
+              </label>
+              <select
+                className="input"
+                value={qualityProfileId}
+                onChange={(e) => setQualityProfileId(e.target.value)}
+                disabled={!configured || confirming}
+              >
+                <option value="">
+                  {configured
+                    ? "Use automatic default"
+                    : "Lidarr is not configured"}
+                </option>
+                {qualityProfiles.map((profile) => (
+                  <option key={profile.id} value={String(profile.id)}>
+                    {profile.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <p className="text-xs" style={{ color: "#c1c1c3" }}>
+              Leaving a field on automatic uses your saved Library Defaults, or
+              the global Lidarr fallback when you do not have a saved default.
+            </p>
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end mt-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-secondary"
+            disabled={confirming}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="btn btn-primary"
+            disabled={loading || !configured || confirming}
+          >
+            {confirming ? "Adding..." : "Add Artist"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+AddArtistCustomizeModal.propTypes = {
+  show: PropTypes.bool,
+  artistName: PropTypes.string,
+  loading: PropTypes.bool,
+  preferences: PropTypes.shape({
+    configured: PropTypes.bool,
+    rootFolders: PropTypes.arrayOf(
+      PropTypes.shape({
+        path: PropTypes.string,
+      }),
+    ),
+    qualityProfiles: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+      }),
+    ),
+  }),
+  rootFolderPath: PropTypes.string,
+  setRootFolderPath: PropTypes.func,
+  qualityProfileId: PropTypes.string,
+  setQualityProfileId: PropTypes.func,
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+  confirming: PropTypes.bool,
+};

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -7,6 +7,7 @@ import {
   CheckCircle,
   RefreshCw,
   ChevronDown,
+  SlidersHorizontal,
   Calendar,
   MapPin,
   Trash2,
@@ -39,6 +40,7 @@ export function ArtistDetailsHero({
   handleDeleteClick,
   canAddArtist,
   handleAddToLibrary,
+  handleOpenAddCustomizeModal,
   addingToLibrary,
   canRefreshArtist,
   handleRefreshArtist,
@@ -104,9 +106,23 @@ export function ArtistDetailsHero({
 
         <div className="flex-1">
           <div className="flex justify-between items-start gap-4">
-            <h1 className="text-4xl font-bold mb-2" style={{ color: "#fff" }}>
-              {artist.name}
-            </h1>
+            <div className="flex items-start gap-3 min-w-0">
+              <h1
+                className="text-4xl font-bold mb-2"
+                style={{ color: "#fff" }}
+              >
+                {artist.name}
+              </h1>
+              <button
+                type="button"
+                onClick={onEditIds}
+                className="btn btn-secondary btn-sm p-2 inline-flex items-center flex-shrink-0 mt-1"
+                aria-label="Edit IDs"
+                title="Edit artist IDs"
+              >
+                <Pencil className="w-5 h-5" />
+              </button>
+            </div>
             {existsInLibrary && canRefreshArtist && (
               <button
                 onClick={handleRefreshArtist}
@@ -317,21 +333,25 @@ export function ArtistDetailsHero({
               </>
             ) : (
               canAddArtist && (
-                <AddToLibraryButton
-                  onClick={handleAddToLibrary}
-                  isLoading={addingToLibrary}
-                />
+                <div className="add-to-library-button-group">
+                  <AddToLibraryButton
+                    onClick={handleAddToLibrary}
+                    isLoading={addingToLibrary}
+                    className="add-to-library-button--split"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleOpenAddCustomizeModal}
+                    disabled={addingToLibrary}
+                    className="add-to-library-button-split-trigger"
+                    aria-label="Customize add options"
+                    title="Customize add options"
+                  >
+                    <SlidersHorizontal className="w-4 h-4" />
+                  </button>
+                </div>
               )
             )}
-
-            <button
-              type="button"
-              onClick={onEditIds}
-              className="btn btn-secondary btn-sm p-2 inline-flex items-center"
-              aria-label="Edit IDs"
-            >
-              <Pencil className="w-5 h-5" />
-            </button>
             <div className="relative inline-flex">
               <button
                 type="button"
@@ -611,6 +631,7 @@ ArtistDetailsHero.propTypes = {
   handleDeleteClick: PropTypes.func,
   canAddArtist: PropTypes.bool,
   handleAddToLibrary: PropTypes.func,
+  handleOpenAddCustomizeModal: PropTypes.func,
   addingToLibrary: PropTypes.bool,
   canRefreshArtist: PropTypes.bool,
   handleRefreshArtist: PropTypes.func,

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -14,6 +14,7 @@ import {
   getDownloadStatus,
   addArtistToLibrary,
   lookupArtistInLibrary,
+  getMyLidarrPreferences,
 } from "../../../utils/api";
 import { deduplicateAlbums } from "../utils";
 import { matchesReleaseTypeFilter } from "../utils";
@@ -53,6 +54,13 @@ export function useArtistDetailsLibrary({
   const [downloadStatuses, setDownloadStatuses] = useState({});
   const [reSearchingAlbum, setReSearchingAlbum] = useState(null);
   const [reSearchOverrides, setReSearchOverrides] = useState({});
+  const [showAddCustomizeModal, setShowAddCustomizeModal] = useState(false);
+  const [loadingLidarrPreferences, setLoadingLidarrPreferences] =
+    useState(false);
+  const [lidarrPreferences, setLidarrPreferences] = useState(null);
+  const [customizeRootFolderPath, setCustomizeRootFolderPath] = useState("");
+  const [customizeQualityProfileId, setCustomizeQualityProfileId] =
+    useState("");
   const reSearchOverridesRef = useRef({});
   const unmonitoredAtRef = useRef({});
   const libraryAlbumIdsRef = useRef([]);
@@ -314,7 +322,52 @@ export function useArtistDetailsLibrary({
     return libraryArtist.monitored ? "all" : "none";
   };
 
-  const handleAddToLibrary = async () => {
+  const applyCustomizeDefaults = (preferences) => {
+    const nextRootFolderPath =
+      preferences?.savedDefaults?.rootFolderPath ||
+      preferences?.fallbacks?.rootFolderPath ||
+      "";
+    const nextQualityProfileId =
+      preferences?.savedDefaults?.qualityProfileId != null
+        ? String(preferences.savedDefaults.qualityProfileId)
+        : preferences?.fallbacks?.qualityProfileId != null
+          ? String(preferences.fallbacks.qualityProfileId)
+          : "";
+    setCustomizeRootFolderPath(nextRootFolderPath);
+    setCustomizeQualityProfileId(nextQualityProfileId);
+  };
+
+  const loadLidarrPreferenceState = async ({ force = false } = {}) => {
+    if (!force && lidarrPreferences) {
+      return lidarrPreferences;
+    }
+    setLoadingLidarrPreferences(true);
+    try {
+      const preferences = await getMyLidarrPreferences();
+      setLidarrPreferences(preferences);
+      return preferences;
+    } finally {
+      setLoadingLidarrPreferences(false);
+    }
+  };
+
+  const handleOpenAddCustomizeModal = async () => {
+    setShowAddCustomizeModal(true);
+    try {
+      const preferences = await loadLidarrPreferenceState();
+      applyCustomizeDefaults(preferences);
+    } catch (err) {
+      setShowAddCustomizeModal(false);
+      showError(
+        err.response?.data?.message ||
+          err.response?.data?.error ||
+          err.message ||
+          "Failed to load Lidarr preferences",
+      );
+    }
+  };
+
+  const addArtistWithOptions = async (overrides = {}) => {
     if (!artist) {
       showError("Artist information not available");
       return;
@@ -325,7 +378,12 @@ export function useArtistDetailsLibrary({
         foreignArtistId: artist.id,
         artistName: artist.name,
         quality: appSettings?.quality || "standard",
-        rootFolderPath: appSettings?.rootFolderPath,
+        ...(Object.hasOwn(overrides, "rootFolderPath")
+          ? { rootFolderPath: overrides.rootFolderPath }
+          : {}),
+        ...(Object.hasOwn(overrides, "qualityProfileId")
+          ? { qualityProfileId: overrides.qualityProfileId }
+          : {}),
       });
       let fullArtist = await resolveArtistFromAddResponse(result, {
         refresh: true,
@@ -357,6 +415,21 @@ export function useArtistDetailsLibrary({
     } finally {
       setAddingToLibrary(false);
     }
+  };
+
+  const handleAddToLibrary = async () => addArtistWithOptions();
+
+  const handleCustomizeAddToLibrary = async () => {
+    const success = await addArtistWithOptions({
+      rootFolderPath: customizeRootFolderPath || null,
+      qualityProfileId: customizeQualityProfileId
+        ? Number(customizeQualityProfileId)
+        : null,
+    });
+    if (success) {
+      setShowAddCustomizeModal(false);
+    }
+    return success;
   };
 
   const handleRequestAlbum = async (albumId, title) => {
@@ -400,7 +473,6 @@ export function useArtistDetailsLibrary({
           foreignArtistId: artist.id,
           artistName: artist.name,
           quality: appSettings?.quality || "standard",
-          rootFolderPath: appSettings?.rootFolderPath,
         });
         let fullArtist = await resolveArtistFromAddResponse(result, {
           refresh: false,
@@ -1003,6 +1075,14 @@ export function useArtistDetailsLibrary({
     setDeleteFiles,
     deletingArtist,
     addingToLibrary,
+    showAddCustomizeModal,
+    setShowAddCustomizeModal,
+    loadingLidarrPreferences,
+    lidarrPreferences,
+    customizeRootFolderPath,
+    setCustomizeRootFolderPath,
+    customizeQualityProfileId,
+    setCustomizeQualityProfileId,
     showMonitorOptionMenu,
     setShowMonitorOptionMenu,
     updatingMonitor,
@@ -1016,6 +1096,8 @@ export function useArtistDetailsLibrary({
     handleUpdateMonitorOption,
     getCurrentMonitorOption,
     handleAddToLibrary,
+    handleOpenAddCustomizeModal,
+    handleCustomizeAddToLibrary,
     handleRequestAlbum,
     handleReSearchAlbum,
     handleLibraryAlbumClick,

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -116,6 +116,13 @@ function SettingsPage() {
             setListenHistoryProvider={account.setListenHistoryProvider}
             listenHistoryUsername={account.listenHistoryUsername}
             setListenHistoryUsername={account.setListenHistoryUsername}
+            lidarrConfigured={account.lidarrConfigured}
+            lidarrRootFolders={account.lidarrRootFolders}
+            lidarrQualityProfiles={account.lidarrQualityProfiles}
+            lidarrRootFolderPath={account.lidarrRootFolderPath}
+            setLidarrRootFolderPath={account.setLidarrRootFolderPath}
+            lidarrQualityProfileId={account.lidarrQualityProfileId}
+            setLidarrQualityProfileId={account.setLidarrQualityProfileId}
             hasUnsavedChanges={account.hasUnsavedChanges}
             loading={account.loading}
             saving={account.saving}

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -7,6 +7,13 @@ export function SettingsAccountTab({
   setListenHistoryProvider,
   listenHistoryUsername,
   setListenHistoryUsername,
+  lidarrConfigured,
+  lidarrRootFolders,
+  lidarrQualityProfiles,
+  lidarrRootFolderPath,
+  setLidarrRootFolderPath,
+  lidarrQualityProfileId,
+  setLidarrQualityProfileId,
   hasUnsavedChanges,
   loading,
   saving,
@@ -128,6 +135,81 @@ export function SettingsAccountTab({
               </p>
             </div>
           </fieldset>
+        </div>
+
+        <div
+          className="p-6 rounded-lg space-y-4"
+          style={{
+            backgroundColor: "#1a1a1e",
+            border: "1px solid #2a2a2e",
+          }}
+        >
+          <div className="mb-2">
+            <h3
+              className="text-lg font-medium flex items-center"
+              style={{ color: "#fff" }}
+            >
+              Library Defaults
+            </h3>
+            <p className="mt-1 text-sm" style={{ color: "#c1c1c3" }}>
+              These defaults apply to one-click artist adds unless you override
+              them from the Customize action on the artist page.
+            </p>
+          </div>
+
+          <fieldset
+            disabled={!lidarrConfigured}
+            className={`space-y-4 ${lidarrConfigured ? "" : "opacity-60"}`}
+          >
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Default Root Folder
+              </label>
+              <select
+                className="input"
+                value={lidarrRootFolderPath}
+                onChange={(e) => setLidarrRootFolderPath(e.target.value)}
+              >
+                <option value="">Use automatic default</option>
+                {lidarrRootFolders.map((folder) => (
+                  <option key={folder.path} value={folder.path}>
+                    {folder.path}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Default Quality Profile
+              </label>
+              <select
+                className="input"
+                value={lidarrQualityProfileId}
+                onChange={(e) => setLidarrQualityProfileId(e.target.value)}
+              >
+                <option value="">Use automatic default</option>
+                {lidarrQualityProfiles.map((profile) => (
+                  <option key={profile.id} value={String(profile.id)}>
+                    {profile.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </fieldset>
+
+          {!lidarrConfigured && (
+            <p className="text-xs" style={{ color: "#c1c1c3" }}>
+              Lidarr must be configured by an admin before personal library
+              defaults can be saved.
+            </p>
+          )}
         </div>
       </form>
     </div>

--- a/frontend/src/pages/Settings/hooks/useAccountSettings.js
+++ b/frontend/src/pages/Settings/hooks/useAccountSettings.js
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import {
   getMyListeningHistory,
+  getMyLidarrPreferences,
   updateMyListeningHistory,
+  updateMyLidarrPreferences,
 } from "../../../utils/api";
 
 export function useAccountSettings(authUser, showSuccess, showError) {
@@ -11,25 +13,57 @@ export function useAccountSettings(authUser, showSuccess, showError) {
     useState("lastfm");
   const [savedListenHistoryUsername, setSavedListenHistoryUsername] =
     useState("");
+  const [lidarrConfigured, setLidarrConfigured] = useState(false);
+  const [lidarrRootFolders, setLidarrRootFolders] = useState([]);
+  const [lidarrQualityProfiles, setLidarrQualityProfiles] = useState([]);
+  const [lidarrRootFolderPath, setLidarrRootFolderPath] = useState("");
+  const [savedLidarrRootFolderPath, setSavedLidarrRootFolderPath] =
+    useState("");
+  const [lidarrQualityProfileId, setLidarrQualityProfileId] = useState("");
+  const [savedLidarrQualityProfileId, setSavedLidarrQualityProfileId] =
+    useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
   const hasUnsavedChanges =
     listenHistoryProvider !== savedListenHistoryProvider ||
-    listenHistoryUsername !== savedListenHistoryUsername;
+    listenHistoryUsername !== savedListenHistoryUsername ||
+    lidarrRootFolderPath !== savedLidarrRootFolderPath ||
+    lidarrQualityProfileId !== savedLidarrQualityProfileId;
 
   const fetchListeningHistory = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await getMyListeningHistory();
-      const provider = data.listenHistoryProvider || "lastfm";
-      const username = data.listenHistoryUsername || "";
+      const [historyData, lidarrData] = await Promise.all([
+        getMyListeningHistory(),
+        getMyLidarrPreferences(),
+      ]);
+      const provider = historyData.listenHistoryProvider || "lastfm";
+      const username = historyData.listenHistoryUsername || "";
       setListenHistoryProvider(provider);
       setListenHistoryUsername(username);
       setSavedListenHistoryProvider(provider);
       setSavedListenHistoryUsername(username);
+      setLidarrConfigured(lidarrData?.configured === true);
+      setLidarrRootFolders(
+        Array.isArray(lidarrData?.rootFolders) ? lidarrData.rootFolders : [],
+      );
+      setLidarrQualityProfiles(
+        Array.isArray(lidarrData?.qualityProfiles)
+          ? lidarrData.qualityProfiles
+          : [],
+      );
+      const nextRootFolderPath = lidarrData?.savedDefaults?.rootFolderPath || "";
+      const nextQualityProfileId =
+        lidarrData?.savedDefaults?.qualityProfileId != null
+          ? String(lidarrData.savedDefaults.qualityProfileId)
+          : "";
+      setLidarrRootFolderPath(nextRootFolderPath);
+      setSavedLidarrRootFolderPath(nextRootFolderPath);
+      setLidarrQualityProfileId(nextQualityProfileId);
+      setSavedLidarrQualityProfileId(nextQualityProfileId);
     } catch {
-      showError("Failed to load listening history settings");
+      showError("Failed to load account settings");
     } finally {
       setLoading(false);
     }
@@ -44,17 +78,43 @@ export function useAccountSettings(authUser, showSuccess, showError) {
     try {
       setSaving(true);
       const trimmedUsername = listenHistoryUsername.trim();
-      await updateMyListeningHistory(
-        authUser.id,
-        listenHistoryProvider,
-        trimmedUsername || null,
-      );
+      const lidarrData = await Promise.all([
+        updateMyListeningHistory(
+          authUser.id,
+          listenHistoryProvider,
+          trimmedUsername || null,
+        ),
+        updateMyLidarrPreferences({
+          rootFolderPath: lidarrRootFolderPath || null,
+          qualityProfileId: lidarrQualityProfileId
+            ? Number(lidarrQualityProfileId)
+            : null,
+        }),
+      ]).then(([, lidarrResponse]) => lidarrResponse);
       setSavedListenHistoryProvider(listenHistoryProvider);
       setSavedListenHistoryUsername(trimmedUsername);
       setListenHistoryUsername(trimmedUsername);
-      showSuccess("Listening history settings saved");
+      setLidarrConfigured(lidarrData?.configured === true);
+      setLidarrRootFolders(
+        Array.isArray(lidarrData?.rootFolders) ? lidarrData.rootFolders : [],
+      );
+      setLidarrQualityProfiles(
+        Array.isArray(lidarrData?.qualityProfiles)
+          ? lidarrData.qualityProfiles
+          : [],
+      );
+      const nextRootFolderPath = lidarrData?.savedDefaults?.rootFolderPath || "";
+      const nextQualityProfileId =
+        lidarrData?.savedDefaults?.qualityProfileId != null
+          ? String(lidarrData.savedDefaults.qualityProfileId)
+          : "";
+      setLidarrRootFolderPath(nextRootFolderPath);
+      setSavedLidarrRootFolderPath(nextRootFolderPath);
+      setLidarrQualityProfileId(nextQualityProfileId);
+      setSavedLidarrQualityProfileId(nextQualityProfileId);
+      showSuccess("Account settings saved");
     } catch {
-      showError("Failed to save listening history settings");
+      showError("Failed to save account settings");
     } finally {
       setSaving(false);
     }
@@ -62,6 +122,8 @@ export function useAccountSettings(authUser, showSuccess, showError) {
     authUser?.id,
     listenHistoryProvider,
     listenHistoryUsername,
+    lidarrRootFolderPath,
+    lidarrQualityProfileId,
     showSuccess,
     showError,
   ]);
@@ -71,6 +133,13 @@ export function useAccountSettings(authUser, showSuccess, showError) {
     setListenHistoryProvider,
     listenHistoryUsername,
     setListenHistoryUsername,
+    lidarrConfigured,
+    lidarrRootFolders,
+    lidarrQualityProfiles,
+    lidarrRootFolderPath,
+    setLidarrRootFolderPath,
+    lidarrQualityProfileId,
+    setLidarrQualityProfileId,
     hasUnsavedChanges,
     loading,
     saving,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -578,6 +578,11 @@ export const getMyListeningHistory = async () => {
   return response.data;
 };
 
+export const getMyLidarrPreferences = async () => {
+  const response = await api.get("/users/me/lidarr-preferences");
+  return response.data;
+};
+
 export const updateMyListeningHistory = async (
   userId,
   listenHistoryProvider,
@@ -587,6 +592,11 @@ export const updateMyListeningHistory = async (
     listenHistoryProvider,
     listenHistoryUsername,
   });
+  return response.data;
+};
+
+export const updateMyLidarrPreferences = async (payload) => {
+  const response = await api.patch("/users/me/lidarr-preferences", payload);
   return response.data;
 };
 

--- a/scripts/normalize-commit-message.js
+++ b/scripts/normalize-commit-message.js
@@ -6,15 +6,23 @@ import { fileURLToPath, pathToFileURL } from "url";
 const CONVENTIONAL_HEADER_RE =
   /^(feat|fix|refactor|chore|docs|ci)(\([a-z0-9-]+\))?(!)?: .+/;
 
+const BRANCH_TYPE_ALIASES = [
+  ["feat/", "feat"],
+  ["feature/", "feat"],
+  ["fix/", "fix"],
+  ["bugfix/", "fix"],
+  ["hotfix/", "fix"],
+  ["refactor/", "refactor"],
+  ["chore/", "chore"],
+  ["docs/", "docs"],
+  ["ci/", "ci"],
+];
+
 export function inferCommitTypeFromBranch(branchName) {
   const branch = String(branchName || "").trim().toLowerCase();
-  if (branch.startsWith("feat/")) return "feat";
-  if (branch.startsWith("fix/")) return "fix";
-  if (branch.startsWith("hotfix/")) return "fix";
-  if (branch.startsWith("refactor/")) return "refactor";
-  if (branch.startsWith("chore/")) return "chore";
-  if (branch.startsWith("docs/")) return "docs";
-  if (branch.startsWith("ci/")) return "ci";
+  for (const [prefix, type] of BRANCH_TYPE_ALIASES) {
+    if (branch.startsWith(prefix)) return type;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Add per-user Lidarr defaults for root folder and quality profile, persisted on user records and exposed through new `/api/users/me/lidarr-preferences` endpoints.
- Update artist-to-Lidarr flows to prefer explicit request values, then saved per-user defaults, then global Lidarr settings as fallback.
- Improve Lidarr validation so stale saved defaults are rejected before queueing an add, and surface clearer API errors.
- Extend settings and normalization logic to carry the global Lidarr root folder path through backend and request handling.
- Add backend and integration coverage for user preference persistence, preference validation, and artist add fallback behavior.

## Testing
- `node --test .tests/auth/lidarr-user-preferences.test.js`
- `node --test .tests/auth/lidarr-preferences.integration.test.js`
- `node --test .tests/helpers/normalize-commit-message.test.js`
- Not run: full repository test suite