### PR TITLE
Link show cards to ticket pages

### DIFF
--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -15,7 +15,6 @@ import {
   CheckCircle2,
   MapPin,
   Pencil,
-  Ticket,
   MoreVertical,
   Ban,
   Loader2,
@@ -686,7 +685,7 @@ const ShowCard = memo(({ show }) => {
                 {showLocation && (
                   <p className="flex items-start gap-2">
                     <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span className="line-clamp-2">{showLocation}</span>
+                    <span className="truncate">{showLocation}</span>
                   </p>
                 )}
               </div>
@@ -699,38 +698,48 @@ const ShowCard = memo(({ show }) => {
         className="group hidden flex-col overflow-hidden border border-white/10 sm:flex"
         style={{ backgroundColor: "#191820" }}
       >
-        <div className="relative aspect-[16/9] overflow-hidden" style={{ backgroundColor: "#211f27" }}>
-          {show.image ? (
-            <img
-              src={show.image}
-              alt={show.eventName || show.artistName}
-              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center">
-              <Music className="w-10 h-10" style={{ color: "#c1c1c3" }} />
-            </div>
-          )}
-          <div className="absolute left-3 top-3 flex gap-2">
-            {Number.isFinite(show.distance) && (
-              <span
-                className="px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
-                style={{ backgroundColor: "rgba(20,20,26,0.82)", color: "#fff" }}
-              >
-                {Math.round(show.distance)} mi
-              </span>
+        <a href={show.url || "#"} target="_blank" rel="noopener noreferrer">
+          <div className="relative aspect-[16/9] overflow-hidden" style={{ backgroundColor: "#211f27" }}>
+            {show.image ? (
+              <img
+                src={show.image}
+                alt={show.eventName || show.artistName}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                loading="lazy"
+                decoding="async"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Music className="w-10 h-10" style={{ color: "#c1c1c3" }} />
+              </div>
             )}
+            <div className="absolute left-3 top-3 flex gap-2">
+              {Number.isFinite(show.distance) && (
+                <span
+                  className="px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+                  style={{ backgroundColor: "rgba(20,20,26,0.82)", color: "#fff" }}
+                >
+                  {Math.round(show.distance)} mi
+                </span>
+              )}
+            </div>
           </div>
-        </div>
+        </a>
         <div className="flex flex-1 flex-col gap-3 p-4">
           <div className="min-w-0">
             <p className="text-xs uppercase tracking-[0.22em]" style={{ color: "#8a8a8f" }}>
               {show.artistName}
             </p>
-            <h3 className="mt-1 text-lg font-semibold leading-tight" style={{ color: "#fff" }}>
-              {show.eventName}
+            <h3 className="mt-1 text-lg font-semibold leading-tight">
+              <a
+                href={show.url || "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="transition-opacity hover:opacity-80"
+                style={{ color: "#fff" }}
+              >
+                {show.eventName}
+              </a>
             </h3>
           </div>
           <div className="space-y-2 text-sm" style={{ color: "#c1c1c3" }}>
@@ -743,21 +752,9 @@ const ShowCard = memo(({ show }) => {
             {showLocation && (
               <p className="flex items-start gap-2">
                 <MapPin className="w-4 h-4 shrink-0 mt-0.5" />
-                <span>{showLocation}</span>
+                <span className="truncate">{showLocation}</span>
               </p>
             )}
-          </div>
-          <div className="mt-auto pt-2">
-            <a
-              href={show.url || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors hover:opacity-90"
-              style={{ backgroundColor: "#707e61", color: "#0b0b0c" }}
-            >
-              <Ticket className="w-4 h-4" />
-              Tickets
-            </a>
           </div>
         </div>
       </article>
@@ -1646,7 +1643,7 @@ function DiscoverPage() {
                   }}
                   className="px-3 py-1.5 text-xs font-medium transition-colors"
                   style={{
-                    backgroundColor: !zipModeActive ? "#707e61" : "transparent",
+                    backgroundColor: !zipModeActive ? "#5a5a5f" : "transparent",
                     color: !zipModeActive ? "#0b0b0c" : "#c1c1c3",
                   }}
                 >
@@ -1662,7 +1659,7 @@ function DiscoverPage() {
                   }}
                   className="px-3 py-1.5 text-xs font-medium transition-colors"
                   style={{
-                    backgroundColor: zipModeActive ? "#707e61" : "transparent",
+                    backgroundColor: zipModeActive ? "#5a5a5f" : "transparent",
                     color: zipModeActive ? "#0b0b0c" : "#c1c1c3",
                   }}
                 >

--- a/frontend/src/pages/ShowsPage.jsx
+++ b/frontend/src/pages/ShowsPage.jsx
@@ -7,7 +7,6 @@ import {
   Clock,
   MapPin,
   Pencil,
-  Ticket,
 } from "lucide-react";
 import { getNearbyShows } from "../utils/api";
 
@@ -49,8 +48,11 @@ const ShowCard = memo(({ show }) => {
         style={{ backgroundColor: "#191820" }}
       >
         <div className="flex min-h-[120px]">
-          <div
-            className="relative w-[112px] shrink-0 overflow-hidden"
+          <a
+            href={show.url || "#"}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="relative block w-[112px] shrink-0 overflow-hidden"
             style={{ backgroundColor: "#211f27" }}
           >
             {show.image ? (
@@ -76,14 +78,22 @@ const ShowCard = memo(({ show }) => {
                 </span>
               </div>
             )}
-          </div>
+          </a>
           <div className="flex min-w-0 flex-1 flex-col gap-2 p-3">
             <div className="min-w-0">
               <p className="truncate text-[11px] uppercase tracking-[0.22em]" style={{ color: "#8a8a8f" }}>
                 {show.artistName}
               </p>
-              <h3 className="mt-1 line-clamp-2 text-base font-semibold leading-tight" style={{ color: "#fff" }}>
-                {show.eventName}
+              <h3 className="mt-1 line-clamp-2 text-base font-semibold leading-tight">
+                <a
+                  href={show.url || "#"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="transition-opacity hover:opacity-80"
+                  style={{ color: "#fff" }}
+                >
+                  {show.eventName}
+                </a>
               </h3>
             </div>
             <div className="space-y-1.5 text-xs" style={{ color: "#c1c1c3" }}>
@@ -100,18 +110,6 @@ const ShowCard = memo(({ show }) => {
                 </p>
               )}
             </div>
-            <div className="mt-auto pt-1">
-              <a
-                href={show.url || "#"}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-3 py-2 text-xs font-medium transition-colors hover:opacity-90"
-                style={{ backgroundColor: "#707e61", color: "#0b0b0c" }}
-              >
-                <Ticket className="h-3.5 w-3.5" />
-                Tickets
-              </a>
-            </div>
           </div>
         </div>
       </article>
@@ -120,41 +118,51 @@ const ShowCard = memo(({ show }) => {
         className="group hidden flex-col overflow-hidden border border-white/10 md:flex"
         style={{ backgroundColor: "#191820" }}
       >
-        <div
-          className="relative aspect-[16/9] overflow-hidden"
-          style={{ backgroundColor: "#211f27" }}
-        >
-          {show.image ? (
-            <img
-              src={show.image}
-              alt={show.eventName || show.artistName}
-              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center">
-              <Music className="w-10 h-10" style={{ color: "#c1c1c3" }} />
-            </div>
-          )}
-          <div className="absolute left-3 top-3 flex gap-2">
-            {Number.isFinite(show.distance) && (
-              <span
-                className="px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
-                style={{ backgroundColor: "rgba(20,20,26,0.82)", color: "#fff" }}
-              >
-                {Math.round(show.distance)} mi
-              </span>
+        <a href={show.url || "#"} target="_blank" rel="noopener noreferrer">
+          <div
+            className="relative aspect-[16/9] overflow-hidden"
+            style={{ backgroundColor: "#211f27" }}
+          >
+            {show.image ? (
+              <img
+                src={show.image}
+                alt={show.eventName || show.artistName}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                loading="lazy"
+                decoding="async"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Music className="w-10 h-10" style={{ color: "#c1c1c3" }} />
+              </div>
             )}
+            <div className="absolute left-3 top-3 flex gap-2">
+              {Number.isFinite(show.distance) && (
+                <span
+                  className="px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+                  style={{ backgroundColor: "rgba(20,20,26,0.82)", color: "#fff" }}
+                >
+                  {Math.round(show.distance)} mi
+                </span>
+              )}
+            </div>
           </div>
-        </div>
+        </a>
         <div className="flex flex-1 flex-col gap-3 p-4">
           <div className="min-w-0">
             <p className="text-xs uppercase tracking-[0.22em]" style={{ color: "#8a8a8f" }}>
               {show.artistName}
             </p>
-            <h3 className="mt-1 text-lg font-semibold leading-tight" style={{ color: "#fff" }}>
-              {show.eventName}
+            <h3 className="mt-1 text-lg font-semibold leading-tight">
+              <a
+                href={show.url || "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="transition-opacity hover:opacity-80"
+                style={{ color: "#fff" }}
+              >
+                {show.eventName}
+              </a>
             </h3>
           </div>
           <div className="space-y-2 text-sm" style={{ color: "#c1c1c3" }}>
@@ -170,18 +178,6 @@ const ShowCard = memo(({ show }) => {
                 <span>{showLocation}</span>
               </p>
             )}
-          </div>
-          <div className="mt-auto pt-2">
-            <a
-              href={show.url || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors hover:opacity-90"
-              style={{ backgroundColor: "#707e61", color: "#0b0b0c" }}
-            >
-              <Ticket className="w-4 h-4" />
-              Tickets
-            </a>
           </div>
         </div>
       </article>
@@ -292,7 +288,7 @@ function ShowsPage() {
               }}
               className="px-3 py-1.5 text-xs font-medium transition-colors"
               style={{
-                backgroundColor: !zipModeActive ? "#707e61" : "transparent",
+                backgroundColor: !zipModeActive ? "#5a5a5f" : "transparent",
                 color: !zipModeActive ? "#0b0b0c" : "#c1c1c3",
               }}
             >
@@ -308,7 +304,7 @@ function ShowsPage() {
               }}
               className="px-3 py-1.5 text-xs font-medium transition-colors"
               style={{
-                backgroundColor: zipModeActive ? "#707e61" : "transparent",
+                backgroundColor: zipModeActive ? "#5a5a5f" : "transparent",
                 color: zipModeActive ? "#0b0b0c" : "#c1c1c3",
               }}
             >


### PR DESCRIPTION
## Summary
- Turned show cards into direct links to each show’s ticket page in both Discover and Shows views.
- Removed the separate `Tickets` button and made the image/title areas clickable instead.
- Tightened text handling for location lines to reduce wrapping and improve card layout.
- Updated the active toggle button styling in both pages for a more muted selected state.

## Testing
- Not run (UI-only change).
- Verified the diff for both `DiscoverPage.jsx` and `ShowsPage.jsx` to ensure ticket links now wrap the image and title.
- Checked that external links still use `target="_blank"` and `rel="noopener noreferrer"`.