### PR TITLE
Refactor CI into reusable validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,77 +3,13 @@ name: CI
 on:
   pull_request:
     branches: ["main", "test"]
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    paths-ignore:
+      - "*.md"
+      - ".github/*.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            backend/package-lock.json
-            frontend/package-lock.json
-
-      - run: npm ci
-
-      - run: npm ci
-        working-directory: backend
-
-      - run: npm ci
-        working-directory: frontend
-
-      - run: npm run lint
-        working-directory: frontend
-
-      - name: Run test suite
-        run: npm test
-
-      - name: Build app
-        run: npm run build
-
-      - name: Start app
-        run: |
-          npm start > /tmp/aurral.log 2>&1 &
-          echo $! > /tmp/aurral.pid
-
-      - name: Wait for health endpoint
-        run: |
-          for i in {1..30}; do
-            if curl -fsS http://127.0.0.1:3001/api/health > /tmp/aurral-health.json; then
-              cat /tmp/aurral-health.json
-              exit 0
-            fi
-            sleep 2
-          done
-          if [ -f /tmp/aurral.log ]; then
-            cat /tmp/aurral.log
-          else
-            echo "App log not found at /tmp/aurral.log"
-          fi
-          exit 1
-
-      - name: Print app log on failure
-        if: failure()
-        run: |
-          if [ -f /tmp/aurral.log ]; then
-            cat /tmp/aurral.log
-          else
-            echo "App log not found at /tmp/aurral.log"
-          fi
-
-      - name: Stop app
-        if: always()
-        run: |
-          if [ -f /tmp/aurral.pid ]; then
-            kill "$(cat /tmp/aurral.pid)" || true
-          fi
+    uses: ./.github/workflows/validate.yml

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   publish-image:
-    if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'test')
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: ["main", "test"]
+    paths-ignore:
+      - "*.md"
+      - ".github/*.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -31,58 +37,6 @@ jobs:
             frontend/package-lock.json
 
       - run: npm ci
-
-      - run: npm ci
-        working-directory: backend
-
-      - run: npm ci
-        working-directory: frontend
-
-      - run: npm run lint
-        working-directory: frontend
-
-      - name: Run test suite
-        run: npm test
-
-      - name: Build app
-        run: npm run build
-
-      - name: Start app
-        run: |
-          npm start > /tmp/aurral.log 2>&1 &
-          echo $! > /tmp/aurral.pid
-
-      - name: Wait for health endpoint
-        run: |
-          for i in {1..30}; do
-            if curl -fsS http://127.0.0.1:3001/api/health > /tmp/aurral-health.json; then
-              cat /tmp/aurral-health.json
-              exit 0
-            fi
-            sleep 2
-          done
-          if [ -f /tmp/aurral.log ]; then
-            cat /tmp/aurral.log
-          else
-            echo "App log not found at /tmp/aurral.log"
-          fi
-          exit 1
-
-      - name: Print app log on failure
-        if: failure()
-        run: |
-          if [ -f /tmp/aurral.log ]; then
-            cat /tmp/aurral.log
-          else
-            echo "App log not found at /tmp/aurral.log"
-          fi
-
-      - name: Stop app
-        if: always()
-        run: |
-          if [ -f /tmp/aurral.pid ]; then
-            kill "$(cat /tmp/aurral.pid)" || true
-          fi
 
       - name: Semantic Release
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,78 @@
+name: Validate
+
+on:
+  workflow_call:
+
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            frontend/package-lock.json
+
+      - run: npm ci
+
+      - run: npm ci
+        working-directory: backend
+
+      - run: npm ci
+        working-directory: frontend
+
+      - run: npm run lint
+        working-directory: frontend
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Build app
+        run: npm run build
+
+      - name: Start app
+        run: |
+          npm start > /tmp/aurral.log 2>&1 &
+          echo $! > /tmp/aurral.pid
+
+      - name: Wait for health endpoint
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:3001/api/health > /tmp/aurral-health.json; then
+              cat /tmp/aurral-health.json
+              exit 0
+            fi
+            sleep 2
+          done
+          if [ -f /tmp/aurral.log ]; then
+            cat /tmp/aurral.log
+          else
+            echo "App log not found at /tmp/aurral.log"
+          fi
+          exit 1
+
+      - name: Print app log on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/aurral.log ]; then
+            cat /tmp/aurral.log
+          else
+            echo "App log not found at /tmp/aurral.log"
+          fi
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f /tmp/aurral.pid ]; then
+            kill "$(cat /tmp/aurral.pid)" || true
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ npm run build
 cd frontend && npm run lint
 ```
 
+CI behavior:
+
+- PRs to `main` and `test` run the full validation suite
+- Pushes to `main` and `test` run release automation only
+- Docs-only changes may skip heavy CI and release workflows
+
 ## Merge strategy
 
 - Prefer merge commits over squash or rebase when landing work that should preserve commit intent for release automation


### PR DESCRIPTION
## Summary
- Extracted the full validation job into a reusable `validate.yml` workflow called from CI.
- Simplified `ci.yml` and `release.yml` by removing duplicated npm, lint, test, build, and health-check steps.
- Relaxed image publishing to trigger on successful workflow runs, and added docs for the new CI behavior in `CONTRIBUTING.md`.

## Testing
- Not run locally.
- Verified the workflow diff for `ci.yml`, `release.yml`, and new `validate.yml` matches the intended split.
- Confirmed `CONTRIBUTING.md` reflects PR, push, and docs-only behavior.