### PR TITLE
Prefer album cover URLs in discover cards

### DIFF
--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -537,7 +537,7 @@ const AlbumCard = memo(
     const releaseCover = coverId ? releaseCovers[coverId] : null;
     const artistId = album.artistMbid || album.foreignArtistId;
     const artistCover = artistId ? artistCovers[artistId] : null;
-    const coverUrl = releaseCover || artistCover;
+    const coverUrl = album.coverUrl || releaseCover || artistCover;
     const navigateTo = album.artistMbid || album.foreignArtistId;
     const hasValidMbid =
       navigateTo && navigateTo !== "null" && navigateTo !== "undefined";
@@ -611,6 +611,7 @@ const AlbumCard = memo(
       prevId === nextId &&
       prevProps.album.albumName === nextProps.album.albumName &&
       prevProps.album.artistName === nextProps.album.artistName &&
+      prevProps.album.coverUrl === nextProps.album.coverUrl &&
       prevProps.album.releaseDate === nextProps.album.releaseDate &&
       prevProps.onNavigate === nextProps.onNavigate &&
       prevProps.releaseCovers === nextProps.releaseCovers &&
@@ -630,6 +631,7 @@ AlbumCard.propTypes = {
     artistMbid: PropTypes.string,
     foreignArtistId: PropTypes.string,
     releaseDate: PropTypes.string,
+    coverUrl: PropTypes.string,
   }).isRequired,
   releaseCovers: PropTypes.object.isRequired,
   artistCovers: PropTypes.object.isRequired,


### PR DESCRIPTION
## Summary
- Use `album.coverUrl` as the primary image source for Discover album cards.
- Fall back to release cover images, then artist cover images when no album cover URL is available.
- Update the memo comparison and prop types so cover URL changes re-render correctly.

## Testing
- Not run
- Verified the diff for `frontend/src/pages/DiscoverPage.jsx` to confirm the new cover precedence and memo dependency update.