### PR TITLE
Add shared playlist track re-search

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -1311,6 +1311,64 @@ router.delete(
   },
 );
 
+router.post(
+  "/shared-playlists/:playlistId/tracks/:jobId/research",
+  async (req, res) => {
+    try {
+      const { playlistId, jobId } = req.params;
+      const playlist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+      if (!playlist) {
+        return res.status(404).json({ error: "Shared playlist not found" });
+      }
+
+      const job = downloadTracker.getJob(jobId);
+      if (!job || job.playlistType !== playlistId) {
+        return res.status(404).json({ error: "Track not found" });
+      }
+
+      if (job.status === "pending" || job.status === "downloading") {
+        return res.status(409).json({
+          error: "Track is already being processed",
+        });
+      }
+
+      if (job.status === "done" && typeof job.finalPath === "string") {
+        const playlistRoot = getPlaylistLibraryRoot(playlistId);
+        const safeFinalPath = path.resolve(job.finalPath);
+        if (!isPathInsideRoot(safeFinalPath, playlistRoot)) {
+          return res.status(400).json({
+            error: "Track path is outside the playlist library",
+          });
+        }
+        await fsp.rm(safeFinalPath, { force: true });
+      }
+
+      const reset = downloadTracker.setPending(jobId, null);
+      if (!reset) {
+        return res.status(500).json({
+          error: "Failed to requeue track",
+        });
+      }
+
+      await restartWorkerIfPending();
+      if (weeklyFlowWorker.running) {
+        weeklyFlowWorker.wake();
+      }
+
+      res.json({
+        success: true,
+        jobId,
+        playlistId,
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: "Failed to re-search shared playlist track",
+        message: error.message,
+      });
+    }
+  },
+);
+
 router.delete("/shared-playlists/:playlistId", async (req, res) => {
   try {
     const { playlistId } = req.params;

--- a/backend/services/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlowDownloadTracker.js
@@ -548,6 +548,7 @@ export class WeeklyFlowDownloadTracker {
     job.startedAt = null;
     job.completedAt = null;
     job.stagingPath = null;
+    job.finalPath = null;
     job.retryCycle = asRetryCycle;
     job.error =
       typeof error === "string" ? error : (error && error.message) || null;

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -18,6 +18,7 @@ import {
   getFlowArtworkUrl,
   updateFlowWorkerSettings,
   setPlaylistRetryCyclePaused,
+  reSearchSharedPlaylistTrack,
 } from "../utils/api";
 import {
   CreatePlaylistModal,
@@ -815,6 +816,7 @@ function FlowPage() {
   const [applyingSharedPlaylistId, setApplyingSharedPlaylistId] = useState(null);
   const [applyingSharedPlaylistNameId, setApplyingSharedPlaylistNameId] = useState(null);
   const [retryActionPlaylistId, setRetryActionPlaylistId] = useState(null);
+  const [reSearchingTrackIds, setReSearchingTrackIds] = useState({});
   const [trackEditingId, setTrackEditingId] = useState(null);
   const [flowStatsById, setFlowStatsById] = useState({});
   const [tracksExpandedId, setTracksExpandedId] = useState(null);
@@ -1818,6 +1820,57 @@ function FlowPage() {
     }
   };
 
+  const handleReSearchSharedPlaylistTrack = async (playlistId, track) => {
+    const jobId = track?.id;
+    if (!playlistId || !jobId || reSearchingTrackIds[jobId]) return;
+    setReSearchingTrackIds((prev) => ({
+      ...prev,
+      [jobId]: true,
+    }));
+    setTracksByFlowId((prev) => {
+      const existing = Array.isArray(prev[playlistId]) ? prev[playlistId] : [];
+      return {
+        ...prev,
+        [playlistId]: existing.map((entry) =>
+          entry?.id === jobId
+            ? {
+                ...entry,
+                status: "pending",
+                error: null,
+                streamUrl: null,
+              }
+            : entry,
+        ),
+      };
+    });
+    try {
+      await reSearchSharedPlaylistTrack(playlistId, jobId);
+      showSuccess(`Re-searching ${track.trackName}`);
+      await fetchStatus();
+      await fetchFlowTracks(playlistId, {
+        showSpinner: false,
+        includeFailed: true,
+      });
+    } catch (err) {
+      const message =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        err.message ||
+        "Failed to re-search track";
+      showError(message);
+      await fetchFlowTracks(playlistId, {
+        showSpinner: false,
+        includeFailed: true,
+      });
+    } finally {
+      setReSearchingTrackIds((prev) => {
+        const next = { ...prev };
+        delete next[jobId];
+        return next;
+      });
+    }
+  };
+
   const handleNavigateArtist = (track) => {
     if (!track?.artistMbid) return;
     navigate(`/artist/${track.artistMbid}`, {
@@ -1952,6 +2005,10 @@ function FlowPage() {
                   })
                 }
                 onNavigateArtist={handleNavigateArtist}
+                reSearchingTrackIds={reSearchingTrackIds}
+                onReSearchTrack={(track) =>
+                  handleReSearchSharedPlaylistTrack(playlist.id, track)
+                }
                 retryCyclePaused={retryCyclePausedByPlaylist[playlist.id] === true}
                 retryCycleScheduled={
                   retryCycleScheduledByPlaylist[playlist.id] === true

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -26,6 +26,7 @@ import {
   Volume2,
   VolumeX,
   Plus,
+  Search,
   ChevronDown,
   MoreHorizontal,
   X,
@@ -1664,7 +1665,7 @@ export function FlowCard({
                     aria-label={`Edit ${flow.name} name`}
                   />
                 ) : (
-                  <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-white sm:text-base">
+                  <h3 className="min-w-0 truncate text-sm font-medium text-white sm:text-base">
                     {flow.name}
                   </h3>
                 )}
@@ -1805,9 +1806,11 @@ export function FlowTracksPanel({
   showFailedDetails = true,
   headerActions = null,
   deletingTrackId = null,
+  reSearchingTrackIds = {},
   onDeleteTrack,
   onAddTrackToPlaylist,
   onNavigateArtist,
+  onReSearchTrack,
 }) {
   const [queue, setQueue] = useState([]);
   const [currentTrackId, setCurrentTrackId] = useState(null);
@@ -2140,6 +2143,11 @@ export function FlowTracksPanel({
               {visibleTracks.map((track, index) => {
                 const canPlay = track.status === "done" && !!track.streamUrl;
                 const canDelete = editable && track.status === "done" && !!track.id;
+                const canReSearch =
+                  typeof onReSearchTrack === "function" &&
+                  !!track.id &&
+                  (track.status === "done" || track.status === "failed");
+                const isReSearching = reSearchingTrackIds[track.id] === true;
                 const isCurrent = track.id === currentTrackId;
                 const progressWidth = `${Math.round(playbackProgress * 100)}%`;
                 return (
@@ -2212,6 +2220,21 @@ export function FlowTracksPanel({
                             disabled={!track.artistName || !track.trackName}
                           >
                             <Plus className="w-3.5 h-3.5" />
+                          </button>
+                        ) : null}
+                        {canReSearch ? (
+                          <button
+                            onClick={() => onReSearchTrack(track)}
+                            className="btn btn-secondary btn-xs px-2"
+                            aria-label={`Re-search ${track.trackName}`}
+                            title={`Re-search ${track.trackName}`}
+                            disabled={isReSearching}
+                          >
+                            {isReSearching ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Search className="w-3.5 h-3.5" />
+                            )}
                           </button>
                         ) : null}
                         {canDelete ? (
@@ -2288,6 +2311,8 @@ export function SharedPlaylistCard({
   onViewTracks,
   onAddTrackToPlaylist,
   onNavigateArtist,
+  reSearchingTrackIds,
+  onReSearchTrack,
   retryCyclePaused,
   retryCycleScheduled,
   retryActionInFlight,
@@ -2449,7 +2474,7 @@ export function SharedPlaylistCard({
                     aria-label={`Edit ${playlist.name} name`}
                   />
                 ) : (
-                  <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-white sm:text-base">
+                  <h3 className="min-w-0 truncate text-sm font-medium text-white sm:text-base">
                     {playlist.name}
                   </h3>
                 )}
@@ -2611,6 +2636,8 @@ export function SharedPlaylistCard({
               }
               onAddTrackToPlaylist={onAddTrackToPlaylist}
               onNavigateArtist={onNavigateArtist}
+              reSearchingTrackIds={reSearchingTrackIds}
+              onReSearchTrack={onReSearchTrack}
             />
           )}
         </div>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -965,6 +965,13 @@ export const deleteSharedPlaylistTrack = async (playlistId, jobId) => {
   return response.data;
 };
 
+export const reSearchSharedPlaylistTrack = async (playlistId, jobId) => {
+  const response = await api.post(
+    `/weekly-flow/shared-playlists/${playlistId}/tracks/${jobId}/research`,
+  );
+  return response.data;
+};
+
 export const startFlowPlaylist = async (flowId, limit = 30) => {
   const response = await api.post(`/weekly-flow/start/${flowId}`, {
     limit,


### PR DESCRIPTION
## Summary
- Add a backend endpoint to requeue a shared playlist track for research after removing any completed output file.
- Reset tracker state so re-researched tracks return to `pending` and can be picked up by the worker again.
- Add a frontend action on shared playlist track rows to trigger re-search with in-flight loading state.
- Wire the new API call through the shared playlist flow UI and keep track lists refreshed after the action completes.

## Testing
- Not run (not requested).
- Verify the new `POST /weekly-flow/shared-playlists/:playlistId/tracks/:jobId/research` endpoint returns `200` for completed shared tracks and `404`/`409` for invalid or active jobs.
- Verify clicking the re-search button updates the track row to pending, shows the spinner while the request is in flight, and refreshes the playlist after completion.
- Verify a previously completed track can be reprocessed end-to-end and that the old final file is removed before the new run starts.