### PR TITLE
Serve album art from cached local image URLs

### DIFF
--- a/.tests/metadata-providers.test.js
+++ b/.tests/metadata-providers.test.js
@@ -17,27 +17,22 @@ const originalSettings = dbOps.getSettings();
 test.after(() => {
   dbOps.updateSettings(originalSettings);
   __setMetadataProviderHealthStateForTests("musicbrainz");
-  __setMetadataProviderHealthStateForTests("coverArtArchive");
 });
 
-test("default settings use hosted metadata providers", () => {
+test("default settings use hosted MusicBrainz and official Cover Art Archive", () => {
   assert.equal(
     defaultData.settings.integrations.musicbrainz.provider,
     "aurralHosted",
   );
-  assert.equal(
-    defaultData.settings.integrations.coverArtArchive.provider,
-    "aurralHosted",
-  );
+  assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
 });
 
-test("backend metadata providers default to hosted when unset", () => {
+test("backend metadata providers default to hosted MusicBrainz when unset", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
       ...(originalSettings.integrations || {}),
       musicbrainz: { email: "test@example.com" },
-      coverArtArchive: {},
     },
   });
 
@@ -45,23 +40,16 @@ test("backend metadata providers default to hosted when unset", () => {
     getMusicbrainzApiBaseUrl(),
     "https://mb.lkly.net/ws/2",
   );
-  assert.equal(
-    getCoverArtArchiveApiBaseUrl(),
-    "https://caa.lkly.net",
-  );
+  assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
 });
 
-test("hosted metadata providers stay pinned to hosted by default", () => {
+test("MusicBrainz hosted mode stays pinned to hosted by default", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
       ...(originalSettings.integrations || {}),
       musicbrainz: {
         email: "test@example.com",
-        provider: "aurralHosted",
-        customUrl: "",
-      },
-      coverArtArchive: {
         provider: "aurralHosted",
         customUrl: "",
       },
@@ -69,20 +57,16 @@ test("hosted metadata providers stay pinned to hosted by default", () => {
   });
 
   assert.deepEqual(getMusicbrainzApiBaseUrls(), ["https://mb.lkly.net/ws/2"]);
-  assert.deepEqual(getCoverArtArchiveApiBaseUrls(), ["https://caa.lkly.net"]);
+  assert.deepEqual(getCoverArtArchiveApiBaseUrls(), ["https://coverartarchive.org"]);
 });
 
-test("automatic provider failover only changes the active base after hosted health degrades", () => {
+test("automatic provider failover only changes the MusicBrainz base after hosted health degrades", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
       ...(originalSettings.integrations || {}),
       musicbrainz: {
         email: "test@example.com",
-        provider: "aurralHosted",
-        customUrl: "",
-      },
-      coverArtArchive: {
         provider: "aurralHosted",
         customUrl: "",
       },
@@ -94,11 +78,6 @@ test("automatic provider failover only changes the active base after hosted heal
     consecutiveFailures: 3,
     lastFailureReason: "HTTP 503",
   });
-  __setMetadataProviderHealthStateForTests("coverArtArchive", {
-    failoverActive: true,
-    consecutiveFailures: 3,
-    lastFailureReason: "ETIMEDOUT",
-  });
 
   assert.equal(getMusicbrainzApiBaseUrl(), "https://musicbrainz.org/ws/2");
   assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
@@ -108,12 +87,9 @@ test("automatic provider failover only changes the active base after hosted heal
   assert.equal(snapshot.musicbrainz.activeProvider, "official");
   assert.equal(snapshot.musicbrainz.failoverActive, true);
   assert.equal(snapshot.musicbrainz.lastFailureReason, "HTTP 503");
-  assert.equal(snapshot.coverArtArchive.activeProvider, "official");
-  assert.equal(snapshot.coverArtArchive.failoverActive, true);
-  assert.equal(snapshot.coverArtArchive.lastFailureReason, "ETIMEDOUT");
 });
 
-test("manual official and custom provider selections bypass automatic failover state", () => {
+test("manual MusicBrainz provider selection bypasses automatic failover state", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
@@ -123,10 +99,6 @@ test("manual official and custom provider selections bypass automatic failover s
         provider: "official",
         customUrl: "",
       },
-      coverArtArchive: {
-        provider: "custom",
-        customUrl: "https://covers.example.net/api",
-      },
     },
   });
 
@@ -134,22 +106,14 @@ test("manual official and custom provider selections bypass automatic failover s
     failoverActive: true,
     consecutiveFailures: 5,
   });
-  __setMetadataProviderHealthStateForTests("coverArtArchive", {
-    failoverActive: true,
-    consecutiveFailures: 5,
-  });
 
   assert.deepEqual(getMusicbrainzApiBaseUrls(), ["https://musicbrainz.org/ws/2"]);
   assert.deepEqual(getCoverArtArchiveApiBaseUrls(), [
-    "https://covers.example.net/api",
+    "https://coverartarchive.org",
   ]);
 
   const snapshot = getMetadataProviderHealthSnapshot();
   assert.equal(snapshot.musicbrainz.mode, "manual");
   assert.equal(snapshot.musicbrainz.activeProvider, "official");
   assert.equal(snapshot.musicbrainz.failoverActive, false);
-  assert.equal(snapshot.coverArtArchive.mode, "manual");
-  assert.equal(snapshot.coverArtArchive.activeProvider, "custom");
-  assert.equal(snapshot.coverArtArchive.activeBaseUrl, "https://covers.example.net/api");
-  assert.equal(snapshot.coverArtArchive.failoverActive, false);
 });

--- a/.tests/search/search-service.test.js
+++ b/.tests/search/search-service.test.js
@@ -26,10 +26,7 @@ test("normalizeArtistSearchItem preserves sort name and cached image", () => {
   assert.equal(item.id, "artist-mbid");
   assert.equal(item.name, "Boards of Canada");
   assert.equal(item.sortName, "Canada, Boards of");
-  assert.match(
-    item.image,
-    /^\/api\/image-proxy\?src=https%3A%2F%2Fimages\.example%2Fartist\.jpg&sig=/,
-  );
+  assert.equal(item.image, "https://images.example/artist.jpg");
   assert.equal(item.imageUrl, item.image);
   assert.equal(item.artistType, null);
   assert.equal(item.country, null);

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -111,7 +111,6 @@ export const UUID_REGEX =
 export const MUSICBRAINZ_API = "https://musicbrainz.org/ws/2";
 export const AURRAL_MUSICBRAINZ_API = "https://mb.lkly.net/ws/2";
 export const OFFICIAL_COVER_ART_ARCHIVE_API = "https://coverartarchive.org";
-export const COVER_ART_ARCHIVE_API = "https://caa.lkly.net";
 export const LASTFM_API = "https://ws.audioscrobbler.com/2.0/";
 export const LISTENBRAINZ_API = "https://api.listenbrainz.org";
 export const APP_NAME = "Aurral";
@@ -189,10 +188,6 @@ export const defaultData = {
       },
       musicbrainz: {
         email: "",
-        provider: "aurralHosted",
-        customUrl: "",
-      },
-      coverArtArchive: {
         provider: "aurralHosted",
         customUrl: "",
       },

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -332,7 +332,8 @@ export const createAuthMiddleware = () => {
       req.path === "/api/health" ||
       req.path === "/api/health/live" ||
       req.path === "/api/health/bootstrap" ||
-      req.path === "/api/image-proxy"
+      req.path === "/api/image-proxy" ||
+      req.path.startsWith("/api/image-proxy/")
     ) {
       return next();
     }

--- a/backend/routes/artists/handlers/cover.js
+++ b/backend/routes/artists/handlers/cover.js
@@ -2,7 +2,7 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { pendingCoverRequests, fetchCoverInBackground } from "../utils.js";
 import { getArtistImage } from "../../../services/imageService.js";
-import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
+import { warmImageProxy } from "../../../services/imageProxyService.js";
 
 export default function registerCover(router) {
   router.get("/:mbid/cover", async (req, res) => {
@@ -35,8 +35,6 @@ export default function registerCover(router) {
         cachedImage.imageUrl !== "NOT_FOUND"
       ) {
         console.log(`[Cover Route] Cache hit for ${mbid}`);
-        const cachedUrl =
-          buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl;
         res.set("Cache-Control", "public, max-age=31536000, immutable");
 
         const cacheAge = cachedImage.cacheAge;
@@ -46,11 +44,15 @@ export default function registerCover(router) {
         if (shouldRefresh) {
           fetchCoverInBackground(mbid).catch(() => {});
         }
+        warmImageProxy(cachedImage.imageUrl).catch(() => {
+          dbOps.deleteImage(mbid);
+          fetchCoverInBackground(mbid).catch(() => {});
+        });
 
         return res.json({
           images: [
             {
-              image: cachedUrl,
+              image: cachedImage.imageUrl,
               front: true,
               types: ["Front"],
             },
@@ -79,7 +81,11 @@ export default function registerCover(router) {
       const fetchPromise = (async () => {
         try {
           const result = await getArtistImage(mbid, !!refresh);
-          return { images: result.images || [] };
+          return {
+            images: result.images || [],
+            notFound: !!result.notFound,
+            transientError: !!result.transientError,
+          };
         } catch (error) {
           console.error(`Error fetching cover for ${mbid}:`, error.message);
           return { images: [] };
@@ -90,18 +96,21 @@ export default function registerCover(router) {
       const result = await fetchPromise;
 
       if (result.images && result.images.length > 0) {
-        result.images = result.images.map((image) => ({
-          ...image,
-          image: buildImageProxyUrl(image.image) || image.image,
-        }));
         console.log(`[Cover Route] Successfully returning cover for ${mbid}`);
         res.set("Cache-Control", "public, max-age=31536000, immutable");
       } else {
-        console.log(
-          `[Cover Route] No cover found for ${mbid}, caching NOT_FOUND`
-        );
-        dbOps.setImage(mbid, "NOT_FOUND");
-        res.set("Cache-Control", "public, max-age=3600");
+        if (result.notFound) {
+          console.log(
+            `[Cover Route] No cover found for ${mbid}, caching NOT_FOUND`
+          );
+          dbOps.setImage(mbid, "NOT_FOUND");
+          res.set("Cache-Control", "public, max-age=3600");
+        } else {
+          console.log(
+            `[Cover Route] Cover lookup for ${mbid} failed transiently; skipping NOT_FOUND cache`,
+          );
+          res.set("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
+        }
       }
 
       res.json({ images: result.images || [] });

--- a/backend/routes/artists/handlers/cover.js
+++ b/backend/routes/artists/handlers/cover.js
@@ -42,11 +42,11 @@ export default function registerCover(router) {
           !cacheAge || Date.now() - cacheAge > 7 * 24 * 60 * 60 * 1000;
 
         if (shouldRefresh) {
-          fetchCoverInBackground(mbid).catch(() => {});
+          fetchCoverInBackground(mbid, artistNameFromQuery).catch(() => {});
         }
         warmImageProxy(cachedImage.imageUrl).catch(() => {
           dbOps.deleteImage(mbid);
-          fetchCoverInBackground(mbid).catch(() => {});
+          fetchCoverInBackground(mbid, artistNameFromQuery).catch(() => {});
         });
 
         return res.json({
@@ -70,7 +70,7 @@ export default function registerCover(router) {
         res.set("Cache-Control", "public, max-age=3600");
 
         setTimeout(() => {
-          fetchCoverInBackground(mbid).catch(() => {});
+          fetchCoverInBackground(mbid, artistNameFromQuery).catch(() => {});
         }, 60000);
 
         return res.json({ images: [] });
@@ -80,7 +80,10 @@ export default function registerCover(router) {
 
       const fetchPromise = (async () => {
         try {
-          const result = await getArtistImage(mbid, !!refresh);
+          const result = await getArtistImage(mbid, {
+            forceRefresh: !!refresh,
+            artistName: artistNameFromQuery,
+          });
           return {
             images: result.images || [],
             notFound: !!result.notFound,

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -94,6 +94,11 @@ export default function registerDetails(router) {
   router.get("/:mbid", cacheMiddleware(300), async (req, res) => {
     try {
       const { mbid } = req.params;
+      const responseMode =
+        typeof req.query.mode === "string" && req.query.mode.trim()
+          ? req.query.mode.trim().toLowerCase()
+          : "full";
+      const coreOnly = responseMode === "core";
 
       if (!UUID_REGEX.test(mbid)) {
         console.log(`[Artists Route] Invalid MBID format: ${mbid}`);
@@ -155,18 +160,22 @@ export default function registerDetails(router) {
       if (lidarrArtist) {
         const artistMbid =
           override?.musicbrainzId || lidarrArtist.foreignArtistId || mbid;
-        const [bio, tagsData] = await Promise.all([
-          getArtistBio(lidarrArtist.artistName, artistMbid),
-          getLastfmApiKey()
-            ? lastfmRequest("artist.getTopTags", { mbid: artistMbid })
-            : null,
-        ]);
-        const tags = tagsData?.toptags?.tag
-          ? (Array.isArray(tagsData.toptags.tag)
-              ? tagsData.toptags.tag
-              : [tagsData.toptags.tag]
-            ).map((t) => ({ name: t.name, count: t.count || 0 }))
-          : [];
+        const [bio, tagsData] = coreOnly
+          ? [null, null]
+          : await Promise.all([
+              getArtistBio(lidarrArtist.artistName, artistMbid),
+              getLastfmApiKey()
+                ? lastfmRequest("artist.getTopTags", { mbid: artistMbid })
+                : null,
+            ]);
+        const tags = coreOnly
+          ? []
+          : tagsData?.toptags?.tag
+            ? (Array.isArray(tagsData.toptags.tag)
+                ? tagsData.toptags.tag
+                : [tagsData.toptags.tag]
+              ).map((t) => ({ name: t.name, count: t.count || 0 }))
+            : [];
         const payload = {
           id: artistMbid,
           name: lidarrArtist.artistName,
@@ -213,25 +222,27 @@ export default function registerDetails(router) {
             : null) ||
           (await musicbrainzGetArtistNameByMbid(resolvedMbid)) ||
           "Unknown Artist";
-        const tagsData = getLastfmApiKey()
-          ? await lastfmRequest("artist.getTopTags", { mbid: resolvedMbid })
-          : null;
-        const tags = tagsData?.toptags?.tag
-          ? (Array.isArray(tagsData.toptags.tag)
-              ? tagsData.toptags.tag
-              : [tagsData.toptags.tag]
-            ).map((t) => ({ name: t.name, count: t.count || 0 }))
-          : [];
+        const tagsData =
+          !coreOnly && getLastfmApiKey()
+            ? await lastfmRequest("artist.getTopTags", { mbid: resolvedMbid })
+            : null;
+        const tags =
+          !coreOnly && tagsData?.toptags?.tag
+            ? (Array.isArray(tagsData.toptags.tag)
+                ? tagsData.toptags.tag
+                : [tagsData.toptags.tag]
+              ).map((t) => ({ name: t.name, count: t.count || 0 }))
+            : [];
         const releaseGroups =
           await musicbrainzGetArtistReleaseGroups(resolvedMbid);
-        if (getLastfmApiKey()) {
+        if (!coreOnly && getLastfmApiKey()) {
           await enrichReleaseGroupsWithLastfm(
             releaseGroups,
             name,
             resolvedMbid,
           );
         }
-        const bio = await getArtistBio(name, resolvedMbid);
+        const bio = coreOnly ? null : await getArtistBio(name, resolvedMbid);
         return {
           id: resolvedMbid,
           name,

--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -15,6 +15,14 @@ export default function registerReleaseGroup(router) {
   router.get("/release-group/:mbid/cover", cacheMiddleware(86400), async (req, res) => {
     try {
       const { mbid } = req.params;
+      const artistName =
+        typeof req.query.artistName === "string" && req.query.artistName.trim()
+          ? req.query.artistName.trim()
+          : "";
+      const albumTitleFromQuery =
+        typeof req.query.albumTitle === "string" && req.query.albumTitle.trim()
+          ? req.query.albumTitle.trim()
+          : "";
 
       if (!UUID_REGEX.test(mbid)) {
         return res.status(400).json({ error: "Invalid MBID format", images: [] });
@@ -59,18 +67,30 @@ export default function registerReleaseGroup(router) {
       }
 
       try {
-        const rgData = await musicbrainzRequest(`/release-group/${mbid}`, {
-          inc: "artist-credits",
-        });
-        const artistName = Array.isArray(rgData?.["artist-credit"])
-          ? rgData["artist-credit"]
-              .map((credit) => credit?.name || credit?.artist?.name || "")
-              .join(" ")
-              .trim()
-          : "";
-        const albumTitle = String(rgData?.title || "").trim();
+        let resolvedArtistName = artistName;
+        let albumTitle = albumTitleFromQuery;
 
-        const itunesImageUrl = await fetchItunesAlbumArt(artistName, albumTitle);
+        if (!resolvedArtistName || !albumTitle) {
+          const rgData = await musicbrainzRequest(`/release-group/${mbid}`, {
+            inc: "artist-credits",
+          });
+          if (!resolvedArtistName) {
+            resolvedArtistName = Array.isArray(rgData?.["artist-credit"])
+              ? rgData["artist-credit"]
+                  .map((credit) => credit?.name || credit?.artist?.name || "")
+                  .join(" ")
+                  .trim()
+              : "";
+          }
+          if (!albumTitle) {
+            albumTitle = String(rgData?.title || "").trim();
+          }
+        }
+
+        const itunesImageUrl = await fetchItunesAlbumArt(
+          resolvedArtistName,
+          albumTitle,
+        );
         if (itunesImageUrl) {
           const cachedImage = await warmImageProxy(itunesImageUrl);
           dbOps.setImage(cacheKey, cachedImage.localUrl);

--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -1,11 +1,15 @@
 import { UUID_REGEX } from "../../../config/constants.js";
 import {
+  fetchItunesAlbumArt,
   fetchCoverArtArchiveReleaseGroup,
   musicbrainzRequest,
 } from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
-import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
+import { warmImageProxy } from "../../../services/imageProxyService.js";
+
+const LEGACY_COVER_HOST_PATTERN =
+  /https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org|archive\.org|[\w-]+\.ca\.archive\.org)\//i;
 
 export default function registerReleaseGroup(router) {
   router.get("/release-group/:mbid/cover", cacheMiddleware(86400), async (req, res) => {
@@ -22,20 +26,31 @@ export default function registerReleaseGroup(router) {
       if (
         cachedImage &&
         cachedImage.imageUrl &&
-        cachedImage.imageUrl !== "NOT_FOUND"
+        cachedImage.imageUrl !== "NOT_FOUND" &&
+        !LEGACY_COVER_HOST_PATTERN.test(cachedImage.imageUrl)
       ) {
-        const cachedUrl =
-          buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl;
+        warmImageProxy(cachedImage.imageUrl).catch(() => {
+          dbOps.deleteImage(cacheKey);
+        });
         res.set("Cache-Control", "public, max-age=31536000, immutable");
         return res.json({
           images: [
             {
-              image: cachedUrl,
+              image: cachedImage.imageUrl,
               front: true,
               types: ["Front"],
             },
           ],
         });
+      }
+
+      if (
+        cachedImage &&
+        cachedImage.imageUrl &&
+        cachedImage.imageUrl !== "NOT_FOUND" &&
+        LEGACY_COVER_HOST_PATTERN.test(cachedImage.imageUrl)
+      ) {
+        dbOps.deleteImage(cacheKey);
       }
 
       if (cachedImage && cachedImage.imageUrl === "NOT_FOUND") {
@@ -44,27 +59,57 @@ export default function registerReleaseGroup(router) {
       }
 
       try {
+        const rgData = await musicbrainzRequest(`/release-group/${mbid}`, {
+          inc: "artist-credits",
+        });
+        const artistName = Array.isArray(rgData?.["artist-credit"])
+          ? rgData["artist-credit"]
+              .map((credit) => credit?.name || credit?.artist?.name || "")
+              .join(" ")
+              .trim()
+          : "";
+        const albumTitle = String(rgData?.title || "").trim();
+
+        const itunesImageUrl = await fetchItunesAlbumArt(artistName, albumTitle);
+        if (itunesImageUrl) {
+          const cachedImage = await warmImageProxy(itunesImageUrl);
+          dbOps.setImage(cacheKey, cachedImage.localUrl);
+          res.set("Cache-Control", "public, max-age=31536000, immutable");
+          return res.json({
+            images: [
+              {
+                image: cachedImage.localUrl,
+                front: true,
+                types: ["Front"],
+              },
+            ],
+          });
+        }
+
         const cover = await fetchCoverArtArchiveReleaseGroup(mbid);
         if (cover?.imageUrl) {
-          dbOps.setImage(cacheKey, cover.imageUrl);
-          const proxiedCoverUrl =
-            buildImageProxyUrl(cover.imageUrl) || cover.imageUrl;
+          const cachedImage = await warmImageProxy(cover.imageUrl);
+          dbOps.setImage(cacheKey, cachedImage.localUrl);
 
           res.set("Cache-Control", "public, max-age=31536000, immutable");
           return res.json({
             images: [
               {
-                image: proxiedCoverUrl,
+                image: cachedImage.localUrl,
                 front: true,
                 types: cover.types,
               },
             ],
           });
         }
+        if (cover?.notFound) {
+          dbOps.setImage(cacheKey, "NOT_FOUND");
+          res.set("Cache-Control", "public, max-age=3600");
+          return res.json({ images: [] });
+        }
       } catch (e) {}
 
-      dbOps.setImage(cacheKey, "NOT_FOUND");
-      res.set("Cache-Control", "public, max-age=3600");
+      res.set("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
       res.json({ images: [] });
     } catch (error) {
       console.error(

--- a/backend/routes/artists/handlers/search.js
+++ b/backend/routes/artists/handlers/search.js
@@ -1,4 +1,4 @@
-import { cacheMiddleware } from "../../../middleware/cache.js";
+import { noCache } from "../../../middleware/cache.js";
 import { searchArtistsLegacy } from "../../../services/searchService.js";
 
 const handleSearch = async (req, res) => {
@@ -19,6 +19,6 @@ const handleSearch = async (req, res) => {
 };
 
 export default function registerSearch(router) {
-  router.get("/search", cacheMiddleware(300), handleSearch);
-  router.get("/artists", cacheMiddleware(300), handleSearch);
+  router.get("/search", noCache, handleSearch);
+  router.get("/artists", noCache, handleSearch);
 }

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -287,9 +287,7 @@ export default function registerStream(router) {
               sendSSE(res, "cover", {
                 images: [
                   {
-                    image:
-                      buildImageProxyUrl(cachedImage.imageUrl) ||
-                      cachedImage.imageUrl,
+                    image: cachedImage.imageUrl,
                     front: true,
                     types: ["Front"],
                   },
@@ -301,15 +299,14 @@ export default function registerStream(router) {
             const cover = await getArtistImage(mbid);
             if (cover?.images?.length) {
               sendSSE(res, "cover", {
-                images: cover.images.map((image) => ({
-                  ...image,
-                  image: buildImageProxyUrl(image.image) || image.image,
-                })),
+                images: cover.images,
               });
               return;
             }
 
-            dbOps.setImage(mbid, "NOT_FOUND");
+            if (cover?.notFound) {
+              dbOps.setImage(mbid, "NOT_FOUND");
+            }
             sendSSE(res, "cover", { images: [] });
           } catch (e) {
             sendSSE(res, "cover", { images: [] });

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -79,62 +79,6 @@ export default function registerStream(router) {
       });
 
       try {
-        const { lidarrClient } =
-          await import("../../../services/lidarrClient.js");
-        const { libraryManager } =
-          await import("../../../services/libraryManager.js");
-
-        let lidarrArtist = null;
-        let lidarrAlbums = [];
-
-        if (lidarrClient.isConfigured()) {
-          try {
-            lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
-            if (lidarrArtist) {
-              console.log(
-                `[Artists Stream] Found artist in Lidarr: ${lidarrArtist.artistName}`,
-              );
-              const libraryArtist = await libraryManager.getArtist(mbid);
-              if (libraryArtist) {
-                lidarrAlbums = await libraryManager.getAlbums(libraryArtist.id);
-              }
-              sendArtist({
-                ...buildArtistBase(lidarrArtist.artistName),
-                _lidarrData: {
-                  id: lidarrArtist.id,
-                  monitored: lidarrArtist.monitored,
-                  statistics: lidarrArtist.statistics,
-                },
-              });
-
-              const libArtist = libraryManager.mapLidarrArtist(lidarrArtist);
-              sendSSE(res, "library", {
-                exists: true,
-                artist: {
-                  ...libArtist,
-                  foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
-                  added: libArtist.addedAt,
-                },
-                albums: lidarrAlbums.map((a) => ({
-                  ...a,
-                  foreignAlbumId: a.foreignAlbumId || a.mbid,
-                  title: a.albumName,
-                  albumType: "Album",
-                  statistics: a.statistics || {
-                    trackCount: 0,
-                    sizeOnDisk: 0,
-                    percentOfTracks: 0,
-                  },
-                })),
-              });
-            }
-          } catch (error) {
-            console.warn(
-              `[Artists Stream] Failed to fetch from Lidarr: ${error.message}`,
-            );
-          }
-        }
-
         const tasks = [];
         let fullArtistPromise = null;
         const pendingPromise = pendingArtistRequests.has(mbid)
@@ -158,6 +102,66 @@ export default function registerStream(router) {
                 "Unknown Artist";
               return name;
             })();
+
+        const libraryTask = (async () => {
+          const { lidarrClient } =
+            await import("../../../services/lidarrClient.js");
+          const { libraryManager } =
+            await import("../../../services/libraryManager.js");
+
+          if (!lidarrClient.isConfigured()) return;
+
+          try {
+            const lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
+            if (!lidarrArtist || !isClientConnected()) return;
+
+            console.log(
+              `[Artists Stream] Found artist in Lidarr: ${lidarrArtist.artistName}`,
+            );
+
+            sendArtist({
+              ...buildArtistBase(lidarrArtist.artistName),
+              _lidarrData: {
+                id: lidarrArtist.id,
+                monitored: lidarrArtist.monitored,
+                statistics: lidarrArtist.statistics,
+              },
+            });
+
+            const libraryArtist = await libraryManager.getArtist(mbid);
+            const lidarrAlbums = libraryArtist
+              ? await libraryManager.getAlbums(libraryArtist.id)
+              : [];
+
+            if (!isClientConnected()) return;
+
+            const libArtist = libraryManager.mapLidarrArtist(lidarrArtist);
+            sendSSE(res, "library", {
+              exists: true,
+              artist: {
+                ...libArtist,
+                foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
+                added: libArtist.addedAt,
+              },
+              albums: lidarrAlbums.map((a) => ({
+                ...a,
+                foreignAlbumId: a.foreignAlbumId || a.mbid,
+                title: a.albumName,
+                albumType: "Album",
+                statistics: a.statistics || {
+                  trackCount: 0,
+                  sizeOnDisk: 0,
+                  percentOfTracks: 0,
+                },
+              })),
+            });
+          } catch (error) {
+            console.warn(
+              `[Artists Stream] Failed to fetch from Lidarr: ${error.message}`,
+            );
+          }
+        })();
+        tasks.push(libraryTask);
 
         if (pendingPromise) {
           console.log(
@@ -296,7 +300,11 @@ export default function registerStream(router) {
               return;
             }
 
-            const cover = await getArtistImage(mbid);
+            const artistName =
+              (await namePromise.catch(() => null)) || streamArtistName || null;
+            const cover = await getArtistImage(mbid, {
+              artistName,
+            });
             if (cover?.images?.length) {
               sendSSE(res, "cover", {
                 images: cover.images,

--- a/backend/routes/artists/utils.js
+++ b/backend/routes/artists/utils.js
@@ -22,12 +22,15 @@ export const sendSSE = (res, event, data) => {
 export const pendingCoverRequests = new Map();
 export const pendingArtistRequests = new Map();
 
-export const fetchCoverInBackground = async (mbid) => {
+export const fetchCoverInBackground = async (mbid, artistName = null) => {
   if (pendingCoverRequests.has(mbid)) return;
 
   const fetchPromise = (async () => {
     try {
-      await getArtistImage(mbid, false);
+      await getArtistImage(mbid, {
+        forceRefresh: false,
+        artistName,
+      });
     } catch (e) {}
   })();
 

--- a/backend/routes/imageProxy.js
+++ b/backend/routes/imageProxy.js
@@ -3,6 +3,6 @@ import { handleImageProxyRequest } from "../services/imageProxyService.js";
 
 const router = express.Router();
 
-router.get("/", handleImageProxyRequest);
+router.get("/:cacheKey", handleImageProxyRequest);
 
 export default router;

--- a/backend/routes/imageProxy.js
+++ b/backend/routes/imageProxy.js
@@ -1,8 +1,12 @@
 import express from "express";
-import { handleImageProxyRequest } from "../services/imageProxyService.js";
+import {
+  handleImageProxyRequest,
+  handleLegacyImageProxyRequest,
+} from "../services/imageProxyService.js";
 
 const router = express.Router();
 
+router.get("/", handleLegacyImageProxyRequest);
 router.get("/:cacheKey", handleImageProxyRequest);
 
 export default router;

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -1,6 +1,7 @@
 import { UUID_REGEX } from "../../../config/constants.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
+import { fetchReleaseGroupCoverUrl } from "../../../services/imageService.js";
 import { libraryManager } from "../../../services/libraryManager.js";
 import { qualityManager } from "../../../services/qualityManager.js";
 
@@ -244,11 +245,42 @@ export default function registerMisc(router) {
           .map((id) => `rg:${id}`),
       );
 
+      const coverTargets = recentMissing.slice(0, 6);
+      const warmedVisibleCovers = await Promise.all(
+        coverTargets.map(async (album) => {
+          const coverId = album.mbid || album.foreignAlbumId;
+          if (!coverId) return [null, null];
+
+          const cachedUrl = cachedCovers[`rg:${coverId}`]?.imageUrl || null;
+          if (cachedUrl && cachedUrl !== "NOT_FOUND") {
+            return [coverId, buildImageProxyUrl(cachedUrl) || cachedUrl];
+          }
+
+          const cover = await fetchReleaseGroupCoverUrl(coverId, {
+            artistName: album.artistName || "",
+            albumTitle: album.albumName || "",
+          }).catch(() => null);
+
+          if (!cover?.imageUrl) {
+            return [coverId, null];
+          }
+
+          return [
+            coverId,
+            buildImageProxyUrl(cover.imageUrl) || cover.imageUrl,
+          ];
+        }),
+      );
+
+      const warmedCoverMap = Object.fromEntries(
+        warmedVisibleCovers.filter(([coverId, coverUrl]) => coverId && coverUrl),
+      );
+
       const withCachedCovers = recentMissing.map((album) => {
         const coverId = album.mbid || album.foreignAlbumId;
-        const coverUrl = coverId
-          ? cachedCovers[`rg:${coverId}`]?.imageUrl || null
-          : null;
+        const coverUrl =
+          (coverId ? warmedCoverMap[coverId] : null) ||
+          (coverId ? cachedCovers[`rg:${coverId}`]?.imageUrl || null : null);
         return {
           ...album,
           coverUrl:

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { cacheMiddleware } from "../middleware/cache.js";
+import { noCache } from "../middleware/cache.js";
 import {
   searchAlbums,
   searchArtists,
@@ -8,7 +8,7 @@ import {
 
 const router = express.Router();
 
-router.get("/", cacheMiddleware(300), async (req, res) => {
+router.get("/", noCache, async (req, res) => {
   try {
     const {
       q,
@@ -40,7 +40,7 @@ router.get("/", cacheMiddleware(300), async (req, res) => {
   }
 });
 
-router.get("/artists", cacheMiddleware(300), async (req, res) => {
+router.get("/artists", noCache, async (req, res) => {
   try {
     const { query, limit = 24, offset = 0 } = req.query;
     if (!String(query || "").trim()) {

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -12,6 +12,9 @@ router.use(requireAdmin);
 router.get("/", noCache, (req, res) => {
   try {
     const settings = dbOps.getSettings();
+    if (settings?.integrations?.coverArtArchive) {
+      delete settings.integrations.coverArtArchive;
+    }
     res.json(settings);
   } catch (error) {
     console.error("Settings GET error:", error);
@@ -56,22 +59,6 @@ router.post("/", async (req, res) => {
       });
     }
 
-    const coverArtArchiveProvider = integrations?.coverArtArchive?.provider;
-    const validCoverArtArchiveProviders = new Set([
-      "aurralHosted",
-      "official",
-      "custom",
-    ]);
-    if (
-      coverArtArchiveProvider !== undefined &&
-      !validCoverArtArchiveProviders.has(coverArtArchiveProvider)
-    ) {
-      return res.status(400).json({
-        error:
-          "Invalid Cover Art Archive provider. Expected aurralHosted, official, or custom.",
-      });
-    }
-
     if (integrations?.musicbrainz) {
       const nextMusicbrainz = {
         ...(currentSettings.integrations?.musicbrainz || {}),
@@ -101,37 +88,8 @@ router.post("/", async (req, res) => {
 
       integrations.musicbrainz = nextMusicbrainz;
     }
-
     if (integrations?.coverArtArchive) {
-      const nextCoverArtArchive = {
-        ...(currentSettings.integrations?.coverArtArchive || {}),
-        ...integrations.coverArtArchive,
-      };
-      const provider = validCoverArtArchiveProviders.has(
-        nextCoverArtArchive.provider,
-      )
-        ? nextCoverArtArchive.provider
-        : "aurralHosted";
-      nextCoverArtArchive.provider = provider;
-
-      if (provider === "custom") {
-        const customUrlValidation = validateExternalUrl(
-          nextCoverArtArchive.customUrl || "",
-        );
-        if (!customUrlValidation.valid) {
-          return res.status(400).json({
-            error: `Invalid custom Cover Art Archive URL: ${customUrlValidation.error}`,
-          });
-        }
-        nextCoverArtArchive.customUrl = customUrlValidation.url;
-      } else {
-        nextCoverArtArchive.customUrl =
-          typeof nextCoverArtArchive.customUrl === "string"
-            ? nextCoverArtArchive.customUrl.trim()
-            : "";
-      }
-
-      integrations.coverArtArchive = nextCoverArtArchive;
+      delete integrations.coverArtArchive;
     }
 
     let mergedIntegrations =
@@ -176,12 +134,6 @@ router.post("/", async (req, res) => {
               ...integrations.musicbrainz,
             }
           : mergedIntegrations.musicbrainz,
-        coverArtArchive: integrations.coverArtArchive
-          ? {
-              ...(mergedIntegrations.coverArtArchive || {}),
-              ...integrations.coverArtArchive,
-            }
-          : mergedIntegrations.coverArtArchive,
         general: integrations.general
           ? {
               ...(mergedIntegrations.general || {}),
@@ -206,6 +158,10 @@ router.post("/", async (req, res) => {
       };
     }
 
+    if (mergedIntegrations?.coverArtArchive) {
+      delete mergedIntegrations.coverArtArchive;
+    }
+
     const updatedSettings = {
       ...currentSettings,
       quality:
@@ -220,6 +176,10 @@ router.post("/", async (req, res) => {
           : currentSettings.releaseTypes || defaultData.settings.releaseTypes,
       integrations: mergedIntegrations,
     };
+
+    if (updatedSettings?.integrations?.coverArtArchive) {
+      delete updatedSettings.integrations.coverArtArchive;
+    }
 
     dbOps.updateSettings(updatedSettings);
     res.json(updatedSettings);

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -39,6 +39,11 @@ const musicbrainzReleaseGroupsCache = new NodeCache({
   checkperiod: 120,
   maxKeys: 500,
 });
+const itunesAlbumArtCache = new NodeCache({
+  stdTTL: 24 * 60 * 60,
+  checkperiod: 10 * 60,
+  maxKeys: 2000,
+});
 
 const METADATA_PROVIDER_HEALTH_CONFIG = {
   failureThreshold: 3,
@@ -282,7 +287,7 @@ const probeCoverArtArchiveHostedHealth = async () => {
 
   state.probeInFlight = axios
     .head(
-      `${COVER_ART_ARCHIVE_API}/release-group/00000000-0000-0000-0000-000000000000/front-250`,
+      `${COVER_ART_ARCHIVE_API}/release-group/00000000-0000-0000-0000-000000000000/front`,
       {
         timeout: METADATA_PROVIDER_HEALTH_CONFIG.probeTimeoutMs,
         validateStatus: (status) => status >= 200 && status < 500,
@@ -473,6 +478,13 @@ const listenbrainzLimiter = new Bottleneck({
   maxConcurrent: 4,
   minTime: 250,
 });
+const itunesLimiter = new Bottleneck({
+  reservoir: 20,
+  reservoirRefreshAmount: 20,
+  reservoirRefreshInterval: 1000,
+  maxConcurrent: 20,
+  minTime: 0,
+});
 
 let musicbrainzLast503Log = 0;
 const lastfmInflightRequests = new Map();
@@ -611,10 +623,100 @@ export const musicbrainzRequest = async (endpoint, params = {}) => {
   );
 };
 
+const normalizeItunesArtworkUrl = (url) =>
+  String(url || "")
+    .trim()
+    .replace(/\/100x100([a-z]+)(?=[/?#]|$)/i, "/600x600$1")
+    .replace(/\/\d+x\d+([a-z]+)(?=[/?#]|$)/i, "/600x600$1");
+
+export async function fetchItunesAlbumArt(artistName, albumName) {
+  const normalizedArtist = String(artistName || "").trim();
+  const normalizedAlbum = String(albumName || "").trim();
+  if (!normalizedArtist || !normalizedAlbum) return null;
+
+  const cacheKey = `${normalizedArtist.toLowerCase()}::${normalizedAlbum.toLowerCase()}`;
+  const cached = itunesAlbumArtCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const response = await itunesLimiter.schedule(() =>
+      axios.get("https://itunes.apple.com/search", {
+        params: {
+          term: `${normalizedArtist} ${normalizedAlbum}`,
+          media: "music",
+          entity: "album",
+          limit: 5,
+        },
+        timeout: 3000,
+      }),
+    );
+
+    const results = Array.isArray(response?.data?.results)
+      ? response.data.results
+      : [];
+
+    const normalizedAlbumTitle = normalizeTitle(normalizedAlbum);
+    const normalizedArtistTitle = normalizeTitle(normalizedArtist);
+    const exactMatch =
+      results.find((item) => {
+        const itemAlbum = normalizeTitle(item?.collectionName || "");
+        const itemArtist = normalizeTitle(item?.artistName || "");
+        return itemAlbum === normalizedAlbumTitle && itemArtist === normalizedArtistTitle;
+      }) || results[0];
+
+    const artworkUrl = normalizeItunesArtworkUrl(exactMatch?.artworkUrl100 || "");
+    const value = artworkUrl || null;
+    itunesAlbumArtCache.set(cacheKey, value);
+    return value;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
   if (!releaseGroupMbid) return null;
   const baseUrl = getCoverArtArchiveApiBaseUrl();
-  const directUrl = `${baseUrl}/release-group/${releaseGroupMbid}/front-250`;
+  const directUrl = `${baseUrl}/release-group/${releaseGroupMbid}/front`;
+  let sawTransientError = false;
+
+  const markHostedHealth = () => {
+    if (
+      getCoverArtArchiveProvider() === "aurralHosted" &&
+      getMetadataProviderSelection("coverArtArchive").activeProvider ===
+        "aurralHosted"
+    ) {
+      probeCoverArtArchiveHostedHealth().catch(() => {});
+    }
+  };
+
+  const fetchReleaseFront = async (releaseMbid) => {
+    if (!releaseMbid) return null;
+    const releaseDirectUrl = `${baseUrl}/release/${releaseMbid}/front`;
+    try {
+      const response = await axios.head(releaseDirectUrl, {
+        timeout: 2000,
+        maxRedirects: 0,
+        validateStatus: (status) =>
+          status === 200 || status === 301 || status === 302 || status === 307,
+      });
+      if (response.status >= 200 && response.status < 400) {
+        return {
+          imageUrl: releaseDirectUrl,
+          types: ["Front"],
+        };
+      }
+    } catch (error) {
+      const status = error?.response?.status;
+      if (status === 404) return { imageUrl: null, notFound: true, types: [] };
+      if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
+        sawTransientError = true;
+      }
+      markHostedHealth();
+    }
+    return null;
+  };
 
   try {
     const response = await axios.head(directUrl, {
@@ -631,24 +733,30 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
       };
     }
   } catch (error) {
-    if (
-      getCoverArtArchiveProvider() === "aurralHosted" &&
-      getMetadataProviderSelection("coverArtArchive").activeProvider ===
-        "aurralHosted"
-    ) {
-      probeCoverArtArchiveHostedHealth().catch(() => {});
+    const status = error?.response?.status;
+    if (status === 404) {
+      return { imageUrl: null, types: [], notFound: true };
     }
+    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
+      sawTransientError = true;
+    }
+    markHostedHealth();
   }
 
   try {
-    const response = await axios.get(`${baseUrl}/release-group/${releaseGroupMbid}`, {
-      headers: { Accept: "application/json" },
-      timeout: 2000,
-    });
+    const response = await axios.get(
+      `${baseUrl}/release-group/${releaseGroupMbid}`,
+      {
+        headers: { Accept: "application/json" },
+        timeout: 2000,
+      },
+    );
     const images = Array.isArray(response?.data?.images)
       ? response.data.images
       : [];
-    if (!images.length) return null;
+    if (!images.length) {
+      return { imageUrl: null, types: [], notFound: true };
+    }
 
     const frontImage = images.find((img) => img.front) || images[0];
     return {
@@ -656,16 +764,39 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
       types: frontImage?.types || ["Front"],
     };
   } catch (error) {
-    if (
-      getCoverArtArchiveProvider() === "aurralHosted" &&
-      getMetadataProviderSelection("coverArtArchive").activeProvider ===
-        "aurralHosted"
-    ) {
-      probeCoverArtArchiveHostedHealth().catch(() => {});
+    const status = error?.response?.status;
+    if (status === 404) {
+      return { imageUrl: null, types: [], notFound: true };
+    }
+    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
+      sawTransientError = true;
+    }
+    markHostedHealth();
+  }
+
+  try {
+    const rgData = await musicbrainzRequest(`/release-group/${releaseGroupMbid}`, {
+      inc: "releases",
+    });
+    const releases = Array.isArray(rgData?.releases) ? rgData.releases : [];
+    for (const release of releases.slice(0, 8)) {
+      const cover = await fetchReleaseFront(release?.id);
+      if (cover?.imageUrl) {
+        return cover;
+      }
+    }
+  } catch (error) {
+    const status = error?.response?.status;
+    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
+      sawTransientError = true;
     }
   }
 
-  return null;
+  if (sawTransientError) {
+    return { imageUrl: null, types: [], transientError: true };
+  }
+
+  return { imageUrl: null, types: [], notFound: true };
 }
 
 export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -5,7 +5,6 @@ import { dbOps } from "../config/db-helpers.js";
 import {
   MUSICBRAINZ_API,
   AURRAL_MUSICBRAINZ_API,
-  COVER_ART_ARCHIVE_API,
   OFFICIAL_COVER_ART_ARCHIVE_API,
   LASTFM_API,
   LISTENBRAINZ_API,
@@ -67,7 +66,6 @@ const createProviderHealthState = () => ({
 
 const metadataProviderHealth = {
   musicbrainz: createProviderHealthState(),
-  coverArtArchive: createProviderHealthState(),
 };
 
 let metadataProviderProbeTimer = null;
@@ -114,19 +112,6 @@ const normalizeMusicbrainzApiBaseUrl = (value) => {
   return parsed.toString().replace(/\/+$/, "");
 };
 
-const normalizeBaseUrl = (value, fallback) => {
-  const raw = String(value || "").trim();
-  if (!raw) return fallback;
-
-  try {
-    const parsed = new URL(raw);
-    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "";
-    return parsed.toString().replace(/\/+$/, "");
-  } catch {
-    return fallback;
-  }
-};
-
 const nowIso = () => new Date().toISOString();
 
 const getMetadataProviderSelection = (serviceKey) => {
@@ -161,37 +146,6 @@ const getMetadataProviderSelection = (serviceKey) => {
         : AURRAL_MUSICBRAINZ_API,
     };
   }
-
-  const provider =
-    settings.integrations?.coverArtArchive?.provider || "aurralHosted";
-  if (provider === "official") {
-    return {
-      mode: "manual",
-      provider,
-      activeProvider: "official",
-      activeBaseUrl: OFFICIAL_COVER_ART_ARCHIVE_API,
-    };
-  }
-  if (provider === "custom") {
-    return {
-      mode: "manual",
-      provider,
-      activeProvider: "custom",
-      activeBaseUrl: normalizeBaseUrl(
-        settings.integrations?.coverArtArchive?.customUrl,
-        OFFICIAL_COVER_ART_ARCHIVE_API,
-      ),
-    };
-  }
-  const state = metadataProviderHealth.coverArtArchive;
-  return {
-    mode: "auto",
-    provider,
-    activeProvider: state.failoverActive ? "official" : "aurralHosted",
-    activeBaseUrl: state.failoverActive
-      ? OFFICIAL_COVER_ART_ARCHIVE_API
-      : COVER_ART_ARCHIVE_API,
-  };
 };
 
 const markMetadataProviderProbeResult = (serviceKey, { success, reason = "" }) => {
@@ -278,46 +232,8 @@ const probeMusicbrainzHostedHealth = async () => {
   return state.probeInFlight;
 };
 
-const probeCoverArtArchiveHostedHealth = async () => {
-  const selection = getMetadataProviderSelection("coverArtArchive");
-  if (selection.provider !== "aurralHosted") return null;
-
-  const state = metadataProviderHealth.coverArtArchive;
-  if (state.probeInFlight) return state.probeInFlight;
-
-  state.probeInFlight = axios
-    .head(
-      `${COVER_ART_ARCHIVE_API}/release-group/00000000-0000-0000-0000-000000000000/front`,
-      {
-        timeout: METADATA_PROVIDER_HEALTH_CONFIG.probeTimeoutMs,
-        validateStatus: (status) => status >= 200 && status < 500,
-      },
-    )
-    .then(() => {
-      markMetadataProviderProbeResult("coverArtArchive", { success: true });
-      return true;
-    })
-    .catch((error) => {
-      const status = error?.response?.status;
-      const reason = status ? `HTTP ${status}` : error?.code || error?.message;
-      markMetadataProviderProbeResult("coverArtArchive", {
-        success: false,
-        reason,
-      });
-      return false;
-    })
-    .finally(() => {
-      state.probeInFlight = null;
-    });
-
-  return state.probeInFlight;
-};
-
 const runMetadataProviderHealthProbes = () =>
-  Promise.allSettled([
-    probeMusicbrainzHostedHealth(),
-    probeCoverArtArchiveHostedHealth(),
-  ]);
+  Promise.allSettled([probeMusicbrainzHostedHealth()]);
 
 const getMetadataProviderProbeIntervalMs = () => {
   const states = Object.values(metadataProviderHealth);
@@ -354,11 +270,6 @@ const getMusicbrainzProvider = () => {
   return settings.integrations?.musicbrainz?.provider || "aurralHosted";
 };
 
-const getCoverArtArchiveProvider = () => {
-  const settings = dbOps.getSettings();
-  return settings.integrations?.coverArtArchive?.provider || "aurralHosted";
-};
-
 export const getMusicbrainzApiBaseUrl = () => {
   ensureMetadataProviderProbeLoop();
   return getMetadataProviderSelection("musicbrainz").activeBaseUrl;
@@ -369,8 +280,7 @@ export const getMusicbrainzApiBaseUrls = () => {
 };
 
 export const getCoverArtArchiveApiBaseUrl = () => {
-  ensureMetadataProviderProbeLoop();
-  return getMetadataProviderSelection("coverArtArchive").activeBaseUrl;
+  return OFFICIAL_COVER_ART_ARCHIVE_API;
 };
 
 export const getCoverArtArchiveApiBaseUrls = () => {
@@ -379,9 +289,6 @@ export const getCoverArtArchiveApiBaseUrls = () => {
 
 export const getMetadataProviderHealthSnapshot = () => {
   const musicbrainzSelection = getMetadataProviderSelection("musicbrainz");
-  const coverArtArchiveSelection = getMetadataProviderSelection(
-    "coverArtArchive",
-  );
 
   return {
     musicbrainz: {
@@ -401,26 +308,6 @@ export const getMetadataProviderHealthSnapshot = () => {
       lastFailureAt: metadataProviderHealth.musicbrainz.lastFailureAt,
       lastFailureReason: metadataProviderHealth.musicbrainz.lastFailureReason,
       lastTransitionAt: metadataProviderHealth.musicbrainz.lastTransitionAt,
-    },
-    coverArtArchive: {
-      mode: coverArtArchiveSelection.mode,
-      configuredProvider: coverArtArchiveSelection.provider,
-      activeProvider: coverArtArchiveSelection.activeProvider,
-      activeBaseUrl: coverArtArchiveSelection.activeBaseUrl,
-      failoverActive:
-        coverArtArchiveSelection.mode === "auto"
-          ? metadataProviderHealth.coverArtArchive.failoverActive
-          : false,
-      consecutiveFailures:
-        metadataProviderHealth.coverArtArchive.consecutiveFailures,
-      consecutiveSuccesses:
-        metadataProviderHealth.coverArtArchive.consecutiveSuccesses,
-      lastCheckedAt: metadataProviderHealth.coverArtArchive.lastCheckedAt,
-      lastSuccessAt: metadataProviderHealth.coverArtArchive.lastSuccessAt,
-      lastFailureAt: metadataProviderHealth.coverArtArchive.lastFailureAt,
-      lastFailureReason:
-        metadataProviderHealth.coverArtArchive.lastFailureReason,
-      lastTransitionAt: metadataProviderHealth.coverArtArchive.lastTransitionAt,
     },
   };
 };
@@ -465,8 +352,8 @@ const configureMusicbrainzLimiter = async () => {
   }
 
   await mbLimiter.updateSettings({
-    maxConcurrent: 4,
-    minTime: 100,
+    maxConcurrent: 20,
+    minTime: 0,
   });
 };
 
@@ -681,16 +568,6 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
   const directUrl = `${baseUrl}/release-group/${releaseGroupMbid}/front`;
   let sawTransientError = false;
 
-  const markHostedHealth = () => {
-    if (
-      getCoverArtArchiveProvider() === "aurralHosted" &&
-      getMetadataProviderSelection("coverArtArchive").activeProvider ===
-        "aurralHosted"
-    ) {
-      probeCoverArtArchiveHostedHealth().catch(() => {});
-    }
-  };
-
   const fetchReleaseFront = async (releaseMbid) => {
     if (!releaseMbid) return null;
     const releaseDirectUrl = `${baseUrl}/release/${releaseMbid}/front`;
@@ -713,7 +590,6 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
       if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
         sawTransientError = true;
       }
-      markHostedHealth();
     }
     return null;
   };
@@ -740,7 +616,6 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
     if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
       sawTransientError = true;
     }
-    markHostedHealth();
   }
 
   try {
@@ -771,7 +646,6 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
     if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
       sawTransientError = true;
     }
-    markHostedHealth();
   }
 
   try {

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -673,7 +673,8 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
   return { imageUrl: null, types: [], notFound: true };
 }
 
-export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {
+export const lastfmRequest = lastfmLimiter.wrap(
+  async (method, params = {}, options = {}) => {
   const apiKey = getLastfmApiKey();
   if (!apiKey) return null;
 
@@ -682,6 +683,12 @@ export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {
   if (cached) return cached;
   const inflight = lastfmInflightRequests.get(cacheKey);
   if (inflight) return inflight;
+  const timeoutMs = Number.isFinite(Number(options?.timeoutMs))
+    ? Math.max(500, Math.floor(Number(options.timeoutMs)))
+    : LASTFM_TIMEOUT_MS;
+  const maxRetries = Number.isFinite(Number(options?.maxRetries))
+    ? Math.max(0, Math.floor(Number(options.maxRetries)))
+    : LASTFM_MAX_RETRIES;
 
   const requestPromise = (async () => {
     const isRetryable = (error) => {
@@ -707,7 +714,7 @@ export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {
       console.error(message, details);
     };
     let lastError = null;
-    for (let retryCount = 0; retryCount <= LASTFM_MAX_RETRIES; retryCount++) {
+    for (let retryCount = 0; retryCount <= maxRetries; retryCount++) {
       try {
         const response = await axios.get(LASTFM_API, {
           params: {
@@ -716,13 +723,13 @@ export const lastfmRequest = lastfmLimiter.wrap(async (method, params = {}) => {
             format: "json",
             ...params,
           },
-          timeout: LASTFM_TIMEOUT_MS,
+          timeout: timeoutMs,
         });
         lastfmCache.set(cacheKey, response.data);
         return response.data;
       } catch (error) {
         lastError = error;
-        if (retryCount < LASTFM_MAX_RETRIES && isRetryable(error)) {
+        if (retryCount < maxRetries && isRetryable(error)) {
           const backoffMs = 300 * Math.pow(2, retryCount) + retryCount * 200;
           await new Promise((resolve) => setTimeout(resolve, backoffMs));
           continue;

--- a/backend/services/artistImageHydration.js
+++ b/backend/services/artistImageHydration.js
@@ -66,7 +66,9 @@ export const hydrateArtistImages = async (
     await Promise.all(
       batch.map(async ({ artist, id }) => {
         try {
-          const cover = await getArtistImage(id);
+          const cover = await getArtistImage(id, {
+            artistName: artist.name || artist.sortName || null,
+          });
           if (!cover?.url) return;
           const proxiedImage = buildImageProxyUrl(cover.url) || cover.url;
           artist.image = proxiedImage;
@@ -84,12 +86,26 @@ export const hydrateArtistImages = async (
 };
 
 export const primeArtistImageCache = (artists = []) => {
-  const ids = [...new Set(
+  return Promise.allSettled(
     (Array.isArray(artists) ? artists : [])
-      .map((artist) => getArtistId(artist))
-      .filter(Boolean),
-  )];
-  if (!ids.length) return Promise.resolve();
-
-  return Promise.allSettled(ids.map((id) => getArtistImage(id))).then(() => {});
+      .map((artist) => ({
+        id: getArtistId(artist),
+        artistName:
+          typeof artist?.name === "string" && artist.name.trim()
+            ? artist.name.trim()
+            : typeof artist?.sortName === "string" && artist.sortName.trim()
+              ? artist.sortName.trim()
+              : null,
+      }))
+      .filter((artist) => artist.id)
+      .filter(
+        (artist, index, list) =>
+          list.findIndex((entry) => entry.id === artist.id) === index,
+      )
+      .map(({ id, artistName }) =>
+        getArtistImage(id, {
+          artistName,
+        }),
+      ),
+  ).then(() => {});
 };

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -12,6 +12,9 @@ const IMAGE_PROXY_DIR = path.join(__dirname, "..", "data", "image-proxy");
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 25000;
 const inflightRequests = new Map();
+const cacheEntriesByKey = new Map();
+const cacheKeysBySourceUrl = new Map();
+let cacheIndexInitialized = false;
 
 const PRIVATE_HOST_PATTERNS = [
   /^localhost$/i,
@@ -35,6 +38,43 @@ const MIME_EXTENSION_MAP = {
 
 const ensureCacheDir = () => {
   fs.mkdirSync(IMAGE_PROXY_DIR, { recursive: true });
+};
+
+const initializeCacheIndex = () => {
+  if (cacheIndexInitialized) return;
+  ensureCacheDir();
+  cacheIndexInitialized = true;
+
+  const files = fs.readdirSync(IMAGE_PROXY_DIR);
+  for (const file of files) {
+    const match = file.match(/^([a-f0-9]{64})\.json$/i);
+    if (!match) continue;
+    const cacheKey = match[1].toLowerCase();
+    const metaPath = path.join(IMAGE_PROXY_DIR, file);
+    let meta = null;
+    try {
+      meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (!meta?.extension) continue;
+    const imagePath = path.join(IMAGE_PROXY_DIR, `${cacheKey}.${meta.extension}`);
+    if (!fs.existsSync(imagePath)) continue;
+    const sourceUrl = normalizeKnownImageUrl(meta.sourceUrl);
+    const entry = {
+      cacheKey,
+      meta,
+      imagePath,
+      localUrl: buildLocalImageUrl(cacheKey, meta.extension),
+      isFresh:
+        Number(meta.fetchedAt || 0) > 0 &&
+        Date.now() - Number(meta.fetchedAt || 0) < CACHE_TTL_MS,
+    };
+    cacheEntriesByKey.set(cacheKey, entry);
+    if (sourceUrl) {
+      cacheKeysBySourceUrl.set(sourceUrl, cacheKey);
+    }
+  }
 };
 
 const isPrivateHostname = (hostname) => {
@@ -88,28 +128,24 @@ const readCacheMetadata = (metaPath) => {
 
 const getCachedEntryFromKey = (cacheKey) => {
   if (!cacheKey) return null;
-  const { metaPath, baseImagePath } = getCachePaths(cacheKey);
-  const meta = readCacheMetadata(metaPath);
-  if (!meta?.extension) return null;
-
-  const imagePath = `${baseImagePath}.${meta.extension}`;
-  if (!fs.existsSync(imagePath)) return null;
-
+  initializeCacheIndex();
+  const entry = cacheEntriesByKey.get(cacheKey);
+  if (!entry) return null;
   return {
-    cacheKey,
-    meta,
-    imagePath,
-    localUrl: buildLocalImageUrl(cacheKey, meta.extension),
+    ...entry,
     isFresh:
-      Number(meta.fetchedAt || 0) > 0 &&
-      Date.now() - Number(meta.fetchedAt || 0) < CACHE_TTL_MS,
+      Number(entry.meta?.fetchedAt || 0) > 0 &&
+      Date.now() - Number(entry.meta?.fetchedAt || 0) < CACHE_TTL_MS,
   };
 };
 
 const getCachedEntry = (sourceUrl) => {
   const normalizedSourceUrl = normalizeKnownImageUrl(sourceUrl);
   if (!normalizedSourceUrl) return null;
-  return getCachedEntryFromKey(hashValue(normalizedSourceUrl));
+  initializeCacheIndex();
+  const cacheKey =
+    cacheKeysBySourceUrl.get(normalizedSourceUrl) || hashValue(normalizedSourceUrl);
+  return getCachedEntryFromKey(cacheKey);
 };
 
 const writeCacheEntry = (cacheKey, buffer, contentType, sourceUrl) => {
@@ -128,14 +164,18 @@ const writeCacheEntry = (cacheKey, buffer, contentType, sourceUrl) => {
 
   fs.writeFileSync(imagePath, buffer);
   fs.writeFileSync(metaPath, JSON.stringify(meta));
-
-  return {
+  const entry = {
     cacheKey,
     meta,
     imagePath,
     localUrl: buildLocalImageUrl(cacheKey, extension),
     isFresh: true,
   };
+  cacheEntriesByKey.set(cacheKey, entry);
+  if (sourceUrl) {
+    cacheKeysBySourceUrl.set(sourceUrl, cacheKey);
+  }
+  return entry;
 };
 
 const fetchAndCacheImage = async (sourceUrl) => {
@@ -249,4 +289,22 @@ export const handleImageProxyRequest = async (req, res) => {
   res.set("Content-Type", cached.meta.contentType || "image/jpeg");
   res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
   return res.sendFile(cached.imagePath);
+};
+
+export const handleLegacyImageProxyRequest = async (req, res) => {
+  const rawSourceUrl =
+    typeof req.query.src === "string" ? req.query.src.trim() : "";
+  if (!rawSourceUrl) {
+    return res.status(404).json({ error: "Image not found" });
+  }
+
+  try {
+    const cached = await warmImageProxy(rawSourceUrl);
+    if (!cached?.localUrl) {
+      return res.status(404).json({ error: "Image not found" });
+    }
+    return res.redirect(302, cached.localUrl);
+  } catch {
+    return res.status(404).json({ error: "Image not found" });
+  }
 };

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -10,7 +10,7 @@ const __dirname = path.dirname(__filename);
 const IMAGE_PROXY_ROUTE = "/api/image-proxy";
 const IMAGE_PROXY_DIR = path.join(__dirname, "..", "data", "image-proxy");
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const FETCH_TIMEOUT_MS = 15000;
+const FETCH_TIMEOUT_MS = 25000;
 const inflightRequests = new Map();
 
 const PRIVATE_HOST_PATTERNS = [
@@ -33,14 +33,6 @@ const MIME_EXTENSION_MAP = {
   "image/svg+xml": "svg",
 };
 
-const getProxySecret = () =>
-  String(
-    process.env.IMAGE_PROXY_SECRET ||
-      process.env.AUTH_PASSWORD ||
-      process.env.CONTACT_EMAIL ||
-      "aurral-image-proxy",
-  );
-
 const ensureCacheDir = () => {
   fs.mkdirSync(IMAGE_PROXY_DIR, { recursive: true });
 };
@@ -56,16 +48,35 @@ const isPrivateHostname = (hostname) => {
 const hashValue = (value) =>
   crypto.createHash("sha256").update(String(value)).digest("hex");
 
-const signSourceUrl = (sourceUrl) =>
-  crypto
-    .createHmac("sha256", getProxySecret())
-    .update(String(sourceUrl))
-    .digest("hex");
+const normalizeKnownImageUrl = (value) =>
+  String(value || "")
+    .trim()
+    .replace(
+      /^(https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org)\/release-group\/[0-9a-f-]+)\/front-250(?=[/?#]|$)/i,
+      "$1/front",
+    )
+    .replace(
+      /^(https?:\/\/(?:[\w-]+\.)?ca\.archive\.org\/.*?)-thumb250(\.[a-z0-9]+)(?=[?#]|$)/i,
+      "$1$2",
+    )
+    .replace(
+      /^(https?:\/\/archive\.org\/download\/[^?#]+?)_thumb250(\.[a-z0-9]+)(?=[?#]|$)/i,
+      "$1$2",
+    );
 
 const getCachePaths = (cacheKey) => ({
   metaPath: path.join(IMAGE_PROXY_DIR, `${cacheKey}.json`),
   baseImagePath: path.join(IMAGE_PROXY_DIR, `${cacheKey}`),
 });
+
+const buildLocalImageUrl = (cacheKey, extension) =>
+  `${IMAGE_PROXY_ROUTE}/${cacheKey}.${extension}`;
+
+const getCacheKeyFromLocalUrl = (value) => {
+  const normalized = String(value || "").trim();
+  const match = normalized.match(/\/api\/image-proxy\/([a-f0-9]{64})(?:\.[a-z0-9]+)?$/i);
+  return match?.[1]?.toLowerCase() || null;
+};
 
 const readCacheMetadata = (metaPath) => {
   try {
@@ -75,8 +86,8 @@ const readCacheMetadata = (metaPath) => {
   }
 };
 
-const getCachedEntry = (sourceUrl) => {
-  const cacheKey = hashValue(sourceUrl);
+const getCachedEntryFromKey = (cacheKey) => {
+  if (!cacheKey) return null;
   const { metaPath, baseImagePath } = getCachePaths(cacheKey);
   const meta = readCacheMetadata(metaPath);
   if (!meta?.extension) return null;
@@ -88,10 +99,17 @@ const getCachedEntry = (sourceUrl) => {
     cacheKey,
     meta,
     imagePath,
+    localUrl: buildLocalImageUrl(cacheKey, meta.extension),
     isFresh:
       Number(meta.fetchedAt || 0) > 0 &&
       Date.now() - Number(meta.fetchedAt || 0) < CACHE_TTL_MS,
   };
+};
+
+const getCachedEntry = (sourceUrl) => {
+  const normalizedSourceUrl = normalizeKnownImageUrl(sourceUrl);
+  if (!normalizedSourceUrl) return null;
+  return getCachedEntryFromKey(hashValue(normalizedSourceUrl));
 };
 
 const writeCacheEntry = (cacheKey, buffer, contentType, sourceUrl) => {
@@ -112,28 +130,35 @@ const writeCacheEntry = (cacheKey, buffer, contentType, sourceUrl) => {
   fs.writeFileSync(metaPath, JSON.stringify(meta));
 
   return {
+    cacheKey,
     meta,
     imagePath,
+    localUrl: buildLocalImageUrl(cacheKey, extension),
     isFresh: true,
   };
 };
 
 const fetchAndCacheImage = async (sourceUrl) => {
-  const parsed = new URL(sourceUrl);
+  const normalizedSourceUrl = normalizeKnownImageUrl(sourceUrl);
+  if (!normalizedSourceUrl) {
+    throw new Error("Missing source image URL");
+  }
+
+  const parsed = new URL(normalizedSourceUrl);
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Unsupported image protocol");
   }
   if (isPrivateHostname(parsed.hostname)) {
-    throw new Error("Refusing to proxy private host");
+    throw new Error("Refusing to cache private host");
   }
 
-  const response = await axios.get(sourceUrl, {
+  const response = await axios.get(normalizedSourceUrl, {
     responseType: "arraybuffer",
     timeout: FETCH_TIMEOUT_MS,
     maxRedirects: 10,
     headers: {
       Accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
-      "User-Agent": "Aurral Image Proxy",
+      "User-Agent": "Aurral Local Image Cache",
     },
   });
 
@@ -146,15 +171,46 @@ const fetchAndCacheImage = async (sourceUrl) => {
   }
 
   return writeCacheEntry(
-    hashValue(sourceUrl),
+    hashValue(normalizedSourceUrl),
     Buffer.from(response.data),
     contentType,
-    sourceUrl,
+    normalizedSourceUrl,
   );
 };
 
+export const warmImageProxy = async (sourceUrl) => {
+  const cacheKeyFromLocalUrl = getCacheKeyFromLocalUrl(sourceUrl);
+  if (cacheKeyFromLocalUrl) {
+    const cachedLocal = getCachedEntryFromKey(cacheKeyFromLocalUrl);
+    if (cachedLocal?.imagePath) {
+      return cachedLocal;
+    }
+    throw new Error("Missing local cached image");
+  }
+
+  const normalizedSourceUrl = normalizeKnownImageUrl(sourceUrl);
+  if (!normalizedSourceUrl) {
+    throw new Error("Missing source image URL");
+  }
+
+  const cached = getCachedEntry(normalizedSourceUrl);
+  if (cached?.isFresh) {
+    return cached;
+  }
+
+  if (inflightRequests.has(normalizedSourceUrl)) {
+    return inflightRequests.get(normalizedSourceUrl);
+  }
+
+  const request = fetchAndCacheImage(normalizedSourceUrl).finally(() => {
+    inflightRequests.delete(normalizedSourceUrl);
+  });
+  inflightRequests.set(normalizedSourceUrl, request);
+  return request;
+};
+
 export const buildImageProxyUrl = (sourceUrl) => {
-  const normalized = String(sourceUrl || "").trim();
+  const normalized = normalizeKnownImageUrl(sourceUrl);
   if (!normalized) return null;
   if (
     normalized.startsWith("/") ||
@@ -173,88 +229,24 @@ export const buildImageProxyUrl = (sourceUrl) => {
     return normalized;
   }
 
-  const sig = signSourceUrl(normalized);
-  return `${IMAGE_PROXY_ROUTE}?src=${encodeURIComponent(normalized)}&sig=${sig}`;
+  const cached = getCachedEntry(normalized);
+  return cached?.localUrl || null;
 };
 
 export const handleImageProxyRequest = async (req, res) => {
-  const sourceUrl = String(req.query.src || "").trim();
-  const signature = String(req.query.sig || "").trim();
-
-  if (!sourceUrl || !signature) {
-    return res.status(400).json({ error: "Missing source image parameters" });
-  }
-  if (signature !== signSourceUrl(sourceUrl)) {
-    return res.status(403).json({ error: "Invalid image proxy signature" });
+  const rawKey = String(req.params.cacheKey || "").trim();
+  const match = rawKey.match(/^([a-f0-9]{64})(?:\.([a-z0-9]+))?$/i);
+  if (!match) {
+    return res.status(404).json({ error: "Image not found" });
   }
 
-  const cached = getCachedEntry(sourceUrl);
-  if (cached?.isFresh) {
-    res.set("Content-Type", cached.meta.contentType || "image/jpeg");
-    res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
-    return res.sendFile(cached.imagePath);
+  const cacheKey = match[1].toLowerCase();
+  const cached = getCachedEntryFromKey(cacheKey);
+  if (!cached?.imagePath) {
+    return res.status(404).json({ error: "Image not found" });
   }
 
-  if (inflightRequests.has(sourceUrl)) {
-    try {
-      const inflight = await inflightRequests.get(sourceUrl);
-      res.set("Content-Type", inflight.meta.contentType || "image/jpeg");
-      res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
-      return res.sendFile(inflight.imagePath);
-    } catch (error) {
-      if (cached?.imagePath) {
-        res.set("Content-Type", cached.meta.contentType || "image/jpeg");
-        res.set(
-          "Cache-Control",
-          "public, max-age=300, stale-while-revalidate=86400",
-        );
-        return res.sendFile(cached.imagePath);
-      }
-      res.set("Cache-Control", "public, max-age=300, stale-while-revalidate=86400");
-      return res.redirect(sourceUrl);
-    }
-  }
-
-  const request = fetchAndCacheImage(sourceUrl).finally(() => {
-    inflightRequests.delete(sourceUrl);
-  });
-  inflightRequests.set(sourceUrl, request);
-
-  try {
-    const fresh = await request;
-    res.set("Content-Type", fresh.meta.contentType || "image/jpeg");
-    res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
-    return res.sendFile(fresh.imagePath);
-  } catch (error) {
-    if (cached?.imagePath) {
-      res.set("Content-Type", cached.meta.contentType || "image/jpeg");
-      res.set("Cache-Control", "public, max-age=300, stale-while-revalidate=86400");
-      return res.sendFile(cached.imagePath);
-    }
-    const upstreamStatus = error?.response?.status;
-    const upstreamCode = error?.code;
-    const upstreamHost = (() => {
-      try {
-        return new URL(sourceUrl).hostname;
-      } catch {
-        return "unknown";
-      }
-    })();
-
-    console.warn(
-      "[Image Proxy] Failed to fetch image:",
-      JSON.stringify({
-        sourceUrl,
-        upstreamHost,
-        message: error?.message || "Unknown error",
-        code: upstreamCode || null,
-        status: upstreamStatus || null,
-      }),
-    );
-
-    // Degrade gracefully: if the proxy cannot warm the image, let the browser
-    // fetch the original source directly instead of showing a broken square.
-    res.set("Cache-Control", "public, max-age=300, stale-while-revalidate=86400");
-    return res.redirect(sourceUrl);
-  }
+  res.set("Content-Type", cached.meta.contentType || "image/jpeg");
+  res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+  return res.sendFile(cached.imagePath);
 };

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -1,20 +1,37 @@
 import { dbOps } from "../config/db-helpers.js";
 import {
+  fetchItunesAlbumArt,
   fetchCoverArtArchiveReleaseGroup,
+  musicbrainzGetArtistNameByMbid,
   musicbrainzGetArtistReleaseGroupsPreview,
 } from "./apiClients.js";
+import { warmImageProxy } from "./imageProxyService.js";
 
 const MAX_NEGATIVE_CACHE = 1000;
 const MAX_PENDING_REQUESTS = 100;
-const negativeImageCache = new Set();
+const NEGATIVE_CACHE_TTL_MS = 60 * 60 * 1000;
+const RELEASE_GROUP_CONCURRENCY = 4;
+const negativeImageCache = new Map();
 const pendingImageRequests = new Map();
+const LEGACY_COVER_HOST_PATTERN =
+  /https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org|archive\.org|[\w-]+\.ca\.archive\.org)\//i;
 
 const addToNegativeCache = (mbid) => {
   if (negativeImageCache.size >= MAX_NEGATIVE_CACHE) {
-    const firstKey = negativeImageCache.values().next().value;
+    const firstKey = negativeImageCache.keys().next().value;
     negativeImageCache.delete(firstKey);
   }
-  negativeImageCache.add(mbid);
+  negativeImageCache.set(mbid, Date.now());
+};
+
+const hasFreshNegativeCache = (mbid) => {
+  const cachedAt = negativeImageCache.get(mbid);
+  if (!cachedAt) return false;
+  if (Date.now() - cachedAt > NEGATIVE_CACHE_TTL_MS) {
+    negativeImageCache.delete(mbid);
+    return false;
+  }
+  return true;
 };
 
 const addToPendingRequests = (mbid, promise) => {
@@ -27,6 +44,14 @@ const addToPendingRequests = (mbid, promise) => {
 
 const getCachedUrl = (cacheKey) => {
   const cached = dbOps.getImage(cacheKey);
+  if (
+    cached?.imageUrl &&
+    cached.imageUrl !== "NOT_FOUND" &&
+    LEGACY_COVER_HOST_PATTERN.test(cached.imageUrl)
+  ) {
+    dbOps.deleteImage(cacheKey);
+    return undefined;
+  }
   if (cached?.imageUrl && cached.imageUrl !== "NOT_FOUND") {
     return cached.imageUrl;
   }
@@ -36,19 +61,48 @@ const getCachedUrl = (cacheKey) => {
   return undefined;
 };
 
-const fetchReleaseGroupCoverUrl = async (releaseGroupMbid) => {
+const fetchReleaseGroupCoverUrl = async (
+  releaseGroupMbid,
+  { artistName = "", albumTitle = "" } = {},
+) => {
   const cacheKey = `rg:${releaseGroupMbid}`;
   const cached = getCachedUrl(cacheKey);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    return { imageUrl: cached, notFound: cached === null, transientError: false };
+  }
   try {
+    const itunesImageUrl = await fetchItunesAlbumArt(artistName, albumTitle);
+    if (itunesImageUrl) {
+      const cachedImage = await warmImageProxy(itunesImageUrl);
+      dbOps.setImage(cacheKey, cachedImage.localUrl);
+      return {
+        imageUrl: cachedImage.localUrl,
+        types: ["Front"],
+        notFound: false,
+        transientError: false,
+      };
+    }
+
     const cover = await fetchCoverArtArchiveReleaseGroup(releaseGroupMbid);
     if (cover?.imageUrl) {
-      dbOps.setImage(cacheKey, cover.imageUrl);
-      return cover.imageUrl;
+      const cachedImage = await warmImageProxy(cover.imageUrl);
+      dbOps.setImage(cacheKey, cachedImage.localUrl);
+      return {
+        imageUrl: cachedImage.localUrl,
+        types: cover.types || ["Front"],
+        notFound: false,
+        transientError: false,
+      };
+    }
+    if (cover?.notFound) {
+      dbOps.setImage(cacheKey, "NOT_FOUND");
+      return { imageUrl: null, types: [], notFound: true, transientError: false };
+    }
+    if (cover?.transientError) {
+      return { imageUrl: null, types: [], notFound: false, transientError: true };
     }
   } catch (e) {}
-  dbOps.setImage(cacheKey, "NOT_FOUND");
-  return null;
+  return { imageUrl: null, types: [], notFound: false, transientError: true };
 };
 
 const typeRank = (primaryType) => {
@@ -66,7 +120,8 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
     !forceRefresh &&
     cachedImage &&
     cachedImage.imageUrl &&
-    cachedImage.imageUrl !== "NOT_FOUND"
+    cachedImage.imageUrl !== "NOT_FOUND" &&
+    !LEGACY_COVER_HOST_PATTERN.test(cachedImage.imageUrl)
   ) {
     return {
       url: cachedImage.imageUrl,
@@ -83,9 +138,9 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
   if (
     !forceRefresh &&
     ((cachedImage && cachedImage.imageUrl === "NOT_FOUND") ||
-      negativeImageCache.has(mbid))
+      hasFreshNegativeCache(mbid))
   ) {
-    return { url: null, images: [] };
+    return { url: null, images: [], notFound: true };
   }
 
   if (pendingImageRequests.has(mbid)) {
@@ -96,12 +151,22 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
     try {
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
+      const resolvedArtistName = await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(
+        () => null,
+      );
       const rgCacheKey = `artist_rg:${resolvedMbid}`;
       const cachedRg = forceRefresh ? null : dbOps.getDeezerMbidCache(rgCacheKey);
       const releaseGroups = cachedRg
         ? cachedRg === "NOT_FOUND"
           ? []
-          : [{ id: cachedRg, "primary-type": "Album", "first-release-date": null }]
+          : [
+              {
+                id: cachedRg,
+                title: "",
+                "primary-type": "Album",
+                "first-release-date": null,
+              },
+            ]
         : await musicbrainzGetArtistReleaseGroupsPreview(resolvedMbid, 30);
 
       const ordered = releaseGroups
@@ -115,18 +180,55 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
         })
         .slice(0, 25);
 
-      for (const rg of ordered) {
-        const coverUrl = await fetchReleaseGroupCoverUrl(rg.id);
-        if (coverUrl) {
-          dbOps.setImage(mbid, coverUrl);
-          if (!cachedRg || forceRefresh) {
-            dbOps.setDeezerMbidCache(rgCacheKey, rg.id);
+      let nextIndex = 0;
+      let foundCover = null;
+      let sawTransientError = false;
+      const workers = Array.from(
+        { length: Math.min(RELEASE_GROUP_CONCURRENCY, ordered.length) },
+        async () => {
+          while (nextIndex < ordered.length && !foundCover) {
+            const rg = ordered[nextIndex++];
+            const cover = await fetchReleaseGroupCoverUrl(rg.id, {
+              artistName: resolvedArtistName || "",
+              albumTitle: rg.title || "",
+            });
+            if (cover?.imageUrl) {
+              foundCover = {
+                releaseGroupId: rg.id,
+                imageUrl: cover.imageUrl,
+                types: cover.types || ["Front"],
+              };
+              return;
+            }
+            if (cover?.transientError) {
+              sawTransientError = true;
+            }
           }
-          return {
-            url: coverUrl,
-            images: [{ image: coverUrl, front: true, types: ["Front"] }],
-          };
+        },
+      );
+
+      await Promise.all(workers);
+
+      if (foundCover) {
+        negativeImageCache.delete(mbid);
+        dbOps.setImage(mbid, foundCover.imageUrl);
+        if (!cachedRg || forceRefresh) {
+          dbOps.setDeezerMbidCache(rgCacheKey, foundCover.releaseGroupId);
         }
+        return {
+          url: foundCover.imageUrl,
+          images: [
+            {
+              image: foundCover.imageUrl,
+              front: true,
+              types: foundCover.types,
+            },
+          ],
+        };
+      }
+
+      if (sawTransientError) {
+        return { url: null, images: [], transientError: true };
       }
 
       if (!cachedRg || forceRefresh) {
@@ -134,12 +236,13 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
       }
     } catch (e) {
       console.warn(`Failed to fetch image for ${mbid}:`, e.message);
+      return { url: null, images: [], transientError: true };
     }
 
     addToNegativeCache(mbid);
     dbOps.setImage(mbid, "NOT_FOUND");
 
-    return { url: null, images: [] };
+    return { url: null, images: [], notFound: true };
   })();
 
   addToPendingRequests(mbid, fetchPromise);

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -61,7 +61,7 @@ const getCachedUrl = (cacheKey) => {
   return undefined;
 };
 
-const fetchReleaseGroupCoverUrl = async (
+export const fetchReleaseGroupCoverUrl = async (
   releaseGroupMbid,
   { artistName = "", albumTitle = "" } = {},
 ) => {
@@ -112,8 +112,41 @@ const typeRank = (primaryType) => {
   return 3;
 };
 
-export const getArtistImage = async (mbid, forceRefresh = false) => {
+const normalizeGetArtistImageOptions = (forceRefreshOrOptions, artistNameHint) => {
+  if (
+    forceRefreshOrOptions &&
+    typeof forceRefreshOrOptions === "object" &&
+    !Array.isArray(forceRefreshOrOptions)
+  ) {
+    return {
+      forceRefresh: !!forceRefreshOrOptions.forceRefresh,
+      artistName:
+        typeof forceRefreshOrOptions.artistName === "string" &&
+        forceRefreshOrOptions.artistName.trim()
+          ? forceRefreshOrOptions.artistName.trim()
+          : null,
+    };
+  }
+
+  return {
+    forceRefresh: !!forceRefreshOrOptions,
+    artistName:
+      typeof artistNameHint === "string" && artistNameHint.trim()
+        ? artistNameHint.trim()
+        : null,
+  };
+};
+
+export const getArtistImage = async (
+  mbid,
+  forceRefreshOrOptions = false,
+  artistNameHint = null,
+) => {
   if (!mbid) return { url: null, images: [] };
+  const { forceRefresh, artistName } = normalizeGetArtistImageOptions(
+    forceRefreshOrOptions,
+    artistNameHint,
+  );
 
   const cachedImage = dbOps.getImage(mbid);
   if (
@@ -151,9 +184,9 @@ export const getArtistImage = async (mbid, forceRefresh = false) => {
     try {
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
-      const resolvedArtistName = await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(
-        () => null,
-      );
+      const resolvedArtistName =
+        artistName ||
+        (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(() => null));
       const rgCacheKey = `artist_rg:${resolvedMbid}`;
       const cachedRg = forceRefresh ? null : dbOps.getDeezerMbidCache(rgCacheKey);
       const releaseGroups = cachedRg

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -6,7 +6,7 @@ import {
   musicbrainzRequest,
 } from "./apiClients.js";
 import { getDiscoveryCache } from "./discoveryService.js";
-import { hydrateArtistImages, primeArtistImageCache } from "./artistImageHydration.js";
+import { primeArtistImageCache } from "./artistImageHydration.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
 import { lidarrClient } from "./lidarrClient.js";
 
@@ -228,7 +228,12 @@ function canUseDirectPrimaryTypeSearch(selectedReleaseTypes) {
 }
 
 function normalizeTagArtistItem(artist, tag) {
-  let imageUrl = artist.image || artist.imageUrl || null;
+  let imageUrl =
+    typeof artist.imageUrl === "string" && artist.imageUrl.trim()
+      ? artist.imageUrl.trim()
+      : typeof artist.image === "string" && artist.image.trim()
+        ? artist.image.trim()
+        : null;
   if (!imageUrl && Array.isArray(artist.image)) {
     const img =
       artist.image.find((entry) => entry.size === "extralarge") ||
@@ -305,20 +310,12 @@ export async function searchArtists(query, limit = 24, offset = 0) {
   const artists = Array.isArray(mbData?.artists) ? mbData.artists : [];
   const filteredArtists = artists.filter((artist) => artist?.id);
   const cachedImages = dbOps.getImages(filteredArtists.map((artist) => artist.id));
-  let items = filteredArtists.map((artist) =>
+  const items = filteredArtists.map((artist) =>
     normalizeArtistSearchItem(artist, cachedImages),
   );
-
-  const warmLimit = Math.min(items.length, Math.max(8, Math.min(limitInt, 12)));
-  items = await hydrateArtistImages(items, {
-    limit: warmLimit,
-    batchSize: 6,
-    delayMs: 15,
-  });
-
-  if (items.length > warmLimit) {
-    primeArtistImageCache(items.slice(warmLimit)).catch(() => {});
-  }
+  primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
+    () => {},
+  );
 
   return {
     scope: "artist",

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -485,13 +485,38 @@ export async function searchTags(
     };
   }
 
+  const getDiscoveryTagFallback = () => {
+    const discoveryCache = getDiscoveryCache();
+    const tagLower = tag.toLowerCase();
+    const matches = (discoveryCache.recommendations || []).filter((artist) => {
+      const tags = Array.isArray(artist.tags) ? artist.tags : [];
+      return tags.some((entry) => String(entry).toLowerCase() === tagLower);
+    });
+    const items = matches
+      .slice(offsetInt, offsetInt + limitInt)
+      .map((artist) => normalizeTagArtistItem(artist, tag));
+    return {
+      scope: "tag",
+      query: tag,
+      count: matches.length,
+      offset: offsetInt,
+      items,
+    };
+  };
+
   if (tagScope === "all" && getLastfmApiKey()) {
     const page = Math.floor(offsetInt / limitInt) + 1;
     const data = await lastfmRequest("tag.getTopArtists", {
       tag,
       limit: limitInt,
       page,
+    }, {
+      timeoutMs: 2500,
+      maxRetries: 0,
     });
+    if (!data?.topartists?.artist) {
+      return getDiscoveryTagFallback();
+    }
     const rawArtists = Array.isArray(data?.topartists?.artist)
       ? data.topartists.artist
       : data?.topartists?.artist
@@ -511,21 +536,5 @@ export async function searchTags(
     };
   }
 
-  const discoveryCache = getDiscoveryCache();
-  const tagLower = tag.toLowerCase();
-  const matches = (discoveryCache.recommendations || []).filter((artist) => {
-    const tags = Array.isArray(artist.tags) ? artist.tags : [];
-    return tags.some((entry) => String(entry).toLowerCase() === tagLower);
-  });
-  const items = matches
-    .slice(offsetInt, offsetInt + limitInt)
-    .map((artist) => normalizeTagArtistItem(artist, tag));
-
-  return {
-    scope: "tag",
-    query: tag,
-    count: matches.length,
-    offset: offsetInt,
-    items,
-  };
+  return getDiscoveryTagFallback();
 }

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -1,7 +1,7 @@
 import NodeCache from "node-cache";
 import axios from "axios";
 import { dbOps } from "../config/db-helpers.js";
-import { musicbrainzRequest } from "./apiClients.js";
+import { getMusicbrainzApiBaseUrl, musicbrainzRequest } from "./apiClients.js";
 import { getDiscoveryCache } from "./discoveryService.js";
 import { primeArtistImageCache } from "./artistImageHydration.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
@@ -27,7 +27,12 @@ const albumLibraryLookupCache = new NodeCache({
   checkperiod: 60,
   maxKeys: 10,
 });
-const MUSICBRAINZ_TAG_PAGE_URL = "https://musicbrainz.org";
+const MUSICBRAINZ_TAG_PAGE_CACHE_TTL_SECONDS = 15 * 60;
+const musicbrainzTagPageCache = new NodeCache({
+  stdTTL: MUSICBRAINZ_TAG_PAGE_CACHE_TTL_SECONDS,
+  checkperiod: 120,
+  maxKeys: 500,
+});
 
 function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(value, 10);
@@ -55,6 +60,23 @@ function decodeHtmlEntities(value) {
     .replace(/&#(\d+);/g, (_, dec) =>
       String.fromCodePoint(Number.parseInt(dec, 10)),
     );
+}
+
+function getMusicbrainzSiteBaseUrl() {
+  const apiBaseUrl = String(getMusicbrainzApiBaseUrl() || "").trim();
+  if (!apiBaseUrl) {
+    return "https://mb.lkly.net";
+  }
+
+  try {
+    const parsed = new URL(apiBaseUrl);
+    parsed.pathname = parsed.pathname.replace(/\/ws\/2\/?$/, "") || "/";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return "https://mb.lkly.net";
+  }
 }
 
 function normalizePercentOfTracks(value) {
@@ -232,10 +254,13 @@ function buildAlbumSearchQuery(query, selectedReleaseTypes) {
 }
 
 async function fetchMusicbrainzTagArtistPage(tag, page) {
+  const cacheKey = `tag-page:${normalizeTagValue(tag)}:${page}`;
+  const cached = musicbrainzTagPageCache.get(cacheKey);
+  if (cached) return cached;
   const normalizedTag = encodeURIComponent(String(tag || "").trim());
-  const url = `${MUSICBRAINZ_TAG_PAGE_URL}/tag/${normalizedTag}/artist?page=${page}`;
+  const url = `${getMusicbrainzSiteBaseUrl()}/tag/${normalizedTag}/artist?page=${page}`;
   const response = await axios.get(url, {
-    timeout: 5000,
+    timeout: 15000,
     headers: {
       "User-Agent": "Aurral Tag Search",
       Accept: "text/html,application/xhtml+xml",
@@ -262,10 +287,40 @@ async function fetchMusicbrainzTagArtistPage(tag, page) {
     });
   }
 
-  return {
+  const result = {
     totalCount,
     items,
     pageSize: items.length,
+  };
+  musicbrainzTagPageCache.set(cacheKey, result);
+  return result;
+}
+
+async function searchTagsAllFallbackViaArtistSearch(tag, limitInt, offsetInt) {
+  const mbData = await musicbrainzRequest("/artist", {
+    query: `tag:"${escapeMusicbrainzQueryTerm(tag)}"`,
+    limit: limitInt,
+    offset: offsetInt,
+  });
+  const artists = Array.isArray(mbData?.artists) ? mbData.artists : [];
+  const filteredArtists = artists.filter((artist) => artist?.id);
+  const cachedImages = dbOps.getImages(filteredArtists.map((artist) => artist.id));
+  const items = filteredArtists.map((artist) => ({
+    ...normalizeArtistSearchItem(artist, cachedImages),
+    tags: [tag],
+  }));
+  primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
+    () => {},
+  );
+  return {
+    scope: "tag",
+    query: tag,
+    count: Number.parseInt(mbData?.count, 10) || items.length,
+    hasMore:
+      (Number.parseInt(mbData?.count, 10) || items.length) >
+      offsetInt + items.length,
+    offset: offsetInt,
+    items,
   };
 }
 
@@ -541,44 +596,57 @@ export async function searchTags(
   }
 
   if (tagScope === "all") {
-    const firstPageNumber = Math.floor(offsetInt / 100) + 1;
-    const pages = [];
-    let totalCount = 0;
-    let pageSize = 100;
-    let currentPage = firstPageNumber;
-    let combined = [];
+    try {
+      const firstPageNumber = Math.floor(offsetInt / 100) + 1;
+      const pages = [];
+      let totalCount = 0;
+      let pageSize = 100;
+      let currentPage = firstPageNumber;
+      let combined = [];
 
-    while (combined.length < limitInt + (offsetInt % pageSize || 0)) {
-      const pageData = await fetchMusicbrainzTagArtistPage(tag, currentPage);
-      totalCount = pageData.totalCount;
-      pageSize = pageData.pageSize || pageSize;
-      if (pageData.items.length === 0) break;
-      pages.push(pageData);
-      combined = pages.flatMap((entry) => entry.items);
-      currentPage += 1;
-      if (pageData.items.length < pageSize) break;
-      const absoluteLoaded =
-        (firstPageNumber - 1) * pageSize + combined.length;
-      if (totalCount > 0 && absoluteLoaded >= totalCount) break;
+      while (combined.length < limitInt + (offsetInt % pageSize || 0)) {
+        const pageData = await fetchMusicbrainzTagArtistPage(tag, currentPage);
+        totalCount = pageData.totalCount;
+        pageSize = pageData.pageSize || pageSize;
+        if (pageData.items.length === 0) break;
+        pages.push(pageData);
+        combined = pages.flatMap((entry) => entry.items);
+        currentPage += 1;
+        if (pageData.items.length < pageSize) break;
+        const absoluteLoaded =
+          (firstPageNumber - 1) * pageSize + combined.length;
+        if (totalCount > 0 && absoluteLoaded >= totalCount) break;
+      }
+
+      const withinPageOffset = offsetInt - (firstPageNumber - 1) * pageSize;
+      const pageArtists = combined.slice(
+        withinPageOffset,
+        withinPageOffset + limitInt,
+      );
+      const cachedImages = dbOps.getImages(pageArtists.map((artist) => artist.id));
+      const items = pageArtists.map((artist) => ({
+        ...normalizeArtistSearchItem(artist, cachedImages),
+        tags: [tag],
+      }));
+      primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
+        () => {},
+      );
+
+      return {
+        scope: "tag",
+        query: tag,
+        count: totalCount || items.length,
+        hasMore: totalCount > offsetInt + items.length,
+        offset: offsetInt,
+        items,
+      };
+    } catch (error) {
+      console.warn(
+        `MusicBrainz tag page fetch failed for "${tag}", falling back to artist search:`,
+        error.message,
+      );
+      return searchTagsAllFallbackViaArtistSearch(tag, limitInt, offsetInt);
     }
-
-    const withinPageOffset = offsetInt - (firstPageNumber - 1) * pageSize;
-    const pageArtists = combined.slice(withinPageOffset, withinPageOffset + limitInt);
-    const cachedImages = dbOps.getImages(pageArtists.map((artist) => artist.id));
-    const items = pageArtists.map((artist) => ({
-      ...normalizeArtistSearchItem(artist, cachedImages),
-      tags: [tag],
-    }));
-    primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(() => {});
-
-    return {
-      scope: "tag",
-      query: tag,
-      count: totalCount || items.length,
-      hasMore: totalCount > offsetInt + items.length,
-      offset: offsetInt,
-      items,
-    };
   }
 
   const discoveryCache = getDiscoveryCache();

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -1,10 +1,7 @@
 import NodeCache from "node-cache";
+import axios from "axios";
 import { dbOps } from "../config/db-helpers.js";
-import {
-  getLastfmApiKey,
-  lastfmRequest,
-  musicbrainzRequest,
-} from "./apiClients.js";
+import { musicbrainzRequest } from "./apiClients.js";
 import { getDiscoveryCache } from "./discoveryService.js";
 import { primeArtistImageCache } from "./artistImageHydration.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
@@ -30,6 +27,7 @@ const albumLibraryLookupCache = new NodeCache({
   checkperiod: 60,
   maxKeys: 10,
 });
+const MUSICBRAINZ_TAG_PAGE_URL = "https://musicbrainz.org";
 
 function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(value, 10);
@@ -38,6 +36,25 @@ function parsePositiveInt(value, fallback) {
 
 function escapeMusicbrainzQueryTerm(value) {
   return String(value || "").replace(/["\\]/g, "\\$&");
+}
+
+function normalizeTagValue(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function decodeHtmlEntities(value) {
+  return String(value || "")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+      String.fromCodePoint(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/g, (_, dec) =>
+      String.fromCodePoint(Number.parseInt(dec, 10)),
+    );
 }
 
 function normalizePercentOfTracks(value) {
@@ -212,6 +229,44 @@ function buildAlbumSearchQuery(query, selectedReleaseTypes) {
   }
 
   return clauses.join(" AND ");
+}
+
+async function fetchMusicbrainzTagArtistPage(tag, page) {
+  const normalizedTag = encodeURIComponent(String(tag || "").trim());
+  const url = `${MUSICBRAINZ_TAG_PAGE_URL}/tag/${normalizedTag}/artist?page=${page}`;
+  const response = await axios.get(url, {
+    timeout: 5000,
+    headers: {
+      "User-Agent": "Aurral Tag Search",
+      Accept: "text/html,application/xhtml+xml",
+    },
+  });
+  const html = String(response.data || "");
+  const countMatch = html.match(/<p>([\d,]+)\s+artists found<\/p>/i);
+  const totalCount = Number.parseInt(
+    String(countMatch?.[1] || "0").replace(/,/g, ""),
+    10,
+  ) || 0;
+  const itemPattern =
+    /<li>(\d+)\s*-\s*<a href="\/artist\/([0-9a-f-]+)" title="([^"]*)"><bdi>(.*?)<\/bdi><\/a>(?:\s*<span class="comment">\(<bdi>(.*?)<\/bdi>\)<\/span>)?<\/li>/gisu;
+  const items = [];
+  let match;
+  while ((match = itemPattern.exec(html)) !== null) {
+    items.push({
+      id: match[2],
+      name: decodeHtmlEntities(match[4] || match[3] || ""),
+      sortName: decodeHtmlEntities(match[4] || match[3] || ""),
+      disambiguation: decodeHtmlEntities(match[5] || ""),
+      tagCount: Number.parseInt(match[1], 10) || 0,
+      type: "artist",
+    });
+  }
+
+  return {
+    totalCount,
+    items,
+    pageSize: items.length,
+  };
 }
 
 function canUseDirectPrimaryTypeSearch(selectedReleaseTypes) {
@@ -485,56 +540,62 @@ export async function searchTags(
     };
   }
 
-  const getDiscoveryTagFallback = () => {
-    const discoveryCache = getDiscoveryCache();
-    const tagLower = tag.toLowerCase();
-    const matches = (discoveryCache.recommendations || []).filter((artist) => {
-      const tags = Array.isArray(artist.tags) ? artist.tags : [];
-      return tags.some((entry) => String(entry).toLowerCase() === tagLower);
-    });
-    const items = matches
-      .slice(offsetInt, offsetInt + limitInt)
-      .map((artist) => normalizeTagArtistItem(artist, tag));
-    return {
-      scope: "tag",
-      query: tag,
-      count: matches.length,
-      offset: offsetInt,
-      items,
-    };
-  };
+  if (tagScope === "all") {
+    const firstPageNumber = Math.floor(offsetInt / 100) + 1;
+    const pages = [];
+    let totalCount = 0;
+    let pageSize = 100;
+    let currentPage = firstPageNumber;
+    let combined = [];
 
-  if (tagScope === "all" && getLastfmApiKey()) {
-    const page = Math.floor(offsetInt / limitInt) + 1;
-    const data = await lastfmRequest("tag.getTopArtists", {
-      tag,
-      limit: limitInt,
-      page,
-    }, {
-      timeoutMs: 2500,
-      maxRetries: 0,
-    });
-    if (!data?.topartists?.artist) {
-      return getDiscoveryTagFallback();
+    while (combined.length < limitInt + (offsetInt % pageSize || 0)) {
+      const pageData = await fetchMusicbrainzTagArtistPage(tag, currentPage);
+      totalCount = pageData.totalCount;
+      pageSize = pageData.pageSize || pageSize;
+      if (pageData.items.length === 0) break;
+      pages.push(pageData);
+      combined = pages.flatMap((entry) => entry.items);
+      currentPage += 1;
+      if (pageData.items.length < pageSize) break;
+      const absoluteLoaded =
+        (firstPageNumber - 1) * pageSize + combined.length;
+      if (totalCount > 0 && absoluteLoaded >= totalCount) break;
     }
-    const rawArtists = Array.isArray(data?.topartists?.artist)
-      ? data.topartists.artist
-      : data?.topartists?.artist
-        ? [data.topartists.artist]
-        : [];
-    const items = rawArtists
-      .map((artist) => normalizeTagArtistItem(artist, tag))
-      .filter((artist) => artist.id);
+
+    const withinPageOffset = offsetInt - (firstPageNumber - 1) * pageSize;
+    const pageArtists = combined.slice(withinPageOffset, withinPageOffset + limitInt);
+    const cachedImages = dbOps.getImages(pageArtists.map((artist) => artist.id));
+    const items = pageArtists.map((artist) => ({
+      ...normalizeArtistSearchItem(artist, cachedImages),
+      tags: [tag],
+    }));
+    primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(() => {});
 
     return {
       scope: "tag",
       query: tag,
-      count:
-        Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length,
+      count: totalCount || items.length,
+      hasMore: totalCount > offsetInt + items.length,
       offset: offsetInt,
       items,
     };
   }
 
-  return getDiscoveryTagFallback();
+  const discoveryCache = getDiscoveryCache();
+  const tagLower = tag.toLowerCase();
+  const matches = (discoveryCache.recommendations || []).filter((artist) => {
+    const tags = Array.isArray(artist.tags) ? artist.tags : [];
+    return tags.some((entry) => String(entry).toLowerCase() === tagLower);
+  });
+  const items = matches
+    .slice(offsetInt, offsetInt + limitInt)
+    .map((artist) => normalizeTagArtistItem(artist, tag));
+
+  return {
+    scope: "tag",
+    query: tag,
+    count: matches.length,
+    offset: offsetInt,
+    items,
+  };
 }

--- a/frontend/src/components/ArtistImage.jsx
+++ b/frontend/src/components/ArtistImage.jsx
@@ -51,6 +51,7 @@ const ArtistImage = ({
   className = "",
   showLoading = true,
   enableBackendFallback = true,
+  loading = "lazy",
 }) => {
   const [currentSrc, setCurrentSrc] = useState(src);
   const [isLoading, setIsLoading] = useState(true);
@@ -255,7 +256,7 @@ const ArtistImage = ({
           }`}
           onLoad={handleLoad}
           onError={handleError}
-          loading="eager"
+          loading={loading}
           decoding="async"
         />
       )}
@@ -271,6 +272,7 @@ ArtistImage.propTypes = {
   className: PropTypes.string,
   showLoading: PropTypes.bool,
   enableBackendFallback: PropTypes.bool,
+  loading: PropTypes.oneOf(["eager", "lazy"]),
 };
 
 export default ArtistImage;

--- a/frontend/src/components/ArtistImage.jsx
+++ b/frontend/src/components/ArtistImage.jsx
@@ -50,6 +50,7 @@ const ArtistImage = ({
   artistName,
   className = "",
   showLoading = true,
+  enableBackendFallback = true,
 }) => {
   const [currentSrc, setCurrentSrc] = useState(src);
   const [isLoading, setIsLoading] = useState(true);
@@ -117,7 +118,7 @@ const ArtistImage = ({
       setCurrentSrc(src);
       setHasError(false);
       setIsLoading(true);
-    } else if (mbid) {
+    } else if (mbid && enableBackendFallback) {
       setCurrentSrc(null);
       setHasError(false);
       setIsLoading(true);
@@ -125,11 +126,11 @@ const ArtistImage = ({
     } else {
       setCurrentSrc(null);
       setIsLoading(false);
-      setHasError(true);
+      setHasError(false);
     }
 
     return () => controller.abort();
-  }, [src, mbid, artistName, fetchBackendCover]);
+  }, [src, mbid, artistName, fetchBackendCover, enableBackendFallback]);
 
   useEffect(() => {
     const image = imgRef.current;
@@ -168,7 +169,7 @@ const ArtistImage = ({
   };
 
   const handleError = () => {
-    if (mbid && !triedBackendFallbackRef.current) {
+    if (enableBackendFallback && mbid && !triedBackendFallbackRef.current) {
       triedBackendFallbackRef.current = true;
       setIsLoading(true);
       setHasError(false);
@@ -269,6 +270,7 @@ ArtistImage.propTypes = {
   artistName: PropTypes.string,
   className: PropTypes.string,
   showLoading: PropTypes.bool,
+  enableBackendFallback: PropTypes.bool,
 };
 
 export default ArtistImage;

--- a/frontend/src/components/SearchAlbumResults.jsx
+++ b/frontend/src/components/SearchAlbumResults.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { useState } from "react";
 import { Loader2, Music } from "lucide-react";
 
 function getAlbumActionLabel(album, isPending, canAddAlbum) {
@@ -15,6 +16,25 @@ function isAlbumActionDisabled(album, isPending, canAddAlbum) {
   if (!canAddAlbum) return true;
   if (album.status === "available") return true;
   return isPending || ["searching", "downloading", "processing"].includes(album.status);
+}
+
+function AlbumCover({ src, alt }) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return <Music className="h-8 w-8" />;
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="h-full w-full object-cover"
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+    />
+  );
 }
 
 function SearchAlbumResults({
@@ -46,15 +66,10 @@ function SearchAlbumResults({
                 className="flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden"
                 style={{ backgroundColor: "#211f27", color: "#8a8a8f" }}
               >
-                {albumCovers[album.id] || album.coverUrl ? (
-                  <img
-                    src={albumCovers[album.id] || album.coverUrl}
-                    alt={album.title}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Music className="h-8 w-8" />
-                )}
+                <AlbumCover
+                  src={albumCovers[album.id] || album.coverUrl}
+                  alt={album.title}
+                />
               </div>
 
               <div className="min-w-0 flex-1">

--- a/frontend/src/components/SearchArtistResults.jsx
+++ b/frontend/src/components/SearchArtistResults.jsx
@@ -214,6 +214,7 @@ function SearchArtistResults({
                 alt={artist.name}
                 className="h-full w-full transition-transform duration-300 group-hover:scale-105"
                 showLoading={false}
+                enableBackendFallback={false}
               />
             </div>
 

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -335,6 +335,20 @@ function ArtistDetailsPage() {
     }
   };
 
+  const handleCoverError = async () => {
+    if (!mbid) return;
+    const name = artist?.name || artistNameFromNav || "";
+    setLoadingCover(true);
+    try {
+      const cover = await getArtistCover(mbid, name, true).catch(() => ({
+        images: [],
+      }));
+      setCoverImages(cover?.images || []);
+    } finally {
+      setLoadingCover(false);
+    }
+  };
+
   const loadSharedPlaylists = async () => {
     setPlaylistModalLoading(true);
     try {
@@ -523,6 +537,7 @@ function ArtistDetailsPage() {
         canRefreshArtist={canChangeMonitoring}
         handleRefreshArtist={library.handleRefreshArtist}
         refreshingArtist={library.refreshingArtist}
+        onCoverError={handleCoverError}
         onNavigate={(path) => navigate(path)}
         loadingPreview={loadingPreview}
         previewTracks={previewTracks}

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -82,6 +82,10 @@ function ArtistDetailsPage() {
   const [playlistModalError, setPlaylistModalError] = useState("");
   const [blockingArtist, setBlockingArtist] = useState(false);
   const [artistBlocked, setArtistBlocked] = useState(false);
+  const [visibleReleaseGroupCoverIds, setVisibleReleaseGroupCoverIds] = useState(
+    [],
+  );
+  const [visibleLibraryCoverIds, setVisibleLibraryCoverIds] = useState([]);
 
   const filter = useReleaseTypeFilter();
   const {
@@ -95,6 +99,12 @@ function ArtistDetailsPage() {
     mbid,
     artistNameFromNav,
     selectedReleaseTypes,
+    {
+      visibleCoverIds: [
+        ...visibleReleaseGroupCoverIds,
+        ...visibleLibraryCoverIds,
+      ],
+    },
   );
   const canAddArtist = hasPermission("addArtist");
   const canAddAlbum = hasPermission("addAlbum");
@@ -575,6 +585,7 @@ function ArtistDetailsPage() {
           handleReSearchAlbum={library.handleReSearchAlbum}
           handleReSearchMissingDownloads={library.handleReSearchMissingDownloads}
           onAddTrackToPlaylist={handleLibraryTrackAdd}
+          onVisibleCoverIdsChange={setVisibleLibraryCoverIds}
         />
       )}
 
@@ -613,6 +624,7 @@ function ArtistDetailsPage() {
             library.isReleaseGroupDownloadedInLibrary
           }
           onAddTrackToPlaylist={handleReleaseTrackAdd}
+          onVisibleCoverIdsChange={setVisibleReleaseGroupCoverIds}
         />
       )}
 

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import {
   Loader,
@@ -57,6 +57,7 @@ export function ArtistDetailsHero({
   canRefreshArtist,
   handleRefreshArtist,
   refreshingArtist,
+  onCoverError,
   onNavigate,
   loadingPreview,
   previewTracks,
@@ -75,6 +76,7 @@ export function ArtistDetailsHero({
   const coverImage = getCoverImage(coverImages);
   const lifeSpan = formatLifeSpan(artist["life-span"]);
   const [showHeroMenu, setShowHeroMenu] = useState(false);
+  const [coverFailed, setCoverFailed] = useState(false);
   const lidarrArtistId =
     artist?.id ||
     libraryArtist?.foreignArtistId ||
@@ -92,6 +94,9 @@ export function ArtistDetailsHero({
         }`
       : null;
   const hasPreview = loadingPreview || (previewTracks && previewTracks.length > 0);
+  useEffect(() => {
+    setCoverFailed(false);
+  }, [coverImage]);
   const metadataItems = [
     artist.type
       ? {
@@ -529,7 +534,7 @@ export function ArtistDetailsHero({
           "linear-gradient(180deg, rgba(33,31,39,0.98) 0%, rgba(29,28,35,0.98) 100%)",
       }}
     >
-      {coverImage && (
+      {coverImage && !coverFailed && (
         <>
           <div
             className="absolute inset-0 opacity-30"
@@ -563,8 +568,18 @@ export function ArtistDetailsHero({
                   <div className="flex h-full w-full items-center justify-center">
                     <Loader className="w-10 h-10 animate-spin" style={{ color: "#c1c1c3" }} />
                   </div>
-                ) : coverImage ? (
-                  <img src={coverImage} alt={artist.name} className="h-full w-full object-cover" />
+                ) : coverImage && !coverFailed ? (
+                  <img
+                    src={coverImage}
+                    alt={artist.name}
+                    className="h-full w-full object-cover"
+                    loading="eager"
+                    decoding="async"
+                    onError={() => {
+                      setCoverFailed(true);
+                      onCoverError?.();
+                    }}
+                  />
                 ) : (
                   <div className="flex h-full w-full items-center justify-center">
                     <Music className="w-16 h-16" style={{ color: "#c1c1c3" }} />
@@ -720,6 +735,7 @@ ArtistDetailsHero.propTypes = {
   canRefreshArtist: PropTypes.bool,
   handleRefreshArtist: PropTypes.func,
   refreshingArtist: PropTypes.bool,
+  onCoverError: PropTypes.func,
   onNavigate: PropTypes.func,
   loadingPreview: PropTypes.bool,
   previewTracks: PropTypes.arrayOf(

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -36,8 +36,10 @@ export function ArtistDetailsLibraryAlbums({
   handleReSearchAlbum,
   handleReSearchMissingDownloads,
   onAddTrackToPlaylist,
+  onVisibleCoverIdsChange,
 }) {
   const railRef = useRef(null);
+  const visibleCoverIdsRef = useRef(new Set());
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const [completionFilter, setCompletionFilter] = useState("all");
@@ -93,6 +95,10 @@ export function ArtistDetailsLibraryAlbums({
     if (completionFilter === "incomplete") return !isComplete;
     return true;
   });
+  const visibleCoverSourceKey = visibleAlbums
+    .map((album) => album.mbid || album.foreignAlbumId || album.id)
+    .filter(Boolean)
+    .join(",");
   const incompleteAlbumCount = sortedAlbums.filter(
     (album) => !getAlbumState(album).isComplete
   ).length;
@@ -186,6 +192,54 @@ export function ArtistDetailsLibraryAlbums({
       window.removeEventListener("resize", updateScrollState);
     };
   }, [visibleAlbums, updateScrollState]);
+
+  useEffect(() => {
+    if (!onVisibleCoverIdsChange || !visibleCoverSourceKey) return undefined;
+
+    visibleCoverIdsRef.current = new Set();
+    const node = railRef.current;
+    if (!node) return undefined;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let changed = false;
+        for (const entry of entries) {
+          const id = entry.target.getAttribute("data-cover-id");
+          if (!id) continue;
+          if (entry.isIntersecting) {
+            if (!visibleCoverIdsRef.current.has(id)) {
+              visibleCoverIdsRef.current.add(id);
+              changed = true;
+            }
+          } else if (visibleCoverIdsRef.current.delete(id)) {
+            changed = true;
+          }
+        }
+        if (changed) {
+          onVisibleCoverIdsChange(Array.from(visibleCoverIdsRef.current));
+        }
+      },
+      {
+        root: node,
+        threshold: 0.6,
+      },
+    );
+
+    node.querySelectorAll("[data-cover-id]").forEach((target) => {
+      observer.observe(target);
+    });
+
+    return () => {
+      observer.disconnect();
+      visibleCoverIdsRef.current = new Set();
+    };
+  }, [onVisibleCoverIdsChange, visibleCoverSourceKey]);
+
+  useEffect(() => {
+    if (!onVisibleCoverIdsChange) return undefined;
+    if (visibleCoverSourceKey) return undefined;
+    onVisibleCoverIdsChange([]);
+  }, [onVisibleCoverIdsChange, visibleCoverSourceKey]);
 
   if (downloadedAlbums.length === 0) return null;
 
@@ -303,6 +357,7 @@ export function ArtistDetailsLibraryAlbums({
             <article
               key={libraryAlbum.id}
               className="group flex w-[170px] min-w-[170px] flex-shrink-0 flex-col items-center"
+              data-cover-id={rgId}
             >
               <div
                 onClick={() => handleLibraryAlbumClick(rgId, libraryAlbum.id)}
@@ -628,4 +683,5 @@ ArtistDetailsLibraryAlbums.propTypes = {
   handleReSearchAlbum: PropTypes.func,
   handleReSearchMissingDownloads: PropTypes.func,
   onAddTrackToPlaylist: PropTypes.func,
+  onVisibleCoverIdsChange: PropTypes.func,
 };

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -52,12 +52,15 @@ export function ArtistDetailsReleaseGroups({
   previewVolume,
   isReleaseGroupDownloadedInLibrary,
   onAddTrackToPlaylist,
+  onVisibleCoverIdsChange,
 }) {
   const [sortMode, setSortMode] = useState("date");
   const [playingTrackId, setPlayingTrackId] = useState(null);
   const [loadingTrackId, setLoadingTrackId] = useState(null);
   const [showMobileFilterMenu, setShowMobileFilterMenu] = useState(false);
   const previewAudioRef = useRef(null);
+  const listRef = useRef(null);
+  const visibleCoverIdsRef = useRef(new Set());
   const releaseGroups = artist["release-groups"] || [];
   const sortTitle =
     sortMode === "date"
@@ -251,11 +254,10 @@ export function ArtistDetailsReleaseGroups({
     }
   };
 
-  if (releaseGroups.length === 0) return null;
-
   const filtered = releaseGroups
     .filter((rg) => matchesReleaseTypeFilter(rg, selectedReleaseTypes))
     .filter((rg) => !isReleaseGroupDownloadedInLibrary(rg.id));
+  const visibleCoverSourceKey = filtered.map((rg) => rg.id).join(",");
   const totalCount = releaseGroups.length;
   const filteredCount = filtered.length;
   const { pivot: popularityPivot } = getPopularityScale(releaseGroups);
@@ -273,6 +275,53 @@ export function ArtistDetailsReleaseGroups({
     const dateB = b["first-release-date"] || "";
     return dateB.localeCompare(dateA);
   });
+
+  useEffect(() => {
+    if (!onVisibleCoverIdsChange || !visibleCoverSourceKey) return undefined;
+
+    visibleCoverIdsRef.current = new Set();
+    const root = listRef.current;
+    if (!root) return undefined;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let changed = false;
+        for (const entry of entries) {
+          const id = entry.target.getAttribute("data-cover-id");
+          if (!id) continue;
+          if (entry.isIntersecting) {
+            if (!visibleCoverIdsRef.current.has(id)) {
+              visibleCoverIdsRef.current.add(id);
+              changed = true;
+            }
+          } else if (visibleCoverIdsRef.current.delete(id)) {
+            changed = true;
+          }
+        }
+        if (changed) {
+          onVisibleCoverIdsChange(Array.from(visibleCoverIdsRef.current));
+        }
+      },
+      { root: null, threshold: 0.15 },
+    );
+
+    root.querySelectorAll("[data-cover-id]").forEach((node) => {
+      observer.observe(node);
+    });
+
+    return () => {
+      observer.disconnect();
+      visibleCoverIdsRef.current = new Set();
+    };
+  }, [onVisibleCoverIdsChange, visibleCoverSourceKey]);
+
+  useEffect(() => {
+    if (!onVisibleCoverIdsChange) return undefined;
+    if (visibleCoverSourceKey) return undefined;
+    onVisibleCoverIdsChange([]);
+  }, [onVisibleCoverIdsChange, visibleCoverSourceKey]);
+
+  if (releaseGroups.length === 0) return null;
 
   return (
     <div className="card p-3 sm:p-4">
@@ -377,7 +426,7 @@ export function ArtistDetailsReleaseGroups({
           </div>
         </div>
       </div>
-      <div className="space-y-2">
+      <div ref={listRef} className="space-y-2">
         {sortedReleaseGroups.map((releaseGroup, releaseGroupIdx) => {
             const status = getAlbumStatus(releaseGroup.id);
             const isExpanded = expandedReleaseGroup === releaseGroup.id;
@@ -491,6 +540,7 @@ export function ArtistDetailsReleaseGroups({
                 key={releaseGroup.id}
                 className="overflow-hidden rounded-2xl transition-colors"
                 style={{ backgroundColor: rowBg }}
+                data-cover-id={releaseGroup.id}
                 onMouseEnter={(e) => {
                   if (!isExpanded) {
                     e.currentTarget.style.backgroundColor = rowHoverBg;
@@ -998,4 +1048,5 @@ ArtistDetailsReleaseGroups.propTypes = {
   previewVolume: PropTypes.number,
   isReleaseGroupDownloadedInLibrary: PropTypes.func,
   onAddTrackToPlaylist: PropTypes.func,
+  onVisibleCoverIdsChange: PropTypes.func,
 };

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsStream.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsStream.js
@@ -13,21 +13,24 @@ import {
 import { emptyArtistShape } from "../constants";
 import { matchesReleaseTypeFilter } from "../utils";
 
+const buildInitialArtist = (mbid, artistNameFromNav) =>
+  mbid && artistNameFromNav
+    ? {
+        id: mbid,
+        name: artistNameFromNav,
+        "sort-name": artistNameFromNav,
+        ...emptyArtistShape,
+        "release-groups": [],
+      }
+    : null;
+
 export function useArtistDetailsStream(
   mbid,
   artistNameFromNav,
   selectedReleaseTypes = [],
+  { visibleCoverIds = [] } = {},
 ) {
-  const initialArtist =
-    mbid && artistNameFromNav
-      ? {
-          id: mbid,
-          name: artistNameFromNav,
-          "sort-name": artistNameFromNav,
-          ...emptyArtistShape,
-          "release-groups": [],
-        }
-      : null;
+  const initialArtist = buildInitialArtist(mbid, artistNameFromNav);
 
   const [artist, setArtist] = useState(initialArtist);
   const [coverImages, setCoverImages] = useState([]);
@@ -61,6 +64,10 @@ export function useArtistDetailsStream(
 
   useEffect(() => {
     if (!mbid) return;
+    setArtist(buildInitialArtist(mbid, artistNameFromNav));
+    setCoverImages([]);
+    setAlbumCovers({});
+    setSimilarArtists([]);
     setLoading(!(mbid && artistNameFromNav));
     setError(null);
     setLoadingCover(true);
@@ -93,31 +100,106 @@ export function useArtistDetailsStream(
     let coverReceived = false;
     let similarReceived = false;
     let libraryReceived = false;
+    let restFallbackStarted = false;
 
-    const fallbackTimeout = setTimeout(() => {
+    const loadCoverAndSimilarFallback = async (nameForCover, refreshCover = false) => {
+      const requests = [];
       if (!coverReceived) {
-        const nameForCover = artistNameRef.current || artistNameFromNav;
-        getArtistCover(mbid, nameForCover)
-          .then((coverData) => {
-            if (coverData.images && coverData.images.length > 0) {
-              setCoverImages(coverData.images);
-            }
-          })
-          .catch(() => {})
-          .finally(() => setLoadingCover(false));
+        requests.push(
+          getArtistCover(mbid, nameForCover, refreshCover)
+            .then((coverData) => {
+              if (coverData.images && coverData.images.length > 0) {
+                setCoverImages(coverData.images);
+              }
+            })
+            .catch(() => {})
+            .finally(() => setLoadingCover(false)),
+        );
       }
       if (!similarReceived) {
-        getSimilarArtistsForArtist(
-          mbid,
-          artistNameRef.current || artistNameFromNav || "",
-        )
-          .then((similarData) => {
-            setSimilarArtists(similarData.artists || []);
-          })
-          .catch(() => {})
-          .finally(() => setLoadingSimilar(false));
+        requests.push(
+          getSimilarArtistsForArtist(mbid, nameForCover || "")
+            .then((similarData) => {
+              setSimilarArtists(similarData.artists || []);
+            })
+            .catch(() => {})
+            .finally(() => setLoadingSimilar(false)),
+        );
       }
-    }, 10000);
+      await Promise.allSettled(requests);
+    };
+
+    const loadLibraryFallback = async () => {
+      setLoadingLibrary(true);
+      try {
+        const lookup = await lookupArtistInLibrary(mbid);
+        setExistsInLibrary(lookup.exists);
+        if (!lookup.exists || !lookup.artist) return;
+
+        const fullArtist = await getLibraryArtist(
+          lookup.artist.mbid || lookup.artist.foreignArtistId,
+        ).catch((err) => {
+          console.error("Failed to fetch full artist details:", err);
+          return lookup.artist;
+        });
+
+        setLibraryArtist(fullArtist);
+
+        const artistId = fullArtist.id || lookup.artist.id;
+        if (!artistId) return;
+
+        const albums = await getLibraryAlbums(artistId).catch((err) => {
+          console.error("Failed to fetch library albums:", err);
+          return [];
+        });
+        setLibraryAlbums(albums);
+      } catch {}
+      finally {
+        setLoadingLibrary(false);
+      }
+    };
+
+    const loadRestFallback = async () => {
+      if (restFallbackStarted) return;
+      restFallbackStarted = true;
+      clearTimeout(fallbackTimeout);
+      eventSource.close();
+
+      try {
+        const artistData = await getArtistDetails(mbid, artistNameFromNav, {
+          mode: "core",
+        });
+        if (!artistData || !artistData.id) {
+          throw new Error("Invalid artist data received");
+        }
+        setArtist(artistData);
+        setLoading(false);
+
+        const nameForCover = artistData?.name || artistNameRef.current || artistNameFromNav || "";
+        artistNameRef.current = nameForCover;
+        await Promise.allSettled([
+          loadCoverAndSimilarFallback(nameForCover),
+          libraryReceived ? Promise.resolve() : loadLibraryFallback(),
+        ]);
+      } catch (err) {
+        console.error("Error fetching artist data:", err);
+        setError(
+          err.response?.data?.message ||
+            err.response?.data?.error ||
+            err.message ||
+            "Failed to fetch artist details",
+        );
+        setLoading(false);
+        setLoadingCover(false);
+        setLoadingSimilar(false);
+        setLoadingLibrary(false);
+      }
+    };
+
+    const fallbackTimeout = setTimeout(() => {
+      const nameForCover = artistNameRef.current || artistNameFromNav || "";
+      loadCoverAndSimilarFallback(nameForCover).catch(() => {});
+    }, 2500);
 
     eventSource.addEventListener("connected", () => {});
 
@@ -203,49 +285,16 @@ export function useArtistDetailsStream(
         return;
       }
 
-      setLoadingLibrary(true);
-      lookupArtistInLibrary(mbid)
-        .then((lookup) => {
-          setExistsInLibrary(lookup.exists);
-          if (lookup.exists && lookup.artist) {
-            return Promise.all([
-              getLibraryArtist(
-                lookup.artist.mbid || lookup.artist.foreignArtistId,
-              ).catch((err) => {
-                console.error("Failed to fetch full artist details:", err);
-                return lookup.artist;
-              }),
-            ]).then(([fullArtist]) => {
-              setLibraryArtist(fullArtist);
-              return fullArtist.id || lookup.artist.id;
-            });
-          }
-          return null;
-        })
-        .then((artistId) => {
-          if (artistId) {
-            setTimeout(() => {
-              getLibraryAlbums(artistId)
-                .then((albums) => {
-                  setLibraryAlbums(albums);
-                })
-                .catch(() => {
-                  setTimeout(() => {
-                    getLibraryAlbums(artistId)
-                      .then((albums) => setLibraryAlbums(albums))
-                      .catch(() => {});
-                  }, 2000);
-                });
-            }, 1000);
-          }
-        })
-        .catch(() => {})
-        .finally(() => setLoadingLibrary(false));
+      loadLibraryFallback().catch(() => {});
     });
 
     eventSource.addEventListener("error", (event) => {
       try {
         const errorData = JSON.parse(event.data);
+        if (!artistReceived) {
+          loadRestFallback().catch(() => {});
+          return;
+        }
         setError(
           errorData.message ||
             errorData.error ||
@@ -255,92 +304,14 @@ export function useArtistDetailsStream(
         eventSource.close();
       } catch {
         if (eventSource.readyState === EventSource.CLOSED) {
-          eventSource.close();
-
-          getArtistDetails(mbid, artistNameFromNav)
-            .then((artistData) => {
-              if (!artistData || !artistData.id) {
-                throw new Error("Invalid artist data received");
-              }
-              setArtist(artistData);
-              setLoading(false);
-
-              const nameForCover = artistNameFromNav || artistData?.name;
-              getArtistCover(mbid, nameForCover)
-                .then((coverData) => {
-                  if (coverData.images && coverData.images.length > 0) {
-                    setCoverImages(coverData.images);
-                  }
-                })
-                .catch(() => {})
-                .finally(() => setLoadingCover(false));
-
-              getSimilarArtistsForArtist(
-                mbid,
-                artistData?.name || artistNameFromNav || "",
-              )
-                .then((similarData) => {
-                  setSimilarArtists(similarData.artists || []);
-                })
-                .catch(() => {})
-                .finally(() => setLoadingSimilar(false));
-            })
-            .catch((err) => {
-              console.error("Error fetching artist data:", err);
-              setError(
-                err.response?.data?.message ||
-                  err.response?.data?.error ||
-                  err.message ||
-                  "Failed to fetch artist details",
-              );
-              setLoading(false);
-            });
+          loadRestFallback().catch(() => {});
         }
       }
     });
 
     eventSource.onerror = () => {
       if (!artistReceived && !streamComplete) {
-        eventSource.close();
-
-        getArtistDetails(mbid, artistNameFromNav)
-          .then((artistData) => {
-            if (!artistData || !artistData.id) {
-              throw new Error("Invalid artist data received");
-            }
-            setArtist(artistData);
-            setLoading(false);
-
-            const nameForCover = artistNameFromNav || artistData?.name;
-            getArtistCover(mbid, nameForCover)
-              .then((coverData) => {
-                if (coverData.images && coverData.images.length > 0) {
-                  setCoverImages(coverData.images);
-                }
-              })
-              .catch(() => {})
-              .finally(() => setLoadingCover(false));
-
-            getSimilarArtistsForArtist(
-              mbid,
-              artistData?.name || artistNameFromNav || "",
-            )
-              .then((similarData) => {
-                setSimilarArtists(similarData.artists || []);
-              })
-              .catch(() => {})
-              .finally(() => setLoadingSimilar(false));
-          })
-          .catch((err) => {
-            console.error("Error fetching artist data:", err);
-            setError(
-              err.response?.data?.message ||
-                err.response?.data?.error ||
-                err.message ||
-                "Failed to fetch artist details",
-            );
-            setLoading(false);
-          });
+        loadRestFallback().catch(() => {});
       }
     };
 
@@ -364,7 +335,9 @@ export function useArtistDetailsStream(
     const needed = [...new Set([...releaseGroupIds, ...libraryMbids])];
     if (!needed.length) return;
 
-    const prioritized = needed.slice(0, 24);
+    const prioritized = visibleCoverIds.length
+      ? visibleCoverIds.filter((id) => needed.includes(id))
+      : needed.slice(0, 8);
     const missing = prioritized.filter(
       (id) => !albumCovers[id] && !requestedAlbumCoversRef.current.has(id),
     );
@@ -377,24 +350,45 @@ export function useArtistDetailsStream(
       for (let i = 0; i < missing.length; i += BATCH_SIZE) {
         if (cancelled) return;
         const batch = missing.slice(i, i + BATCH_SIZE);
-        await Promise.allSettled(
+        const batchResults = await Promise.allSettled(
           batch.map(async (rgId) => {
             requestedAlbumCoversRef.current.add(rgId);
             try {
-              const data = await getReleaseGroupCover(rgId);
+              const releaseGroup = artist?.["release-groups"]?.find(
+                (item) => item?.id === rgId,
+              );
+              const data = await getReleaseGroupCover(rgId, {
+                artistName: artistNameRef.current || artist?.name || "",
+                albumTitle:
+                  releaseGroup?.title ||
+                  libraryAlbums?.find(
+                    (album) => (album.mbid || album.foreignAlbumId) === rgId,
+                  )?.albumName ||
+                  "",
+              });
               if (cancelled || !data?.images?.length) return;
               const front =
                 data.images.find((img) => img.front) || data.images[0];
               const url = front?.image;
               if (url) {
-                setAlbumCovers((prev) => ({ ...prev, [rgId]: url }));
+                return [rgId, url];
               }
             } catch {
             } finally {
               requestedAlbumCoversRef.current.delete(rgId);
             }
+            return null;
           }),
         );
+        if (cancelled) return;
+        const nextBatch = Object.fromEntries(
+          batchResults.filter(
+            (entry) => Array.isArray(entry.value) && entry.value[0] && entry.value[1],
+          ).map((entry) => entry.value),
+        );
+        if (Object.keys(nextBatch).length > 0) {
+          setAlbumCovers((prev) => ({ ...prev, ...nextBatch }));
+        }
       }
     };
 
@@ -403,7 +397,14 @@ export function useArtistDetailsStream(
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [mbid, artist, libraryAlbums, albumCovers, selectedReleaseTypes]);
+  }, [
+    mbid,
+    artist,
+    libraryAlbums,
+    albumCovers,
+    selectedReleaseTypes,
+    visibleCoverIds,
+  ]);
 
   return {
     artist,

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -1140,7 +1140,17 @@ function DiscoverPage() {
     );
     missing.forEach((id) => {
       requestedReleaseCoversRef.current.add(id);
-      getReleaseGroupCover(id)
+      const release = recentReleases.find(
+        (album) => (album.mbid || album.foreignAlbumId) === id,
+      );
+      getReleaseGroupCover(id, {
+        artistName:
+          release?.artistName ||
+          release?.artist ||
+          release?.artistCredit ||
+          "",
+        albumTitle: release?.title || release?.albumName || "",
+      })
         .then((data) => {
           if (data?.images?.length > 0) {
             const front = data.images.find((img) => img.front) || data.images[0];

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -332,36 +332,34 @@ function SearchResultsPage() {
     }
 
     const hydrateArtistImages = async () => {
-      let nextIndex = 0;
-      const workers = Array.from(
-        {
-          length: Math.min(
-            ARTIST_IMAGE_HYDRATION_CONCURRENCY,
-            pendingArtists.length,
-          ),
-        },
-        async () => {
-          while (!cancelled && nextIndex < pendingArtists.length) {
-            const artist = pendingArtists[nextIndex++];
+      for (
+        let index = 0;
+        index < pendingArtists.length && !cancelled;
+        index += ARTIST_IMAGE_HYDRATION_CONCURRENCY
+      ) {
+        const batch = pendingArtists.slice(
+          index,
+          index + ARTIST_IMAGE_HYDRATION_CONCURRENCY,
+        );
+        const results = await Promise.allSettled(
+          batch.map(async (artist) => {
             const artistId = getArtistId(artist);
-            if (!artistId) continue;
-            try {
-              const data = await getArtistCover(artistId, artist.name);
-              const imageUrl = data?.images?.[0]?.image || null;
-              if (!imageUrl || cancelled) continue;
-              setArtistImages((prev) => {
-                if (prev[artistId] === imageUrl) return prev;
-                return {
-                  ...prev,
-                  [artistId]: imageUrl,
-                };
-              });
-            } catch {}
-          }
-        },
-      );
-
-      await Promise.allSettled(workers);
+            if (!artistId) return null;
+            const data = await getArtistCover(artistId, artist.name);
+            const imageUrl = data?.images?.[0]?.image || null;
+            return imageUrl ? [artistId, imageUrl] : null;
+          }),
+        );
+        if (cancelled) return;
+        const nextBatch = Object.fromEntries(
+          results.filter(
+            (entry) => Array.isArray(entry.value) && entry.value[0] && entry.value[1],
+          ).map((entry) => entry.value),
+        );
+        if (Object.keys(nextBatch).length > 0) {
+          setArtistImages((prev) => ({ ...prev, ...nextBatch }));
+        }
+      }
     };
 
     hydrateArtistImages();
@@ -424,8 +422,12 @@ function SearchResultsPage() {
     const hydrateCovers = async () => {
       const coverResults = await Promise.all(
         missingCoverIds.map(async (id) => {
+          const album = results.find((item) => item.id === id);
           try {
-            const data = await getReleaseGroupCover(id);
+            const data = await getReleaseGroupCover(id, {
+              artistName: album?.artistName || "",
+              albumTitle: album?.title || "",
+            });
             return [id, data?.images?.[0]?.image || null];
           } catch {
             return [id, null];

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -30,7 +30,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
 import { useReleaseTypeFilter } from "./ArtistDetails/hooks/useReleaseTypeFilter";
 
-const PAGE_SIZE = 24;
+const PAGE_SIZE = 20;
 const MBID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -315,7 +315,7 @@ function SearchResultsPage() {
   ]);
 
   useEffect(() => {
-    if (isAlbumSearch || results.length === 0) return undefined;
+    if (isAlbumSearch || isTagSearch || results.length === 0) return undefined;
 
     let cancelled = false;
     const pendingArtists = results.filter((artist) => {
@@ -368,7 +368,7 @@ function SearchResultsPage() {
     return () => {
       cancelled = true;
     };
-  }, [artistImages, isAlbumSearch, results]);
+  }, [artistImages, isAlbumSearch, isTagSearch, results]);
 
   useEffect(() => {
     if (isAlbumSearch) return undefined;

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -65,6 +65,7 @@ function dedupeAlbums(albums) {
 }
 
 const ARTIST_IMAGE_HYDRATION_CONCURRENCY = 6;
+const ALBUM_COVER_HYDRATION_CONCURRENCY = 6;
 
 function normalizeBlocklistArtists(artists) {
   const source = Array.isArray(artists) ? artists : [];
@@ -420,30 +421,43 @@ function SearchResultsPage() {
     }
 
     const hydrateCovers = async () => {
-      const coverResults = await Promise.all(
-        missingCoverIds.map(async (id) => {
-          const album = results.find((item) => item.id === id);
-          try {
+      for (
+        let index = 0;
+        index < missingCoverIds.length && !cancelled;
+        index += ALBUM_COVER_HYDRATION_CONCURRENCY
+      ) {
+        const batch = missingCoverIds.slice(
+          index,
+          index + ALBUM_COVER_HYDRATION_CONCURRENCY,
+        );
+        const coverResults = await Promise.allSettled(
+          batch.map(async (id) => {
+            const album = results.find((item) => item.id === id);
             const data = await getReleaseGroupCover(id, {
               artistName: album?.artistName || "",
               albumTitle: album?.title || "",
             });
             return [id, data?.images?.[0]?.image || null];
-          } catch {
-            return [id, null];
-          }
-        }),
-      );
-
-      if (cancelled) return;
-
-      setAlbumCovers((prev) => {
-        const next = { ...prev };
-        for (const [id, image] of coverResults) {
-          next[id] = image;
+          }),
+        );
+        if (cancelled) return;
+        const nextBatch = Object.fromEntries(
+          coverResults
+            .filter(
+              (entry) =>
+                Array.isArray(entry.value) &&
+                entry.value[0] &&
+                entry.value[1] !== undefined,
+            )
+            .map((entry) => entry.value),
+        );
+        if (Object.keys(nextBatch).length > 0) {
+          setAlbumCovers((prev) => ({
+            ...prev,
+            ...nextBatch,
+          }));
         }
-        return next;
-      });
+      }
     };
 
     hydrateCovers();

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -15,6 +15,7 @@ import {
   getBlocklist,
   getDiscovery,
   getBootstrapStatus,
+  getArtistCover,
   getReleaseGroupCover,
   lookupAlbumsInLibraryBatch,
   lookupArtistsInLibraryBatch,
@@ -62,6 +63,8 @@ function dedupeAlbums(albums) {
     return true;
   });
 }
+
+const ARTIST_IMAGE_HYDRATION_CONCURRENCY = 6;
 
 function normalizeBlocklistArtists(artists) {
   const source = Array.isArray(artists) ? artists : [];
@@ -223,14 +226,14 @@ function SearchResultsPage() {
           setVisibleCount(PAGE_SIZE);
           setHasMore(list.length > PAGE_SIZE);
           setSearchTotalCount(list.length);
-          if (list.length > 0) {
-            const imagesMap = {};
-            list.forEach((artist) => {
-              const artistId = getArtistId(artist);
-              if (artist.image && artistId) imagesMap[artistId] = artist.image;
-            });
-            setArtistImages(imagesMap);
-          }
+          const imagesMap = {};
+          list.forEach((artist) => {
+            const artistId = getArtistId(artist);
+            if ((artist.image || artist.imageUrl) && artistId) {
+              imagesMap[artistId] = artist.image || artist.imageUrl;
+            }
+          });
+          setArtistImages(imagesMap);
         } catch (err) {
           setError(
             err.response?.data?.message || "Failed to load. Please try again.",
@@ -285,6 +288,8 @@ function SearchResultsPage() {
             }
           });
           setArtistImages(imagesMap);
+        } else if (!isAlbumSearch) {
+          setArtistImages({});
         }
       } catch (err) {
         setError(
@@ -307,6 +312,64 @@ function SearchResultsPage() {
     isTagSearch,
     selectedReleaseTypes,
   ]);
+
+  useEffect(() => {
+    if (isAlbumSearch || results.length === 0) return undefined;
+
+    let cancelled = false;
+    const pendingArtists = results.filter((artist) => {
+      const artistId = getArtistId(artist);
+      if (!artistId) return false;
+      if (artistImages[artistId]) return false;
+      if (artist.image || artist.imageUrl) return false;
+      return true;
+    });
+
+    if (pendingArtists.length === 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const hydrateArtistImages = async () => {
+      let nextIndex = 0;
+      const workers = Array.from(
+        {
+          length: Math.min(
+            ARTIST_IMAGE_HYDRATION_CONCURRENCY,
+            pendingArtists.length,
+          ),
+        },
+        async () => {
+          while (!cancelled && nextIndex < pendingArtists.length) {
+            const artist = pendingArtists[nextIndex++];
+            const artistId = getArtistId(artist);
+            if (!artistId) continue;
+            try {
+              const data = await getArtistCover(artistId, artist.name);
+              const imageUrl = data?.images?.[0]?.image || null;
+              if (!imageUrl || cancelled) continue;
+              setArtistImages((prev) => {
+                if (prev[artistId] === imageUrl) return prev;
+                return {
+                  ...prev,
+                  [artistId]: imageUrl,
+                };
+              });
+            } catch {}
+          }
+        },
+      );
+
+      await Promise.allSettled(workers);
+    };
+
+    hydrateArtistImages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artistImages, isAlbumSearch, results]);
 
   useEffect(() => {
     if (isAlbumSearch) return undefined;

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -375,7 +375,9 @@ function SearchResultsPage() {
     let cancelled = false;
     const ids = results.map((artist) => getArtistId(artist)).filter(Boolean);
     if (ids.length === 0) {
-      setLibraryLookup({});
+      if (Object.keys(libraryLookup).length > 0) {
+        setLibraryLookup({});
+      }
       return () => {
         cancelled = true;
       };
@@ -393,11 +395,7 @@ function SearchResultsPage() {
         if (!cancelled && lookup) {
           setLibraryLookup((prev) => ({ ...prev, ...lookup }));
         }
-      } catch {
-        if (!cancelled) {
-          setLibraryLookup((prev) => ({ ...prev }));
-        }
-      }
+      } catch {}
     };
 
     fetchLookup();
@@ -814,12 +812,12 @@ function SearchResultsPage() {
           )}
         </div>
 
-        {isTagSearch && lastfmConfigured === false && (
+        {isTagSearch && !showAllTagResults && lastfmConfigured === false && (
           <div className="mt-4 bg-yellow-500/20 p-4">
             <div className="flex flex-wrap items-center gap-3">
               <p className="text-sm text-yellow-300">
-                Tag search and discovery recommendations use Last.fm. Add an
-                API key to enable full results.
+                Recommended tag results use the hydrated Last.fm discovery
+                cache. Add an API key to enable that path.
               </p>
               <button
                 type="button"

--- a/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
@@ -40,7 +40,6 @@ export function SettingsMetadataTab({
   handleSaveSettings,
 }) {
   const [musicbrainzEditing, setMusicbrainzEditing] = useState(false);
-  const [coverArtArchiveEditing, setCoverArtArchiveEditing] = useState(false);
   const providerHealth = health?.metadataProviders || {};
 
   return (
@@ -178,120 +177,6 @@ export function SettingsMetadataTab({
                 <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
                   Enter the MusicBrainz API base URL. If you omit `/ws/2`, it
                   will be added automatically.
-                </p>
-              </div>
-            )}
-          </fieldset>
-        </div>
-        <div
-          className="p-6 rounded-lg space-y-4"
-          style={{
-            backgroundColor: "#1a1a1e",
-            border: "1px solid #2a2a2e",
-          }}
-        >
-          <div className="flex items-center justify-between mb-2">
-            <h3
-              className="text-lg font-medium flex items-center"
-              style={{ color: "#fff" }}
-            >
-              Cover Art Archive
-            </h3>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                className={`btn ${
-                  coverArtArchiveEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setCoverArtArchiveEditing((value) => !value)}
-                aria-label={
-                  coverArtArchiveEditing
-                    ? "Lock Cover Art Archive settings"
-                    : "Edit Cover Art Archive settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
-          <fieldset
-            disabled={!coverArtArchiveEditing}
-            className={`space-y-4 ${coverArtArchiveEditing ? "" : "opacity-60"}`}
-          >
-            <div>
-              <label
-                className="block text-sm font-medium mb-1"
-                style={{ color: "#fff" }}
-              >
-                Cover art source
-              </label>
-              <select
-                className="input"
-                value={
-                  settings.integrations?.coverArtArchive?.provider ||
-                  "aurralHosted"
-                }
-                onChange={(e) =>
-                  updateSettings({
-                    ...settings,
-                    integrations: {
-                      ...settings.integrations,
-                      coverArtArchive: {
-                        ...(settings.integrations?.coverArtArchive || {}),
-                        provider: e.target.value,
-                      },
-                    },
-                  })
-                }
-              >
-                <option value="aurralHosted">
-                  Aurral-hosted Cover Art Archive proxy
-                </option>
-                <option value="official">Official Cover Art Archive</option>
-                <option value="custom">Custom self-hosted instance</option>
-              </select>
-              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Aurral-hosted uses your default proxy. Official goes back to
-                the public Cover Art Archive. Custom lets users point at their
-                own host.
-              </p>
-              <ProviderStatusNote
-                providerHealth={providerHealth.coverArtArchive}
-                hostedLabel="Aurral-hosted Cover Art Archive proxy"
-                officialLabel="Official Cover Art Archive"
-              />
-            </div>
-            {(settings.integrations?.coverArtArchive?.provider ||
-              "aurralHosted") === "custom" && (
-              <div>
-                <label
-                  className="block text-sm font-medium mb-1"
-                  style={{ color: "#fff" }}
-                >
-                  Custom API URL
-                </label>
-                <input
-                  type="url"
-                  className="input"
-                  placeholder="https://coverartarchive.example.com"
-                  autoComplete="off"
-                  value={settings.integrations?.coverArtArchive?.customUrl || ""}
-                  onChange={(e) =>
-                    updateSettings({
-                      ...settings,
-                      integrations: {
-                        ...settings.integrations,
-                        coverArtArchive: {
-                          ...(settings.integrations?.coverArtArchive || {}),
-                          customUrl: e.target.value,
-                        },
-                      },
-                    })
-                  }
-                />
-                <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                  Enter the Cover Art Archive base URL without a trailing
-                  release-group path.
                 </p>
               </div>
             )}

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -46,10 +46,6 @@ const defaultSettings = {
       provider: "aurralHosted",
       customUrl: "",
     },
-    coverArtArchive: {
-      provider: "aurralHosted",
-      customUrl: "",
-    },
     general: { authUser: "", authPassword: "" },
     gotify: {
       url: "",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -68,11 +68,6 @@ export const normalizeSettings = (savedSettings) => {
         customUrl: "",
         ...(savedSettings.integrations?.musicbrainz || {}),
       },
-      coverArtArchive: {
-        provider: "aurralHosted",
-        customUrl: "",
-        ...(savedSettings.integrations?.coverArtArchive || {}),
-      },
       general: {
         authUser: "",
         authPassword: "",

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -277,9 +277,20 @@ export const searchCatalog = async (
   });
 };
 
-export const getArtistDetails = async (mbid, artistName) => {
+export const getArtistDetails = async (
+  mbid,
+  artistName,
+  { mode = "" } = {},
+) => {
+  const params = {};
+  if (artistName) {
+    params.artistName = artistName;
+  }
+  if (mode) {
+    params.mode = mode;
+  }
   const response = await api.get(`/artists/${mbid}`, {
-    params: artistName ? { artistName } : {},
+    params,
   });
   return response.data;
 };
@@ -311,10 +322,22 @@ export const getArtistCover = async (mbid, artistName, refresh = false) => {
   );
 };
 
-export const getReleaseGroupCover = async (mbid) => {
+export const getReleaseGroupCover = async (
+  mbid,
+  { artistName = "", albumTitle = "" } = {},
+) => {
   const cacheKey = `release-group:${mbid}`;
   return fetchCoverWithMemo(cacheKey, async () => {
-    const response = await api.get(`/artists/release-group/${mbid}/cover`);
+    const params = {};
+    if (typeof artistName === "string" && artistName.trim()) {
+      params.artistName = artistName.trim();
+    }
+    if (typeof albumTitle === "string" && albumTitle.trim()) {
+      params.albumTitle = albumTitle.trim();
+    }
+    const response = await api.get(`/artists/release-group/${mbid}/cover`, {
+      params,
+    });
     return response.data;
   });
 };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -78,6 +78,8 @@ const MAX_LIBRARY_LOOKUP_CACHE_SIZE = 1000;
 const coverResponseCache = new Map();
 const coverInflightRequests = new Map();
 const MAX_COVER_CACHE_SIZE = 1000;
+const COVER_CACHE_TTL_MS = 30 * 60 * 1000;
+const EMPTY_COVER_CACHE_TTL_MS = 60 * 1000;
 const searchInflightRequests = new Map();
 
 const setLibraryLookupCacheEntry = (id, value) => {
@@ -96,10 +98,15 @@ const setLibraryLookupCacheEntry = (id, value) => {
 
 const setCoverCacheEntry = (key, value) => {
   if (!key) return;
+  const images = Array.isArray(value?.images) ? value.images : [];
+  const ttlMs = images.length > 0 ? COVER_CACHE_TTL_MS : EMPTY_COVER_CACHE_TTL_MS;
   if (coverResponseCache.has(key)) {
     coverResponseCache.delete(key);
   }
-  coverResponseCache.set(key, value);
+  coverResponseCache.set(key, {
+    value,
+    expiresAt: Date.now() + ttlMs,
+  });
   if (coverResponseCache.size > MAX_COVER_CACHE_SIZE) {
     const oldestKey = coverResponseCache.keys().next().value;
     if (oldestKey !== undefined) {
@@ -108,9 +115,22 @@ const setCoverCacheEntry = (key, value) => {
   }
 };
 
+const getCoverCacheEntry = (key) => {
+  const entry = coverResponseCache.get(key);
+  if (!entry) return null;
+  if (Date.now() >= Number(entry.expiresAt || 0)) {
+    coverResponseCache.delete(key);
+    return null;
+  }
+  return entry.value;
+};
+
 const fetchCoverWithMemo = async (key, requestFactory, { bypassCache = false } = {}) => {
-  if (!bypassCache && coverResponseCache.has(key)) {
-    return coverResponseCache.get(key);
+  if (!bypassCache) {
+    const cached = getCoverCacheEntry(key);
+    if (cached) {
+      return cached;
+    }
   }
 
   if (coverInflightRequests.has(key)) {


### PR DESCRIPTION
## Summary
- Switch cover image responses to use locally cached image URLs instead of signed proxy URLs.
- Add local image warm-up and proxy routing so cached artwork is served directly from `/api/image-proxy/:cacheKey`.
- Improve cover discovery with iTunes artwork fallback, broader MusicBrainz/Cover Art Archive lookup, and transient-error handling to avoid over-caching misses.
- Update artist and search UI components to handle image failures and retry cover loading when needed.

## Testing
- Not run.
- Verified the diff updates backend cover/image lookup flow and frontend image fallbacks.
- Confirmed the new image proxy route is exposed without auth for cached image reads.