### PR TITLE
Expand weekly flow metadata and Soulseek matching

### DIFF
--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -83,6 +83,20 @@ test("stores full shared playlists but exposes trackless summaries for hot paths
   assert.equal(summaries[0].sourceName, "Discover Weekly");
 });
 
+test("supports empty manual playlists", () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Empty Queue",
+  });
+
+  const stored = flowPlaylistConfig.getSharedPlaylist(playlist.id);
+  const summary = flowPlaylistConfig
+    .getSharedPlaylistSummaries()
+    .find((entry) => entry.id === playlist.id);
+
+  assert.equal(stored?.tracks?.length, 0);
+  assert.equal(summary?.trackCount, 0);
+});
+
 test("updates shared playlists and keeps summaries in sync", () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({
     name: "Gym Mix",
@@ -104,4 +118,52 @@ test("updates shared playlists and keeps summaries in sync", () => {
   assert.equal(updated?.tracks?.length, 1);
   assert.equal(summary?.name, "Gym Mix Updated");
   assert.equal(summary?.trackCount, 1);
+});
+
+test("preserves rich track metadata when shared playlists are updated", () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Metadata Mix",
+    tracks: [
+      {
+        artistName: "Artist A",
+        trackName: "Song A",
+        albumName: "Album A",
+        artistMbid: "artist-mbid",
+        albumMbid: "album-mbid",
+        trackMbid: "track-mbid",
+        releaseYear: "1999",
+        durationMs: 185000,
+        artistAliases: ["Artist Alias"],
+      },
+    ],
+  });
+
+  const updated = flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
+    tracks: [
+      {
+        artistName: "Artist B",
+        trackName: "Song B",
+        albumName: "Album B",
+        artistMbid: "artist-b",
+        albumMbid: "album-b",
+        trackMbid: "track-b",
+        releaseYear: "2004",
+        durationMs: 201000,
+        artistAliases: ["Alias B"],
+      },
+    ],
+  });
+
+  assert.deepEqual(updated?.tracks?.[0], {
+    artistName: "Artist B",
+    trackName: "Song B",
+    albumName: "Album B",
+    artistMbid: "artist-b",
+    albumMbid: "album-b",
+    trackMbid: "track-b",
+    releaseYear: "2004",
+    durationMs: 201000,
+    artistAliases: ["Alias B"],
+    reason: null,
+  });
 });

--- a/.tests/weekly-flow/status-snapshot.test.js
+++ b/.tests/weekly-flow/status-snapshot.test.js
@@ -60,3 +60,16 @@ test("status snapshot includes shared playlist summaries without embedding track
   assert.equal(serialized.includes("Artist 249"), false);
   assert.equal(serialized.includes("Track 249"), false);
 });
+
+test("status snapshot includes empty manual playlists", () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Manual Empty",
+  });
+
+  const status = getWeeklyFlowStatusSnapshot();
+  const shared = (status.sharedPlaylists || []).find((p) => p.id === playlist.id);
+
+  assert.ok(shared);
+  assert.equal(shared.name, "Manual Empty");
+  assert.equal(shared.trackCount, 0);
+});

--- a/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
+++ b/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { importFromRepo } from "../helpers/backendTestHarness.js";
+
+const [{ buildFlowSearchQueries, rankFlowSearchResults }] = await Promise.all([
+  importFromRepo("backend/services/weeklyFlowSoulseekMatcher.js"),
+]);
+
+test("buildFlowSearchQueries generates album-first and fallback track searches", () => {
+  const queries = buildFlowSearchQueries({
+    artistName: "Massive Attack",
+    trackName: "Teardrop",
+    albumName: "Mezzanine",
+    releaseYear: "1998",
+    artistAliases: ["Massive Attk"],
+  });
+
+  assert.deepEqual(queries.slice(0, 3), [
+    "Massive Attack Mezzanine",
+    "Massive Attack Mezzanine 1998",
+    "Massive Attack Teardrop",
+  ]);
+  assert.ok(queries.includes("Massive Attk Mezzanine"));
+  assert.ok(queries.includes("Massive Attk Teardrop"));
+});
+
+test("rankFlowSearchResults prefers album-matching directories with the target track", () => {
+  const ranked = rankFlowSearchResults(
+    [
+      {
+        user: "albumUser",
+        file: "Artist Name\\Album Name (1999)\\01 - Correct Track.flac",
+        size: 100,
+        slots: true,
+        bitrate: 900,
+        speed: 900000,
+      },
+      {
+        user: "albumUser",
+        file: "Artist Name\\Album Name (1999)\\02 - Other Song.flac",
+        size: 100,
+        slots: true,
+        bitrate: 900,
+        speed: 900000,
+      },
+      {
+        user: "singleUser",
+        file: "Artist Name\\Misc Folder\\Correct Track.mp3",
+        size: 100,
+        slots: true,
+        bitrate: 320,
+        speed: 600000,
+      },
+    ],
+    {
+      artistName: "Artist Name",
+      trackName: "Correct Track",
+      albumName: "Album Name",
+      releaseYear: "1999",
+      artistAliases: [],
+      albumTrackCount: 2,
+    },
+    {
+      preferredFormat: "flac",
+      strictFormat: false,
+    },
+  );
+
+  assert.ok(ranked.length > 0);
+  assert.match(ranked[0].raw.file, /Album Name/);
+  assert.equal(ranked[0].ext, ".flac");
+  assert.equal(ranked[0].isLikelyMatch, true);
+  assert.ok(ranked[0].score > ranked[ranked.length - 1].score);
+});

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -26,6 +26,16 @@ const db = new Database(DB_PATH);
 
 db.pragma("journal_mode = WAL");
 
+function tryAddColumn(sql) {
+  try {
+    db.exec(sql);
+  } catch (error) {
+    if (!String(error?.message || "").toLowerCase().includes("duplicate column name")) {
+      throw error;
+    }
+  }
+}
+
 db.exec(`
   CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
@@ -68,6 +78,14 @@ db.exec(`
     id TEXT PRIMARY KEY,
     artist_name TEXT NOT NULL,
     track_name TEXT NOT NULL,
+    album_name TEXT,
+    reason TEXT,
+    artist_mbid TEXT,
+    album_mbid TEXT,
+    track_mbid TEXT,
+    release_year TEXT,
+    duration_ms INTEGER,
+    artist_aliases TEXT,
     playlist_type TEXT NOT NULL,
     status TEXT NOT NULL,
     staging_path TEXT,
@@ -111,13 +129,28 @@ const tableColumns = db
   .map((column) => column.name);
 
 if (!tableColumns.includes("album_name")) {
-  db.exec("ALTER TABLE weekly_flow_jobs ADD COLUMN album_name TEXT");
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN album_name TEXT");
 }
 if (!tableColumns.includes("reason")) {
-  db.exec("ALTER TABLE weekly_flow_jobs ADD COLUMN reason TEXT");
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN reason TEXT");
 }
 if (!tableColumns.includes("artist_mbid")) {
-  db.exec("ALTER TABLE weekly_flow_jobs ADD COLUMN artist_mbid TEXT");
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN artist_mbid TEXT");
+}
+if (!tableColumns.includes("album_mbid")) {
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN album_mbid TEXT");
+}
+if (!tableColumns.includes("track_mbid")) {
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN track_mbid TEXT");
+}
+if (!tableColumns.includes("release_year")) {
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN release_year TEXT");
+}
+if (!tableColumns.includes("duration_ms")) {
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN duration_ms INTEGER");
+}
+if (!tableColumns.includes("artist_aliases")) {
+  tryAddColumn("ALTER TABLE weekly_flow_jobs ADD COLUMN artist_aliases TEXT");
 }
 
 const userColumns = db
@@ -126,19 +159,19 @@ const userColumns = db
   .map((column) => column.name);
 
 if (!userColumns.includes("lastfm_username")) {
-  db.exec("ALTER TABLE users ADD COLUMN lastfm_username TEXT");
+  tryAddColumn("ALTER TABLE users ADD COLUMN lastfm_username TEXT");
 }
 if (!userColumns.includes("listen_history_provider")) {
-  db.exec("ALTER TABLE users ADD COLUMN listen_history_provider TEXT");
+  tryAddColumn("ALTER TABLE users ADD COLUMN listen_history_provider TEXT");
 }
 if (!userColumns.includes("listen_history_username")) {
-  db.exec("ALTER TABLE users ADD COLUMN listen_history_username TEXT");
+  tryAddColumn("ALTER TABLE users ADD COLUMN listen_history_username TEXT");
 }
 if (!userColumns.includes("lidarr_root_folder_path")) {
-  db.exec("ALTER TABLE users ADD COLUMN lidarr_root_folder_path TEXT");
+  tryAddColumn("ALTER TABLE users ADD COLUMN lidarr_root_folder_path TEXT");
 }
 if (!userColumns.includes("lidarr_quality_profile_id")) {
-  db.exec("ALTER TABLE users ADD COLUMN lidarr_quality_profile_id INTEGER");
+  tryAddColumn("ALTER TABLE users ADD COLUMN lidarr_quality_profile_id INTEGER");
 }
 
 db.exec(`

--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -63,12 +63,33 @@ const normalizeImportedTrackList = (value) => {
       const artistMbid = String(
         track.artistMbid ?? track.artistId ?? track.mbid ?? "",
       ).trim();
+      const albumMbid = String(
+        track.albumMbid ?? track.releaseGroupMbid ?? track.albumId ?? "",
+      ).trim();
+      const trackMbid = String(
+        track.trackMbid ?? track.recordingMbid ?? track.recordingId ?? "",
+      ).trim();
+      const releaseYear = String(track.releaseYear ?? track.year ?? "").trim();
+      const durationMs =
+        track.durationMs != null && Number.isFinite(Number(track.durationMs))
+          ? Math.max(0, Math.round(Number(track.durationMs)))
+          : null;
+      const artistAliases = Array.isArray(track.artistAliases)
+        ? track.artistAliases
+            .map((entry) => String(entry || "").trim())
+            .filter(Boolean)
+        : [];
       const reason = String(track.reason ?? "").trim();
       return {
         artistName,
         trackName,
         albumName: albumName || null,
         artistMbid: artistMbid || null,
+        albumMbid: albumMbid || null,
+        trackMbid: trackMbid || null,
+        releaseYear: releaseYear || null,
+        durationMs,
+        artistAliases,
         reason: reason || null,
       };
     })
@@ -81,6 +102,9 @@ const buildTrackIdentity = (track) =>
     String(track?.trackName || "").trim(),
     String(track?.albumName || "").trim(),
     String(track?.artistMbid || "").trim(),
+    String(track?.albumMbid || "").trim(),
+    String(track?.trackMbid || "").trim(),
+    String(track?.releaseYear || "").trim(),
   ].join("\u0001");
 
 const sortJobsForTrackReuse = (jobs) =>
@@ -688,6 +712,11 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       trackName: job.trackName,
       albumName: job.albumName || null,
       artistMbid: job.artistMbid || null,
+      albumMbid: job.albumMbid || null,
+      trackMbid: job.trackMbid || null,
+      releaseYear: job.releaseYear || null,
+      durationMs: job.durationMs || null,
+      artistAliases: job.artistAliases || [],
       reason: job.reason || null,
     }));
     playlist = flowPlaylistConfig.createSharedPlaylist({
@@ -724,6 +753,11 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
           trackName: job.trackName,
           albumName: job.albumName || null,
           artistMbid: job.artistMbid || null,
+          albumMbid: job.albumMbid || null,
+          trackMbid: job.trackMbid || null,
+          releaseYear: job.releaseYear || null,
+          durationMs: job.durationMs || null,
+          artistAliases: job.artistAliases || [],
           reason: job.reason || null,
         },
         playlist.id,
@@ -758,6 +792,69 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
     }
     res.status(500).json({
       error: "Failed to create static playlist",
+      message: error.message,
+    });
+  }
+});
+
+router.post("/shared-playlists", async (req, res) => {
+  try {
+    const {
+      name,
+      sourceName = null,
+      sourceFlowId = null,
+      tracks,
+    } = req.body || {};
+    const safeName = String(name || "").trim();
+    const normalizedTracks = normalizeImportedTrackList(tracks);
+    const rawTracksProvided = Array.isArray(tracks);
+
+    if (!safeName) {
+      return res.status(400).json({ error: "name is required" });
+    }
+    if (rawTracksProvided && tracks.length > 0 && normalizedTracks.length === 0) {
+      return res.status(400).json({
+        error: "tracks are invalid",
+        message: "Add at least one valid track",
+      });
+    }
+
+    const playlist = flowPlaylistConfig.createSharedPlaylist({
+      name: safeName,
+      sourceName,
+      sourceFlowId,
+      tracks: normalizedTracks,
+    });
+
+    let tracksQueued = 0;
+    if (normalizedTracks.length > 0) {
+      tracksQueued = downloadTracker.addJobs(normalizedTracks, playlist.id).length;
+    }
+
+    playlistManager.updateConfig(false);
+    await playlistManager.ensureSmartPlaylists();
+    if (tracksQueued > 0) {
+      if (!weeklyFlowWorker.running) {
+        await weeklyFlowWorker.start();
+      } else {
+        weeklyFlowWorker.wake();
+      }
+    }
+
+    res.json({
+      success: true,
+      playlist,
+      tracksQueued,
+    });
+  } catch (error) {
+    if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
+      return res.status(400).json({
+        error: "Shared playlist name already exists",
+        message: error.message,
+      });
+    }
+    res.status(500).json({
+      error: "Failed to create shared playlist",
       message: error.message,
     });
   }
@@ -825,6 +922,58 @@ router.post("/shared-playlists/import", async (req, res) => {
   }
 });
 
+router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
+  try {
+    const { playlistId } = req.params;
+    const playlist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+    if (!playlist) {
+      return res.status(404).json({ error: "Shared playlist not found" });
+    }
+    const rawTracks = req.body?.tracks;
+    const normalizedTracks = normalizeImportedTrackList(rawTracks);
+    if (Array.isArray(rawTracks) && rawTracks.length > 0 && normalizedTracks.length === 0) {
+      return res.status(400).json({
+        error: "tracks are invalid",
+        message: "Add at least one valid track",
+      });
+    }
+    if (normalizedTracks.length === 0) {
+      return res.status(400).json({
+        error: "tracks are required",
+        message: "Add at least one valid track",
+      });
+    }
+
+    const updatedPlaylist = flowPlaylistConfig.appendSharedPlaylistTracks(
+      playlistId,
+      normalizedTracks,
+    );
+    const jobIds = downloadTracker.addJobs(normalizedTracks, playlistId);
+
+    playlistManager.updateConfig(false);
+    await playlistManager.ensureSmartPlaylists();
+    if (jobIds.length > 0) {
+      if (!weeklyFlowWorker.running) {
+        await weeklyFlowWorker.start();
+      } else {
+        weeklyFlowWorker.wake();
+      }
+    }
+
+    res.json({
+      success: true,
+      playlist: updatedPlaylist,
+      tracksQueued: jobIds.length,
+      jobIds,
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: "Failed to add playlist tracks",
+      message: error.message,
+    });
+  }
+});
+
 router.put("/shared-playlists/:playlistId", async (req, res) => {
   try {
     const { playlistId } = req.params;
@@ -855,10 +1004,15 @@ router.put("/shared-playlists/:playlistId", async (req, res) => {
     const normalizedTracks = hasTracksUpdate
       ? normalizeImportedTrackList(tracks)
       : currentPlaylist.tracks;
-    if (hasTracksUpdate && normalizedTracks.length === 0) {
+    if (
+      hasTracksUpdate &&
+      Array.isArray(tracks) &&
+      tracks.length > 0 &&
+      normalizedTracks.length === 0
+    ) {
       return res.status(400).json({
-        error: "tracks are required",
-        message: "Playlist must include at least one valid track",
+        error: "tracks are invalid",
+        message: "Playlist update must include at least one valid track",
       });
     }
 
@@ -1002,7 +1156,10 @@ router.delete(
           String(track.trackName || "") === String(job.trackName || "") &&
           String(track.albumName || "") === String(job.albumName || "") &&
           String(track.reason || "") === String(job.reason || "") &&
-          String(track.artistMbid || "") === String(job.artistMbid || "")
+          String(track.artistMbid || "") === String(job.artistMbid || "") &&
+          String(track.albumMbid || "") === String(job.albumMbid || "") &&
+          String(track.trackMbid || "") === String(job.trackMbid || "") &&
+          String(track.releaseYear || "") === String(job.releaseYear || "")
         );
       });
       if (trackIndex >= 0) {

--- a/backend/services/simpleSoulseekClient.js
+++ b/backend/services/simpleSoulseekClient.js
@@ -722,8 +722,11 @@ export class SimpleSoulseekClient {
     }, this._getConnectionKeepAliveMs());
   }
 
-  async search(artistName, trackName, options = {}) {
-    const query = `${artistName} ${trackName}`;
+  async searchQuery(rawQuery, options = {}) {
+    const query = String(rawQuery || "").trim();
+    if (!query) {
+      return [];
+    }
     const forceFresh = options?.forceFresh === true;
     if (!forceFresh) {
       if (this._hasCachedNoResults(query)) {
@@ -764,6 +767,11 @@ export class SimpleSoulseekClient {
     } finally {
       this.releaseConnection();
     }
+  }
+
+  async search(artistName, trackName, options = {}) {
+    const query = `${artistName} ${trackName}`;
+    return this.searchQuery(query, options);
   }
 
   pickBestMatch(results, trackName) {

--- a/backend/services/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlowDownloadTracker.js
@@ -1,6 +1,26 @@
 import { randomUUID } from "crypto";
 import { db } from "../config/db-sqlite.js";
 
+function parseArtistAliases(value) {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.map((entry) => String(entry || "").trim()).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function stringifyArtistAliases(value) {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const normalized = value
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? JSON.stringify(normalized) : null;
+}
+
 function rowToJob(row) {
   return {
     id: row.id,
@@ -9,6 +29,14 @@ function rowToJob(row) {
     albumName: row.album_name || null,
     reason: row.reason || null,
     artistMbid: row.artist_mbid || null,
+    albumMbid: row.album_mbid || null,
+    trackMbid: row.track_mbid || null,
+    releaseYear: row.release_year || null,
+    durationMs:
+      row.duration_ms != null && Number.isFinite(Number(row.duration_ms))
+        ? Number(row.duration_ms)
+        : null,
+    artistAliases: parseArtistAliases(row.artist_aliases),
     playlistType: row.playlist_type,
     status: row.status,
     startedAt: row.started_at,
@@ -22,12 +50,46 @@ function rowToJob(row) {
 }
 
 const insertStmt = db.prepare(`
-  INSERT INTO weekly_flow_jobs (id, artist_name, track_name, album_name, reason, artist_mbid, playlist_type, status, staging_path, final_path, error, started_at, completed_at, created_at)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO weekly_flow_jobs (
+    id,
+    artist_name,
+    track_name,
+    album_name,
+    reason,
+    artist_mbid,
+    album_mbid,
+    track_mbid,
+    release_year,
+    duration_ms,
+    artist_aliases,
+    playlist_type,
+    status,
+    staging_path,
+    final_path,
+    error,
+    started_at,
+    completed_at,
+    created_at
+  )
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateStmt = db.prepare(`
-  UPDATE weekly_flow_jobs SET status = ?, staging_path = ?, final_path = ?, error = ?, started_at = ?, completed_at = ?, album_name = ?
+  UPDATE weekly_flow_jobs
+  SET status = ?,
+      staging_path = ?,
+      final_path = ?,
+      error = ?,
+      started_at = ?,
+      completed_at = ?,
+      album_name = ?,
+      reason = ?,
+      artist_mbid = ?,
+      album_mbid = ?,
+      track_mbid = ?,
+      release_year = ?,
+      duration_ms = ?,
+      artist_aliases = ?
   WHERE id = ?
 `);
 
@@ -154,6 +216,13 @@ export class WeeklyFlowDownloadTracker {
           job.startedAt,
           job.completedAt,
           job.albumName ?? null,
+          job.reason ?? null,
+          job.artistMbid ?? null,
+          job.albumMbid ?? null,
+          job.trackMbid ?? null,
+          job.releaseYear ?? null,
+          job.durationMs ?? null,
+          stringifyArtistAliases(job.artistAliases),
           job.id,
         );
         updatePlaylistTypeStmt.run("discover", "recommended");
@@ -170,6 +239,13 @@ export class WeeklyFlowDownloadTracker {
           job.startedAt,
           job.completedAt,
           job.albumName ?? null,
+          job.reason ?? null,
+          job.artistMbid ?? null,
+          job.albumMbid ?? null,
+          job.trackMbid ?? null,
+          job.releaseYear ?? null,
+          job.durationMs ?? null,
+          stringifyArtistAliases(job.artistAliases),
           job.id,
         );
       }
@@ -188,6 +264,11 @@ export class WeeklyFlowDownloadTracker {
       job.albumName ?? null,
       job.reason ?? null,
       job.artistMbid ?? null,
+      job.albumMbid ?? null,
+      job.trackMbid ?? null,
+      job.releaseYear ?? null,
+      job.durationMs ?? null,
+      stringifyArtistAliases(job.artistAliases),
       job.playlistType,
       job.status,
       job.stagingPath ?? null,
@@ -208,6 +289,13 @@ export class WeeklyFlowDownloadTracker {
       job.startedAt ?? null,
       job.completedAt ?? null,
       job.albumName ?? null,
+      job.reason ?? null,
+      job.artistMbid ?? null,
+      job.albumMbid ?? null,
+      job.trackMbid ?? null,
+      job.releaseYear ?? null,
+      job.durationMs ?? null,
+      stringifyArtistAliases(job.artistAliases),
       job.id,
     );
   }
@@ -226,6 +314,18 @@ export class WeeklyFlowDownloadTracker {
       albumName: track?.albumName ? String(track.albumName).trim() : null,
       reason: track?.reason ? String(track.reason).trim() : null,
       artistMbid: track?.artistMbid ? String(track.artistMbid).trim() : null,
+      albumMbid: track?.albumMbid ? String(track.albumMbid).trim() : null,
+      trackMbid: track?.trackMbid ? String(track.trackMbid).trim() : null,
+      releaseYear: track?.releaseYear ? String(track.releaseYear).trim() : null,
+      durationMs:
+        track?.durationMs != null && Number.isFinite(Number(track.durationMs))
+          ? Math.max(0, Math.round(Number(track.durationMs)))
+          : null,
+      artistAliases: Array.isArray(track?.artistAliases)
+        ? track.artistAliases
+            .map((entry) => String(entry || "").trim())
+            .filter(Boolean)
+        : [],
       playlistType,
       status: "pending",
       startedAt: null,
@@ -253,6 +353,57 @@ export class WeeklyFlowDownloadTracker {
       ids.push(id);
     }
     return ids;
+  }
+
+  updateMetadata(id, metadata = {}) {
+    const job = this.jobs.get(id);
+    if (!job || !metadata || typeof metadata !== "object") return false;
+    let changed = false;
+    const assignString = (key) => {
+      if (!(key in metadata)) return;
+      const nextValue = metadata[key]
+        ? String(metadata[key]).trim() || null
+        : null;
+      if (job[key] !== nextValue) {
+        job[key] = nextValue;
+        changed = true;
+      }
+    };
+    assignString("artistName");
+    assignString("trackName");
+    assignString("albumName");
+    assignString("reason");
+    assignString("artistMbid");
+    assignString("albumMbid");
+    assignString("trackMbid");
+    assignString("releaseYear");
+    if ("durationMs" in metadata) {
+      const nextDuration =
+        metadata.durationMs != null && Number.isFinite(Number(metadata.durationMs))
+          ? Math.max(0, Math.round(Number(metadata.durationMs)))
+          : null;
+      if (job.durationMs !== nextDuration) {
+        job.durationMs = nextDuration;
+        changed = true;
+      }
+    }
+    if ("artistAliases" in metadata) {
+      const nextAliases = Array.isArray(metadata.artistAliases)
+        ? metadata.artistAliases
+            .map((entry) => String(entry || "").trim())
+            .filter(Boolean)
+        : [];
+      const previousSerialized = JSON.stringify(job.artistAliases || []);
+      const nextSerialized = JSON.stringify(nextAliases);
+      if (previousSerialized !== nextSerialized) {
+        job.artistAliases = nextAliases;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this._update(job);
+    }
+    return changed;
   }
 
   getJob(id) {

--- a/backend/services/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlowPlaylistConfig.js
@@ -342,12 +342,33 @@ const normalizeSharedTrack = (track) => {
   const artistMbid = String(
     track.artistMbid ?? track.artistId ?? track.mbid ?? "",
   ).trim();
+  const albumMbid = String(
+    track.albumMbid ?? track.releaseGroupMbid ?? track.albumId ?? "",
+  ).trim();
+  const trackMbid = String(
+    track.trackMbid ?? track.recordingMbid ?? track.recordingId ?? "",
+  ).trim();
+  const releaseYear = String(track.releaseYear ?? track.year ?? "").trim();
+  const durationMs =
+    track.durationMs != null && Number.isFinite(Number(track.durationMs))
+      ? Math.max(0, Math.round(Number(track.durationMs)))
+      : null;
+  const artistAliases = Array.isArray(track.artistAliases)
+    ? track.artistAliases
+        .map((entry) => String(entry || "").trim())
+        .filter(Boolean)
+    : [];
   const reason = String(track.reason ?? "").trim();
   return {
     artistName,
     trackName,
     albumName: albumName || null,
     artistMbid: artistMbid || null,
+    albumMbid: albumMbid || null,
+    trackMbid: trackMbid || null,
+    releaseYear: releaseYear || null,
+    durationMs,
+    artistAliases,
     reason: reason || null,
   };
 };
@@ -724,7 +745,7 @@ export const flowPlaylistConfig = {
     );
   },
 
-  createSharedPlaylist({ name, sourceName, sourceFlowId, tracks }) {
+  createSharedPlaylist({ name, sourceName, sourceFlowId, tracks = [] }) {
     const playlists = getStoredSharedPlaylists();
     assertUniqueSharedPlaylistName(playlists, name);
     const playlist = normalizeSharedPlaylist({
@@ -739,6 +760,25 @@ export const flowPlaylistConfig = {
     playlists.push(playlist);
     setSharedPlaylists(playlists);
     return playlist;
+  },
+
+  appendSharedPlaylistTracks(playlistId, tracks) {
+    const playlists = getStoredSharedPlaylists();
+    const index = playlists.findIndex((playlist) => playlist.id === playlistId);
+    if (index === -1) return null;
+    const current = playlists[index];
+    const appendedTracks = Array.isArray(tracks)
+      ? tracks.map(normalizeSharedTrack).filter(Boolean)
+      : [];
+    const next = normalizeSharedPlaylist({
+      ...current,
+      tracks: [...current.tracks, ...appendedTracks],
+      importedAt: current.importedAt,
+      createdAt: current.createdAt,
+    });
+    playlists[index] = next;
+    setSharedPlaylists(playlists);
+    return next;
   },
 
   updateSharedPlaylist(playlistId, updates) {

--- a/backend/services/weeklyFlowPlaylistSource.js
+++ b/backend/services/weeklyFlowPlaylistSource.js
@@ -123,6 +123,11 @@ export class WeeklyFlowPlaylistSource {
     trackName,
     albumName,
     artistMbid,
+    albumMbid,
+    trackMbid,
+    releaseYear,
+    durationMs,
+    artistAliases,
     reason,
   }) {
     const safeArtist = String(artistName || "").trim();
@@ -130,11 +135,26 @@ export class WeeklyFlowPlaylistSource {
     if (!safeArtist || !safeTrack) return null;
     const safeAlbum = String(albumName || "").trim();
     const safeMbid = String(artistMbid || "").trim();
+    const safeAlbumMbid = String(albumMbid || "").trim();
+    const safeTrackMbid = String(trackMbid || "").trim();
+    const safeReleaseYear = String(releaseYear || "").trim();
+    const safeDuration =
+      durationMs != null && Number.isFinite(Number(durationMs))
+        ? Math.max(0, Math.round(Number(durationMs)))
+        : null;
+    const normalizedAliases = Array.isArray(artistAliases)
+      ? artistAliases.map((entry) => String(entry || "").trim()).filter(Boolean)
+      : [];
     return {
       artistName: safeArtist,
       trackName: safeTrack,
       albumName: safeAlbum || null,
       artistMbid: safeMbid || null,
+      albumMbid: safeAlbumMbid || null,
+      trackMbid: safeTrackMbid || null,
+      releaseYear: safeReleaseYear || null,
+      durationMs: safeDuration,
+      artistAliases: normalizedAliases,
       reason: this._normalizeTrackReason(reason),
     };
   }

--- a/backend/services/weeklyFlowSoulseekMatcher.js
+++ b/backend/services/weeklyFlowSoulseekMatcher.js
@@ -1,0 +1,391 @@
+import path from "path";
+import { parseFile } from "music-metadata";
+
+const AUDIO_EXTENSIONS = new Set([
+  ".flac",
+  ".mp3",
+  ".m4a",
+  ".ogg",
+  ".wav",
+  ".aac",
+  ".opus",
+  ".alac",
+  ".ape",
+  ".wma",
+]);
+
+const TITLE_STOP_WORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "feat",
+  "featuring",
+  "ft",
+  "with",
+]);
+
+function normalizeText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/\(.*?\)|\[.*?\]/g, " ")
+    .replace(
+      /\b(deluxe|expanded|anniversary|remaster(?:ed)?|bonus|edition|live|mono|stereo|explicit|clean)\b/g,
+      " ",
+    )
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeTitle(value) {
+  return normalizeText(value)
+    .split(" ")
+    .filter((word) => word && !TITLE_STOP_WORDS.has(word))
+    .join(" ");
+}
+
+function getYear(value) {
+  const match = String(value || "").match(/\b(19\d{2}|20\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function splitWords(value) {
+  return normalizeText(value)
+    .split(" ")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function scoreTextMatch(left, right) {
+  const a = normalizeText(left);
+  const b = normalizeText(right);
+  if (!a || !b) return 0;
+  if (a === b) return 100;
+  if (a.includes(b) || b.includes(a)) return 92;
+  const leftWords = new Set(splitWords(a));
+  const rightWords = new Set(splitWords(b));
+  if (leftWords.size === 0 || rightWords.size === 0) return 0;
+  let overlap = 0;
+  for (const word of leftWords) {
+    if (rightWords.has(word)) overlap += 1;
+  }
+  const ratio =
+    (2 * overlap) / Math.max(1, leftWords.size + rightWords.size);
+  return Math.round(ratio * 100);
+}
+
+function getDistinctiveAlbumPhrase(albumName) {
+  const words = splitWords(albumName).filter(
+    (word) => word.length > 2 && !TITLE_STOP_WORDS.has(word),
+  );
+  if (words.length <= 2) return words.join(" ");
+  return words
+    .sort((left, right) => right.length - left.length)
+    .slice(0, 3)
+    .sort((left, right) => String(albumName).toLowerCase().indexOf(left) - String(albumName).toLowerCase().indexOf(right))
+    .join(" ");
+}
+
+function uniqueQueries(values) {
+  const seen = new Set();
+  const queries = [];
+  for (const value of values) {
+    const query = String(value || "").trim().replace(/\s+/g, " ");
+    if (!query) continue;
+    const key = query.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    queries.push(query);
+  }
+  return queries.slice(0, 6);
+}
+
+export function buildFlowSearchQueries(context) {
+  const artistName = String(context?.artistName || "").trim();
+  const trackName = String(context?.trackName || "").trim();
+  const albumName = String(context?.albumName || "").trim();
+  const releaseYear = getYear(context?.releaseYear);
+  const aliases = Array.isArray(context?.artistAliases)
+    ? context.artistAliases
+        .map((entry) => String(entry || "").trim())
+        .filter(Boolean)
+        .slice(0, 2)
+    : [];
+  const normalizedAlbum = normalizeTitle(albumName);
+  const distinctiveAlbum = getDistinctiveAlbumPhrase(albumName);
+  const isSelfTitled =
+    artistName && albumName
+      ? scoreTextMatch(artistName, albumName) >= 92
+      : false;
+
+  const queries = [];
+  if (artistName && albumName) {
+    if (isSelfTitled && releaseYear) {
+      queries.push(`${artistName} ${releaseYear}`);
+    }
+    queries.push(`${artistName} ${albumName}`);
+    if (releaseYear) {
+      queries.push(`${artistName} ${albumName} ${releaseYear}`);
+    }
+    if (normalizedAlbum && normalizedAlbum !== normalizeTitle(albumName)) {
+      queries.push(`${artistName} ${normalizedAlbum}`);
+    }
+    if (distinctiveAlbum && normalizeText(distinctiveAlbum) !== normalizeText(albumName)) {
+      queries.push(`${artistName} ${distinctiveAlbum}`);
+    }
+  }
+  if (artistName && trackName) {
+    queries.push(`${artistName} ${trackName}`);
+  }
+  for (const alias of aliases) {
+    if (albumName) queries.push(`${alias} ${albumName}`);
+    queries.push(`${alias} ${trackName}`);
+  }
+  return uniqueQueries(queries);
+}
+
+function getPathParts(filePath) {
+  return String(filePath || "")
+    .split(/[\\/]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function getDirectoryKey(item) {
+  const parts = getPathParts(item?.file);
+  if (parts.length === 0) return null;
+  const directory = parts.slice(0, -1).join("/");
+  const user = String(item?.user || "").trim();
+  return `${user}\0${directory}`;
+}
+
+function formatRank(ext, preferredFormat) {
+  if (preferredFormat === "mp3") {
+    if (ext === ".mp3") return 0;
+    if (ext === ".flac") return 1;
+  } else {
+    if (ext === ".flac") return 0;
+    if (ext === ".mp3") return 1;
+  }
+  return 2;
+}
+
+function countAudioFiles(files) {
+  return files.filter((item) => AUDIO_EXTENSIONS.has(path.extname(String(item?.file || "")).toLowerCase())).length;
+}
+
+function scoreTrackCount(expected, actual) {
+  if (!expected || !actual) return 0;
+  if (actual === expected) return 30;
+  const diff = Math.abs(actual - expected);
+  if (diff === 1) return 18;
+  if (diff === 2) return 6;
+  return -Math.min(20, diff * 5);
+}
+
+function scoreYearMatch(directoryText, releaseYear) {
+  const expected = getYear(releaseYear);
+  if (!expected) return 0;
+  return directoryText.includes(expected) ? 12 : 0;
+}
+
+function pickBestArtistScore(context, text) {
+  const candidates = [
+    context?.artistName,
+    ...(Array.isArray(context?.artistAliases) ? context.artistAliases : []),
+  ];
+  return candidates.reduce(
+    (best, entry) => Math.max(best, scoreTextMatch(text, entry)),
+    0,
+  );
+}
+
+function buildGroupCandidate(group, context, options = {}) {
+  const preferredFormat = options?.preferredFormat === "mp3" ? "mp3" : "flac";
+  const strictFormat = options?.strictFormat === true;
+  const directoryText = normalizeText(group.directoryPath);
+  const albumDir = group.parts.at(-2) || "";
+  const artistDir = group.parts.at(-3) || "";
+  const artistScore = Math.max(
+    pickBestArtistScore(context, group.directoryPath),
+    pickBestArtistScore(context, artistDir),
+  );
+  const albumScore = context?.albumName
+    ? Math.max(
+        scoreTextMatch(group.directoryPath, context.albumName),
+        scoreTextMatch(albumDir, context.albumName),
+      )
+    : 0;
+  const yearScore = scoreYearMatch(directoryText, context?.releaseYear);
+  const audioFiles = group.audioFiles;
+  const trackCountScore = scoreTrackCount(context?.albumTrackCount, audioFiles.length);
+  const availabilityScore = audioFiles.some((item) => item?.slots) ? 8 : 0;
+  const speedScore = Math.min(
+    12,
+    Math.round(
+      audioFiles.reduce((best, item) => Math.max(best, Number(item?.speed || 0)), 0) /
+        250000,
+    ),
+  );
+
+  const files = strictFormat
+    ? audioFiles.filter(
+        (item) => path.extname(String(item?.file || "")).toLowerCase() === `.${preferredFormat}`,
+      )
+    : audioFiles;
+  const candidates = [];
+  for (const item of files) {
+    const ext = path.extname(String(item?.file || "")).toLowerCase();
+    const baseName = path.basename(String(item?.file || ""), ext);
+    const titleScore = Math.max(
+      scoreTextMatch(baseName, context?.trackName),
+      scoreTextMatch(path.basename(String(item?.file || "")), context?.trackName),
+    );
+    const formatScore =
+      ext === `.${preferredFormat}` ? 18 : ext === ".flac" || ext === ".mp3" ? 9 : 0;
+    const bitrateScore = Number.isFinite(Number(item?.bitrate))
+      ? Math.min(8, Math.round(Number(item.bitrate) / 64))
+      : 0;
+    const totalScore =
+      artistScore +
+      albumScore +
+      titleScore +
+      yearScore +
+      trackCountScore +
+      availabilityScore +
+      speedScore +
+      formatScore +
+      bitrateScore;
+    candidates.push({
+      raw: item,
+      group,
+      ext,
+      score: totalScore,
+      isLikelyMatch:
+        titleScore >= 75 &&
+        artistScore >= 55 &&
+        (!context?.albumName || albumScore >= 35 || trackCountScore >= 18),
+      breakdown: {
+        artistScore,
+        albumScore,
+        titleScore,
+        yearScore,
+        trackCountScore,
+        formatScore,
+      },
+      resolvedAlbumName: context?.albumName || albumDir || null,
+    });
+  }
+  return candidates.sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    const leftRank = formatRank(left.ext, preferredFormat);
+    const rightRank = formatRank(right.ext, preferredFormat);
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return Number(right.raw?.speed || 0) - Number(left.raw?.speed || 0);
+  });
+}
+
+export function rankFlowSearchResults(results, context, options = {}) {
+  const groups = new Map();
+  for (const item of Array.isArray(results) ? results : []) {
+    const key = getDirectoryKey(item);
+    if (!key) continue;
+    const existing = groups.get(key) || {
+      key,
+      user: String(item?.user || "").trim(),
+      directoryPath: getPathParts(item?.file).slice(0, -1).join("/"),
+      parts: getPathParts(item?.file),
+      files: [],
+    };
+    existing.files.push(item);
+    groups.set(key, existing);
+  }
+
+  const ranked = [];
+  for (const group of groups.values()) {
+    group.audioFiles = group.files.filter((item) =>
+      AUDIO_EXTENSIONS.has(path.extname(String(item?.file || "")).toLowerCase()),
+    );
+    if (group.audioFiles.length === 0) continue;
+    group.audioFileCount = countAudioFiles(group.files);
+    ranked.push(...buildGroupCandidate(group, context, options));
+  }
+
+  return ranked.sort((left, right) => right.score - left.score);
+}
+
+function getRemoteFilename(candidate) {
+  return String(candidate?.raw?.file || candidate?.file || "");
+}
+
+function bestArtistTag(common) {
+  const values = [];
+  if (common?.artist) values.push(common.artist);
+  if (Array.isArray(common?.artists)) values.push(...common.artists);
+  if (common?.albumartist) values.push(common.albumartist);
+  return values.filter(Boolean).join(" ");
+}
+
+export async function validateDownloadedTrack(filePath, candidate, context) {
+  const remoteFilename = getRemoteFilename(candidate);
+  const expectedDuration = Number(context?.durationMs || 0);
+  let metadata = null;
+  let parsed = null;
+  try {
+    parsed = await parseFile(filePath, { duration: true });
+    metadata = parsed?.common || null;
+  } catch {}
+
+  const titleFromTags = metadata?.title || "";
+  const artistFromTags = bestArtistTag(metadata);
+  const albumFromTags = metadata?.album || "";
+  const titleScore = Math.max(
+    scoreTextMatch(titleFromTags, context?.trackName),
+    scoreTextMatch(remoteFilename, context?.trackName),
+  );
+  const artistScore = Math.max(
+    pickBestArtistScore(context, artistFromTags),
+    pickBestArtistScore(context, remoteFilename),
+  );
+  const albumScore = context?.albumName
+    ? Math.max(
+        scoreTextMatch(albumFromTags, context.albumName),
+        scoreTextMatch(remoteFilename, context.albumName),
+      )
+    : 0;
+  const durationSeconds = Number(parsed?.format?.duration || 0);
+  const actualDurationMs =
+    durationSeconds > 0 ? Math.round(durationSeconds * 1000) : null;
+  const durationDiffMs =
+    expectedDuration > 0 && actualDurationMs != null
+      ? Math.abs(actualDurationMs - expectedDuration)
+      : null;
+  const durationValid =
+    durationDiffMs == null ||
+    durationDiffMs <= 25000 ||
+    durationDiffMs <= Math.max(12000, expectedDuration * 0.18);
+
+  const valid =
+    titleScore >= 82 &&
+    artistScore >= 60 &&
+    durationValid &&
+    (!context?.albumName || albumScore >= 28 || titleScore >= 95);
+
+  return {
+    valid,
+    reason: valid
+      ? null
+      : `title=${titleScore}, artist=${artistScore}, album=${albumScore}, durationValid=${durationValid}`,
+    scores: {
+      title: titleScore,
+      artist: artistScore,
+      album: albumScore,
+      durationValid,
+    },
+    actualDurationMs,
+    remoteFilename,
+  };
+}

--- a/backend/services/weeklyFlowTrackResolver.js
+++ b/backend/services/weeklyFlowTrackResolver.js
@@ -1,0 +1,377 @@
+import {
+  lastfmRequest,
+  musicbrainzRequest,
+  musicbrainzResolveArtistMbidByName,
+} from "./apiClients.js";
+
+const artistAliasCache = new Map();
+const releaseGroupSearchCache = new Map();
+const releaseContextCache = new Map();
+
+function escapeMbQuery(value) {
+  return String(value || "")
+    .trim()
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+}
+
+function normalizeText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(
+      /\b(deluxe|expanded|anniversary|remaster(?:ed)?|bonus|edition|live|mono|stereo|single|ep)\b/g,
+      " ",
+    )
+    .replace(/\(.*?\)|\[.*?\]/g, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function getYear(value) {
+  const match = String(value || "").match(/\b(19\d{2}|20\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function splitWords(value) {
+  return normalizeText(value)
+    .split(" ")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function scoreTextMatch(left, right) {
+  const a = normalizeText(left);
+  const b = normalizeText(right);
+  if (!a || !b) return 0;
+  if (a === b) return 100;
+  if (a.includes(b) || b.includes(a)) return 92;
+  const leftWords = new Set(splitWords(a));
+  const rightWords = new Set(splitWords(b));
+  if (leftWords.size === 0 || rightWords.size === 0) return 0;
+  let overlap = 0;
+  for (const word of leftWords) {
+    if (rightWords.has(word)) overlap += 1;
+  }
+  const ratio =
+    (2 * overlap) / Math.max(1, leftWords.size + rightWords.size);
+  return Math.round(ratio * 100);
+}
+
+function pickBestCandidate(candidates, expectedTitle, expectedYear = null) {
+  const list = Array.isArray(candidates) ? candidates : [];
+  if (list.length === 0) return null;
+  const targetYear = getYear(expectedYear);
+  return [...list]
+    .map((candidate) => {
+      const title =
+        candidate?.title ||
+        candidate?.["title"] ||
+        candidate?.["release-group"]?.title ||
+        "";
+      const year =
+        candidate?.["first-release-date"] ||
+        candidate?.date ||
+        candidate?.["release-group"]?.["first-release-date"] ||
+        null;
+      const titleScore = scoreTextMatch(title, expectedTitle);
+      const yearScore =
+        targetYear && getYear(year) === targetYear
+          ? 10
+          : targetYear && getYear(year)
+            ? -5
+            : 0;
+      return {
+        candidate,
+        score: titleScore + yearScore,
+      };
+    })
+    .sort((left, right) => right.score - left.score)[0]?.candidate;
+}
+
+async function fetchArtistAliases(artistMbid) {
+  const key = String(artistMbid || "").trim();
+  if (!key) return [];
+  if (artistAliasCache.has(key)) {
+    return artistAliasCache.get(key);
+  }
+  const promise = (async () => {
+    try {
+      const data = await musicbrainzRequest(`/artist/${key}`, { inc: "aliases" });
+      const aliases = Array.isArray(data?.aliases)
+        ? data.aliases
+            .map((entry) => String(entry?.name || "").trim())
+            .filter(Boolean)
+        : [];
+      return [...new Set(aliases)].slice(0, 8);
+    } catch {
+      return [];
+    }
+  })();
+  artistAliasCache.set(key, promise);
+  const aliases = await promise;
+  artistAliasCache.set(key, aliases);
+  return aliases;
+}
+
+async function resolveReleaseGroup(artistName, artistMbid, albumName, releaseYear) {
+  const safeAlbum = String(albumName || "").trim();
+  if (!safeAlbum) return null;
+  const safeArtist = String(artistName || "").trim();
+  const safeMbid = String(artistMbid || "").trim();
+  const cacheKey = JSON.stringify([safeArtist, safeMbid, safeAlbum]);
+  if (releaseGroupSearchCache.has(cacheKey)) {
+    return releaseGroupSearchCache.get(cacheKey);
+  }
+  const promise = (async () => {
+    const escapedAlbum = escapeMbQuery(safeAlbum);
+    const searchQueries = [];
+    if (safeMbid) {
+      searchQueries.push(`arid:${safeMbid} AND releasegroup:"${escapedAlbum}"`);
+    }
+    if (safeArtist) {
+      searchQueries.push(
+        `artist:"${escapeMbQuery(safeArtist)}" AND releasegroup:"${escapedAlbum}"`,
+      );
+    }
+    for (const query of searchQueries) {
+      try {
+        const data = await musicbrainzRequest("/release-group", {
+          query,
+          limit: 5,
+        });
+        const releaseGroups = Array.isArray(data?.["release-groups"])
+          ? data["release-groups"]
+          : [];
+        const best = pickBestCandidate(releaseGroups, safeAlbum, releaseYear);
+        if (best?.id) {
+          return {
+            id: String(best.id),
+            title: String(best.title || safeAlbum).trim() || safeAlbum,
+            releaseYear: getYear(best["first-release-date"]),
+          };
+        }
+      } catch {}
+    }
+    return null;
+  })();
+  releaseGroupSearchCache.set(cacheKey, promise);
+  const resolved = await promise;
+  releaseGroupSearchCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+function flattenReleaseTracks(releaseData) {
+  const media = Array.isArray(releaseData?.media) ? releaseData.media : [];
+  const tracks = [];
+  for (const medium of media) {
+    const mediumTracks = Array.isArray(medium?.tracks) ? medium.tracks : [];
+    for (const track of mediumTracks) {
+      const recording = track?.recording || null;
+      const trackTitle =
+        String(
+          recording?.title ||
+            track?.title ||
+            track?.name ||
+            "",
+        ).trim();
+      if (!trackTitle) continue;
+      tracks.push({
+        title: trackTitle,
+        trackNumber:
+          track?.position != null && Number.isFinite(Number(track.position))
+            ? Number(track.position)
+            : null,
+        durationMs:
+          track?.length != null && Number.isFinite(Number(track.length))
+            ? Number(track.length)
+            : recording?.length != null && Number.isFinite(Number(recording.length))
+              ? Number(recording.length)
+              : null,
+        recordingId: recording?.id ? String(recording.id) : null,
+      });
+    }
+  }
+  return tracks;
+}
+
+function matchTrackByTitle(tracks, trackName) {
+  const safeTrackName = String(trackName || "").trim();
+  if (!safeTrackName) return null;
+  return [...(Array.isArray(tracks) ? tracks : [])]
+    .map((track) => ({
+      ...track,
+      _score: scoreTextMatch(track?.title, safeTrackName),
+    }))
+    .sort((left, right) => right._score - left._score)[0] || null;
+}
+
+async function fetchReleaseContext(albumMbid) {
+  const key = String(albumMbid || "").trim();
+  if (!key) return null;
+  if (releaseContextCache.has(key)) {
+    return releaseContextCache.get(key);
+  }
+  const promise = (async () => {
+    try {
+      const releaseGroupData = await musicbrainzRequest(`/release-group/${key}`, {
+        inc: "releases",
+      });
+      const releases = Array.isArray(releaseGroupData?.releases)
+        ? releaseGroupData.releases
+        : [];
+      const pickedRelease =
+        releases.find((release) => String(release?.status || "").toLowerCase() === "official") ||
+        releases[0] ||
+        null;
+      if (!pickedRelease?.id) {
+        return {
+          releaseYear: getYear(releaseGroupData?.["first-release-date"]),
+          albumTrackCount: null,
+          albumTrackTitles: [],
+          tracks: [],
+        };
+      }
+      const releaseData = await musicbrainzRequest(`/release/${pickedRelease.id}`, {
+        inc: "recordings+artist-credits",
+      });
+      const tracks = flattenReleaseTracks(releaseData);
+      return {
+        releaseYear:
+          getYear(pickedRelease?.date) ||
+          getYear(releaseData?.date) ||
+          getYear(releaseGroupData?.["first-release-date"]),
+        albumTrackCount: tracks.length > 0 ? tracks.length : null,
+        albumTrackTitles: tracks.map((track) => track.title),
+        tracks,
+      };
+    } catch {
+      return null;
+    }
+  })();
+  releaseContextCache.set(key, promise);
+  const resolved = await promise;
+  releaseContextCache.set(key, resolved);
+  return resolved;
+}
+
+async function fetchLastfmTrackInfo(track) {
+  const artistName = String(track?.artistName || "").trim();
+  const trackName = String(track?.trackName || "").trim();
+  if (!artistName || !trackName) return null;
+  try {
+    return await lastfmRequest("track.getInfo", {
+      artist: artistName,
+      track: trackName,
+      autocorrect: 1,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveWeeklyFlowTrackContext(track) {
+  const base = {
+    ...track,
+    artistName: String(track?.artistName || "").trim(),
+    trackName: String(track?.trackName || "").trim(),
+    albumName: String(track?.albumName || "").trim() || null,
+    artistMbid: String(track?.artistMbid || "").trim() || null,
+    albumMbid: String(track?.albumMbid || "").trim() || null,
+    trackMbid: String(track?.trackMbid || "").trim() || null,
+    releaseYear: getYear(track?.releaseYear) || null,
+    durationMs:
+      track?.durationMs != null && Number.isFinite(Number(track.durationMs))
+        ? Math.max(0, Math.round(Number(track.durationMs)))
+        : null,
+    artistAliases: Array.isArray(track?.artistAliases)
+      ? track.artistAliases.map((entry) => String(entry || "").trim()).filter(Boolean)
+      : [],
+  };
+  if (!base.artistName || !base.trackName) {
+    return base;
+  }
+
+  const lastfmInfo =
+    !base.albumName || !base.trackMbid || !base.durationMs
+      ? await fetchLastfmTrackInfo(base)
+      : null;
+  const lastfmTrack = lastfmInfo?.track || null;
+  const lastfmAlbumName = String(
+    lastfmTrack?.album?.title || lastfmTrack?.album?.["#text"] || "",
+  ).trim();
+  const lastfmTrackMbid = String(lastfmTrack?.mbid || "").trim();
+  const lastfmDuration =
+    lastfmTrack?.duration != null && Number.isFinite(Number(lastfmTrack.duration))
+      ? Math.max(0, Math.round(Number(lastfmTrack.duration)))
+      : null;
+
+  if (!base.albumName && lastfmAlbumName) {
+    base.albumName = lastfmAlbumName;
+  }
+  if (!base.trackMbid && lastfmTrackMbid) {
+    base.trackMbid = lastfmTrackMbid;
+  }
+  if (!base.durationMs && lastfmDuration) {
+    base.durationMs = lastfmDuration;
+  }
+
+  if (!base.artistMbid) {
+    base.artistMbid = await musicbrainzResolveArtistMbidByName(base.artistName);
+  }
+
+  if ((base.artistAliases?.length || 0) === 0 && base.artistMbid) {
+    base.artistAliases = await fetchArtistAliases(base.artistMbid);
+  }
+
+  let releaseContext = null;
+  if (!base.albumMbid && base.albumName) {
+    const releaseGroup = await resolveReleaseGroup(
+      base.artistName,
+      base.artistMbid,
+      base.albumName,
+      base.releaseYear,
+    );
+    if (releaseGroup?.id) {
+      base.albumMbid = releaseGroup.id;
+      if (!base.releaseYear && releaseGroup.releaseYear) {
+        base.releaseYear = releaseGroup.releaseYear;
+      }
+      if (!base.albumName && releaseGroup.title) {
+        base.albumName = releaseGroup.title;
+      }
+    }
+  }
+
+  if (base.albumMbid) {
+    releaseContext = await fetchReleaseContext(base.albumMbid);
+    if (releaseContext?.releaseYear && !base.releaseYear) {
+      base.releaseYear = releaseContext.releaseYear;
+    }
+    const matchedTrack = matchTrackByTitle(releaseContext?.tracks, base.trackName);
+    if (matchedTrack) {
+      if (!base.trackMbid && matchedTrack.recordingId) {
+        base.trackMbid = matchedTrack.recordingId;
+      }
+      if (!base.durationMs && matchedTrack.durationMs) {
+        base.durationMs = matchedTrack.durationMs;
+      }
+      base.trackNumber =
+        matchedTrack.trackNumber != null &&
+        Number.isFinite(Number(matchedTrack.trackNumber))
+          ? Number(matchedTrack.trackNumber)
+          : null;
+    }
+    base.albumTrackCount = releaseContext?.albumTrackCount ?? null;
+    base.albumTrackTitles = Array.isArray(releaseContext?.albumTrackTitles)
+      ? releaseContext.albumTrackTitles
+      : [];
+  } else {
+    base.albumTrackCount = null;
+    base.albumTrackTitles = [];
+    base.trackNumber = null;
+  }
+
+  return base;
+}

--- a/backend/services/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlowWorker.js
@@ -6,6 +6,12 @@ import { playlistManager } from "./weeklyFlowPlaylistManager.js";
 import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 import { playlistSource } from "./weeklyFlowPlaylistSource.js";
 import { dbOps } from "../config/db-helpers.js";
+import { resolveWeeklyFlowTrackContext } from "./weeklyFlowTrackResolver.js";
+import {
+  buildFlowSearchQueries,
+  rankFlowSearchResults,
+  validateDownloadedTrack,
+} from "./weeklyFlowSoulseekMatcher.js";
 
 const DEFAULT_CONCURRENCY = 3;
 const MIN_CONCURRENCY = 1;
@@ -888,14 +894,55 @@ export class WeeklyFlowWorker {
     try {
       let phaseStart = process.hrtime.bigint();
       const retryAttempt = Number(this.retryAttempts.get(job.id) || 0);
-      const initialResults = await soulseekClient.search(
-        job.artistName,
-        job.trackName,
-        { forceFresh: true },
+      const resolvedTrack = await resolveWeeklyFlowTrackContext(job);
+      downloadTracker.updateMetadata(job.id, resolvedTrack);
+      Object.assign(job, resolvedTrack);
+      const searchQueries = buildFlowSearchQueries(resolvedTrack);
+      if (searchQueries.length === 0) {
+        throw new Error("No search queries could be built");
+      }
+      const { preferredFormat, preferredFormatStrict } =
+        this.getWorkerSettings();
+      const preferredExt = preferredFormat === "mp3" ? ".mp3" : ".flac";
+      const matchLimit = this._getAdaptiveMatchLimit(
+        preferredFormatStrict,
+        retryAttempt,
       );
+      const aggregatedResults = [];
+      const seenResults = new Set();
+      let rankedMatches = [];
+      for (let queryIndex = 0; queryIndex < searchQueries.length; queryIndex += 1) {
+        this._assertJobCanContinue(job, runGeneration);
+        const query = searchQueries[queryIndex];
+        const searchResults = await soulseekClient.searchQuery(query, {
+          forceFresh: queryIndex === 0,
+        });
+        for (const result of Array.isArray(searchResults) ? searchResults : []) {
+          const file = String(result?.file || "").trim();
+          const user = String(result?.user || "").trim();
+          if (!file || !user) continue;
+          const key = `${user}\0${file}`;
+          if (seenResults.has(key)) continue;
+          seenResults.add(key);
+          aggregatedResults.push(result);
+        }
+        rankedMatches = rankFlowSearchResults(aggregatedResults, resolvedTrack, {
+          preferredFormat,
+          strictFormat: preferredFormatStrict,
+        });
+        if (
+          rankedMatches.length >= Math.min(matchLimit, 3) &&
+          rankedMatches[0]?.isLikelyMatch
+        ) {
+          break;
+        }
+        if (queryIndex >= 2 && rankedMatches.length > 0) {
+          break;
+        }
+      }
       this._assertJobCanContinue(job, runGeneration);
       timingsMs.search += Number(process.hrtime.bigint() - phaseStart) / 1e6;
-      if (!initialResults || initialResults.length === 0) {
+      if (aggregatedResults.length === 0) {
         throw new Error("No search results found");
       }
 
@@ -908,45 +955,11 @@ export class WeeklyFlowWorker {
       await fs.mkdir(stagingDir, { recursive: true });
       stagingPrepared = true;
       this._assertJobCanContinue(job, runGeneration);
-      const stagingFile = `${job.artistName} - ${job.trackName}`;
+      const stagingFile = `${resolvedTrack.artistName} - ${resolvedTrack.trackName}`;
       const stagingFilePath = path.join(stagingDir, stagingFile);
 
       phaseStart = process.hrtime.bigint();
-      const { preferredFormat, preferredFormatStrict } =
-        this.getWorkerSettings();
-      const preferredExt = preferredFormat === "mp3" ? ".mp3" : ".flac";
-      const secondaryExt = preferredFormat === "mp3" ? ".flac" : ".mp3";
-      const strictSourcePool = preferredFormatStrict
-        ? initialResults.filter((candidate) => {
-            if (typeof candidate?.file !== "string" || !candidate.file.trim()) {
-              return false;
-            }
-            return path.extname(candidate.file).toLowerCase() === preferredExt;
-          })
-        : null;
-      const sourcePool = preferredFormatStrict
-        ? strictSourcePool
-        : initialResults;
-      const matchLimit = this._getAdaptiveMatchLimit(
-        preferredFormatStrict,
-        retryAttempt,
-      );
-      const rankedCandidates = soulseekClient.pickBestMatches(
-        sourcePool,
-        job.trackName,
-        matchLimit,
-      );
-      const candidatePool =
-        Array.isArray(rankedCandidates) && rankedCandidates.length > 0
-          ? rankedCandidates
-          : Array.isArray(sourcePool)
-            ? sourcePool
-            : [];
-      const candidates = candidatePool
-        .filter((candidate) => {
-          return typeof candidate?.file === "string" && candidate.file.trim();
-        })
-        .slice(0, matchLimit);
+      const candidates = rankedMatches.slice(0, matchLimit);
       if (candidates.length === 0) {
         if (preferredFormatStrict) {
           lastError = new Error(
@@ -957,32 +970,15 @@ export class WeeklyFlowWorker {
         }
         timingsMs.search += Number(process.hrtime.bigint() - phaseStart) / 1e6;
       } else {
-        const rankedCandidates = candidates
-          .map((candidate, index) => ({
-            candidate,
-            index,
-            ext: path.extname(candidate?.file || "").toLowerCase(),
-          }))
-          .sort((a, b) => {
-            const rankA =
-              a.ext === preferredExt ? 0 : a.ext === secondaryExt ? 1 : 2;
-            const rankB =
-              b.ext === preferredExt ? 0 : b.ext === secondaryExt ? 1 : 2;
-            if (rankA !== rankB) return rankA - rankB;
-            return a.index - b.index;
-          });
-        const orderedCandidates = preferredFormatStrict
-          ? rankedCandidates.filter((entry) => entry.ext === preferredExt)
-          : rankedCandidates;
         const maxDownloadAttempts =
           retryAttempt > 0
             ? MAX_DOWNLOAD_ATTEMPTS_PER_RETRY
             : MAX_DOWNLOAD_ATTEMPTS_PER_JOB;
-        const attemptCandidates = orderedCandidates.slice(
+        const attemptCandidates = candidates.slice(
           0,
           maxDownloadAttempts,
         );
-        if (orderedCandidates.length === 0) {
+        if (attemptCandidates.length === 0) {
           lastError = new Error(
             `No ${preferredFormat.toUpperCase()} candidate files returned`,
           );
@@ -994,7 +990,7 @@ export class WeeklyFlowWorker {
         ) {
           this._assertJobCanContinue(job, runGeneration);
           const candidate = attemptCandidates[attemptIndex];
-          const extFromSoulseek = path.extname(candidate.candidate.file || "");
+          const extFromSoulseek = path.extname(candidate.raw?.file || "");
           const ext =
             extFromSoulseek &&
             /^\.(flac|mp3|m4a|ogg|wav)$/i.test(extFromSoulseek)
@@ -1003,7 +999,7 @@ export class WeeklyFlowWorker {
           try {
             const downloadStart = process.hrtime.bigint();
             downloadedSourcePath = await soulseekClient.download(
-              candidate.candidate,
+              candidate.raw,
               stagingFilePath,
               (progressPct) => {
                 if (!this.currentJob || this.currentJob.id !== job.id) return;
@@ -1025,7 +1021,20 @@ export class WeeklyFlowWorker {
             if (this.currentJob && this.currentJob.id === job.id) {
               this.currentJob.progressPct = 100;
             }
-            selectedMatch = candidate.candidate;
+            const validation = await validateDownloadedTrack(
+              downloadedSourcePath,
+              candidate,
+              resolvedTrack,
+            );
+            if (!validation.valid) {
+              await fs.rm(downloadedSourcePath, { force: true }).catch(() => {});
+              downloadedSourcePath = null;
+              lastError = new Error(
+                `Downloaded track validation failed: ${validation.reason}`,
+              );
+              continue;
+            }
+            selectedMatch = candidate;
             selectedExt = ext;
             lastError = null;
             break;
@@ -1052,11 +1061,17 @@ export class WeeklyFlowWorker {
           ? downloadedExt
           : selectedExt;
 
-      const artistDir = this._sanitizePathPart(job.artistName);
-      const albumFromApi = this._normalizeAlbumName(job.albumName);
-      const albumFromPath = this._parseAlbumFromPath(selectedMatch.file);
-      const resolvedAlbum = albumFromApi || albumFromPath || "Unknown Album";
-      const albumDir = this._sanitizePathPart(resolvedAlbum);
+      const artistDir = this._sanitizePathPart(resolvedTrack.artistName);
+      const albumFromApi = this._normalizeAlbumName(resolvedTrack.albumName);
+      const albumFromCandidate = this._normalizeAlbumName(
+        selectedMatch?.resolvedAlbumName,
+      );
+      const albumFromPath = this._parseAlbumFromPath(selectedMatch?.raw?.file);
+      const resolvedAlbum =
+        albumFromApi || albumFromCandidate || albumFromPath || "Unknown Album";
+      const albumDir = this._sanitizePathPart(
+        resolvedAlbum,
+      );
       const finalDir = path.join(
         this.weeklyFlowRoot,
         "aurral-weekly-flow",
@@ -1064,7 +1079,7 @@ export class WeeklyFlowWorker {
         artistDir,
         albumDir,
       );
-      const finalFileName = `${this._sanitizePathPart(job.trackName)}${finalExt}`;
+      const finalFileName = `${this._sanitizePathPart(resolvedTrack.trackName)}${finalExt}`;
       const finalPath = path.join(finalDir, finalFileName);
 
       phaseStart = process.hrtime.bigint();

--- a/frontend/src/components/PlaylistModals.jsx
+++ b/frontend/src/components/PlaylistModals.jsx
@@ -1,0 +1,478 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ListMusic, Loader2, Plus, X } from "lucide-react";
+
+function ModalShell({
+  open,
+  title,
+  description = "",
+  onClose,
+  children,
+  footer,
+  disableClose = false,
+}) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.78)" }}
+      onClick={disableClose ? undefined : onClose}
+    >
+      <div
+        className="card w-full max-w-2xl border border-white/10 bg-[#1c1b22] shadow-[0_24px_80px_rgba(0,0,0,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-white/10 px-5 py-4">
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold text-white">{title}</h3>
+            {description ? (
+              <p className="text-sm text-[#b8b8bf]">{description}</p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={disableClose ? undefined : onClose}
+            className="btn btn-ghost btn-sm p-2"
+            aria-label="Close"
+            disabled={disableClose}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="px-5 py-4">{children}</div>
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-white/10 px-5 py-4">
+          {footer}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function normalizeTrackDraft(track, index) {
+  return {
+    rowId: `track-${index}`,
+    artistName: String(track?.artistName || "").trim(),
+    trackName: String(track?.trackName || "").trim(),
+    albumName: String(track?.albumName || "").trim(),
+    artistMbid: String(track?.artistMbid || "").trim(),
+    albumMbid: String(track?.albumMbid || "").trim(),
+    trackMbid: String(track?.trackMbid || "").trim(),
+    releaseYear: String(track?.releaseYear || "").trim(),
+    durationMs:
+      track?.durationMs != null && Number.isFinite(Number(track.durationMs))
+        ? Math.max(0, Math.round(Number(track.durationMs)))
+        : null,
+    artistAliases: Array.isArray(track?.artistAliases)
+      ? track.artistAliases
+          .map((entry) => String(entry || "").trim())
+          .filter(Boolean)
+      : [],
+    reason: String(track?.reason || "").trim(),
+  };
+}
+
+function buildTrackPayload(drafts) {
+  return (Array.isArray(drafts) ? drafts : []).map((draft) => {
+    const artistName = String(draft?.artistName || "").trim();
+    const trackName = String(draft?.trackName || "").trim();
+    const albumName = String(draft?.albumName || "").trim();
+    if (!artistName || !trackName) {
+      throw new Error("Each track needs both an artist and song name");
+    }
+    const artistMbid = String(draft?.artistMbid || "").trim();
+    const albumMbid = String(draft?.albumMbid || "").trim();
+    const trackMbid = String(draft?.trackMbid || "").trim();
+    const releaseYear = String(draft?.releaseYear || "").trim();
+    const reason = String(draft?.reason || "").trim();
+    const durationMs =
+      draft?.durationMs != null && Number.isFinite(Number(draft.durationMs))
+        ? Math.max(0, Math.round(Number(draft.durationMs)))
+        : null;
+    const artistAliases = Array.isArray(draft?.artistAliases)
+      ? draft.artistAliases
+          .map((entry) => String(entry || "").trim())
+          .filter(Boolean)
+      : [];
+    return {
+      artistName,
+      trackName,
+      albumName: albumName || null,
+      artistMbid: artistMbid || null,
+      albumMbid: albumMbid || null,
+      trackMbid: trackMbid || null,
+      releaseYear: releaseYear || null,
+      durationMs,
+      artistAliases,
+      reason: reason || null,
+    };
+  });
+}
+
+export function CreatePlaylistModal({
+  open,
+  defaultName = "",
+  saving = false,
+  error = "",
+  onClose,
+  onSubmit,
+}) {
+  const [name, setName] = useState(defaultName);
+  const [localError, setLocalError] = useState("");
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      setName(defaultName);
+      setLocalError("");
+    }
+    wasOpenRef.current = open;
+  }, [defaultName, open]);
+
+  const handleSubmit = async () => {
+    const nextName = String(name || "").trim();
+    if (!nextName) {
+      setLocalError("Playlist name is required");
+      return;
+    }
+    setLocalError("");
+    await onSubmit?.(nextName);
+  };
+
+  return (
+    <ModalShell
+      open={open}
+      title="New Playlist"
+      description="Create a manual playlist you can build up track by track."
+      onClose={onClose}
+      disableClose={saving}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-secondary btn-sm"
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="btn btn-primary btn-sm gap-2"
+            disabled={saving}
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Create Playlist
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-white">
+          Playlist Name
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(event) => {
+            setName(event.target.value);
+            if (localError) setLocalError("");
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              handleSubmit();
+            }
+          }}
+          className="input h-11 w-full bg-[#15151a]"
+          placeholder="Night Drive"
+          autoFocus
+        />
+        {localError || error ? (
+          <p className="text-sm text-red-400">{localError || error}</p>
+        ) : null}
+      </div>
+    </ModalShell>
+  );
+}
+
+export function PlaylistTrackModal({
+  open,
+  title = "Add To Playlist",
+  description = "",
+  playlists = [],
+  initialTracks = [],
+  excludedPlaylistIds = [],
+  defaultNewPlaylistName = "",
+  saving = false,
+  error = "",
+  onClose,
+  onSubmit,
+}) {
+  const availablePlaylists = useMemo(() => {
+    const excluded = new Set(
+      (Array.isArray(excludedPlaylistIds) ? excludedPlaylistIds : [])
+        .map((entry) => String(entry || "").trim())
+        .filter(Boolean),
+    );
+    return (Array.isArray(playlists) ? playlists : []).filter(
+      (playlist) => !excluded.has(String(playlist?.id || "").trim()),
+    );
+  }, [excludedPlaylistIds, playlists]);
+
+  const [targetMode, setTargetMode] = useState(
+    availablePlaylists.length > 0 ? "existing" : "new",
+  );
+  const [playlistId, setPlaylistId] = useState("");
+  const [playlistName, setPlaylistName] = useState(defaultNewPlaylistName);
+  const [trackDrafts, setTrackDrafts] = useState(() =>
+    (Array.isArray(initialTracks) ? initialTracks : []).map(normalizeTrackDraft),
+  );
+  const [localError, setLocalError] = useState("");
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      setTargetMode(availablePlaylists.length > 0 ? "existing" : "new");
+      setPlaylistId(String(availablePlaylists[0]?.id || ""));
+      setPlaylistName(defaultNewPlaylistName);
+      setTrackDrafts(
+        (Array.isArray(initialTracks) ? initialTracks : []).map(
+          normalizeTrackDraft,
+        ),
+      );
+      setLocalError("");
+    }
+    wasOpenRef.current = open;
+  }, [availablePlaylists, defaultNewPlaylistName, initialTracks, open]);
+
+  const updateTrackField = (rowId, key, value) => {
+    setTrackDrafts((prev) =>
+      prev.map((track) =>
+        track.rowId === rowId ? { ...track, [key]: value } : track,
+      ),
+    );
+    if (localError) {
+      setLocalError("");
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const tracks = buildTrackPayload(trackDrafts);
+      if (tracks.length === 0) {
+        throw new Error("No track is ready to add");
+      }
+      if (targetMode === "existing") {
+        if (!playlistId) {
+          throw new Error("Choose a playlist");
+        }
+        setLocalError("");
+        await onSubmit?.({
+          mode: "existing",
+          playlistId,
+          tracks,
+        });
+        return;
+      }
+      const nextName = String(playlistName || "").trim();
+      if (!nextName) {
+        throw new Error("Playlist name is required");
+      }
+      setLocalError("");
+      await onSubmit?.({
+        mode: "new",
+        name: nextName,
+        tracks,
+      });
+    } catch (submitError) {
+      setLocalError(submitError?.message || "Failed to add track");
+    }
+  };
+
+  return (
+    <ModalShell
+      open={open}
+      title={title}
+      description={description}
+      onClose={onClose}
+      disableClose={saving}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-secondary btn-sm"
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="btn btn-primary btn-sm gap-2"
+            disabled={saving}
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="h-4 w-4" />
+            )}
+            Save To Playlist
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {availablePlaylists.length > 0 ? (
+          <div className="inline-flex rounded-lg border border-white/10 bg-black/20 p-1">
+            <button
+              type="button"
+              onClick={() => setTargetMode("existing")}
+              className={`rounded-md px-3 py-2 text-sm transition ${
+                targetMode === "existing"
+                  ? "bg-[#707e61] text-white"
+                  : "text-[#c2c2c8]"
+              }`}
+            >
+              Existing Playlist
+            </button>
+            <button
+              type="button"
+              onClick={() => setTargetMode("new")}
+              className={`rounded-md px-3 py-2 text-sm transition ${
+                targetMode === "new"
+                  ? "bg-[#707e61] text-white"
+                  : "text-[#c2c2c8]"
+              }`}
+            >
+              New Playlist
+            </button>
+          </div>
+        ) : null}
+
+        {targetMode === "existing" && availablePlaylists.length > 0 ? (
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-white">
+              Choose Playlist
+            </label>
+            <div className="grid gap-2">
+              {availablePlaylists.map((playlist) => {
+                const selected = playlistId === playlist.id;
+                return (
+                  <button
+                    key={playlist.id}
+                    type="button"
+                    onClick={() => setPlaylistId(playlist.id)}
+                    className={`flex items-center justify-between rounded-xl border px-3 py-3 text-left transition ${
+                      selected
+                        ? "border-[#8fa07b] bg-[#2a3223]"
+                        : "border-white/10 bg-[#15151a] hover:border-white/20"
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-white">
+                        {playlist.name}
+                      </div>
+                      <div className="text-xs text-[#b8b8bf]">
+                        {playlist.trackCount || 0} tracks
+                      </div>
+                    </div>
+                    {selected ? (
+                      <Check className="h-4 w-4 shrink-0 text-[#dfe8d2]" />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-white">
+              New Playlist Name
+            </label>
+            <input
+              type="text"
+              value={playlistName}
+              onChange={(event) => {
+                setPlaylistName(event.target.value);
+                if (localError) setLocalError("");
+              }}
+              className="input h-11 w-full bg-[#15151a]"
+              placeholder="Sunday picks"
+            />
+          </div>
+        )}
+
+        <div className="rounded-xl border border-white/10 bg-[#15151a]">
+          <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2 text-xs uppercase tracking-[0.18em] text-[#9ea0a8]">
+            <ListMusic className="h-3.5 w-3.5" />
+            Tracks
+          </div>
+          <div className="divide-y divide-white/5">
+            {trackDrafts.map((track) => (
+              <div
+                key={track.rowId}
+                className="grid gap-3 px-3 py-3 md:grid-cols-3"
+              >
+                <div className="grid gap-1">
+                  <label className="text-xs text-[#aeb0b7]">Song</label>
+                  <input
+                    type="text"
+                    value={track.trackName}
+                    onChange={(event) =>
+                      updateTrackField(
+                        track.rowId,
+                        "trackName",
+                        event.target.value,
+                      )
+                    }
+                    className="input input-sm bg-[#101015]"
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-[#aeb0b7]">Artist</label>
+                  <input
+                    type="text"
+                    value={track.artistName}
+                    onChange={(event) =>
+                      updateTrackField(
+                        track.rowId,
+                        "artistName",
+                        event.target.value,
+                      )
+                    }
+                    className="input input-sm bg-[#101015]"
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-[#aeb0b7]">Album</label>
+                  <input
+                    type="text"
+                    value={track.albumName}
+                    onChange={(event) =>
+                      updateTrackField(
+                        track.rowId,
+                        "albumName",
+                        event.target.value,
+                      )
+                    }
+                    className="input input-sm bg-[#101015]"
+                    placeholder="Optional"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {localError || error ? (
+          <p className="text-sm text-red-400">{localError || error}</p>
+        ) : null}
+      </div>
+    </ModalShell>
+  );
+}

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -14,17 +14,47 @@ import { ArtistDetailsSimilar } from "./components/ArtistDetailsSimilar";
 import { DeleteArtistModal } from "./components/DeleteArtistModal";
 import { DeleteAlbumModal } from "./components/DeleteAlbumModal";
 import { AddArtistCustomizeModal } from "./components/AddArtistCustomizeModal";
+import { PlaylistTrackModal } from "../../components/PlaylistModals";
 import {
+  addSharedPlaylistTracks,
   getArtistCover,
   getArtistDetails,
   getArtistOverrides,
   getArtistPreview,
+  getFlowStatus,
   getSimilarArtistsForArtist,
+  createSharedPlaylist,
   updateArtistOverrides,
 } from "../../utils/api";
 
 const MBID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const normalizePlaylistNameKey = (value) =>
+  String(value || "")
+    .trim()
+    .toLowerCase();
+
+const reserveUniquePlaylistName = (playlists, baseName = "Playlist") => {
+  const normalizedBase = String(baseName || "").trim() || "Playlist";
+  const existing = new Set(
+    (Array.isArray(playlists) ? playlists : [])
+      .map((playlist) => normalizePlaylistNameKey(playlist?.name))
+      .filter(Boolean),
+  );
+  if (!existing.has(normalizedBase.toLowerCase())) {
+    return normalizedBase;
+  }
+  let index = 2;
+  while (index < 10000) {
+    const candidate = `${normalizedBase} ${index}`;
+    if (!existing.has(candidate.toLowerCase())) {
+      return candidate;
+    }
+    index += 1;
+  }
+  return `${normalizedBase} ${Date.now()}`;
+};
 
 function ArtistDetailsPage() {
   const { mbid } = useParams();
@@ -43,6 +73,11 @@ function ArtistDetailsPage() {
     musicbrainzId: "",
     deezerArtistId: "",
   });
+  const [sharedPlaylists, setSharedPlaylists] = useState([]);
+  const [playlistTrackModal, setPlaylistTrackModal] = useState(null);
+  const [playlistModalLoading, setPlaylistModalLoading] = useState(false);
+  const [playlistModalSubmitting, setPlaylistModalSubmitting] = useState(false);
+  const [playlistModalError, setPlaylistModalError] = useState("");
 
   const stream = useArtistDetailsStream(mbid, artistNameFromNav);
   const canAddArtist = hasPermission("addArtist");
@@ -189,6 +224,127 @@ function ArtistDetailsPage() {
     }
   };
 
+  const loadSharedPlaylists = async () => {
+    setPlaylistModalLoading(true);
+    try {
+      const data = await getFlowStatus();
+      const playlists = Array.isArray(data?.sharedPlaylists)
+        ? data.sharedPlaylists
+        : [];
+      setSharedPlaylists(playlists);
+      return playlists;
+    } catch (err) {
+      const message =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        err.message ||
+        "Failed to load playlists";
+      setPlaylistModalError(message);
+      showError(message);
+      return null;
+    } finally {
+      setPlaylistModalLoading(false);
+    }
+  };
+
+  const openPlaylistTrackModal = async (trackPayload) => {
+    if (!trackPayload?.artistName || !trackPayload?.trackName) {
+      showError("Track details are incomplete");
+      return;
+    }
+    setPlaylistModalError("");
+    const playlists = await loadSharedPlaylists();
+    if (!playlists) return;
+    setPlaylistTrackModal({
+      tracks: [trackPayload],
+      defaultNewPlaylistName: reserveUniquePlaylistName(
+        playlists,
+        `${trackPayload.artistName} Picks`,
+      ),
+    });
+  };
+
+  const handleReleaseTrackAdd = (track, releaseGroup) => {
+    const year = String(
+      releaseGroup?.["first-release-date"] || "",
+    ).slice(0, 4);
+    void openPlaylistTrackModal({
+      artistName: artist?.name || artistNameFromNav || "",
+      trackName: track?.trackName || track?.title || "",
+      albumName: releaseGroup?.title || "",
+      artistMbid: mbid || "",
+      albumMbid: releaseGroup?.id || "",
+      trackMbid: track?.mbid || track?.id || "",
+      releaseYear: year || null,
+      durationMs:
+        track?.length != null && Number.isFinite(Number(track.length))
+          ? Number(track.length)
+          : null,
+      reason: null,
+      artistAliases: [],
+    });
+  };
+
+  const handleLibraryTrackAdd = (track, libraryAlbum, releaseGroupId) => {
+    const year = String(libraryAlbum?.releaseDate || "").slice(0, 4);
+    void openPlaylistTrackModal({
+      artistName: artist?.name || artistNameFromNav || "",
+      trackName: track?.trackName || track?.title || "",
+      albumName: libraryAlbum?.albumName || "",
+      artistMbid: mbid || "",
+      albumMbid: releaseGroupId || libraryAlbum?.mbid || "",
+      trackMbid: track?.mbid || track?.id || "",
+      releaseYear: year || null,
+      durationMs:
+        track?.length != null && Number.isFinite(Number(track.length))
+          ? Number(track.length)
+          : null,
+      reason: null,
+      artistAliases: [],
+    });
+  };
+
+  const handleSubmitPlaylistTrackModal = async (payload) => {
+    setPlaylistModalSubmitting(true);
+    setPlaylistModalError("");
+    try {
+      if (payload?.mode === "new") {
+        const response = await createSharedPlaylist({
+          name: payload.name,
+          tracks: payload.tracks,
+        });
+        showSuccess(
+          `Track saved to ${response?.playlist?.name || payload.name}`,
+        );
+      } else {
+        const targetPlaylist = sharedPlaylists.find(
+          (playlist) => playlist.id === payload?.playlistId,
+        );
+        await addSharedPlaylistTracks(payload.playlistId, {
+          tracks: payload.tracks,
+        });
+        showSuccess(
+          `Track added to ${targetPlaylist?.name || "playlist"}`,
+        );
+      }
+      setPlaylistTrackModal(null);
+      const nextPlaylists = await loadSharedPlaylists();
+      if (nextPlaylists) {
+        setSharedPlaylists(nextPlaylists);
+      }
+    } catch (err) {
+      const message =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        err.message ||
+        "Failed to save track to playlist";
+      setPlaylistModalError(message);
+      showError(message);
+    } finally {
+      setPlaylistModalSubmitting(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center items-center py-20">
@@ -295,6 +451,7 @@ function ArtistDetailsPage() {
           handleDeleteAlbumClick={library.handleDeleteAlbumClick}
           canReSearchAlbum={canAddAlbum}
           handleReSearchAlbum={library.handleReSearchAlbum}
+          onAddTrackToPlaylist={handleLibraryTrackAdd}
         />
       )}
 
@@ -332,6 +489,7 @@ function ArtistDetailsPage() {
           isReleaseGroupDownloadedInLibrary={
             library.isReleaseGroupDownloadedInLibrary
           }
+          onAddTrackToPlaylist={handleReleaseTrackAdd}
         />
       )}
 
@@ -393,6 +551,29 @@ function ArtistDetailsPage() {
         onChange={setIdsValues}
         onClose={() => setShowEditIdsModal(false)}
         onSave={handleSaveIds}
+      />
+
+      <PlaylistTrackModal
+        open={!!playlistTrackModal}
+        title="Add Track To Playlist"
+        description={
+          playlistModalLoading
+            ? "Loading your playlists..."
+            : "Save this song into an existing playlist or start a new one."
+        }
+        playlists={sharedPlaylists}
+        initialTracks={playlistTrackModal?.tracks || []}
+        defaultNewPlaylistName={
+          playlistTrackModal?.defaultNewPlaylistName || "Playlist"
+        }
+        saving={playlistModalSubmitting || playlistModalLoading}
+        error={playlistModalError}
+        onClose={() => {
+          if (playlistModalSubmitting || playlistModalLoading) return;
+          setPlaylistModalError("");
+          setPlaylistTrackModal(null);
+        }}
+        onSubmit={handleSubmitPlaylistTrackModal}
       />
     </div>
   );

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -13,6 +13,7 @@ import {
   ExternalLink,
   Trash2,
   RefreshCw,
+  Plus,
 } from "lucide-react";
 import { getPopularityScale, segmentsFromScale } from "../utils";
 
@@ -33,6 +34,7 @@ export function ArtistDetailsLibraryAlbums({
   handleDeleteAlbumClick,
   canReSearchAlbum,
   handleReSearchAlbum,
+  onAddTrackToPlaylist,
 }) {
   const [sortMode, setSortMode] = useState("date");
   const downloadedAlbums = libraryAlbums.filter((album) => {
@@ -598,6 +600,24 @@ export function ArtistDetailsLibraryAlbums({
                                 </span>
                               </div>
                               <div className="flex items-center gap-2 flex-shrink-0">
+                                {onAddTrackToPlaylist ? (
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      onAddTrackToPlaylist(track, libraryAlbum, rgId);
+                                    }}
+                                    className="w-7 h-7 rounded-full flex items-center justify-center transition-colors"
+                                    style={{
+                                      backgroundColor: "rgba(255,255,255,0.06)",
+                                      color: "#fff",
+                                    }}
+                                    title="Add to playlist"
+                                    aria-label="Add to playlist"
+                                  >
+                                    <Plus className="w-3.5 h-3.5" />
+                                  </button>
+                                ) : null}
                                 {track.length && (
                                   <span
                                     className="text-xs "
@@ -664,5 +684,6 @@ ArtistDetailsLibraryAlbums.propTypes = {
   handleDeleteAlbumClick: PropTypes.func,
   canReSearchAlbum: PropTypes.bool,
   handleReSearchAlbum: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func,
   reSearchingAlbum: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -58,6 +58,7 @@ export function ArtistDetailsReleaseGroups({
   previewVolume,
   setPreviewVolume,
   isReleaseGroupDownloadedInLibrary,
+  onAddTrackToPlaylist,
 }) {
   const [sortMode, setSortMode] = useState("date");
   const [playingTrackId, setPlayingTrackId] = useState(null);
@@ -887,6 +888,24 @@ export function ArtistDetailsReleaseGroups({
                                   </span>
                                 </div>
                                 <div className="flex items-center gap-2 flex-shrink-0">
+                                  {onAddTrackToPlaylist ? (
+                                    <button
+                                      type="button"
+                                      className="w-7 h-7 rounded-full flex items-center justify-center transition-colors"
+                                      style={{
+                                        backgroundColor: "rgba(255,255,255,0.06)",
+                                        color: "#fff",
+                                      }}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        onAddTrackToPlaylist(track, releaseGroup);
+                                      }}
+                                      title="Add to playlist"
+                                      aria-label="Add to playlist"
+                                    >
+                                      <Plus className="w-3.5 h-3.5" />
+                                    </button>
+                                  ) : null}
                                   {hasPreview && (
                                     <button
                                       type="button"
@@ -996,4 +1015,5 @@ ArtistDetailsReleaseGroups.propTypes = {
   previewVolume: PropTypes.number,
   setPreviewVolume: PropTypes.func,
   isReleaseGroupDownloadedInLibrary: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func,
 };

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -7,6 +7,8 @@ import {
   createFlow,
   updateFlow,
   deleteFlow,
+  createSharedPlaylist,
+  addSharedPlaylistTracks,
   convertFlowToStaticPlaylist,
   deleteSharedPlaylist,
   importSharedPlaylist,
@@ -17,6 +19,10 @@ import {
   updateFlowWorkerSettings,
   setPlaylistRetryCyclePaused,
 } from "../utils/api";
+import {
+  CreatePlaylistModal,
+  PlaylistTrackModal,
+} from "../components/PlaylistModals";
 import { useToast } from "../contexts/ToastContext";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
 import {
@@ -159,6 +165,15 @@ const reserveUniqueFlowName = (reservedNames, baseName) => {
   const fallback = `${normalizedBase} ${Date.now()}`;
   reservedNames.add(normalizeNameKey(fallback));
   return fallback;
+};
+
+const buildTrackForPlaylistModal = (track) => {
+  const normalized = normalizeSharedTrackEntry(track);
+  if (!normalized) return null;
+  return {
+    ...normalized,
+    reason: track?.reason ? String(track.reason).trim() : null,
+  };
 };
 
 const parseListInput = (value) =>
@@ -545,11 +560,32 @@ const normalizeSharedTrackEntry = (track) => {
     track.albumName ?? track.album ?? track["Album Name"] ?? "",
   ).trim();
   const artistMbid = String(track.artistMbid ?? track.artistId ?? track.mbid ?? "").trim();
+  const albumMbid = String(
+    track.albumMbid ?? track.releaseGroupMbid ?? track.albumId ?? "",
+  ).trim();
+  const trackMbid = String(
+    track.trackMbid ?? track.recordingMbid ?? track.recordingId ?? "",
+  ).trim();
+  const releaseYear = String(track.releaseYear ?? track.year ?? "").trim();
+  const durationMs =
+    track.durationMs != null && Number.isFinite(Number(track.durationMs))
+      ? Math.max(0, Math.round(Number(track.durationMs)))
+      : null;
+  const artistAliases = Array.isArray(track.artistAliases)
+    ? track.artistAliases
+        .map((entry) => String(entry || "").trim())
+        .filter(Boolean)
+    : [];
   return {
     artistName,
     trackName,
     albumName: albumName || null,
     artistMbid: artistMbid || null,
+    albumMbid: albumMbid || null,
+    trackMbid: trackMbid || null,
+    releaseYear: releaseYear || null,
+    durationMs,
+    artistAliases,
   };
 };
 
@@ -566,6 +602,18 @@ const buildSharedTracklistPayload = ({ name, sourceName, sourceFlowId, tracks })
     trackName: String(track.trackName || "").trim(),
     albumName: track.albumName ? String(track.albumName).trim() : null,
     artistMbid: track.artistMbid ? String(track.artistMbid).trim() : null,
+    albumMbid: track.albumMbid ? String(track.albumMbid).trim() : null,
+    trackMbid: track.trackMbid ? String(track.trackMbid).trim() : null,
+    releaseYear: track.releaseYear ? String(track.releaseYear).trim() : null,
+    durationMs:
+      track.durationMs != null && Number.isFinite(Number(track.durationMs))
+        ? Math.max(0, Math.round(Number(track.durationMs)))
+        : null,
+    artistAliases: Array.isArray(track.artistAliases)
+      ? track.artistAliases
+          .map((entry) => String(entry || "").trim())
+          .filter(Boolean)
+      : [],
   })),
 });
 
@@ -776,6 +824,12 @@ function FlowPage() {
   const [countdownNow, setCountdownNow] = useState(() => Date.now());
   const [importReview, setImportReview] = useState(null);
   const [importing, setImporting] = useState(false);
+  const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
+  const [creatingPlaylist, setCreatingPlaylist] = useState(false);
+  const [createPlaylistError, setCreatePlaylistError] = useState("");
+  const [playlistTrackModal, setPlaylistTrackModal] = useState(null);
+  const [playlistTrackSubmitting, setPlaylistTrackSubmitting] = useState(false);
+  const [playlistTrackError, setPlaylistTrackError] = useState("");
   const lastFlowWsMessageAtRef = useRef(0);
   const importInputRef = useRef(null);
   const { showSuccess, showError } = useToast();
@@ -1103,6 +1157,111 @@ function FlowPage() {
     }
   };
 
+  const handleOpenCreatePlaylist = () => {
+    setCreatePlaylistError("");
+    setIsCreatePlaylistOpen(true);
+  };
+
+  const handleCreatePlaylist = async (name) => {
+    setCreatingPlaylist(true);
+    setCreatePlaylistError("");
+    try {
+      await createSharedPlaylist({ name });
+      showSuccess("Playlist created");
+      setIsCreatePlaylistOpen(false);
+      await fetchStatus();
+    } catch (err) {
+      const message =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        err.message ||
+        "Failed to create playlist";
+      setCreatePlaylistError(message);
+      showError(message);
+    } finally {
+      setCreatingPlaylist(false);
+    }
+  };
+
+  const openPlaylistTrackModal = ({
+    track,
+    title = "Add To Playlist",
+    description = "",
+    excludedPlaylistIds = [],
+  }) => {
+    const normalizedTrack = buildTrackForPlaylistModal(track);
+    if (!normalizedTrack) {
+      showError("Track details are incomplete");
+      return;
+    }
+    setPlaylistTrackError("");
+    setPlaylistTrackModal({
+      title,
+      description,
+      tracks: [normalizedTrack],
+      excludedPlaylistIds,
+      defaultNewPlaylistName: getNextPlaylistName(
+        `${normalizedTrack.artistName} Picks`,
+      ),
+    });
+  };
+
+  const handleAddTrackToPlaylist = (track, options = {}) => {
+    openPlaylistTrackModal({
+      track,
+      title: options.title || "Add Track To Playlist",
+      description:
+        options.description ||
+        "Save this song into an existing playlist or start a new one.",
+      excludedPlaylistIds: options.excludedPlaylistIds || [],
+    });
+  };
+
+  const handleSubmitPlaylistTrackModal = async (payload) => {
+    setPlaylistTrackSubmitting(true);
+    setPlaylistTrackError("");
+    try {
+      if (payload?.mode === "new") {
+        const response = await createSharedPlaylist({
+          name: payload.name,
+          tracks: payload.tracks,
+        });
+        showSuccess(
+          `Track saved to ${response?.playlist?.name || payload.name}`,
+        );
+      } else {
+        const targetPlaylist = sharedPlaylists.find(
+          (playlist) => playlist.id === payload?.playlistId,
+        );
+        await addSharedPlaylistTracks(payload.playlistId, {
+          tracks: payload.tracks,
+        });
+        showSuccess(
+          `Track added to ${targetPlaylist?.name || "playlist"}`,
+        );
+      }
+      const expandedId = tracksExpandedId;
+      setPlaylistTrackModal(null);
+      await fetchStatus();
+      if (expandedId) {
+        await fetchFlowTracks(expandedId, {
+          showSpinner: false,
+          includeFailed: true,
+        });
+      }
+    } catch (err) {
+      const message =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        err.message ||
+        "Failed to save track to playlist";
+      setPlaylistTrackError(message);
+      showError(message);
+    } finally {
+      setPlaylistTrackSubmitting(false);
+    }
+  };
+
   const handleDelete = async (flow) => {
     setConfirmDelete({
       flowId: flow.id,
@@ -1167,7 +1326,21 @@ function FlowPage() {
   };
 
   const flowList = status?.flows || [];
-  const sharedPlaylists = status?.sharedPlaylists || [];
+  const sharedPlaylists = useMemo(
+    () => status?.sharedPlaylists || [],
+    [status?.sharedPlaylists],
+  );
+  const getNextPlaylistName = useCallback(
+    (baseName = "Playlist") => {
+      const reservedNames = new Set(
+        sharedPlaylists
+          .map((playlist) => normalizeNameKey(playlist?.name))
+          .filter(Boolean),
+      );
+      return reserveUniqueFlowName(reservedNames, baseName);
+    },
+    [sharedPlaylists],
+  );
   const effectiveFlowList = flowList.map((flow) => {
     const optimisticValue = optimisticEnabled[flow.id];
     if (typeof optimisticValue !== "boolean") return flow;
@@ -1229,6 +1402,11 @@ function FlowPage() {
         trackName: job.trackName,
         albumName: job.albumName || null,
         artistMbid: job.artistMbid || null,
+        albumMbid: job.albumMbid || null,
+        trackMbid: job.trackMbid || null,
+        releaseYear: job.releaseYear || null,
+        durationMs: job.durationMs || null,
+        artistAliases: job.artistAliases || [],
       }))
       .filter((track) => track.artistName && track.trackName);
     if (tracks.length === 0) {
@@ -1698,6 +1876,14 @@ function FlowPage() {
           </a>
           <button
             type="button"
+            onClick={handleOpenCreatePlaylist}
+            className="btn btn-secondary btn-sm"
+            disabled={creatingPlaylist}
+          >
+            {creatingPlaylist ? "Creating..." : "New Playlist"}
+          </button>
+          <button
+            type="button"
             onClick={handleCreateInline}
             className="btn btn-primary btn-sm"
             disabled={creating}
@@ -1747,6 +1933,11 @@ function FlowPage() {
                 onExport={() => handleExportFlow(playlist)}
                 onViewTracks={() =>
                   handleToggleTracks(playlist.id, { includeFailed: true })
+                }
+                onAddTrackToPlaylist={(track) =>
+                  handleAddTrackToPlaylist(track, {
+                    excludedPlaylistIds: [playlist.id],
+                  })
                 }
                 onNavigateArtist={handleNavigateArtist}
                 retryCyclePaused={retryCyclePausedByPlaylist[playlist.id] === true}
@@ -1829,6 +2020,7 @@ function FlowPage() {
               onToggleEnabled={(checked) => handleToggleRequest(flow, checked)}
               onDelete={() => handleDelete(flow)}
               onViewTracks={() => handleToggleTracks(flow.id)}
+              onAddTrackToPlaylist={(track) => handleAddTrackToPlaylist(track)}
               onNavigateArtist={handleNavigateArtist}
               onNameCancel={() => handleCancelFlowNameEdit(flow)}
               onNameApply={() => handleApplyFlowNameEdit(flow)}
@@ -1901,6 +2093,38 @@ function FlowPage() {
           setImportReview(null);
         }}
         onConfirm={handleConfirmImport}
+      />
+      <CreatePlaylistModal
+        open={isCreatePlaylistOpen}
+        defaultName={getNextPlaylistName("Playlist")}
+        saving={creatingPlaylist}
+        error={createPlaylistError}
+        onClose={() => {
+          if (creatingPlaylist) return;
+          setCreatePlaylistError("");
+          setIsCreatePlaylistOpen(false);
+        }}
+        onSubmit={handleCreatePlaylist}
+      />
+      <PlaylistTrackModal
+        open={!!playlistTrackModal}
+        title={playlistTrackModal?.title || "Add To Playlist"}
+        description={playlistTrackModal?.description || ""}
+        playlists={sharedPlaylists}
+        initialTracks={playlistTrackModal?.tracks || []}
+        excludedPlaylistIds={playlistTrackModal?.excludedPlaylistIds || []}
+        defaultNewPlaylistName={
+          playlistTrackModal?.defaultNewPlaylistName ||
+          getNextPlaylistName("Playlist")
+        }
+        saving={playlistTrackSubmitting}
+        error={playlistTrackError}
+        onClose={() => {
+          if (playlistTrackSubmitting) return;
+          setPlaylistTrackError("");
+          setPlaylistTrackModal(null);
+        }}
+        onSubmit={handleSubmitPlaylistTrackModal}
       />
     </div>
   );

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -804,6 +804,18 @@ function buildEditableTrackRows(tracks) {
     trackName: String(track?.trackName || ""),
     albumName: String(track?.albumName || ""),
     artistMbid: String(track?.artistMbid || ""),
+    albumMbid: String(track?.albumMbid || ""),
+    trackMbid: String(track?.trackMbid || ""),
+    releaseYear: String(track?.releaseYear || ""),
+    durationMs:
+      track?.durationMs != null && Number.isFinite(Number(track.durationMs))
+        ? Math.max(0, Math.round(Number(track.durationMs)))
+        : null,
+    artistAliases: Array.isArray(track?.artistAliases)
+      ? track.artistAliases
+          .map((entry) => String(entry || "").trim())
+          .filter(Boolean)
+      : [],
     reason: String(track?.reason || ""),
     status: String(track?.status || "draft"),
     error: String(track?.error || ""),
@@ -851,8 +863,29 @@ function buildTrackSavePayload(tracks) {
     const trackName = String(track?.trackName || "").trim();
     const albumName = String(track?.albumName || "").trim();
     const artistMbid = String(track?.artistMbid || "").trim();
+    const albumMbid = String(track?.albumMbid || "").trim();
+    const trackMbid = String(track?.trackMbid || "").trim();
+    const releaseYear = String(track?.releaseYear || "").trim();
     const reason = String(track?.reason || "").trim();
-    if (!artistName && !trackName && !albumName && !artistMbid && !reason) {
+    const durationMs =
+      track?.durationMs != null && Number.isFinite(Number(track.durationMs))
+        ? Math.max(0, Math.round(Number(track.durationMs)))
+        : null;
+    const artistAliases = Array.isArray(track?.artistAliases)
+      ? track.artistAliases
+          .map((entry) => String(entry || "").trim())
+          .filter(Boolean)
+      : [];
+    if (
+      !artistName &&
+      !trackName &&
+      !albumName &&
+      !artistMbid &&
+      !albumMbid &&
+      !trackMbid &&
+      !releaseYear &&
+      !reason
+    ) {
       continue;
     }
     if (!artistName || !trackName) {
@@ -863,11 +896,13 @@ function buildTrackSavePayload(tracks) {
       trackName,
       albumName: albumName || null,
       artistMbid: artistMbid || null,
+      albumMbid: albumMbid || null,
+      trackMbid: trackMbid || null,
+      releaseYear: releaseYear || null,
+      durationMs,
+      artistAliases,
       reason: reason || null,
     });
-  }
-  if (nextTracks.length === 0) {
-    throw new Error("Playlist must include at least one track");
   }
   return nextTracks;
 }
@@ -952,6 +987,11 @@ export const SharedPlaylistTrackEditor = forwardRef(function SharedPlaylistTrack
         trackName: "",
         albumName: "",
         artistMbid: "",
+        albumMbid: "",
+        trackMbid: "",
+        releaseYear: "",
+        durationMs: null,
+        artistAliases: [],
         reason: "",
         status: "draft",
         error: "",
@@ -1235,6 +1275,7 @@ export function FlowCard({
   onToggleEnabled,
   onDelete,
   onViewTracks,
+  onAddTrackToPlaylist,
   onNavigateArtist,
   onNameCancel,
   onNameApply,
@@ -1567,6 +1608,7 @@ export function FlowCard({
             tracks={tracks}
             loading={tracksLoading}
             error={tracksError}
+            onAddTrackToPlaylist={onAddTrackToPlaylist}
             onNavigateArtist={onNavigateArtist}
           />
         </div>
@@ -1587,6 +1629,7 @@ export function FlowTracksPanel({
   headerActions = null,
   deletingTrackId = null,
   onDeleteTrack,
+  onAddTrackToPlaylist,
   onNavigateArtist,
 }) {
   const [queue, setQueue] = useState([]);
@@ -1980,6 +2023,17 @@ export function FlowTracksPanel({
                             <ExternalLink className="w-3.5 h-3.5" />
                           </button>
                         ) : null}
+                        {onAddTrackToPlaylist ? (
+                          <button
+                            onClick={() => onAddTrackToPlaylist(track)}
+                            className="btn btn-secondary btn-xs px-2"
+                            aria-label={`Add ${track.trackName} to playlist`}
+                            title={`Add ${track.trackName} to playlist`}
+                            disabled={!track.artistName || !track.trackName}
+                          >
+                            <Plus className="w-3.5 h-3.5" />
+                          </button>
+                        ) : null}
                         {canDelete ? (
                           <button
                             onClick={() => onDeleteTrack?.(track)}
@@ -2052,6 +2106,7 @@ export function SharedPlaylistCard({
   onDelete,
   onExport,
   onViewTracks,
+  onAddTrackToPlaylist,
   onNavigateArtist,
   retryCyclePaused,
   retryCycleScheduled,
@@ -2318,6 +2373,7 @@ export function SharedPlaylistCard({
                   )}
                 </button>
               }
+              onAddTrackToPlaylist={onAddTrackToPlaylist}
               onNavigateArtist={onNavigateArtist}
             />
           )}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -743,6 +743,11 @@ export const convertFlowToStaticPlaylist = async (flowId, payload = {}) => {
   return response.data;
 };
 
+export const createSharedPlaylist = async (payload) => {
+  const response = await api.post("/weekly-flow/shared-playlists", payload);
+  return response.data;
+};
+
 export const setFlowEnabled = async (flowId, enabled) => {
   const response = await api.put(`/weekly-flow/flows/${flowId}/enabled`, {
     enabled,
@@ -761,6 +766,14 @@ export const importSharedPlaylist = async (payload) => {
 export const updateSharedPlaylist = async (playlistId, payload) => {
   const response = await api.put(
     `/weekly-flow/shared-playlists/${playlistId}`,
+    payload,
+  );
+  return response.data;
+};
+
+export const addSharedPlaylistTracks = async (playlistId, payload) => {
+  const response = await api.post(
+    `/weekly-flow/shared-playlists/${playlistId}/tracks`,
     payload,
   );
   return response.data;


### PR DESCRIPTION
## Summary
- Expanded weekly flow playlist and job metadata to carry album MBIDs, track MBIDs, release year, duration, and artist aliases end to end.
- Added shared-playlist creation and track-append routes, including support for empty manual playlists and richer validation.
- Introduced a new Soulseek matcher that builds album-first search queries and ranks results by artist, album, year, format, and directory structure.
- Updated the frontend flow and artist details pages to work with the richer playlist metadata and shared playlist management.

## Testing
- Added unit coverage for shared playlist creation, empty manual playlists, and metadata preservation on updates.
- Added unit coverage for weekly flow status snapshots including empty shared playlists.
- Added unit coverage for Soulseek query generation and result ranking.
- Not run: full backend/frontend test suite or manual UI verification.