### PR TITLE
Reuse Lidarr library tracks for static playlists

### DIFF
--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -15,6 +15,7 @@ import {
 } from "../services/weeklyFlowPlaylistConfig.js";
 import { weeklyFlowOperationQueue } from "../services/weeklyFlowOperationQueue.js";
 import { getWeeklyFlowStatusSnapshot } from "../services/weeklyFlowStatusSnapshot.js";
+import { reuseTrackForStaticPlaylist } from "../services/staticPlaylistLibraryReuse.js";
 import { noCache } from "../middleware/cache.js";
 import { hasPermission, verifyTokenAuth } from "../middleware/auth.js";
 import {
@@ -912,12 +913,37 @@ router.post("/shared-playlists", async (req, res) => {
     });
 
     let tracksQueued = 0;
-    if (normalizedTracks.length > 0) {
-      tracksQueued = downloadTracker.addJobs(normalizedTracks, playlist.id).length;
+    let tracksReused = 0;
+    const reusedJobIds = [];
+    const tracksToQueue = [];
+    for (const track of normalizedTracks) {
+      try {
+        const reused = await reuseTrackForStaticPlaylist(track, playlist.id);
+        if (reused?.jobId) {
+          reusedJobIds.push(reused.jobId);
+          tracksReused += 1;
+        } else {
+          tracksToQueue.push(track);
+        }
+      } catch (error) {
+        console.warn(
+          `[WeeklyFlow] Failed Lidarr reuse for ${playlist.id}:`,
+          error.message,
+        );
+        tracksToQueue.push(track);
+      }
     }
+    const queuedJobIds =
+      tracksToQueue.length > 0
+        ? downloadTracker.addJobs(tracksToQueue, playlist.id)
+        : [];
+    tracksQueued = queuedJobIds.length;
 
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
+    if (tracksReused > 0) {
+      await playlistManager.scanLibrary();
+    }
     if (tracksQueued > 0) {
       if (!weeklyFlowWorker.running) {
         await weeklyFlowWorker.start();
@@ -930,6 +956,8 @@ router.post("/shared-playlists", async (req, res) => {
       success: true,
       playlist,
       tracksQueued,
+      tracksReused,
+      jobIds: [...reusedJobIds, ...queuedJobIds],
     });
   } catch (error) {
     if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
@@ -946,6 +974,7 @@ router.post("/shared-playlists", async (req, res) => {
 });
 
 router.post("/shared-playlists/import", async (req, res) => {
+  let playlist = null;
   try {
     const {
       name,
@@ -965,22 +994,47 @@ router.post("/shared-playlists/import", async (req, res) => {
         message: "Import file must include at least one track",
       });
     }
-    if (!soulseekClient.isConfigured()) {
-      return res.status(400).json({
-        error: "Soulseek credentials not configured",
-      });
-    }
-
-    const playlist = flowPlaylistConfig.createSharedPlaylist({
+    playlist = flowPlaylistConfig.createSharedPlaylist({
       name: safeName,
       sourceName,
       sourceFlowId,
       tracks: normalizedTracks,
     });
 
-    const jobIds = downloadTracker.addJobs(normalizedTracks, playlist.id);
+    const reusedJobIds = [];
+    const tracksToQueue = [];
+    for (const track of normalizedTracks) {
+      try {
+        const reused = await reuseTrackForStaticPlaylist(track, playlist.id);
+        if (reused?.jobId) {
+          reusedJobIds.push(reused.jobId);
+        } else {
+          tracksToQueue.push(track);
+        }
+      } catch (error) {
+        console.warn(
+          `[WeeklyFlow] Failed Lidarr reuse for ${playlist.id}:`,
+          error.message,
+        );
+        tracksToQueue.push(track);
+      }
+    }
+
+    if (tracksToQueue.length > 0 && !soulseekClient.isConfigured()) {
+      await playlistManager.weeklyReset([playlist.id]);
+      flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+      playlist = null;
+      return res.status(400).json({
+        error: "Soulseek credentials not configured",
+      });
+    }
+
+    const jobIds = downloadTracker.addJobs(tracksToQueue, playlist.id);
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
+    if (reusedJobIds.length > 0) {
+      await playlistManager.scanLibrary();
+    }
     if (jobIds.length > 0 && !weeklyFlowWorker.running) {
       await weeklyFlowWorker.start();
     } else if (jobIds.length > 0) {
@@ -991,9 +1045,17 @@ router.post("/shared-playlists/import", async (req, res) => {
       success: true,
       playlist,
       tracksQueued: jobIds.length,
-      jobIds,
+      tracksReused: reusedJobIds.length,
+      jobIds: [...reusedJobIds, ...jobIds],
     });
   } catch (error) {
+    if (playlist?.id) {
+      try {
+        await playlistManager.weeklyReset([playlist.id]);
+        flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+        await playlistManager.ensureSmartPlaylists();
+      } catch {}
+    }
     if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
       return res.status(400).json({
         error: "Shared playlist name already exists",
@@ -1069,7 +1131,24 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
         tracksToQueue.push(track);
       }
     }
-    const jobIds = downloadTracker.addJobs(tracksToQueue, playlistId);
+    const libraryFallbackQueue = [];
+    for (const track of tracksToQueue) {
+      try {
+        const reused = await reuseTrackForStaticPlaylist(track, playlistId);
+        if (reused?.jobId) {
+          reusedJobIds.push(reused.jobId);
+        } else {
+          libraryFallbackQueue.push(track);
+        }
+      } catch (error) {
+        console.warn(
+          `[WeeklyFlow] Failed Lidarr reuse for ${playlistId}:`,
+          error.message,
+        );
+        libraryFallbackQueue.push(track);
+      }
+    }
+    const jobIds = downloadTracker.addJobs(libraryFallbackQueue, playlistId);
 
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -72,6 +72,18 @@ function getSettings() {
   return dbOps.getSettings();
 }
 
+function normalizeTrackLookupText(value) {
+  return String(value || "")
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function parseReleaseYear(value) {
+  const match = /^(\d{4})/.exec(String(value || "").trim());
+  return match ? match[1] : null;
+}
+
 function normalizeReleaseTypeName(value) {
   return String(value || "")
     .toLowerCase()
@@ -1279,6 +1291,141 @@ export class LibraryManager {
         `[LibraryManager] Failed to fetch tracks from Lidarr: ${error.message}`,
       );
       return [];
+    }
+  }
+
+  async findReusableTrack(track) {
+    const lidarr = await getLidarrClient();
+    if (!lidarr || !lidarr.isConfigured()) {
+      return null;
+    }
+
+    const incomingArtist = normalizeTrackLookupText(track?.artistName);
+    const incomingTrack = normalizeTrackLookupText(track?.trackName);
+    const incomingAlbum = normalizeTrackLookupText(track?.albumName);
+    const incomingTrackMbid = String(track?.trackMbid || "").trim();
+    const incomingAlbumMbid = String(track?.albumMbid || "").trim();
+    const incomingYear = parseReleaseYear(track?.releaseYear);
+
+    if (!incomingArtist || !incomingTrack) {
+      return null;
+    }
+
+    try {
+      const rawAlbums = await lidarr.request("/album");
+      const albums = Array.isArray(rawAlbums) ? rawAlbums : [];
+      const narrowedAlbums = albums.filter((album) => {
+        const albumArtist = normalizeTrackLookupText(
+          album?.artistName ||
+            album?.artist?.artistName ||
+            album?.artist?.name ||
+            album?.artist?.sortName ||
+            "",
+        );
+        return albumArtist === incomingArtist;
+      });
+
+      if (narrowedAlbums.length === 0) {
+        return null;
+      }
+
+      const candidates = [];
+      for (const album of narrowedAlbums) {
+        const albumId = album?.id;
+        if (albumId == null) continue;
+        const albumName = String(album?.title || "").trim() || null;
+        const artistName =
+          String(
+            album?.artistName ||
+              album?.artist?.artistName ||
+              album?.artist?.name ||
+              "",
+          ).trim() || null;
+        const releaseYear = parseReleaseYear(album?.releaseDate);
+        const tracks = await this.getTracks(String(albumId));
+        for (const entry of tracks) {
+          const candidatePath = String(entry?.path || "").trim();
+          if (!candidatePath || entry?.hasFile !== true) {
+            continue;
+          }
+          const candidateTrackMbid = String(entry?.mbid || "").trim();
+          const candidateArtist = normalizeTrackLookupText(artistName);
+          const candidateTrack = normalizeTrackLookupText(entry?.trackName);
+          if (candidateArtist !== incomingArtist || candidateTrack !== incomingTrack) {
+            continue;
+          }
+          candidates.push({
+            path: candidatePath,
+            artistName,
+            trackName: String(entry?.trackName || "").trim() || null,
+            albumName,
+            trackMbid: candidateTrackMbid || null,
+            size:
+              entry?.size != null && Number.isFinite(Number(entry.size))
+                ? Number(entry.size)
+                : 0,
+            hasFile: true,
+            releaseYear,
+            _score: {
+              mbid:
+                incomingTrackMbid &&
+                candidateTrackMbid &&
+                candidateTrackMbid === incomingTrackMbid
+                  ? 1
+                  : 0,
+              album:
+                (incomingAlbumMbid &&
+                  String(album?.foreignAlbumId || "").trim() === incomingAlbumMbid) ||
+                (incomingAlbum &&
+                  normalizeTrackLookupText(albumName) === incomingAlbum)
+                  ? 1
+                  : 0,
+              year:
+                incomingYear && releaseYear && incomingYear === releaseYear ? 1 : 0,
+            },
+          });
+        }
+      }
+
+      if (candidates.length === 0) {
+        return null;
+      }
+
+      candidates.sort((left, right) => {
+        if (right._score.mbid !== left._score.mbid) {
+          return right._score.mbid - left._score.mbid;
+        }
+        if (right._score.album !== left._score.album) {
+          return right._score.album - left._score.album;
+        }
+        if (right._score.year !== left._score.year) {
+          return right._score.year - left._score.year;
+        }
+        if (right.size !== left.size) {
+          return right.size - left.size;
+        }
+        return String(left.path).localeCompare(String(right.path));
+      });
+
+      const [best] = candidates;
+      if (!best) {
+        return null;
+      }
+      return {
+        path: best.path,
+        artistName: best.artistName,
+        trackName: best.trackName,
+        albumName: best.albumName,
+        trackMbid: best.trackMbid,
+        size: best.size,
+        hasFile: true,
+        releaseYear: best.releaseYear,
+      };
+    } catch (error) {
+      console.error(
+        `[LibraryManager] Failed reusable track lookup for ${track?.artistName || "Unknown Artist"} - ${track?.trackName || "Unknown Track"}: ${error.message}`,
+      );
+      return null;
     }
   }
 

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -79,6 +79,48 @@ function normalizeTrackLookupText(value) {
     .replace(/\s+/g, " ");
 }
 
+function buildLidarrTrackHydrationKeys(track) {
+  const keys = [];
+  const mbid = String(track?.foreignRecordingId || track?.foreignTrackId || "").trim();
+  if (mbid) {
+    keys.push(`mbid:${mbid}`);
+  }
+  const id = String(track?.id || "").trim();
+  if (id) {
+    keys.push(`id:${id}`);
+  }
+  const title = normalizeTrackLookupText(track?.title || track?.trackTitle || "");
+  const trackNumber = String(track?.trackNumber || track?.absoluteTrackNumber || "").trim();
+  if (title && trackNumber) {
+    keys.push(`title:${title}|track:${trackNumber}`);
+  }
+  if (title) {
+    keys.push(`title:${title}`);
+  }
+  return keys;
+}
+
+function buildMappedTrackHydrationKeys(track) {
+  const keys = [];
+  const mbid = String(track?.mbid || "").trim();
+  if (mbid) {
+    keys.push(`mbid:${mbid}`);
+  }
+  const id = String(track?.id || "").trim();
+  if (id) {
+    keys.push(`id:${id}`);
+  }
+  const title = normalizeTrackLookupText(track?.trackName || "");
+  const trackNumber = String(track?.trackNumber || "").trim();
+  if (title && trackNumber) {
+    keys.push(`title:${title}|track:${trackNumber}`);
+  }
+  if (title) {
+    keys.push(`title:${title}`);
+  }
+  return keys;
+}
+
 function parseReleaseYear(value) {
   const match = /^(\d{4})/.exec(String(value || "").trim());
   return match ? match[1] : null;
@@ -1272,6 +1314,52 @@ export class LibraryManager {
             this.mapLidarrTrack(t, lidarrAlbum, index + 1, isAlbumComplete),
           );
         }
+      }
+
+      const needsTrackFileHydration = result.some(
+        (track) =>
+          track?.hasFile === true &&
+          (!track?.path || !String(track.path).trim()),
+      );
+      if (needsTrackFileHydration) {
+        const rawTracks = await lidarr.getTracksByAlbumId(albumId);
+        const trackFiles = await lidarr.getTrackFilesByAlbumId(albumId);
+        const trackFileIdsByKey = new Map();
+        for (const rawTrack of Array.isArray(rawTracks) ? rawTracks : []) {
+          const trackFileId = rawTrack?.trackFileId;
+          if (trackFileId == null) continue;
+          for (const key of buildLidarrTrackHydrationKeys(rawTrack)) {
+            if (!trackFileIdsByKey.has(key)) {
+              trackFileIdsByKey.set(key, String(trackFileId));
+            }
+          }
+        }
+        const trackFilesById = new Map(
+          (Array.isArray(trackFiles) ? trackFiles : [])
+            .filter((entry) => entry?.id != null)
+            .map((entry) => [String(entry.id), entry]),
+        );
+        result = result.map((track) => {
+          const trackFileId =
+            buildMappedTrackHydrationKeys(track)
+              .map((key) => trackFileIdsByKey.get(key))
+              .find(Boolean) || null;
+          if (trackFileId == null) return track;
+          const trackFile = trackFilesById.get(String(trackFileId));
+          if (!trackFile?.path) return track;
+          return {
+            ...track,
+            path: String(trackFile.path).trim() || track.path,
+            size:
+              trackFile?.size != null && Number.isFinite(Number(trackFile.size))
+                ? Number(trackFile.size)
+                : track.size,
+            quality:
+              trackFile?.mediaInfo?.audioCodec ||
+              trackFile?.quality?.quality?.name ||
+              track.quality,
+          };
+        });
       }
 
       if (_tracksCache.size >= TRACKS_CACHE_MAX) {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1053,6 +1053,19 @@ export class LidarrClient {
     }
   }
 
+  async getTrackFilesByAlbumId(albumId) {
+    try {
+      const result = await this.request(`/trackfile?albumId=${albumId}`);
+      if (Array.isArray(result)) return result;
+      if (result?.records && Array.isArray(result.records)) {
+        return result.records;
+      }
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
   async getAlbumByMbid(albumMbid) {
     const albums = await this.request("/album");
     return albums.find((a) => a.foreignAlbumId === albumMbid);

--- a/backend/services/staticPlaylistLibraryReuse.js
+++ b/backend/services/staticPlaylistLibraryReuse.js
@@ -1,0 +1,161 @@
+import path from "path";
+import fsp from "fs/promises";
+import { libraryManager } from "./libraryManager.js";
+import { downloadTracker } from "./weeklyFlowDownloadTracker.js";
+import { weeklyFlowWorker } from "./weeklyFlowWorker.js";
+
+const LINK_FALLBACK_ERROR_CODES = new Set([
+  "EXDEV",
+  "EPERM",
+  "EACCES",
+  "EMLINK",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+]);
+
+const sanitizePathPart = (value) =>
+  String(value || "")
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .trim();
+
+const isPathInsideRoot = (candidatePath, rootPath) => {
+  const relative = path.relative(rootPath, candidatePath);
+  return (
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+  );
+};
+
+const getPlaylistLibraryRoot = (playlistId) =>
+  path.resolve(
+    weeklyFlowWorker.weeklyFlowRoot,
+    "aurral-weekly-flow",
+    String(playlistId || "").trim(),
+  );
+
+const buildUniqueTargetPath = async (track, playlistId, sourcePath, albumName = null) => {
+  const ext = path.extname(sourcePath).toLowerCase();
+  const artistDir = sanitizePathPart(track?.artistName || "Unknown Artist");
+  const albumDir = sanitizePathPart(albumName || track?.albumName || "Unknown Album");
+  const targetRoot = getPlaylistLibraryRoot(playlistId);
+  let targetPath = path.resolve(
+    targetRoot,
+    artistDir,
+    albumDir,
+    `${sanitizePathPart(track?.trackName || "Unknown Track")}${ext}`,
+  );
+  if (!isPathInsideRoot(targetPath, targetRoot)) {
+    throw new Error(`Target path is outside the playlist library: ${targetPath}`);
+  }
+
+  const parsed = path.parse(targetPath);
+  let suffix = 1;
+  while (true) {
+    try {
+      await fsp.access(targetPath);
+      targetPath = path.resolve(
+        parsed.dir,
+        `${parsed.name}-${suffix}${parsed.ext}`,
+      );
+      suffix += 1;
+    } catch {
+      break;
+    }
+  }
+
+  await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+  return targetPath;
+};
+
+export const findReusableLibraryTrack = async (track) =>
+  libraryManager.findReusableTrack(track);
+
+export const materializePlaylistTrackFromLibrary = async ({
+  track,
+  playlistId,
+  sourcePath,
+  albumName = null,
+}) => {
+  const safeSourcePath = path.resolve(sourcePath);
+  const sourceStat = await fsp.stat(safeSourcePath);
+  if (!sourceStat.isFile()) {
+    throw new Error(`Library source is not a file: ${safeSourcePath}`);
+  }
+
+  const targetPath = await buildUniqueTargetPath(
+    track,
+    playlistId,
+    safeSourcePath,
+    albumName,
+  );
+
+  let mode = "hardlink";
+  try {
+    await fsp.link(safeSourcePath, targetPath);
+  } catch (error) {
+    if (!LINK_FALLBACK_ERROR_CODES.has(String(error?.code || ""))) {
+      throw error;
+    }
+    await fsp.copyFile(safeSourcePath, targetPath);
+    mode = "copy-fallback";
+  }
+
+  return { targetPath, mode, safeSourcePath };
+};
+
+export const reuseTrackForStaticPlaylist = async (track, playlistId) => {
+  const match = await findReusableLibraryTrack(track);
+  if (!match?.path) {
+    console.log(
+      `[StaticPlaylistReuse] No library match for ${playlistId}: ${track?.artistName || "Unknown Artist"} - ${track?.trackName || "Unknown Track"}`,
+    );
+    return null;
+  }
+
+  let stat = null;
+  try {
+    stat = await fsp.stat(path.resolve(match.path));
+  } catch {
+    stat = null;
+  }
+  if (!stat?.isFile()) {
+    console.warn(
+      `[StaticPlaylistReuse] Library match missing on disk for ${playlistId}: ${match.path}`,
+    );
+    return null;
+  }
+
+  console.log(
+    `[StaticPlaylistReuse] Library match for ${playlistId}: ${track.artistName} - ${track.trackName} <- ${match.path}`,
+  );
+
+  const { targetPath, mode, safeSourcePath } =
+    await materializePlaylistTrackFromLibrary({
+      track,
+      playlistId,
+      sourcePath: match.path,
+      albumName: match.albumName || track?.albumName || null,
+    });
+
+  const jobId = downloadTracker.addJob(track, playlistId);
+  if (!jobId) {
+    await fsp.rm(targetPath, { force: true }).catch(() => {});
+    return null;
+  }
+
+  downloadTracker.setDone(
+    jobId,
+    targetPath,
+    match.albumName || track?.albumName || null,
+  );
+
+  console.log(
+    `[StaticPlaylistReuse] Materialized ${mode} for ${playlistId}: ${track.artistName} - ${track.trackName} (${safeSourcePath} -> ${targetPath})`,
+  );
+
+  return {
+    jobId,
+    targetPath,
+    mode,
+    match,
+  };
+};

--- a/backend/tests/libraryManager.test.js
+++ b/backend/tests/libraryManager.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("getTracks hydrates missing track paths from Lidarr track files", async () => {
+  const [{ libraryManager }, { lidarrClient }] = await Promise.all([
+    import("../services/libraryManager.js"),
+    import("../services/lidarrClient.js"),
+  ]);
+
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetAlbum = lidarrClient.getAlbum;
+  const originalGetTracksByAlbumId = lidarrClient.getTracksByAlbumId;
+  const originalGetTrackFilesByAlbumId = lidarrClient.getTrackFilesByAlbumId;
+
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getAlbum = async () => ({
+    id: 999001,
+    statistics: {
+      percentOfTracks: 100,
+      sizeOnDisk: 1234,
+    },
+    media: [],
+  });
+  lidarrClient.getTracksByAlbumId = async () => [
+    {
+      id: 281188,
+      foreignRecordingId: "b13278c0-31fb-45ff-ade1-2678a1824563",
+      trackFileId: 11126,
+      albumId: 999001,
+      trackNumber: "2",
+      title: "Hot Dog",
+      hasFile: true,
+    },
+  ];
+  lidarrClient.getTrackFilesByAlbumId = async () => [
+    {
+      id: 11126,
+      path: "/music/Limp Bizkit/Chocolate Starfish/02 Hot Dog.flac",
+      size: 30511974,
+      mediaInfo: {
+        audioCodec: "FLAC",
+      },
+    },
+  ];
+
+  try {
+    const tracks = await libraryManager.getTracks("999001");
+    assert.equal(tracks.length, 1);
+    assert.equal(
+      tracks[0].path,
+      "/music/Limp Bizkit/Chocolate Starfish/02 Hot Dog.flac",
+    );
+    assert.equal(tracks[0].size, 30511974);
+    assert.equal(tracks[0].quality, "FLAC");
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getAlbum = originalGetAlbum;
+    lidarrClient.getTracksByAlbumId = originalGetTracksByAlbumId;
+    lidarrClient.getTrackFilesByAlbumId = originalGetTrackFilesByAlbumId;
+  }
+});

--- a/backend/tests/staticPlaylistLibraryReuse.test.js
+++ b/backend/tests/staticPlaylistLibraryReuse.test.js
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "os";
+import path from "path";
+import fsp from "fs/promises";
+
+const makeTrack = () => ({
+  artistName: "Test Artist",
+  trackName: "Test Track",
+  albumName: "Test Album",
+  artistMbid: "artist-mbid-1",
+  albumMbid: "album-mbid-1",
+  trackMbid: "track-mbid-1",
+  releaseYear: "2024",
+  durationMs: 123000,
+  artistAliases: [],
+  reason: null,
+});
+
+test("reuseTrackForStaticPlaylist hardlinks a matched Lidarr track into playlist storage", async () => {
+  const tempDataDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "aurral-reuse-data-"),
+  );
+  const tempRoot = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "aurral-reuse-root-"),
+  );
+  process.env.AURRAL_DATA_DIR = tempDataDir;
+
+  const [{ reuseTrackForStaticPlaylist }, { libraryManager }, { downloadTracker }, { weeklyFlowWorker }] =
+    await Promise.all([
+      import("../services/staticPlaylistLibraryReuse.js"),
+      import("../services/libraryManager.js"),
+      import("../services/weeklyFlowDownloadTracker.js"),
+      import("../services/weeklyFlowWorker.js"),
+    ]);
+
+  const sourceDir = path.join(tempRoot, "lidarr-library", "Test Artist", "Test Album");
+  const sourcePath = path.join(sourceDir, "01 Test Track.flac");
+  await fsp.mkdir(sourceDir, { recursive: true });
+  await fsp.writeFile(sourcePath, "audio-bytes");
+
+  const originalFindReusableTrack = libraryManager.findReusableTrack;
+  const originalWeeklyFlowRoot = weeklyFlowWorker.weeklyFlowRoot;
+  const originalAddJob = downloadTracker.addJob;
+  const originalSetDone = downloadTracker.setDone;
+
+  const setDoneCalls = [];
+  weeklyFlowWorker.weeklyFlowRoot = tempRoot;
+  libraryManager.findReusableTrack = async () => ({
+    path: sourcePath,
+    artistName: "Test Artist",
+    trackName: "Test Track",
+    albumName: "Test Album",
+    trackMbid: "track-mbid-1",
+    size: 11,
+    hasFile: true,
+    releaseYear: "2024",
+  });
+  downloadTracker.addJob = () => "job-1";
+  downloadTracker.setDone = (...args) => {
+    setDoneCalls.push(args);
+    return true;
+  };
+
+  try {
+    const result = await reuseTrackForStaticPlaylist(makeTrack(), "playlist-1");
+
+    assert.ok(result);
+    assert.equal(result.jobId, "job-1");
+    assert.equal(result.mode, "hardlink");
+    assert.equal(setDoneCalls.length, 1);
+    assert.equal(setDoneCalls[0][0], "job-1");
+    assert.equal(setDoneCalls[0][2], "Test Album");
+
+    const sourceStat = await fsp.stat(sourcePath);
+    const targetStat = await fsp.stat(result.targetPath);
+    assert.equal(sourceStat.ino, targetStat.ino);
+    assert.ok(sourceStat.nlink >= 2);
+
+    await fsp.rm(result.targetPath, { force: true });
+    const sourceAfterDelete = await fsp.readFile(sourcePath, "utf8");
+    assert.equal(sourceAfterDelete, "audio-bytes");
+  } finally {
+    libraryManager.findReusableTrack = originalFindReusableTrack;
+    weeklyFlowWorker.weeklyFlowRoot = originalWeeklyFlowRoot;
+    downloadTracker.addJob = originalAddJob;
+    downloadTracker.setDone = originalSetDone;
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+    await fsp.rm(tempDataDir, { recursive: true, force: true });
+  }
+});
+
+test("reuseTrackForStaticPlaylist falls back to copy when hardlinking is unsupported", async () => {
+  const tempDataDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "aurral-reuse-data-"),
+  );
+  const tempRoot = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "aurral-reuse-root-"),
+  );
+  process.env.AURRAL_DATA_DIR = tempDataDir;
+
+  const fspModule = (await import("fs/promises")).default;
+  const [{ reuseTrackForStaticPlaylist }, { libraryManager }, { downloadTracker }, { weeklyFlowWorker }] =
+    await Promise.all([
+      import("../services/staticPlaylistLibraryReuse.js"),
+      import("../services/libraryManager.js"),
+      import("../services/weeklyFlowDownloadTracker.js"),
+      import("../services/weeklyFlowWorker.js"),
+    ]);
+
+  const sourceDir = path.join(tempRoot, "lidarr-library", "Test Artist", "Test Album");
+  const sourcePath = path.join(sourceDir, "01 Test Track.flac");
+  await fsp.mkdir(sourceDir, { recursive: true });
+  await fsp.writeFile(sourcePath, "audio-bytes");
+
+  const originalFindReusableTrack = libraryManager.findReusableTrack;
+  const originalWeeklyFlowRoot = weeklyFlowWorker.weeklyFlowRoot;
+  const originalAddJob = downloadTracker.addJob;
+  const originalSetDone = downloadTracker.setDone;
+  const originalLink = fspModule.link;
+
+  weeklyFlowWorker.weeklyFlowRoot = tempRoot;
+  libraryManager.findReusableTrack = async () => ({
+    path: sourcePath,
+    artistName: "Test Artist",
+    trackName: "Test Track",
+    albumName: "Test Album",
+    trackMbid: "track-mbid-1",
+    size: 11,
+    hasFile: true,
+    releaseYear: "2024",
+  });
+  downloadTracker.addJob = () => "job-2";
+  downloadTracker.setDone = () => true;
+  fspModule.link = async () => {
+    const error = new Error("Cross-device link not permitted");
+    error.code = "EXDEV";
+    throw error;
+  };
+
+  try {
+    const result = await reuseTrackForStaticPlaylist(makeTrack(), "playlist-2");
+
+    assert.ok(result);
+    assert.equal(result.jobId, "job-2");
+    assert.equal(result.mode, "copy-fallback");
+
+    const sourceStat = await fsp.stat(sourcePath);
+    const targetStat = await fsp.stat(result.targetPath);
+    assert.notEqual(sourceStat.ino, targetStat.ino);
+    assert.equal(await fsp.readFile(result.targetPath, "utf8"), "audio-bytes");
+  } finally {
+    libraryManager.findReusableTrack = originalFindReusableTrack;
+    weeklyFlowWorker.weeklyFlowRoot = originalWeeklyFlowRoot;
+    downloadTracker.addJob = originalAddJob;
+    downloadTracker.setDone = originalSetDone;
+    fspModule.link = originalLink;
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+    await fsp.rm(tempDataDir, { recursive: true, force: true });
+  }
+});

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -58,6 +58,24 @@ const reserveUniquePlaylistName = (playlists, baseName = "Playlist") => {
   return `${normalizedBase} ${Date.now()}`;
 };
 
+const formatPlaylistSaveSuccess = (
+  actionLabel,
+  playlistName,
+  { tracksReused = 0, tracksQueued = 0 } = {},
+) => {
+  const base = `${actionLabel} ${playlistName || "playlist"}`;
+  if (tracksReused > 0 && tracksQueued > 0) {
+    return `${base} (${tracksReused} reused from Lidarr, ${tracksQueued} queued for download)`;
+  }
+  if (tracksReused > 0) {
+    return `${base} (${tracksReused} reused from Lidarr library)`;
+  }
+  if (tracksQueued > 0) {
+    return `${base} (${tracksQueued} queued for download)`;
+  }
+  return base;
+};
+
 function ArtistDetailsPage() {
   const { mbid } = useParams();
   const { state: locationState } = useLocation();
@@ -463,17 +481,25 @@ function ArtistDetailsPage() {
           tracks: payload.tracks,
         });
         showSuccess(
-          `Track saved to ${response?.playlist?.name || payload.name}`,
+          formatPlaylistSaveSuccess(
+            "Track saved to",
+            response?.playlist?.name || payload.name,
+            response,
+          ),
         );
       } else {
         const targetPlaylist = sharedPlaylists.find(
           (playlist) => playlist.id === payload?.playlistId,
         );
-        await addSharedPlaylistTracks(payload.playlistId, {
+        const response = await addSharedPlaylistTracks(payload.playlistId, {
           tracks: payload.tracks,
         });
         showSuccess(
-          `Track added to ${targetPlaylist?.name || "playlist"}`,
+          formatPlaylistSaveSuccess(
+            "Track added to",
+            targetPlaylist?.name || "playlist",
+            response,
+          ),
         );
       }
       setPlaylistTrackModal(null);


### PR DESCRIPTION
## Summary
- Add static-playlist library reuse so matched Lidarr tracks can be hardlinked into playlist storage instead of always queued for download.
- Update shared playlist create/import/add-tracks flows to reuse library matches first, track reused vs queued counts, and trigger a library scan when reused tracks are materialized.
- Add reusable track lookup logic in `LibraryManager` with artist/track matching plus MBID, album, and year scoring.
- Cover the reuse path with tests for hardlink success and copy fallback when hardlinking is unsupported.

## Testing
- `Not run` (changes reviewed from diff only).
- Added unit tests for hardlink creation and EXDEV copy fallback in `backend/tests/staticPlaylistLibraryReuse.test.js`.
- Added path-safety and target-uniqueness checks in the new reuse helper.