### PR TITLE
Dedupe shared playlist tracks and normalize release layout

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -44,62 +44,64 @@ const normalizeImportedTrackList = (value) => {
   if (!Array.isArray(value)) return [];
   return dedupeSharedTracks(
     value
-    .map((track) => {
-      if (!track || typeof track !== "object" || Array.isArray(track))
-        return null;
-      const artistName = String(
-        track.artistName ??
-          track.artist ??
-          track.artist_name ??
-          track["Artist Name(s)"] ??
-          "",
-      ).trim();
-      const trackName = String(
-        track.trackName ??
-          track.title ??
-          track.name ??
-          track.track ??
-          track["Track Name"] ??
-          "",
-      ).trim();
-      if (!artistName || !trackName) return null;
-      const albumName = String(
-        track.albumName ?? track.album ?? track["Album Name"] ?? "",
-      ).trim();
-      const artistMbid = String(
-        track.artistMbid ?? track.artistId ?? track.mbid ?? "",
-      ).trim();
-      const albumMbid = String(
-        track.albumMbid ?? track.releaseGroupMbid ?? track.albumId ?? "",
-      ).trim();
-      const trackMbid = String(
-        track.trackMbid ?? track.recordingMbid ?? track.recordingId ?? "",
-      ).trim();
-      const releaseYear = String(track.releaseYear ?? track.year ?? "").trim();
-      const durationMs =
-        track.durationMs != null && Number.isFinite(Number(track.durationMs))
-          ? Math.max(0, Math.round(Number(track.durationMs)))
-          : null;
-      const artistAliases = Array.isArray(track.artistAliases)
-        ? track.artistAliases
-            .map((entry) => String(entry || "").trim())
-            .filter(Boolean)
-        : [];
-      const reason = String(track.reason ?? "").trim();
-      return {
-        artistName,
-        trackName,
-        albumName: albumName || null,
-        artistMbid: artistMbid || null,
-        albumMbid: albumMbid || null,
-        trackMbid: trackMbid || null,
-        releaseYear: releaseYear || null,
-        durationMs,
-        artistAliases,
-        reason: reason || null,
-      };
-    })
-    .filter(Boolean),
+      .map((track) => {
+        if (!track || typeof track !== "object" || Array.isArray(track))
+          return null;
+        const artistName = String(
+          track.artistName ??
+            track.artist ??
+            track.artist_name ??
+            track["Artist Name(s)"] ??
+            "",
+        ).trim();
+        const trackName = String(
+          track.trackName ??
+            track.title ??
+            track.name ??
+            track.track ??
+            track["Track Name"] ??
+            "",
+        ).trim();
+        if (!artistName || !trackName) return null;
+        const albumName = String(
+          track.albumName ?? track.album ?? track["Album Name"] ?? "",
+        ).trim();
+        const artistMbid = String(
+          track.artistMbid ?? track.artistId ?? track.mbid ?? "",
+        ).trim();
+        const albumMbid = String(
+          track.albumMbid ?? track.releaseGroupMbid ?? track.albumId ?? "",
+        ).trim();
+        const trackMbid = String(
+          track.trackMbid ?? track.recordingMbid ?? track.recordingId ?? "",
+        ).trim();
+        const releaseYear = String(
+          track.releaseYear ?? track.year ?? "",
+        ).trim();
+        const durationMs =
+          track.durationMs != null && Number.isFinite(Number(track.durationMs))
+            ? Math.max(0, Math.round(Number(track.durationMs)))
+            : null;
+        const artistAliases = Array.isArray(track.artistAliases)
+          ? track.artistAliases
+              .map((entry) => String(entry || "").trim())
+              .filter(Boolean)
+          : [];
+        const reason = String(track.reason ?? "").trim();
+        return {
+          artistName,
+          trackName,
+          albumName: albumName || null,
+          artistMbid: artistMbid || null,
+          albumMbid: albumMbid || null,
+          trackMbid: trackMbid || null,
+          releaseYear: releaseYear || null,
+          durationMs,
+          artistAliases,
+          reason: reason || null,
+        };
+      })
+      .filter(Boolean),
   );
 };
 

--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -7,7 +7,12 @@ import { weeklyFlowWorker } from "../services/weeklyFlowWorker.js";
 import { playlistSource } from "../services/weeklyFlowPlaylistSource.js";
 import { soulseekClient } from "../services/simpleSoulseekClient.js";
 import { playlistManager } from "../services/weeklyFlowPlaylistManager.js";
-import { flowPlaylistConfig } from "../services/weeklyFlowPlaylistConfig.js";
+import {
+  buildSharedTrackIdentity,
+  dedupeSharedTracks,
+  filterMissingSharedTracks,
+  flowPlaylistConfig,
+} from "../services/weeklyFlowPlaylistConfig.js";
 import { weeklyFlowOperationQueue } from "../services/weeklyFlowOperationQueue.js";
 import { getWeeklyFlowStatusSnapshot } from "../services/weeklyFlowStatusSnapshot.js";
 import { noCache } from "../middleware/cache.js";
@@ -37,7 +42,8 @@ const isPathInsideRoot = (candidatePath, rootPath) => {
 
 const normalizeImportedTrackList = (value) => {
   if (!Array.isArray(value)) return [];
-  return value
+  return dedupeSharedTracks(
+    value
     .map((track) => {
       if (!track || typeof track !== "object" || Array.isArray(track))
         return null;
@@ -93,19 +99,11 @@ const normalizeImportedTrackList = (value) => {
         reason: reason || null,
       };
     })
-    .filter(Boolean);
+    .filter(Boolean),
+  );
 };
 
-const buildTrackIdentity = (track) =>
-  [
-    String(track?.artistName || "").trim(),
-    String(track?.trackName || "").trim(),
-    String(track?.albumName || "").trim(),
-    String(track?.artistMbid || "").trim(),
-    String(track?.albumMbid || "").trim(),
-    String(track?.trackMbid || "").trim(),
-    String(track?.releaseYear || "").trim(),
-  ].join("\u0001");
+const buildTrackIdentity = (track) => buildSharedTrackIdentity(track);
 
 const sortJobsForTrackReuse = (jobs) =>
   [...jobs].sort((a, b) => {
@@ -785,7 +783,14 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       "aurral-weekly-flow",
       flowId,
     );
-    const tracks = completedJobs.map((job) => ({
+    const uniqueCompletedJobsByIdentity = new Map();
+    for (const job of completedJobs) {
+      const identity = buildTrackIdentity(job);
+      if (uniqueCompletedJobsByIdentity.has(identity)) continue;
+      uniqueCompletedJobsByIdentity.set(identity, job);
+    }
+    const uniqueCompletedJobs = [...uniqueCompletedJobsByIdentity.values()];
+    const tracks = uniqueCompletedJobs.map((job) => ({
       artistName: job.artistName,
       trackName: job.trackName,
       albumName: job.albumName || null,
@@ -809,7 +814,7 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       "aurral-weekly-flow",
       playlist.id,
     );
-    for (const job of completedJobs) {
+    for (const job of uniqueCompletedJobs) {
       const safeSourcePath = path.resolve(job.finalPath);
       if (!isPathInsideRoot(safeSourcePath, sourceRoot)) {
         throw new Error(
@@ -852,7 +857,7 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
     res.json({
       success: true,
       playlist,
-      trackCount: completedJobs.length,
+      trackCount: uniqueCompletedJobs.length,
     });
   } catch (error) {
     if (playlist?.id) {
@@ -1022,9 +1027,13 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
       });
     }
 
+    const tracksToAdd = filterMissingSharedTracks(
+      playlist.tracks,
+      normalizedTracks,
+    );
     const updatedPlaylist = flowPlaylistConfig.appendSharedPlaylistTracks(
       playlistId,
-      normalizedTracks,
+      tracksToAdd,
     );
     const reusableJobsByIdentity = buildReusableJobsByIdentity(
       downloadTracker
@@ -1033,7 +1042,7 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
     );
     const reusedJobIds = [];
     const tracksToQueue = [];
-    for (const track of normalizedTracks) {
+    for (const track of tracksToAdd) {
       const reusableJob = (reusableJobsByIdentity.get(buildTrackIdentity(track)) || [])[0];
       if (!reusableJob) {
         tracksToQueue.push(track);

--- a/backend/services/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlowPlaylistConfig.js
@@ -373,11 +373,52 @@ const normalizeSharedTrack = (track) => {
   };
 };
 
+export const buildSharedTrackIdentity = (track) =>
+  [
+    String(track?.artistName || "").trim().toLocaleLowerCase(),
+    String(track?.trackName || "").trim().toLocaleLowerCase(),
+    String(track?.albumName || "").trim().toLocaleLowerCase(),
+    String(track?.artistMbid || "").trim(),
+    String(track?.albumMbid || "").trim(),
+    String(track?.trackMbid || "").trim(),
+    String(track?.releaseYear || "").trim(),
+  ].join("\u0001");
+
+export const dedupeSharedTracks = (tracks) => {
+  const seen = new Set();
+  const uniqueTracks = [];
+  for (const track of Array.isArray(tracks) ? tracks : []) {
+    const normalizedTrack = normalizeSharedTrack(track);
+    if (!normalizedTrack) continue;
+    const identity = buildSharedTrackIdentity(normalizedTrack);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    uniqueTracks.push(normalizedTrack);
+  }
+  return uniqueTracks;
+};
+
+export const filterMissingSharedTracks = (existingTracks, incomingTracks) => {
+  const seen = new Set(
+    dedupeSharedTracks(existingTracks).map((track) =>
+      buildSharedTrackIdentity(track),
+    ),
+  );
+  const missingTracks = [];
+  for (const track of Array.isArray(incomingTracks) ? incomingTracks : []) {
+    const normalizedTrack = normalizeSharedTrack(track);
+    if (!normalizedTrack) continue;
+    const identity = buildSharedTrackIdentity(normalizedTrack);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    missingTracks.push(normalizedTrack);
+  }
+  return missingTracks;
+};
+
 const normalizeSharedPlaylist = (playlist) => {
   const name = String(playlist?.name || "").trim();
-  const tracks = Array.isArray(playlist?.tracks)
-    ? playlist.tracks.map(normalizeSharedTrack).filter(Boolean)
-    : [];
+  const tracks = dedupeSharedTracks(playlist?.tracks);
   return {
     id: playlist?.id || randomUUID(),
     name: name || "Shared Playlist",
@@ -767,9 +808,7 @@ export const flowPlaylistConfig = {
     const index = playlists.findIndex((playlist) => playlist.id === playlistId);
     if (index === -1) return null;
     const current = playlists[index];
-    const appendedTracks = Array.isArray(tracks)
-      ? tracks.map(normalizeSharedTrack).filter(Boolean)
-      : [];
+    const appendedTracks = filterMissingSharedTracks(current.tracks, tracks);
     const next = normalizeSharedPlaylist({
       ...current,
       tracks: [...current.tracks, ...appendedTracks],

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -503,7 +503,7 @@ export function ArtistDetailsReleaseGroups({
                 }}
               >
                 <div
-                  className="flex cursor-pointer items-start justify-between gap-3 px-3 py-3 sm:items-center"
+                  className="flex min-w-0 cursor-pointer items-start justify-between gap-3 px-3 py-3 sm:items-center"
                   onClick={() =>
                     handleReleaseGroupAlbumClick(
                       releaseGroup.id,
@@ -511,7 +511,7 @@ export function ArtistDetailsReleaseGroups({
                     )
                   }
                 >
-                  <div className="flex flex-1 items-start gap-3 sm:items-center">
+                  <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
                     <button
                       type="button"
                       onClick={(e) => {


### PR DESCRIPTION
## Summary
- Deduplicates shared playlist tracks by normalized identity so repeated imports and appends do not create duplicate entries.
- Filters incoming shared playlist tracks against existing playlist contents before appending or queueing work.
- Reuses the same shared-track identity logic across weekly flow playlist handling and static playlist generation.
- Fixes release group row layout by adding `min-w-0` constraints so long text truncates correctly instead of overflowing.

## Testing
- Not run
- Verified the code paths that append shared playlist tracks now only operate on missing, normalized tracks.
- Verified static playlist creation now builds track output and copies files from a deduplicated completed-job list.