### PR TITLE
Reuse completed weekly-flow tracks and improve mobile card interactions

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -121,6 +121,84 @@ const sortJobsForTrackReuse = (jobs) =>
     return Number(a?.createdAt || 0) - Number(b?.createdAt || 0);
   });
 
+const getPlaylistLibraryRoot = (playlistType) =>
+  path.resolve(
+    weeklyFlowWorker.weeklyFlowRoot,
+    "aurral-weekly-flow",
+    String(playlistType || "").trim(),
+  );
+
+const buildReusableJobsByIdentity = (jobs) => {
+  const reusableJobsByIdentity = new Map();
+  for (const job of Array.isArray(jobs) ? jobs : []) {
+    if (job?.status !== "done" || typeof job?.finalPath !== "string") continue;
+    const identity = buildTrackIdentity(job);
+    const current = reusableJobsByIdentity.get(identity) || [];
+    current.push(job);
+    reusableJobsByIdentity.set(identity, current);
+  }
+  for (const [identity, jobsForIdentity] of reusableJobsByIdentity.entries()) {
+    reusableJobsByIdentity.set(identity, sortJobsForTrackReuse(jobsForIdentity));
+  }
+  return reusableJobsByIdentity;
+};
+
+const buildUniqueReuseTargetPath = async (sourceJob, targetPlaylistId) => {
+  const safeSourcePath = path.resolve(sourceJob.finalPath);
+  const sourceRoot = getPlaylistLibraryRoot(sourceJob.playlistType);
+  if (!isPathInsideRoot(safeSourcePath, sourceRoot)) {
+    throw new Error(`Track path is outside the playlist library: ${sourceJob.finalPath}`);
+  }
+  const sourceStat = await fsp.stat(safeSourcePath);
+  if (!sourceStat.isFile()) {
+    throw new Error(`Track file is missing: ${sourceJob.finalPath}`);
+  }
+
+  const relativePath = path.relative(sourceRoot, safeSourcePath);
+  const targetRoot = getPlaylistLibraryRoot(targetPlaylistId);
+  let targetPath = path.resolve(targetRoot, relativePath);
+  if (!isPathInsideRoot(targetPath, targetRoot)) {
+    throw new Error(`Target path is outside the playlist library: ${targetPath}`);
+  }
+
+  const parsed = path.parse(targetPath);
+  let suffix = 1;
+  while (true) {
+    try {
+      await fsp.access(targetPath);
+      targetPath = path.resolve(
+        parsed.dir,
+        `${parsed.name}-${suffix}${parsed.ext}`,
+      );
+      suffix += 1;
+    } catch {
+      break;
+    }
+  }
+
+  await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+  return { safeSourcePath, targetPath };
+};
+
+const reuseCompletedTrackForPlaylist = async (track, targetPlaylistId, sourceJob) => {
+  const { safeSourcePath, targetPath } = await buildUniqueReuseTargetPath(
+    sourceJob,
+    targetPlaylistId,
+  );
+  await fsp.copyFile(safeSourcePath, targetPath);
+  const jobId = downloadTracker.addJob(track, targetPlaylistId);
+  if (!jobId) {
+    await fsp.rm(targetPath, { force: true });
+    return null;
+  }
+  downloadTracker.setDone(
+    jobId,
+    targetPath,
+    sourceJob.albumName || track.albumName || null,
+  );
+  return jobId;
+};
+
 router.get("/stream/:jobId", noCache, async (req, res) => {
   if (!verifyTokenAuth(req)) {
     return res
@@ -948,10 +1026,45 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
       playlistId,
       normalizedTracks,
     );
-    const jobIds = downloadTracker.addJobs(normalizedTracks, playlistId);
+    const reusableJobsByIdentity = buildReusableJobsByIdentity(
+      downloadTracker
+        .getAll()
+        .filter((job) => String(job?.playlistType || "") !== String(playlistId)),
+    );
+    const reusedJobIds = [];
+    const tracksToQueue = [];
+    for (const track of normalizedTracks) {
+      const reusableJob = (reusableJobsByIdentity.get(buildTrackIdentity(track)) || [])[0];
+      if (!reusableJob) {
+        tracksToQueue.push(track);
+        continue;
+      }
+      try {
+        const reusedJobId = await reuseCompletedTrackForPlaylist(
+          track,
+          playlistId,
+          reusableJob,
+        );
+        if (reusedJobId) {
+          reusedJobIds.push(reusedJobId);
+        } else {
+          tracksToQueue.push(track);
+        }
+      } catch (error) {
+        console.warn(
+          `[WeeklyFlow] Failed to reuse completed track for ${playlistId}:`,
+          error.message,
+        );
+        tracksToQueue.push(track);
+      }
+    }
+    const jobIds = downloadTracker.addJobs(tracksToQueue, playlistId);
 
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
+    if (reusedJobIds.length > 0) {
+      await playlistManager.scanLibrary();
+    }
     if (jobIds.length > 0) {
       if (!weeklyFlowWorker.running) {
         await weeklyFlowWorker.start();
@@ -964,7 +1077,8 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
       success: true,
       playlist: updatedPlaylist,
       tracksQueued: jobIds.length,
-      jobIds,
+      tracksReused: reusedJobIds.length,
+      jobIds: [...reusedJobIds, ...jobIds],
     });
   } catch (error) {
     res.status(500).json({

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -1836,7 +1836,7 @@ function FlowPage() {
       currentWorkerSettings.retryCycleMinutes;
 
   return (
-    <div className="flow-page max-w-6xl mx-auto px-4 pb-10">
+    <div className="flow-page max-w-6xl mx-auto pb-10 sm:px-4">
       <input
         ref={importInputRef}
         type="file"
@@ -1844,7 +1844,7 @@ function FlowPage() {
         className="hidden"
         onChange={handleImportFileChange}
       />
-      <div className="mb-4 flex items-center justify-between gap-3">
+      <div className="mb-4 flex items-center justify-between gap-3 px-4 sm:px-0">
         <div className="flex min-w-0 items-end gap-2">
           <h2 className="text-base font-semibold text-white">Playlists / Flows</h2>
         </div>

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -23,7 +23,6 @@ import {
   Shuffle,
   SkipBack,
   SkipForward,
-  ExternalLink,
   Volume2,
   VolumeX,
   Plus,
@@ -98,6 +97,13 @@ export function MixSlider({ mix, onChange, normalizeMixPercent }) {
   const normalized = normalizeMixPercent(mix);
   const barRef = useRef(null);
   const dragRef = useRef(null);
+
+  const startDrag = (event, handle) => {
+    event.preventDefault();
+    dragRef.current = { handle };
+    event.currentTarget?.setPointerCapture?.(event.pointerId);
+    updateFromClientX(event.clientX, handle);
+  };
 
   const updateFromClientX = useCallback(
     (clientX, handle) => {
@@ -182,6 +188,7 @@ export function MixSlider({ mix, onChange, normalizeMixPercent }) {
       <div
         ref={barRef}
         className="relative h-9 rounded-full border border-white/10 bg-white/5 select-none"
+        style={{ touchAction: "none" }}
       >
         <div className="absolute inset-0 flex overflow-hidden rounded-full">
           <div
@@ -214,10 +221,7 @@ export function MixSlider({ mix, onChange, normalizeMixPercent }) {
         </div>
         <button
           type="button"
-          onPointerDown={(event) => {
-            dragRef.current = { handle: "left" };
-            updateFromClientX(event.clientX, "left");
-          }}
+          onPointerDown={(event) => startDrag(event, "left")}
           className="absolute top-0 h-full w-4 -ml-2 cursor-ew-resize z-10"
           style={{ left: `${displayLeft}%` }}
           aria-label="Adjust discover and library mix"
@@ -226,10 +230,7 @@ export function MixSlider({ mix, onChange, normalizeMixPercent }) {
         </button>
         <button
           type="button"
-          onPointerDown={(event) => {
-            dragRef.current = { handle: "right" };
-            updateFromClientX(event.clientX, "right");
-          }}
+          onPointerDown={(event) => startDrag(event, "right")}
           className="absolute top-0 h-full w-4 -ml-2 cursor-ew-resize z-10"
           style={{ left: `${displayRight}%` }}
           aria-label="Adjust library and trending mix"
@@ -1342,6 +1343,21 @@ function PlaylistArtworkThumb({ artworkUrl, name }) {
   );
 }
 
+const MOBILE_CARD_MEDIA_QUERY = "(max-width: 639px)";
+
+const shouldHandleMobileCardTap = (event) => {
+  if (
+    typeof window === "undefined" ||
+    !window.matchMedia(MOBILE_CARD_MEDIA_QUERY).matches
+  ) {
+    return false;
+  }
+  const interactiveTarget = event.target?.closest(
+    'button, a, input, textarea, select, label, [role="button"], [data-no-card-toggle="true"]',
+  );
+  return !interactiveTarget;
+};
+
 export function FlowCard({
   flow,
   artworkUrl,
@@ -1467,10 +1483,18 @@ export function FlowCard({
   const typeLabel = enabled ? "Flow" : "Flow Draft";
   const statusSummary = enabled ? "" : "Flow ready when enabled";
 
+  const handleMobileTrackToggle = (event) => {
+    if (!shouldHandleMobileCardTap(event)) return;
+    onViewTracks?.();
+  };
+
   return (
-    <div className="bg-card rounded-lg border border-white/5 overflow-visible">
+    <div className="bg-card overflow-visible border border-white/5 -mx-4 rounded-none sm:mx-0 sm:rounded-lg">
       <div className="p-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
-        <div className={`min-w-0 flex-1 flex gap-3 sm:gap-4 ${enabled ? "" : "opacity-50"}`}>
+        <div
+          className={`min-w-0 flex-1 flex gap-3 sm:gap-4 ${enabled ? "" : "opacity-50"} cursor-pointer sm:cursor-default`}
+          onClick={handleMobileTrackToggle}
+        >
           <PlaylistArtworkThumb artworkUrl={artworkUrl} name={flow.name} />
           <div className="min-w-0 flex-1 grid gap-2">
             <div className="flex flex-col gap-2 min-[420px]:flex-row min-[420px]:items-start min-[420px]:justify-between">
@@ -1689,11 +1713,14 @@ export function FlowCard({
                 {metaItems.length > 0 ? <span>{metaItems.join(" • ")}</span> : null}
               </div>
             </div>
-            {flowWorkerMessage ? (
+              {flowWorkerMessage ? (
               <div className="hidden truncate text-xs text-[#9aa886] sm:block">
                 {flowWorkerMessage}
               </div>
             ) : null}
+            <div className="text-[11px] text-[#9aa886] sm:hidden">
+              {isTracksOpen ? "Tap card to hide tracks" : "Tap card to view tracks"}
+            </div>
             {(state === "running" || state === "completed") && total > 0 ? (
               <div className="grid gap-1.5">
                 <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
@@ -1752,8 +1779,8 @@ export function FlowCard({
       )}
 
       {isTracksOpen && (
-        <div className="px-4 pb-4">
-          <div className="card-separator mb-4" />
+        <div className="pb-4 sm:px-4">
+          <div className="card-separator mx-4 mb-4 sm:mx-0" />
           <FlowTracksPanel
             tracks={tracks}
             loading={tracksLoading}
@@ -2018,7 +2045,7 @@ export function FlowTracksPanel({
   }, []);
 
   return (
-    <div className="rounded-lg border border-white/10 bg-[#211f27] overflow-hidden">
+    <div className="overflow-hidden border border-white/10 bg-[#211f27] rounded-none sm:rounded-lg">
       <div className="relative bg-[#211f27] px-3 py-2.5 border-b border-white/10 flex items-center">
         <div className="absolute left-1/2 -translate-x-1/2 flex items-center justify-center gap-2">
           <button
@@ -2140,7 +2167,19 @@ export function FlowTracksPanel({
                       </td>
                     ) : null}
                     <td className="px-3 py-2">{track.trackName}</td>
-                    <td className="px-3 py-2">{track.artistName}</td>
+                    <td className="px-3 py-2">
+                      {track.artistMbid ? (
+                        <button
+                          type="button"
+                          onClick={() => onNavigateArtist(track)}
+                          className="text-left text-[#d6d6d8] transition-colors hover:text-white hover:underline"
+                        >
+                          {track.artistName}
+                        </button>
+                      ) : (
+                        track.artistName
+                      )}
+                    </td>
                     <td className="px-3 py-2">
                       <div className="grid gap-1">
                         <span>{track.albumName || "Unknown Album"}</span>
@@ -2164,15 +2203,6 @@ export function FlowTracksPanel({
                             <Play className="w-3.5 h-3.5" />
                           )}
                         </button>
-                        {track.artistMbid ? (
-                          <button
-                            onClick={() => onNavigateArtist(track)}
-                            className="btn btn-secondary btn-xs px-2"
-                            aria-label={`Open artist details for ${track.artistName}`}
-                          >
-                            <ExternalLink className="w-3.5 h-3.5" />
-                          </button>
-                        ) : null}
                         {onAddTrackToPlaylist ? (
                           <button
                             onClick={() => onAddTrackToPlaylist(track)}
@@ -2280,10 +2310,18 @@ export function SharedPlaylistCard({
     currentJob?.artistName &&
     currentJob?.trackName;
 
+  const handleMobileTrackToggle = (event) => {
+    if (!shouldHandleMobileCardTap(event)) return;
+    onViewTracks?.();
+  };
+
   return (
-    <div className="overflow-visible rounded-lg border border-white/5 bg-card">
+    <div className="overflow-visible border border-white/5 bg-card -mx-4 rounded-none sm:mx-0 sm:rounded-lg">
       <div className="flex flex-col gap-3 px-4 py-4 md:flex-row md:items-start md:justify-between md:gap-4">
-        <div className="min-w-0 flex-1 flex gap-3 sm:gap-4">
+        <div
+          className="min-w-0 flex-1 flex gap-3 sm:gap-4 cursor-pointer sm:cursor-default"
+          onClick={handleMobileTrackToggle}
+        >
           <PlaylistArtworkThumb artworkUrl={artworkUrl} name={playlist.name} />
           <div className="min-w-0 flex-1 space-y-2">
             <div className="flex flex-col gap-2 min-[420px]:flex-row min-[420px]:items-start min-[420px]:justify-between">
@@ -2461,6 +2499,9 @@ export function SharedPlaylistCard({
                   Waiting for next retry cycle
                 </p>
               ) : null}
+              <p className="text-[11px] text-[#9aa886] sm:hidden">
+                {isTracksOpen ? "Tap card to hide tracks" : "Tap card to view tracks"}
+              </p>
             </div>
             <div className="grid gap-1.5">
               <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
@@ -2487,8 +2528,8 @@ export function SharedPlaylistCard({
       </div>
 
       {isTracksOpen && (
-        <div className="px-4 pb-4">
-          <div className="card-separator mb-4" />
+        <div className="pb-4 sm:px-4">
+          <div className="card-separator mx-4 mb-4 sm:mx-0" />
           {isTrackEditing ? (
             <SharedPlaylistTrackEditor
               ref={trackEditorRef}


### PR DESCRIPTION
## Summary
- Reuses completed tracks across playlists by copying existing finished audio into the target library path instead of re-queuing downloads when a matching track identity is found.
- Falls back to the normal download queue when reuse is not possible, and triggers a library scan after reused tracks are added so the UI stays in sync.
- Improves mobile usability for Flow and Shared Playlist cards by making the card body toggle tracks on tap, adding mobile-only tap hints, and tightening card edge spacing on small screens.
- Refines the tracks table so artist names can open artist details directly from the name cell, and updates mix slider dragging to use pointer capture for more reliable touch interaction.

## Testing
- Not run.
- Suggested checks: add a shared playlist track set containing previously completed tracks and confirm reused items are reported and appear without re-downloading.
- Suggested checks: verify mobile taps on Flow and Shared Playlist cards toggle the track panel without hijacking button/link interactions.
- Suggested checks: confirm the artist name button opens artist details in the tracks panel and the mix slider still drags smoothly on touch devices.