### PR TITLE
Add signed image proxy and hydrate artist artwork

### DIFF
--- a/.tests/search/search-service.test.js
+++ b/.tests/search/search-service.test.js
@@ -22,21 +22,22 @@ test("normalizeArtistSearchItem preserves sort name and cached image", () => {
     },
   );
 
-  assert.deepEqual(item, {
-    type: "artist",
-    id: "artist-mbid",
-    name: "Boards of Canada",
-    sortName: "Canada, Boards of",
-    image: "https://images.example/artist.jpg",
-    imageUrl: "https://images.example/artist.jpg",
-    artistType: null,
-    country: null,
-    area: null,
-    begin: null,
-    end: null,
-    disambiguation: null,
-    inLibrary: false,
-  });
+  assert.equal(item.type, "artist");
+  assert.equal(item.id, "artist-mbid");
+  assert.equal(item.name, "Boards of Canada");
+  assert.equal(item.sortName, "Canada, Boards of");
+  assert.match(
+    item.image,
+    /^\/api\/image-proxy\?src=https%3A%2F%2Fimages\.example%2Fartist\.jpg&sig=/,
+  );
+  assert.equal(item.imageUrl, item.image);
+  assert.equal(item.artistType, null);
+  assert.equal(item.country, null);
+  assert.equal(item.area, null);
+  assert.equal(item.begin, null);
+  assert.equal(item.end, null);
+  assert.equal(item.disambiguation, null);
+  assert.equal(item.inLibrary, false);
 });
 
 test("normalizeAlbumSearchItem preserves compilation metadata and library state", () => {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -331,7 +331,8 @@ export const createAuthMiddleware = () => {
     if (
       req.path === "/api/health" ||
       req.path === "/api/health/live" ||
-      req.path === "/api/health/bootstrap"
+      req.path === "/api/health/bootstrap" ||
+      req.path === "/api/image-proxy"
     ) {
       return next();
     }

--- a/backend/routes/artists/handlers/cover.js
+++ b/backend/routes/artists/handlers/cover.js
@@ -2,6 +2,7 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { pendingCoverRequests, fetchCoverInBackground } from "../utils.js";
 import { getArtistImage } from "../../../services/imageService.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 
 export default function registerCover(router) {
   router.get("/:mbid/cover", async (req, res) => {
@@ -34,7 +35,8 @@ export default function registerCover(router) {
         cachedImage.imageUrl !== "NOT_FOUND"
       ) {
         console.log(`[Cover Route] Cache hit for ${mbid}`);
-        const cachedUrl = cachedImage.imageUrl;
+        const cachedUrl =
+          buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl;
         res.set("Cache-Control", "public, max-age=31536000, immutable");
 
         const cacheAge = cachedImage.cacheAge;
@@ -88,6 +90,10 @@ export default function registerCover(router) {
       const result = await fetchPromise;
 
       if (result.images && result.images.length > 0) {
+        result.images = result.images.map((image) => ({
+          ...image,
+          image: buildImageProxyUrl(image.image) || image.image,
+        }));
         console.log(`[Cover Route] Successfully returning cover for ${mbid}`);
         res.set("Cache-Control", "public, max-age=31536000, immutable");
       } else {

--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -5,6 +5,7 @@ import {
 } from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 
 export default function registerReleaseGroup(router) {
   router.get("/release-group/:mbid/cover", cacheMiddleware(86400), async (req, res) => {
@@ -23,7 +24,8 @@ export default function registerReleaseGroup(router) {
         cachedImage.imageUrl &&
         cachedImage.imageUrl !== "NOT_FOUND"
       ) {
-        const cachedUrl = cachedImage.imageUrl;
+        const cachedUrl =
+          buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl;
         res.set("Cache-Control", "public, max-age=31536000, immutable");
         return res.json({
           images: [
@@ -45,12 +47,14 @@ export default function registerReleaseGroup(router) {
         const cover = await fetchCoverArtArchiveReleaseGroup(mbid);
         if (cover?.imageUrl) {
           dbOps.setImage(cacheKey, cover.imageUrl);
+          const proxiedCoverUrl =
+            buildImageProxyUrl(cover.imageUrl) || cover.imageUrl;
 
           res.set("Cache-Control", "public, max-age=31536000, immutable");
           return res.json({
             images: [
               {
-                image: cover.imageUrl,
+                image: proxiedCoverUrl,
                 front: true,
                 types: cover.types,
               },

--- a/backend/routes/artists/handlers/similar.js
+++ b/backend/routes/artists/handlers/similar.js
@@ -1,7 +1,13 @@
 import { UUID_REGEX } from "../../../config/constants.js";
-import { getLastfmApiKey, lastfmRequest } from "../../../services/apiClients.js";
+import {
+  getLastfmApiKey,
+  lastfmRequest,
+  lastfmGetArtistNameByMbid,
+  musicbrainzGetArtistNameByMbid,
+} from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 
 export default function registerSimilar(router) {
   router.get("/:mbid/similar", cacheMiddleware(300), async (req, res) => {
@@ -13,6 +19,7 @@ export default function registerSimilar(router) {
       }
 
       const { limit = 10 } = req.query;
+      const artistNameParam = String(req.query.artistName || "").trim();
 
       if (!getLastfmApiKey()) {
         return res.json({ artists: [] });
@@ -21,10 +28,25 @@ export default function registerSimilar(router) {
       const limitInt = Math.min(Math.max(parseInt(limit, 10) || 7, 1), 20);
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
-      const data = await lastfmRequest("artist.getSimilar", {
+      let data = await lastfmRequest("artist.getSimilar", {
         mbid: resolvedMbid,
         limit: limitInt,
       });
+
+      if (!data?.similarartists?.artist) {
+        const fallbackArtistName =
+          artistNameParam ||
+          (await lastfmGetArtistNameByMbid(resolvedMbid).catch(() => null)) ||
+          (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(() => null)) ||
+          "";
+
+        if (fallbackArtistName) {
+          data = await lastfmRequest("artist.getSimilar", {
+            artist: fallbackArtistName,
+            limit: limitInt,
+          });
+        }
+      }
 
       if (!data?.similarartists?.artist) {
         return res.json({ artists: [] });
@@ -51,7 +73,7 @@ export default function registerSimilar(router) {
           return {
             id: a.mbid,
             name: a.name,
-            image: img,
+            image: buildImageProxyUrl(img) || img,
             match: Math.round((a.match || 0) * 100),
           };
         })

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -13,6 +13,7 @@ import { noCache } from "../../../middleware/cache.js";
 import { verifyTokenAuth } from "../../../middleware/auth.js";
 import { sendSSE, pendingArtistRequests } from "../utils.js";
 import { getArtistImage } from "../../../services/imageService.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 
 export default function registerStream(router) {
   router.get("/:mbid/stream", noCache, async (req, res) => {
@@ -286,7 +287,9 @@ export default function registerStream(router) {
               sendSSE(res, "cover", {
                 images: [
                   {
-                    image: cachedImage.imageUrl,
+                    image:
+                      buildImageProxyUrl(cachedImage.imageUrl) ||
+                      cachedImage.imageUrl,
                     front: true,
                     types: ["Front"],
                   },
@@ -297,7 +300,12 @@ export default function registerStream(router) {
 
             const cover = await getArtistImage(mbid);
             if (cover?.images?.length) {
-              sendSSE(res, "cover", { images: cover.images });
+              sendSSE(res, "cover", {
+                images: cover.images.map((image) => ({
+                  ...image,
+                  image: buildImageProxyUrl(image.image) || image.image,
+                })),
+              });
               return;
             }
 
@@ -313,10 +321,30 @@ export default function registerStream(router) {
           if (!isClientConnected()) return;
           if (getLastfmApiKey()) {
             try {
-              const similarData = await lastfmRequest("artist.getSimilar", {
+              let similarData = await lastfmRequest("artist.getSimilar", {
                 mbid: resolvedMbid,
                 limit: 10,
               });
+
+              if (!similarData?.similarartists?.artist) {
+                const fallbackArtistName =
+                  streamArtistName ||
+                  (await namePromise.catch(() => null)) ||
+                  (await lastfmGetArtistNameByMbid(resolvedMbid).catch(
+                    () => null,
+                  )) ||
+                  (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(
+                    () => null,
+                  )) ||
+                  "";
+
+                if (fallbackArtistName) {
+                  similarData = await lastfmRequest("artist.getSimilar", {
+                    artist: fallbackArtistName,
+                    limit: 10,
+                  });
+                }
+              }
 
               if (similarData?.similarartists?.artist) {
                 const artists = Array.isArray(similarData.similarartists.artist)
@@ -340,7 +368,7 @@ export default function registerStream(router) {
                     return {
                       id: a.mbid,
                       name: a.name,
-                      image: img,
+                      image: buildImageProxyUrl(img) || img,
                       match: Math.round((a.match || 0) * 100),
                     };
                   })

--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -15,6 +15,8 @@ import {
 import { libraryManager } from "../services/libraryManager.js";
 import { dbOps, userOps } from "../config/db-helpers.js";
 import { imagePrefetchService } from "../services/imagePrefetchService.js";
+import { hydrateArtistImages } from "../services/artistImageHydration.js";
+import { buildImageProxyUrl } from "../services/imageProxyService.js";
 import { defaultDiscoveryPreferences } from "../config/constants.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
 import { getNearbyShows } from "../services/nearbyShowsService.js";
@@ -37,31 +39,6 @@ let discoveryPreferences = { ...defaultDiscoveryPreferences };
 
 const getDiscoveryStaleMs = () =>
   getDiscoveryAutoRefreshHours() * 60 * 60 * 1000;
-
-const getArtistId = (artist) =>
-  artist?.id || artist?.mbid || artist?.foreignArtistId || null;
-
-const withCachedImages = (artists = []) => {
-  const list = Array.isArray(artists) ? artists : [];
-  const ids = [
-    ...new Set(list.map((artist) => getArtistId(artist)).filter(Boolean)),
-  ];
-  if (!ids.length) return list;
-
-  const cachedImages = dbOps.getImages(ids);
-  return list.map((artist) => {
-    if (!artist || typeof artist !== "object") return artist;
-    if (artist.image || artist.imageUrl) return artist;
-
-    const imageUrl = cachedImages[getArtistId(artist)]?.imageUrl;
-    if (!imageUrl || imageUrl === "NOT_FOUND") return artist;
-    return {
-      ...artist,
-      image: imageUrl,
-      imageUrl,
-    };
-  });
-};
 
 const normalizeTextList = (value) => {
   if (!Array.isArray(value)) return [];
@@ -359,9 +336,21 @@ router.get("/", requireAuth, async (req, res) => {
     (artist) => !existingArtistIds.has(artist.id),
   );
   globalTop = globalTop.filter((artist) => !existingArtistIds.has(artist.id));
-  recommendations = withCachedImages(recommendations);
-  globalTop = withCachedImages(globalTop);
-  basedOn = withCachedImages(basedOn);
+  recommendations = await hydrateArtistImages(recommendations, {
+    limit: Math.min(recommendations.length, 12),
+    batchSize: 6,
+    delayMs: 15,
+  });
+  globalTop = await hydrateArtistImages(globalTop, {
+    limit: Math.min(globalTop.length, 12),
+    batchSize: 6,
+    delayMs: 15,
+  });
+  basedOn = await hydrateArtistImages(basedOn, {
+    limit: Math.min(basedOn.length, 8),
+    batchSize: 4,
+    delayMs: 15,
+  });
 
   const blocklist = getStoredBlocklist();
   recommendations = applyBlocklistToArtistCollection(recommendations, blocklist);
@@ -572,7 +561,7 @@ router.get("/by-tag", async (req, res) => {
                   sortName: artist.name,
                   type: "Artist",
                   tags: [tag],
-                  image: imageUrl,
+                  image: buildImageProxyUrl(imageUrl) || imageUrl,
                 };
               })
               .filter((a) => a.id);

--- a/backend/routes/imageProxy.js
+++ b/backend/routes/imageProxy.js
@@ -1,0 +1,8 @@
+import express from "express";
+import { handleImageProxyRequest } from "../services/imageProxyService.js";
+
+const router = express.Router();
+
+router.get("/", handleImageProxyRequest);
+
+export default router;

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -1,5 +1,6 @@
 import { UUID_REGEX } from "../../../config/constants.js";
 import { dbOps } from "../../../config/db-helpers.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import { libraryManager } from "../../../services/libraryManager.js";
 import { qualityManager } from "../../../services/qualityManager.js";
 
@@ -250,7 +251,10 @@ export default function registerMisc(router) {
           : null;
         return {
           ...album,
-          coverUrl: coverUrl && coverUrl !== "NOT_FOUND" ? coverUrl : null,
+          coverUrl:
+            coverUrl && coverUrl !== "NOT_FOUND"
+              ? buildImageProxyUrl(coverUrl) || coverUrl
+              : null,
         };
       });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -47,6 +47,7 @@ import discoveryRouter from "./routes/discovery.js";
 import requestsRouter from "./routes/requests.js";
 import healthRouter from "./routes/health.js";
 import weeklyFlowRouter from "./routes/weeklyFlow.js";
+import imageProxyRouter from "./routes/imageProxy.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -105,6 +106,7 @@ app.use("/api/discover", discoveryRouter);
 app.use("/api/requests", requestsRouter);
 app.use("/api/health", healthRouter);
 app.use("/api/weekly-flow", weeklyFlowRouter);
+app.use("/api/image-proxy", imageProxyRouter);
 
 setInterval(updateDiscoveryCache, 24 * 60 * 60 * 1000);
 

--- a/backend/services/artistImageHydration.js
+++ b/backend/services/artistImageHydration.js
@@ -1,0 +1,95 @@
+import { dbOps } from "../config/db-helpers.js";
+import { getArtistImage } from "./imageService.js";
+import { buildImageProxyUrl } from "./imageProxyService.js";
+
+const DEFAULT_BATCH_SIZE = 6;
+const DEFAULT_DELAY_MS = 25;
+
+const getArtistId = (artist) =>
+  artist?.id || artist?.mbid || artist?.foreignArtistId || null;
+
+const withProxiedImageFields = (artist) => {
+  if (!artist || typeof artist !== "object") return artist;
+  const rawImage = artist.imageUrl || artist.image || null;
+  if (!rawImage) return artist;
+
+  const proxiedImage = buildImageProxyUrl(rawImage) || rawImage;
+  if (artist.image === proxiedImage && artist.imageUrl === proxiedImage) {
+    return artist;
+  }
+
+  return {
+    ...artist,
+    image: proxiedImage,
+    imageUrl: proxiedImage,
+  };
+};
+
+const applyCachedImages = (artists = []) => {
+  const list = Array.isArray(artists) ? artists : [];
+  const ids = [...new Set(list.map((artist) => getArtistId(artist)).filter(Boolean))];
+  if (!ids.length) return list;
+
+  const cachedImages = dbOps.getImages(ids);
+  return list.map((artist) => {
+    if (!artist || typeof artist !== "object") return artist;
+    if (artist.image || artist.imageUrl) return withProxiedImageFields(artist);
+
+    const cachedImage = cachedImages[getArtistId(artist)]?.imageUrl;
+    if (!cachedImage || cachedImage === "NOT_FOUND") return artist;
+    return withProxiedImageFields({
+      ...artist,
+      image: cachedImage,
+      imageUrl: cachedImage,
+    });
+  });
+};
+
+export const hydrateArtistImages = async (
+  artists = [],
+  { limit = artists.length, batchSize = DEFAULT_BATCH_SIZE, delayMs = DEFAULT_DELAY_MS } = {},
+) => {
+  const withCached = applyCachedImages(artists);
+  const pending = [];
+
+  for (const artist of withCached) {
+    if (!artist || typeof artist !== "object") continue;
+    if (artist.image || artist.imageUrl) continue;
+    const id = getArtistId(artist);
+    if (!id) continue;
+    pending.push({ artist, id });
+    if (pending.length >= limit) break;
+  }
+
+  for (let index = 0; index < pending.length; index += batchSize) {
+    const batch = pending.slice(index, index + batchSize);
+    await Promise.all(
+      batch.map(async ({ artist, id }) => {
+        try {
+          const cover = await getArtistImage(id);
+          if (!cover?.url) return;
+          const proxiedImage = buildImageProxyUrl(cover.url) || cover.url;
+          artist.image = proxiedImage;
+          artist.imageUrl = proxiedImage;
+        } catch {}
+      }),
+    );
+
+    if (index + batchSize < pending.length && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return withCached;
+};
+
+export const primeArtistImageCache = (artists = []) => {
+  const ids = [...new Set(
+    (Array.isArray(artists) ? artists : [])
+      .map((artist) => getArtistId(artist))
+      .filter(Boolean),
+  )];
+  if (!ids.length) return Promise.resolve();
+
+  return Promise.allSettled(ids.map((id) => getArtistImage(id))).then(() => {});
+};

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -7,7 +7,7 @@ import {
   musicbrainzGetCachedArtistMbidByName,
   musicbrainzResolveArtistMbidByName,
 } from "./apiClients.js";
-import { getArtistImage } from "./imageService.js";
+import { hydrateArtistImages } from "./artistImageHydration.js";
 import { websocketService } from "./websocketService.js";
 import { libraryManager } from "./libraryManager.js";
 import {
@@ -882,12 +882,24 @@ export const updateDiscoveryCache = async () => {
       lastUpdated: new Date().toISOString(),
     };
 
+    const allToHydrate = [
+      ...(discoveryData.globalTop || []),
+      ...recommendationsArray,
+    ].filter((a) => !a.image);
+    console.log(`Hydrating images for ${allToHydrate.length} artists...`);
+    emitDiscoveryProgress("hydrating_images", "Hydrating artist images", 90);
+    await hydrateArtistImages(allToHydrate, {
+      limit: allToHydrate.length,
+      batchSize: 10,
+      delayMs: 50,
+    });
+
     Object.assign(discoveryCache, discoveryData);
     dbOps.updateDiscoveryCache(discoveryData);
     emitDiscoveryProgress(
       "saving_results",
       "Saving refreshed discovery cache",
-      82,
+      96,
     );
     const { notifyDiscoveryUpdated } = await import("./notificationService.js");
     notifyDiscoveryUpdated().catch((err) =>
@@ -896,45 +908,6 @@ export const updateDiscoveryCache = async () => {
     console.log(
       `Discovery data written to database: ${discoveryData.recommendations.length} recommendations, ${discoveryData.topGenres.length} genres, ${discoveryData.globalTop.length} trending`,
     );
-
-    const allToHydrate = [
-      ...(discoveryCache.globalTop || []),
-      ...recommendationsArray,
-    ].filter((a) => !a.image);
-    console.log(`Hydrating images for ${allToHydrate.length} artists...`);
-    emitDiscoveryProgress("hydrating_images", "Hydrating artist images", 90);
-
-    const batchSize = 10;
-    for (let i = 0; i < allToHydrate.length; i += batchSize) {
-      const batch = allToHydrate.slice(i, i + batchSize);
-      await Promise.all(
-        batch.map(async (item) => {
-          try {
-            try {
-              const artistName = item.name || item.artistName;
-
-              if (artistName) {
-                const resolvedMbid =
-                  item.id ||
-                  item.mbid ||
-                  musicbrainzGetCachedArtistMbidByName(artistName) ||
-                  (await musicbrainzResolveArtistMbidByName(artistName));
-                const cover = resolvedMbid
-                  ? await getArtistImage(resolvedMbid)
-                  : null;
-                if (cover?.url) {
-                  item.image = cover.url;
-                }
-              }
-            } catch (e) {}
-          } catch (e) {}
-        }),
-      );
-
-      if (i + batchSize < allToHydrate.length) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      }
-    }
 
     console.log("Discovery cache updated successfully.");
     console.log(
@@ -1077,33 +1050,11 @@ export const updateUserDiscoveryCache = async (listenHistoryProfile) => {
       40,
     );
 
-    // Hydrate images
-    const toHydrate = recommendationsArray.filter((a) => !a.image);
-    const batchSize = 10;
-    for (let i = 0; i < toHydrate.length; i += batchSize) {
-      const batch = toHydrate.slice(i, i + batchSize);
-      await Promise.all(
-        batch.map(async (item) => {
-          try {
-            const artistName = item.name || item.artistName;
-            if (artistName) {
-              const resolvedMbid =
-                item.id ||
-                item.mbid ||
-                musicbrainzGetCachedArtistMbidByName(artistName) ||
-                (await musicbrainzResolveArtistMbidByName(artistName));
-              const cover = resolvedMbid
-                ? await getArtistImage(resolvedMbid)
-                : null;
-              if (cover?.url) item.image = cover.url;
-            }
-          } catch {}
-        }),
-      );
-      if (i + batchSize < toHydrate.length) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      }
-    }
+    await hydrateArtistImages(recommendationsArray, {
+      limit: recommendationsArray.length,
+      batchSize: 10,
+      delayMs: 50,
+    });
 
     const userData = {
       recommendations: recommendationsArray,

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -1,0 +1,236 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import axios from "axios";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const IMAGE_PROXY_ROUTE = "/api/image-proxy";
+const IMAGE_PROXY_DIR = path.join(__dirname, "..", "data", "image-proxy");
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+const inflightRequests = new Map();
+
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^::1$/i,
+  /^0:0:0:0:0:0:0:1$/i,
+];
+
+const PRIVATE_172_RANGE = /^172\.(1[6-9]|2\d|3[0-1])\./;
+const MIME_EXTENSION_MAP = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "image/svg+xml": "svg",
+};
+
+const getProxySecret = () =>
+  String(
+    process.env.IMAGE_PROXY_SECRET ||
+      process.env.AUTH_PASSWORD ||
+      process.env.CONTACT_EMAIL ||
+      "aurral-image-proxy",
+  );
+
+const ensureCacheDir = () => {
+  fs.mkdirSync(IMAGE_PROXY_DIR, { recursive: true });
+};
+
+const isPrivateHostname = (hostname) => {
+  const normalized = String(hostname || "").trim().toLowerCase();
+  if (!normalized) return true;
+  if (normalized.endsWith(".local")) return true;
+  if (PRIVATE_172_RANGE.test(normalized)) return true;
+  return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(normalized));
+};
+
+const hashValue = (value) =>
+  crypto.createHash("sha256").update(String(value)).digest("hex");
+
+const signSourceUrl = (sourceUrl) =>
+  crypto
+    .createHmac("sha256", getProxySecret())
+    .update(String(sourceUrl))
+    .digest("hex");
+
+const getCachePaths = (cacheKey) => ({
+  metaPath: path.join(IMAGE_PROXY_DIR, `${cacheKey}.json`),
+  baseImagePath: path.join(IMAGE_PROXY_DIR, `${cacheKey}`),
+});
+
+const readCacheMetadata = (metaPath) => {
+  try {
+    return JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  } catch {
+    return null;
+  }
+};
+
+const getCachedEntry = (sourceUrl) => {
+  const cacheKey = hashValue(sourceUrl);
+  const { metaPath, baseImagePath } = getCachePaths(cacheKey);
+  const meta = readCacheMetadata(metaPath);
+  if (!meta?.extension) return null;
+
+  const imagePath = `${baseImagePath}.${meta.extension}`;
+  if (!fs.existsSync(imagePath)) return null;
+
+  return {
+    cacheKey,
+    meta,
+    imagePath,
+    isFresh:
+      Number(meta.fetchedAt || 0) > 0 &&
+      Date.now() - Number(meta.fetchedAt || 0) < CACHE_TTL_MS,
+  };
+};
+
+const writeCacheEntry = (cacheKey, buffer, contentType, sourceUrl) => {
+  ensureCacheDir();
+  const extension = MIME_EXTENSION_MAP[contentType] || "img";
+  const { metaPath, baseImagePath } = getCachePaths(cacheKey);
+  const imagePath = `${baseImagePath}.${extension}`;
+  const fetchedAt = Date.now();
+  const meta = {
+    sourceUrl,
+    contentType,
+    extension,
+    fetchedAt,
+    size: buffer.length,
+  };
+
+  fs.writeFileSync(imagePath, buffer);
+  fs.writeFileSync(metaPath, JSON.stringify(meta));
+
+  return {
+    meta,
+    imagePath,
+    isFresh: true,
+  };
+};
+
+const fetchAndCacheImage = async (sourceUrl) => {
+  const parsed = new URL(sourceUrl);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Unsupported image protocol");
+  }
+  if (isPrivateHostname(parsed.hostname)) {
+    throw new Error("Refusing to proxy private host");
+  }
+
+  const response = await axios.get(sourceUrl, {
+    responseType: "arraybuffer",
+    timeout: FETCH_TIMEOUT_MS,
+    maxRedirects: 5,
+    headers: {
+      Accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+      "User-Agent": "Aurral Image Proxy",
+    },
+  });
+
+  const contentType = String(response.headers["content-type"] || "")
+    .split(";")[0]
+    .trim()
+    .toLowerCase();
+  if (!contentType.startsWith("image/")) {
+    throw new Error("Upstream response is not an image");
+  }
+
+  return writeCacheEntry(
+    hashValue(sourceUrl),
+    Buffer.from(response.data),
+    contentType,
+    sourceUrl,
+  );
+};
+
+export const buildImageProxyUrl = (sourceUrl) => {
+  const normalized = String(sourceUrl || "").trim();
+  if (!normalized) return null;
+  if (
+    normalized.startsWith("/") ||
+    normalized.startsWith("data:") ||
+    normalized.startsWith("blob:")
+  ) {
+    return normalized;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return normalized;
+    }
+  } catch {
+    return normalized;
+  }
+
+  const sig = signSourceUrl(normalized);
+  return `${IMAGE_PROXY_ROUTE}?src=${encodeURIComponent(normalized)}&sig=${sig}`;
+};
+
+export const handleImageProxyRequest = async (req, res) => {
+  const sourceUrl = String(req.query.src || "").trim();
+  const signature = String(req.query.sig || "").trim();
+
+  if (!sourceUrl || !signature) {
+    return res.status(400).json({ error: "Missing source image parameters" });
+  }
+  if (signature !== signSourceUrl(sourceUrl)) {
+    return res.status(403).json({ error: "Invalid image proxy signature" });
+  }
+
+  const cached = getCachedEntry(sourceUrl);
+  if (cached?.isFresh) {
+    res.set("Content-Type", cached.meta.contentType || "image/jpeg");
+    res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+    return res.sendFile(cached.imagePath);
+  }
+
+  if (inflightRequests.has(sourceUrl)) {
+    try {
+      const inflight = await inflightRequests.get(sourceUrl);
+      res.set("Content-Type", inflight.meta.contentType || "image/jpeg");
+      res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+      return res.sendFile(inflight.imagePath);
+    } catch (error) {
+      if (cached?.imagePath) {
+        res.set("Content-Type", cached.meta.contentType || "image/jpeg");
+        res.set(
+          "Cache-Control",
+          "public, max-age=300, stale-while-revalidate=86400",
+        );
+        return res.sendFile(cached.imagePath);
+      }
+      return res.status(502).json({ error: "Failed to fetch image" });
+    }
+  }
+
+  const request = fetchAndCacheImage(sourceUrl).finally(() => {
+    inflightRequests.delete(sourceUrl);
+  });
+  inflightRequests.set(sourceUrl, request);
+
+  try {
+    const fresh = await request;
+    res.set("Content-Type", fresh.meta.contentType || "image/jpeg");
+    res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+    return res.sendFile(fresh.imagePath);
+  } catch (error) {
+    if (cached?.imagePath) {
+      res.set("Content-Type", cached.meta.contentType || "image/jpeg");
+      res.set("Cache-Control", "public, max-age=300, stale-while-revalidate=86400");
+      return res.sendFile(cached.imagePath);
+    }
+    console.warn("[Image Proxy] Failed to fetch image:", error.message);
+    return res.status(502).json({ error: "Failed to fetch image" });
+  }
+};

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -6,6 +6,8 @@ import {
   musicbrainzRequest,
 } from "./apiClients.js";
 import { getDiscoveryCache } from "./discoveryService.js";
+import { hydrateArtistImages, primeArtistImageCache } from "./artistImageHydration.js";
+import { buildImageProxyUrl } from "./imageProxyService.js";
 import { lidarrClient } from "./lidarrClient.js";
 
 const PRIMARY_RELEASE_TYPES = new Set(["Album", "EP", "Single"]);
@@ -54,12 +56,15 @@ function normalizeArtistImage(cachedImage) {
 
 function normalizeReleaseGroupCover(cachedImage) {
   return cachedImage?.imageUrl && cachedImage.imageUrl !== "NOT_FOUND"
-    ? cachedImage.imageUrl
+    ? buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl
     : null;
 }
 
 export function normalizeArtistSearchItem(artist, cachedImages = {}) {
-  const imageUrl = normalizeArtistImage(cachedImages[artist.id]);
+  const rawImageUrl = normalizeArtistImage(cachedImages[artist.id]);
+  const imageUrl = rawImageUrl
+    ? buildImageProxyUrl(rawImageUrl) || rawImageUrl
+    : null;
   const areaName =
     artist?.area?.name || artist?.["begin-area"]?.name || artist?.area || null;
   const lifeSpan = artist?.["life-span"] || artist?.lifeSpan || null;
@@ -237,13 +242,15 @@ function normalizeTagArtistItem(artist, tag) {
     }
   }
 
+  const proxiedImageUrl = imageUrl ? buildImageProxyUrl(imageUrl) || imageUrl : null;
+
   return {
     type: "artist",
     id: artist.id || artist.mbid,
     name: artist.name,
     sortName: artist.sortName || artist.name,
-    image: imageUrl,
-    imageUrl,
+    image: proxiedImageUrl,
+    imageUrl: proxiedImageUrl,
     inLibrary: false,
     tags: [tag],
   };
@@ -298,9 +305,20 @@ export async function searchArtists(query, limit = 24, offset = 0) {
   const artists = Array.isArray(mbData?.artists) ? mbData.artists : [];
   const filteredArtists = artists.filter((artist) => artist?.id);
   const cachedImages = dbOps.getImages(filteredArtists.map((artist) => artist.id));
-  const items = filteredArtists.map((artist) =>
+  let items = filteredArtists.map((artist) =>
     normalizeArtistSearchItem(artist, cachedImages),
   );
+
+  const warmLimit = Math.min(items.length, Math.max(8, Math.min(limitInt, 12)));
+  items = await hydrateArtistImages(items, {
+    limit: warmLimit,
+    batchSize: 6,
+    delayMs: 15,
+  });
+
+  if (items.length > warmLimit) {
+    primeArtistImageCache(items.slice(warmLimit)).catch(() => {});
+  }
 
   return {
     scope: "artist",

--- a/frontend/src/components/ArtistImage.jsx
+++ b/frontend/src/components/ArtistImage.jsx
@@ -56,7 +56,7 @@ const ArtistImage = ({
   const [hasError, setHasError] = useState(false);
   const fetchingRef = useRef(false);
   const triedBackendFallbackRef = useRef(false);
-
+  const imgRef = useRef(null);
   const abortRef = useRef(null);
 
   const fetchBackendCover = useCallback(
@@ -131,6 +131,38 @@ const ArtistImage = ({
     return () => controller.abort();
   }, [src, mbid, artistName, fetchBackendCover]);
 
+  useEffect(() => {
+    const image = imgRef.current;
+    if (!currentSrc || !image) return;
+
+    // Chrome/Safari can restore cached images without reliably firing a fresh
+    // load event during refresh navigation. If the browser already has decoded
+    // dimensions for the current source, promote the image to visible
+    // immediately instead of waiting on onLoad.
+    if (image.complete && image.naturalWidth > 0) {
+      setIsLoading(false);
+      setHasError(false);
+      return;
+    }
+
+    let cancelled = false;
+    if (typeof image.decode === "function") {
+      image
+        .decode()
+        .then(() => {
+          if (!cancelled) {
+            setIsLoading(false);
+            setHasError(false);
+          }
+        })
+        .catch(() => {});
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentSrc]);
+
   const handleLoad = () => {
     setIsLoading(false);
   };
@@ -147,6 +179,8 @@ const ArtistImage = ({
     setIsLoading(false);
   };
 
+  const showPlaceholder = !currentSrc;
+
   if (hasError) {
     return (
       <div
@@ -158,22 +192,38 @@ const ArtistImage = ({
     );
   }
 
-  if (!currentSrc && !isLoading && !hasError) {
+  if (showPlaceholder) {
     return (
       <div
         className={`relative overflow-hidden ${className}`}
-        style={{ backgroundColor: "#211f27" }}
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(33,31,39,1) 0%, rgba(46,43,54,1) 100%)",
+        }}
       >
-        {showLoading && (
-          <div
-            className="absolute inset-0 flex items-center justify-center z-10"
-            style={{ backgroundColor: "#211f27" }}
-          >
+        <div
+          className="absolute inset-0 flex items-center justify-center z-10"
+          style={{ backgroundColor: "transparent" }}
+        >
+          {isLoading ? (
             <Loader
-              className="w-6 h-6 animate-spin"
+              className={`w-6 h-6 ${showLoading ? "animate-spin" : "opacity-60"}`}
               style={{ color: "#c1c1c3" }}
             />
-          </div>
+          ) : (
+            <Music className="w-1/3 h-1/3" style={{ color: "#c1c1c3" }} />
+          )}
+        </div>
+        {isLoading && (
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(110deg, rgba(255,255,255,0.02) 8%, rgba(255,255,255,0.08) 18%, rgba(255,255,255,0.02) 33%)",
+              backgroundSize: "200% 100%",
+              animation: "shimmer 1.6s linear infinite",
+            }}
+          />
         )}
       </div>
     );
@@ -189,11 +239,14 @@ const ArtistImage = ({
           className="absolute inset-0 flex items-center justify-center z-10"
           style={{ backgroundColor: "#211f27" }}
         >
-          <Loader className="w-6 h-6 text-primary-500 animate-spin" />
+          <Loader
+            className="w-6 h-6 text-primary-500 animate-spin"
+          />
         </div>
       )}
       {currentSrc && (
         <img
+          ref={imgRef}
           src={currentSrc}
           alt={alt || "Artist cover"}
           className={`w-full h-full object-cover transition-opacity duration-200 ${
@@ -201,9 +254,8 @@ const ArtistImage = ({
           }`}
           onLoad={handleLoad}
           onError={handleError}
-          loading="lazy"
+          loading="eager"
           decoding="async"
-          style={{ contentVisibility: "auto" }}
         />
       )}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
 @theme {
   --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -311,7 +311,7 @@ function ArtistDetailsPage() {
         getArtistDetails(mbid, name).catch(() => null),
         getArtistCover(mbid, name, true).catch(() => ({ images: [] })),
         getArtistPreview(mbid, name).catch(() => ({ tracks: [] })),
-        getSimilarArtistsForArtist(mbid).catch(() => ({ artists: [] })),
+        getSimilarArtistsForArtist(mbid, name).catch(() => ({ artists: [] })),
       ]);
       if (details?.id) {
         setArtist(details);

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsStream.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsStream.js
@@ -107,7 +107,10 @@ export function useArtistDetailsStream(
           .finally(() => setLoadingCover(false));
       }
       if (!similarReceived) {
-        getSimilarArtistsForArtist(mbid)
+        getSimilarArtistsForArtist(
+          mbid,
+          artistNameRef.current || artistNameFromNav || "",
+        )
           .then((similarData) => {
             setSimilarArtists(similarData.artists || []);
           })
@@ -272,7 +275,10 @@ export function useArtistDetailsStream(
                 .catch(() => {})
                 .finally(() => setLoadingCover(false));
 
-              getSimilarArtistsForArtist(mbid)
+              getSimilarArtistsForArtist(
+                mbid,
+                artistData?.name || artistNameFromNav || "",
+              )
                 .then((similarData) => {
                   setSimilarArtists(similarData.artists || []);
                 })
@@ -315,7 +321,10 @@ export function useArtistDetailsStream(
               .catch(() => {})
               .finally(() => setLoadingCover(false));
 
-            getSimilarArtistsForArtist(mbid)
+            getSimilarArtistsForArtist(
+              mbid,
+              artistData?.name || artistNameFromNav || "",
+            )
               .then((similarData) => {
                 setSimilarArtists(similarData.artists || []);
               })
@@ -323,6 +332,7 @@ export function useArtistDetailsStream(
               .finally(() => setLoadingSimilar(false));
           })
           .catch((err) => {
+            console.error("Error fetching artist data:", err);
             setError(
               err.response?.data?.message ||
                 err.response?.data?.error ||

--- a/frontend/src/pages/ArtistDetails/utils.js
+++ b/frontend/src/pages/ArtistDetails/utils.js
@@ -108,3 +108,14 @@ export const getCoverImage = (coverImages) => {
   const front = coverImages.find((img) => img.front);
   return front?.image || coverImages[0]?.image;
 };
+
+export const encodeLastfmPathSegment = (value) =>
+  encodeURIComponent(String(value || "").trim())
+    .replace(/%20/g, "+")
+    .replace(/%26/g, "&");
+
+export const buildLastfmArtistUrl = (artistName) =>
+  `https://www.last.fm/music/${encodeLastfmPathSegment(artistName)}`;
+
+export const buildLastfmAlbumUrl = (artistName, albumTitle) =>
+  `${buildLastfmArtistUrl(artistName)}/${encodeLastfmPathSegment(albumTitle)}`;

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -81,6 +81,7 @@ const getTagCardBackground = (tag) => {
 };
 
 const DISCOVER_LAYOUT_KEY = "discoverLayout";
+const DISCOVERY_CACHE_KEY = "discoverData";
 
 const DEFAULT_DISCOVER_SECTIONS = [
   { id: "recentlyAdded", label: "Recently Added", enabled: true },
@@ -126,6 +127,54 @@ const normalizeBlocklistArtists = (artists) => {
 
 const getDiscoverLayoutStorageKey = (userId) =>
   userId ? `${DISCOVER_LAYOUT_KEY}:${userId}` : DISCOVER_LAYOUT_KEY;
+
+const getDiscoveryCacheStorageKey = (userId) =>
+  userId ? `${DISCOVERY_CACHE_KEY}:${userId}` : DISCOVERY_CACHE_KEY;
+
+const normalizeDiscoveryData = (value) => {
+  if (!value || typeof value !== "object") return null;
+  return {
+    recommendations: Array.isArray(value.recommendations)
+      ? value.recommendations
+      : [],
+    globalTop: Array.isArray(value.globalTop) ? value.globalTop : [],
+    basedOn: Array.isArray(value.basedOn) ? value.basedOn : [],
+    topTags: Array.isArray(value.topTags) ? value.topTags : [],
+    topGenres: Array.isArray(value.topGenres) ? value.topGenres : [],
+    lastUpdated: value.lastUpdated || null,
+    isUpdating: !!value.isUpdating,
+    stale: !!value.stale,
+    configured:
+      typeof value.configured === "boolean" ? value.configured : true,
+  };
+};
+
+const readStoredDiscoveryData = (userId) => {
+  try {
+    const primaryKey = getDiscoveryCacheStorageKey(userId);
+    const primary = normalizeDiscoveryData(
+      JSON.parse(localStorage.getItem(primaryKey) || "null"),
+    );
+    if (primary) return primary;
+    if (primaryKey === DISCOVERY_CACHE_KEY) return null;
+    return normalizeDiscoveryData(
+      JSON.parse(localStorage.getItem(DISCOVERY_CACHE_KEY) || "null"),
+    );
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredDiscoveryData = (value, userId) => {
+  const normalized = normalizeDiscoveryData(value);
+  if (!normalized) return;
+  try {
+    localStorage.setItem(
+      getDiscoveryCacheStorageKey(userId),
+      JSON.stringify(normalized),
+    );
+  } catch {}
+};
 
 const normalizeDiscoverLayout = (value) => {
   if (!Array.isArray(value)) return null;
@@ -844,7 +893,8 @@ DiscoverRail.propTypes = {
 };
 
 function DiscoverPage() {
-  const [data, setData] = useState(null);
+  const { user: authUser, hasPermission } = useAuth();
+  const [data, setData] = useState(() => readStoredDiscoveryData(authUser?.id));
   const [recentlyAdded, setRecentlyAdded] = useState([]);
   const [recentReleases, setRecentReleases] = useState([]);
   const [releaseCovers, setReleaseCovers] = useState({});
@@ -873,7 +923,6 @@ function DiscoverPage() {
   const requestedArtistCoversRef = useRef(new Set());
   const lastDiscoveryWsMessageAtRef = useRef(0);
   const navigate = useNavigate();
-  const { user: authUser, hasPermission } = useAuth();
   const { showSuccess, showError } = useToast();
   const canAddArtist = hasPermission("addArtist");
 
@@ -883,7 +932,7 @@ function DiscoverPage() {
     (msg) => {
       if (msg.type === "discovery_update" && msg.recommendations) {
         lastDiscoveryWsMessageAtRef.current = Date.now();
-        setData({
+        const nextData = {
           recommendations: msg.recommendations || [],
           globalTop: msg.globalTop || [],
           basedOn: msg.basedOn || [],
@@ -893,7 +942,9 @@ function DiscoverPage() {
           isUpdating: false,
           stale: false,
           configured: true,
-        });
+        };
+        setData(nextData);
+        writeStoredDiscoveryData(nextData, authUser?.id);
       }
     },
   );
@@ -904,10 +955,11 @@ function DiscoverPage() {
     getDiscovery()
       .then((discoveryData) => {
         setData(discoveryData);
+        writeStoredDiscoveryData(discoveryData, authUser?.id);
         setError(null);
       })
       .catch(() => {});
-  }, [isDiscoverySocketConnected, data?.isUpdating, data?.stale]);
+  }, [authUser?.id, isDiscoverySocketConnected, data?.isUpdating, data?.stale]);
 
   useEffect(() => {
     if (!data?.isUpdating) return;
@@ -918,6 +970,7 @@ function DiscoverPage() {
       getDiscovery(true)
         .then((next) => {
           setData(next);
+          writeStoredDiscoveryData(next, authUser?.id);
           setError(null);
         })
         .catch(() => {});
@@ -925,7 +978,7 @@ function DiscoverPage() {
     pollDiscovery();
     const id = setInterval(pollDiscovery, 10000);
     return () => clearInterval(id);
-  }, [data?.isUpdating, isDiscoverySocketConnected]);
+  }, [authUser?.id, data?.isUpdating, isDiscoverySocketConnected]);
 
   useEffect(() => {
     if (!data?.stale || data?.isUpdating) return;
@@ -934,12 +987,13 @@ function DiscoverPage() {
       getDiscovery(true)
         .then((next) => {
           setData(next);
+          writeStoredDiscoveryData(next, authUser?.id);
           setError(null);
         })
         .catch(() => {});
     }, 15000);
     return () => clearTimeout(id);
-  }, [data?.stale, data?.isUpdating, isDiscoverySocketConnected]);
+  }, [authUser?.id, data?.stale, data?.isUpdating, isDiscoverySocketConnected]);
 
   useEffect(() => {
     if (!data) return;
@@ -949,9 +1003,10 @@ function DiscoverPage() {
   }, [data, data?.isUpdating, data?.stale]);
 
   useEffect(() => {
-    getDiscovery(true)
+    getDiscovery()
       .then((discoveryData) => {
         setData(discoveryData);
+        writeStoredDiscoveryData(discoveryData, authUser?.id);
         setError(null);
       })
       .catch((err) => {
@@ -1007,7 +1062,7 @@ function DiscoverPage() {
       setAppliedNearbyZip(storedZip);
       setNearbyZipDraft(storedZip);
     } catch {}
-  }, []);
+  }, [authUser?.id]);
 
   useEffect(() => {
     const shouldUseZip = nearbyLocationMode === "zip";

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -299,9 +299,18 @@ export const getReleaseGroupCover = async (mbid) => {
   });
 };
 
-export const getSimilarArtistsForArtist = async (mbid, limit = 20) => {
+export const getSimilarArtistsForArtist = async (
+  mbid,
+  artistName = "",
+  limit = 20,
+) => {
   const response = await api.get(`/artists/${mbid}/similar`, {
-    params: { limit },
+    params: {
+      limit,
+      ...(artistName && typeof artistName === "string" && artistName.trim()
+        ? { artistName: artistName.trim() }
+        : {}),
+    },
   });
   return response.data;
 };

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ import requestsRouter from "./backend/routes/requests.js";
 import healthRouter from "./backend/routes/health.js";
 import weeklyFlowRouter from "./backend/routes/weeklyFlow.js";
 import authRouter from "./backend/routes/auth.js";
+import imageProxyRouter from "./backend/routes/imageProxy.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -138,6 +139,7 @@ app.use("/api/requests", requestsRouter);
 app.use("/api/health", healthRouter);
 app.use("/api/weekly-flow", weeklyFlowRouter);
 app.use("/api/auth", authRouter);
+app.use("/api/image-proxy", imageProxyRouter);
 
 const HOUR_MS = 60 * 60 * 1000;
 setInterval(() => {


### PR DESCRIPTION
## Summary
- Add a signed `/api/image-proxy` endpoint that fetches, caches, and serves remote artist art through the backend.
- Proxy artist, release group, library, search, discovery, and similar-artist images so clients use cached backend URLs instead of raw upstream links.
- Introduce shared artist image hydration to warm missing artwork during discovery/search flows and reuse cached covers when available.
- Improve similar-artist fallback behavior by resolving artist names when MBIDs alone do not return results.
- Update the artist image component to handle cached loads more smoothly with a better placeholder and eager image handling.

## Testing
- Not run
- Updated search-service unit coverage to assert proxied artist image URLs.
- Not run: backend route and proxy fetch/cache behavior.
- Not run: frontend artist image loading and fallback rendering in browser.