### PR TITLE
Persist Last.fm banner dismissal and delete-file preference

### DIFF
--- a/frontend/src/components/LastfmBanner.jsx
+++ b/frontend/src/components/LastfmBanner.jsx
@@ -1,15 +1,43 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getMyListeningHistory } from "../utils/api";
+import { useAuth } from "../contexts/AuthContext";
 
-const DISMISS_KEY = "lastfm_banner_dismissed";
+const LEGACY_DISMISS_KEY = "lastfm_banner_dismissed";
+const DISMISS_KEY_PREFIX = "aurral:lastfm-banner-dismissed";
+
+const getDismissKey = (user) => {
+  if (user?.id != null) return `${DISMISS_KEY_PREFIX}:${user.id}`;
+  if (user?.username) return `${DISMISS_KEY_PREFIX}:${user.username}`;
+  return DISMISS_KEY_PREFIX;
+};
+
+const readDismissed = (user) => {
+  try {
+    const dismissKey = getDismissKey(user);
+    if (localStorage.getItem(dismissKey) === "1") {
+      return true;
+    }
+
+    if (sessionStorage.getItem(LEGACY_DISMISS_KEY) === "1") {
+      localStorage.setItem(dismissKey, "1");
+      sessionStorage.removeItem(LEGACY_DISMISS_KEY);
+      return true;
+    }
+  } catch {}
+
+  return false;
+};
 
 const LastfmBanner = () => {
-  const [dismissed, setDismissed] = useState(
-    () => sessionStorage.getItem(DISMISS_KEY) === "1",
-  );
+  const { user } = useAuth();
+  const [dismissed, setDismissed] = useState(() => readDismissed(user));
   const [listenHistoryUsername, setListenHistoryUsername] = useState(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setDismissed(readDismissed(user));
+  }, [user]);
 
   useEffect(() => {
     if (dismissed) return;
@@ -51,7 +79,10 @@ const LastfmBanner = () => {
             className="btn btn-ghost btn-sm hover:bg-gray-700/50 w-full sm:w-auto"
             onClick={() => {
               setDismissed(true);
-              sessionStorage.setItem(DISMISS_KEY, "1");
+              try {
+                localStorage.setItem(getDismissKey(user), "1");
+                sessionStorage.removeItem(LEGACY_DISMISS_KEY);
+              } catch {}
             }}
           >
             Dismiss

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -20,6 +20,22 @@ import { deduplicateAlbums } from "../utils";
 import { matchesReleaseTypeFilter } from "../utils";
 import { useWebSocketChannel } from "../../../hooks/useWebSocket";
 
+const DELETE_FILES_PREFERENCE_KEY = "aurral:library-delete-files";
+
+const readDeleteFilesPreference = () => {
+  try {
+    return localStorage.getItem(DELETE_FILES_PREFERENCE_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+const writeDeleteFilesPreference = (value) => {
+  try {
+    localStorage.setItem(DELETE_FILES_PREFERENCE_KEY, value ? "1" : "0");
+  } catch {}
+};
+
 export function useArtistDetailsLibrary({
   artist,
   libraryArtist,
@@ -37,7 +53,9 @@ export function useArtistDetailsLibrary({
   const [removingAlbum, setRemovingAlbum] = useState(null);
   const [albumDropdownOpen, setAlbumDropdownOpen] = useState(null);
   const [showDeleteAlbumModal, setShowDeleteAlbumModal] = useState(null);
-  const [deleteAlbumFiles, setDeleteAlbumFiles] = useState(false);
+  const [deleteAlbumFiles, setDeleteAlbumFilesState] = useState(() =>
+    readDeleteFilesPreference(),
+  );
   const [processingBulk, setProcessingBulk] = useState(false);
   const [expandedLibraryAlbum, setExpandedLibraryAlbum] = useState(null);
   const [expandedReleaseGroup, setExpandedReleaseGroup] = useState(null);
@@ -45,7 +63,9 @@ export function useArtistDetailsLibrary({
   const [loadingTracks, setLoadingTracks] = useState({});
   const [showRemoveDropdown, setShowRemoveDropdown] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [deleteFiles, setDeleteFiles] = useState(false);
+  const [deleteFiles, setDeleteFilesState] = useState(() =>
+    readDeleteFilesPreference(),
+  );
   const [deletingArtist, setDeletingArtist] = useState(false);
   const [addingToLibrary, setAddingToLibrary] = useState(false);
   const [showMonitorOptionMenu, setShowMonitorOptionMenu] = useState(false);
@@ -71,6 +91,12 @@ export function useArtistDetailsLibrary({
       .map((album) => String(album.id))
       .filter(Boolean);
   }, [libraryAlbums]);
+
+  const updateDeleteFilesPreference = (value) => {
+    writeDeleteFilesPreference(value);
+    setDeleteFilesState(value);
+    setDeleteAlbumFilesState(value);
+  };
 
   useWebSocketChannel("downloads", (msg) => {
     if (msg?.type !== "download_statuses") return;
@@ -137,12 +163,10 @@ export function useArtistDetailsLibrary({
 
   const handleDeleteClick = () => {
     setShowDeleteModal(true);
-    setDeleteFiles(false);
   };
 
   const handleDeleteCancel = () => {
     setShowDeleteModal(false);
-    setDeleteFiles(false);
   };
 
   const handleDeleteConfirm = async () => {
@@ -159,7 +183,6 @@ export function useArtistDetailsLibrary({
         }`,
       );
       setShowDeleteModal(false);
-      setDeleteFiles(false);
     } catch (err) {
       showError(
         `Failed to delete artist: ${err.response?.data?.message || err.message}`,
@@ -776,13 +799,11 @@ export function useArtistDetailsLibrary({
 
   const handleDeleteAlbumClick = (albumId, title) => {
     setShowDeleteAlbumModal({ id: albumId, title });
-    setDeleteAlbumFiles(false);
     setAlbumDropdownOpen(null);
   };
 
   const handleDeleteAlbumCancel = () => {
     setShowDeleteAlbumModal(null);
-    setDeleteAlbumFiles(false);
   };
 
   const handleDeleteAlbumConfirm = async () => {
@@ -811,7 +832,6 @@ export function useArtistDetailsLibrary({
         showSuccess(`Successfully unmonitored ${title}`);
       }
       setShowDeleteAlbumModal(null);
-      setDeleteAlbumFiles(false);
     } catch (err) {
       showError(
         `Failed to ${deleteAlbumFiles ? "delete" : "unmonitor"} album: ${
@@ -1070,7 +1090,7 @@ export function useArtistDetailsLibrary({
     setAlbumDropdownOpen,
     showDeleteAlbumModal,
     deleteAlbumFiles,
-    setDeleteAlbumFiles,
+    setDeleteAlbumFiles: updateDeleteFilesPreference,
     processingBulk,
     expandedLibraryAlbum,
     setExpandedLibraryAlbum,
@@ -1082,7 +1102,7 @@ export function useArtistDetailsLibrary({
     setShowRemoveDropdown,
     showDeleteModal,
     deleteFiles,
-    setDeleteFiles,
+    setDeleteFiles: updateDeleteFilesPreference,
     deletingArtist,
     addingToLibrary,
     showAddCustomizeModal,


### PR DESCRIPTION
## Summary
- Persist Last.fm banner dismissal in `localStorage` using a user-scoped key, with migration from the legacy session-based flag.
- Remember the artist/album delete-files preference across modal opens by storing it in `localStorage`.
- Remove the reset-on-open/reset-on-close behavior so the selected delete preference stays consistent.

## Testing
- Not run (not requested).
- Manually verify dismissing the Last.fm banner keeps it hidden after reload and after sign-in/out changes.
- Manually verify the delete-files checkbox/prefix preference remains selected across repeated artist and album delete flows.