### PR TITLE
feat: Persist discover layout per user

### DIFF
--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -69,14 +69,14 @@ const getUserByUsernameStmt = db.prepare(
   "SELECT * FROM users WHERE username = ?"
 );
 const getAllUsersStmt = db.prepare(
-  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username, lidarr_root_folder_path, lidarr_quality_profile_id FROM users ORDER BY username"
+  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username, lidarr_root_folder_path, lidarr_quality_profile_id, discover_layout FROM users ORDER BY username"
 );
 const getUserByIdStmt = db.prepare("SELECT * FROM users WHERE id = ?");
 const insertUserStmt = db.prepare(
-  "INSERT INTO users (username, password_hash, role, permissions, lidarr_root_folder_path, lidarr_quality_profile_id) VALUES (?, ?, ?, ?, ?, ?)"
+  "INSERT INTO users (username, password_hash, role, permissions, lidarr_root_folder_path, lidarr_quality_profile_id, discover_layout) VALUES (?, ?, ?, ?, ?, ?, ?)"
 );
 const updateUserStmt = db.prepare(
-  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ?, lidarr_root_folder_path = ?, lidarr_quality_profile_id = ? WHERE id = ?"
+  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ?, lidarr_root_folder_path = ?, lidarr_quality_profile_id = ?, discover_layout = ? WHERE id = ?"
 );
 const deleteUserStmt = db.prepare("DELETE FROM users WHERE id = ?");
 const getAllListeningHistoryUsersStmt = db.prepare(
@@ -114,6 +114,7 @@ export const userOps = {
         row.lidarr_quality_profile_id != null
           ? Number(row.lidarr_quality_profile_id)
           : null,
+      discoverLayout: dbHelpers.parseJSON(row.discover_layout) || null,
       ...history,
     };
   },
@@ -152,6 +153,7 @@ export const userOps = {
         r.lidarr_quality_profile_id != null
           ? Number(r.lidarr_quality_profile_id)
           : null,
+      discoverLayout: dbHelpers.parseJSON(r.discover_layout) || null,
     }));
   },
   createUser(username, passwordHash, role = "user", permissions = null) {
@@ -168,6 +170,7 @@ export const userOps = {
         dbHelpers.stringifyJSON(perms),
         null,
         null,
+        null,
       );
       return {
         id: result.lastInsertRowid,
@@ -179,6 +182,7 @@ export const userOps = {
         lastfmUsername: null,
         lidarrRootFolderPath: null,
         lidarrQualityProfileId: null,
+        discoverLayout: null,
       };
     } catch (e) {
       return null;
@@ -236,6 +240,8 @@ export const userOps = {
         : parsedLidarrQualityProfileId === null
           ? null
           : existing.lidarrQualityProfileId;
+    const discoverLayout =
+      data.discoverLayout !== undefined ? data.discoverLayout : existing.discoverLayout;
     try {
       updateUserStmt.run(
         username.toLowerCase(),
@@ -247,6 +253,7 @@ export const userOps = {
         listenHistoryUsername,
         lidarrRootFolderPath,
         lidarrQualityProfileId,
+        dbHelpers.stringifyJSON(discoverLayout),
         parseInt(id, 10)
       );
       return {
@@ -259,6 +266,7 @@ export const userOps = {
         lastfmUsername,
         lidarrRootFolderPath,
         lidarrQualityProfileId,
+        discoverLayout,
       };
     } catch (e) {
       return null;

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -309,6 +309,25 @@ let settingsCacheTime = 0;
 const SETTINGS_CACHE_TTL = 5000;
 
 export const dbOps = {
+  getJSONSetting(key) {
+    return dbHelpers.parseJSON(getSettingStmt.get(key)?.value) || null;
+  },
+
+  setJSONSetting(key, value) {
+    upsertSettingStmt.run(key, dbHelpers.stringifyJSON(value));
+  },
+
+  getUserDiscoverLayout(userId) {
+    return dbOps.getJSONSetting(`user:${parseInt(userId, 10)}:discoverLayout`);
+  },
+
+  setUserDiscoverLayout(userId, layout) {
+    dbOps.setJSONSetting(
+      `user:${parseInt(userId, 10)}:discoverLayout`,
+      layout,
+    );
+  },
+
   getSettings() {
     const now = Date.now();
     if (settingsCache && now - settingsCacheTime < SETTINGS_CACHE_TTL) {

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -60,7 +60,8 @@ db.exec(`
     username TEXT UNIQUE NOT NULL,
     password_hash TEXT NOT NULL,
     role TEXT NOT NULL DEFAULT 'user',
-    permissions TEXT
+    permissions TEXT,
+    discover_layout TEXT
   );
 
   CREATE TABLE IF NOT EXISTS sessions (
@@ -172,6 +173,9 @@ if (!userColumns.includes("lidarr_root_folder_path")) {
 }
 if (!userColumns.includes("lidarr_quality_profile_id")) {
   tryAddColumn("ALTER TABLE users ADD COLUMN lidarr_quality_profile_id INTEGER");
+}
+if (!userColumns.includes("discover_layout")) {
+  tryAddColumn("ALTER TABLE users ADD COLUMN discover_layout TEXT");
 }
 
 db.exec(`

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -29,6 +29,40 @@ const normalizeQualityProfileId = (value) => {
   return Math.trunc(parsed);
 };
 
+const DEFAULT_DISCOVER_LAYOUT = [
+  { id: "recentlyAdded", enabled: true },
+  { id: "recommendedShows", enabled: true },
+  { id: "recentReleases", enabled: true },
+  { id: "recommended", enabled: true },
+  { id: "globalTop", enabled: true },
+  { id: "genreSections", enabled: true },
+  { id: "topTags", enabled: true },
+];
+
+const normalizeDiscoverLayout = (value) => {
+  if (!Array.isArray(value)) return null;
+  const defaultsById = new Map(
+    DEFAULT_DISCOVER_LAYOUT.map((item) => [item.id, item]),
+  );
+  const normalized = [];
+  for (const item of value) {
+    const id = String(item?.id || "").trim();
+    if (!id || !defaultsById.has(id)) continue;
+    normalized.push({
+      id,
+      enabled:
+        typeof item?.enabled === "boolean"
+          ? item.enabled
+          : defaultsById.get(id).enabled,
+    });
+    defaultsById.delete(id);
+  }
+  for (const item of defaultsById.values()) {
+    normalized.push({ ...item });
+  }
+  return normalized;
+};
+
 const clearOrphanedDiscoveryCache = (userId, existingProfile, nextProfile) => {
   if (
     !hasListenHistoryProfile(existingProfile) ||
@@ -89,6 +123,7 @@ router.post("/", requireAuth, requireAdmin, (req, res) => {
         permissions: created.permissions,
         lidarrRootFolderPath: created.lidarrRootFolderPath,
         lidarrQualityProfileId: created.lidarrQualityProfileId,
+        discoverLayout: created.discoverLayout,
       });
   } catch (e) {
     res
@@ -170,6 +205,7 @@ router.patch("/:id", requireAuth, (req, res) => {
           lastfmUsername: existing.lastfmUsername,
           lidarrRootFolderPath: existing.lidarrRootFolderPath,
           lidarrQualityProfileId: existing.lidarrQualityProfileId,
+          discoverLayout: existing.discoverLayout,
         });
       }
       const updated = userOps.updateUser(id, updates);
@@ -209,6 +245,7 @@ router.patch("/:id", requireAuth, (req, res) => {
         lastfmUsername: existing.lastfmUsername,
         lidarrRootFolderPath: existing.lidarrRootFolderPath,
         lidarrQualityProfileId: existing.lidarrQualityProfileId,
+        discoverLayout: existing.discoverLayout,
       });
     }
     const updated = userOps.updateUser(id, updates);
@@ -254,6 +291,54 @@ router.get("/me/lidarr-preferences", requireAuth, async (req, res) => {
   } catch (e) {
     res.status(500).json({
       error: "Failed to get Lidarr preferences",
+      message: e.message,
+    });
+  }
+});
+
+router.get("/me/discover-layout", requireAuth, (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.json({
+      layout: normalizeDiscoverLayout(user.discoverLayout),
+    });
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to get discover layout",
+      message: e.message,
+    });
+  }
+});
+
+router.patch("/me/discover-layout", requireAuth, (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    const normalized = normalizeDiscoverLayout(req.body?.layout);
+    if (!normalized) {
+      return res.status(400).json({
+        error: "Invalid discover layout",
+        message: "layout must be an array of discover section entries",
+        field: "layout",
+      });
+    }
+    const updated = userOps.updateUser(req.user.id, {
+      discoverLayout: normalized,
+    });
+    if (!updated) {
+      return res.status(500).json({ error: "Failed to save discover layout" });
+    }
+    res.json({
+      layout: normalizeDiscoverLayout(updated.discoverLayout),
+    });
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to save discover layout",
       message: e.message,
     });
   }

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -302,8 +302,9 @@ router.get("/me/discover-layout", requireAuth, (req, res) => {
     if (!user) {
       return res.status(404).json({ error: "User not found" });
     }
+    const storedLayout = dbOps.getUserDiscoverLayout(req.user.id);
     res.json({
-      layout: normalizeDiscoverLayout(user.discoverLayout),
+      layout: normalizeDiscoverLayout(storedLayout),
     });
   } catch (e) {
     res.status(500).json({
@@ -327,14 +328,9 @@ router.patch("/me/discover-layout", requireAuth, (req, res) => {
         field: "layout",
       });
     }
-    const updated = userOps.updateUser(req.user.id, {
-      discoverLayout: normalized,
-    });
-    if (!updated) {
-      return res.status(500).json({ error: "Failed to save discover layout" });
-    }
+    dbOps.setUserDiscoverLayout(req.user.id, normalized);
     res.json({
-      layout: normalizeDiscoverLayout(updated.discoverLayout),
+      layout: normalizeDiscoverLayout(dbOps.getUserDiscoverLayout(req.user.id)),
     });
   } catch (e) {
     res.status(500).json({

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -1049,7 +1049,6 @@ function DiscoverPage() {
   useEffect(() => {
     if (!authUser?.id) return;
     let cancelled = false;
-    const localLayout = readStoredDiscoverLayout(authUser.id);
     const loadDiscoverLayout = async () => {
       try {
         const response = await getMyDiscoverLayout();
@@ -1060,13 +1059,8 @@ function DiscoverPage() {
           writeStoredDiscoverLayout(serverLayout, authUser.id);
           return;
         }
-        if (localLayout) {
-          try {
-            await updateMyDiscoverLayout(localLayout);
-            writeStoredDiscoverLayout(localLayout, authUser.id);
-          } catch {}
-        }
       } catch {
+        const localLayout = readStoredDiscoverLayout(authUser.id);
         if (!cancelled && localLayout) {
           setDiscoverSections(localLayout);
         }

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -26,12 +26,14 @@ import {
   getBlocklist,
   getDiscovery,
   getNearbyShows,
+  getMyDiscoverLayout,
   getRecentlyAdded,
   getRecentReleases,
   getReleaseGroupCover,
   getArtistCover,
   lookupArtistsInLibraryBatch,
   readLibraryLookupCache,
+  updateMyDiscoverLayout,
   updateBlocklist,
 } from "../utils/api";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
@@ -120,6 +122,54 @@ const normalizeBlocklistArtists = (artists) => {
     out.push({ mbid: entryMbid, name: entryName || null });
   }
   return out;
+};
+
+const getDiscoverLayoutStorageKey = (userId) =>
+  userId ? `${DISCOVER_LAYOUT_KEY}:${userId}` : DISCOVER_LAYOUT_KEY;
+
+const normalizeDiscoverLayout = (value) => {
+  if (!Array.isArray(value)) return null;
+  const defaultsById = new Map(
+    DEFAULT_DISCOVER_SECTIONS.map((item) => [item.id, item]),
+  );
+  const normalized = [];
+  value.forEach((item) => {
+    const id = String(item?.id || "").trim();
+    if (!id || !defaultsById.has(id)) return;
+    const base = defaultsById.get(id);
+    normalized.push({
+      ...base,
+      enabled: typeof item?.enabled === "boolean" ? item.enabled : base.enabled,
+    });
+    defaultsById.delete(id);
+  });
+  defaultsById.forEach((item) => normalized.push({ ...item }));
+  return normalized;
+};
+
+const readStoredDiscoverLayout = (userId) => {
+  try {
+    const primaryKey = getDiscoverLayoutStorageKey(userId);
+    const primary = normalizeDiscoverLayout(
+      JSON.parse(localStorage.getItem(primaryKey) || "null"),
+    );
+    if (primary) return primary;
+    if (primaryKey === DISCOVER_LAYOUT_KEY) return null;
+    return normalizeDiscoverLayout(
+      JSON.parse(localStorage.getItem(DISCOVER_LAYOUT_KEY) || "null"),
+    );
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredDiscoverLayout = (layout, userId) => {
+  try {
+    localStorage.setItem(
+      getDiscoverLayoutStorageKey(userId),
+      JSON.stringify(layout),
+    );
+  } catch {}
 };
 
 const isArtistInEntries = (artist, entries) => {
@@ -803,6 +853,7 @@ function DiscoverPage() {
     DEFAULT_DISCOVER_SECTIONS.map((item) => ({ ...item })),
   );
   const [showDiscoverModal, setShowDiscoverModal] = useState(false);
+  const [isSavingDiscoverLayout, setIsSavingDiscoverLayout] = useState(false);
   const [draggingId, setDraggingId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
   const [error, setError] = useState(null);
@@ -989,28 +1040,43 @@ function DiscoverPage() {
   }, [nearbyLocationMode, appliedNearbyZip]);
 
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(DISCOVER_LAYOUT_KEY);
-      if (!stored) return;
-      const parsed = JSON.parse(stored);
-      if (!Array.isArray(parsed)) return;
-      const byId = new Map(
-        DEFAULT_DISCOVER_SECTIONS.map((item) => [item.id, item]),
-      );
-      const normalized = [];
-      parsed.forEach((item) => {
-        if (!item?.id || !byId.has(item.id)) return;
-        const base = byId.get(item.id);
-        normalized.push({
-          ...base,
-          enabled: item.enabled ?? base.enabled,
-        });
-        byId.delete(item.id);
-      });
-      byId.forEach((item) => normalized.push({ ...item }));
-      setDiscoverSections(normalized);
-    } catch {}
-  }, []);
+    const stored = readStoredDiscoverLayout(authUser?.id);
+    if (stored) {
+      setDiscoverSections(stored);
+    }
+  }, [authUser?.id]);
+
+  useEffect(() => {
+    if (!authUser?.id) return;
+    let cancelled = false;
+    const localLayout = readStoredDiscoverLayout(authUser.id);
+    const loadDiscoverLayout = async () => {
+      try {
+        const response = await getMyDiscoverLayout();
+        if (cancelled) return;
+        const serverLayout = normalizeDiscoverLayout(response?.layout);
+        if (serverLayout) {
+          setDiscoverSections(serverLayout);
+          writeStoredDiscoverLayout(serverLayout, authUser.id);
+          return;
+        }
+        if (localLayout) {
+          try {
+            await updateMyDiscoverLayout(localLayout);
+            writeStoredDiscoverLayout(localLayout, authUser.id);
+          } catch {}
+        }
+      } catch {
+        if (!cancelled && localLayout) {
+          setDiscoverSections(localLayout);
+        }
+      }
+    };
+    loadDiscoverLayout();
+    return () => {
+      cancelled = true;
+    };
+  }, [authUser?.id]);
 
   useEffect(() => {
     const ids = recentReleases
@@ -1233,14 +1299,26 @@ function DiscoverPage() {
   }, [showDiscoverModal]);
 
   const handleDiscoverSave = () => {
-    setDiscoverSections(draftSections.map((item) => ({ ...item })));
-    try {
-      localStorage.setItem(
-        DISCOVER_LAYOUT_KEY,
-        JSON.stringify(draftSections),
-      );
-    } catch {}
-    setShowDiscoverModal(false);
+    const nextLayout = draftSections.map((item) => ({ ...item }));
+    setDiscoverSections(nextLayout);
+    writeStoredDiscoverLayout(nextLayout, authUser?.id);
+    setIsSavingDiscoverLayout(true);
+    updateMyDiscoverLayout(nextLayout)
+      .then((response) => {
+        const savedLayout = normalizeDiscoverLayout(response?.layout) || nextLayout;
+        setDiscoverSections(savedLayout);
+        writeStoredDiscoverLayout(savedLayout, authUser?.id);
+        showSuccess("Discover layout saved");
+        setShowDiscoverModal(false);
+      })
+      .catch((err) => {
+        showError(
+          err.response?.data?.message || "Failed to save discover layout",
+        );
+      })
+      .finally(() => {
+        setIsSavingDiscoverLayout(false);
+      });
   };
 
   const handleDiscoverReset = () => {
@@ -2097,8 +2175,9 @@ function DiscoverPage() {
                   type="button"
                   onClick={handleDiscoverSave}
                   className="btn btn-primary"
+                  disabled={isSavingDiscoverLayout}
                 >
-                  Save Layout
+                  {isSavingDiscoverLayout ? "Saving..." : "Save Layout"}
                 </button>
               </div>
             </div>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -645,6 +645,11 @@ export const getMyLidarrPreferences = async () => {
   return response.data;
 };
 
+export const getMyDiscoverLayout = async () => {
+  const response = await api.get("/users/me/discover-layout");
+  return response.data;
+};
+
 export const updateMyListeningHistory = async (
   userId,
   listenHistoryProvider,
@@ -659,6 +664,11 @@ export const updateMyListeningHistory = async (
 
 export const updateMyLidarrPreferences = async (payload) => {
   const response = await api.patch("/users/me/lidarr-preferences", payload);
+  return response.data;
+};
+
+export const updateMyDiscoverLayout = async (layout) => {
+  const response = await api.patch("/users/me/discover-layout", { layout });
   return response.data;
 };
 


### PR DESCRIPTION
- Store discover section layout in the users table
- Add API endpoints for reading and saving layout
- Sync Discover page saves with the server and local fallback