### PR TITLE
Replace repository icon with GitHub logo

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { Link, useLocation } from "react-router-dom";
 import {
   Menu,
-  GitBranch,
   Heart,
   Sparkles,
   Library,
@@ -20,6 +19,23 @@ import GlobalSearch from "./GlobalSearch";
 import { useAuth } from "../contexts/AuthContext";
 
 const VALID_SIDEBAR_MODES = ["full", "icons", "hidden"];
+
+function GitHubIcon({ className = "" }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M12 .5C5.649.5.5 5.649.5 12c0 5.084 3.292 9.398 7.861 10.919.575.106.786-.25.786-.556 0-.274-.01-1-.016-1.962-3.197.695-3.872-1.541-3.872-1.541-.523-1.328-1.277-1.682-1.277-1.682-1.044-.714.079-.699.079-.699 1.154.081 1.761 1.185 1.761 1.185 1.026 1.758 2.692 1.25 3.348.956.104-.743.402-1.251.731-1.539-2.552-.291-5.236-1.276-5.236-5.681 0-1.255.449-2.282 1.184-3.086-.119-.291-.513-1.462.112-3.048 0 0 .966-.309 3.165 1.179A10.98 10.98 0 0 1 12 6.033c.973.004 1.954.132 2.87.388 2.197-1.488 3.162-1.179 3.162-1.179.627 1.586.233 2.757.114 3.048.737.804 1.182 1.831 1.182 3.086 0 4.416-2.688 5.387-5.249 5.673.413.355.781 1.055.781 2.126 0 1.535-.014 2.772-.014 3.149 0 .309.207.668.792.555C20.211 21.394 23.5 17.082 23.5 12 23.5 5.649 18.351.5 12 .5Z" />
+    </svg>
+  );
+}
+
+GitHubIcon.propTypes = {
+  className: PropTypes.string,
+};
 
 function Layout({ children, appVersion }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -147,7 +163,7 @@ function Layout({ children, appVersion }) {
               style={{ color: "#c1c1c3" }}
               aria-label="GitHub Repository"
             >
-              <GitBranch className="w-5 h-5 transition-colors group-hover:text-white" />
+              <GitHubIcon className="w-5 h-5 transition-colors group-hover:text-white" />
             </a>
             <a
               href="https://github.com/sponsors/lklynet/"


### PR DESCRIPTION
## Summary
- Replaced the sidebar repository icon with an inline GitHub logo SVG in `Layout.jsx`.
- Removed the previous `GitBranch` icon import since it is no longer used.
- Kept the existing hover styling and accessibility attributes unchanged.

## Testing
- Not run (not requested).