### PR TITLE
Add BrainzMash metadata provider support

### DIFF
--- a/.tests/metadata-providers.test.js
+++ b/.tests/metadata-providers.test.js
@@ -19,101 +19,71 @@ test.after(() => {
   __setMetadataProviderHealthStateForTests("musicbrainz");
 });
 
-test("default settings use hosted MusicBrainz and official Cover Art Archive", () => {
+test("default settings use BrainzMash metadata and the official Cover Art Archive endpoint", () => {
   assert.equal(
-    defaultData.settings.integrations.musicbrainz.provider,
-    "aurralHosted",
+    defaultData.settings.integrations.metadata.provider,
+    "brainzmash",
   );
-  assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
-});
-
-test("backend metadata providers default to hosted MusicBrainz when unset", () => {
-  dbOps.updateSettings({
-    ...originalSettings,
-    integrations: {
-      ...(originalSettings.integrations || {}),
-      musicbrainz: { email: "test@example.com" },
-    },
-  });
-
   assert.equal(
-    getMusicbrainzApiBaseUrl(),
-    "https://mb.lkly.net/ws/2",
+    defaultData.settings.integrations.metadata.baseUrl,
+    "https://lidarrapi.brainzmash.cc",
   );
+  assert.equal(getMusicbrainzApiBaseUrl(), "https://lidarrapi.brainzmash.cc");
   assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
 });
 
-test("MusicBrainz hosted mode stays pinned to hosted by default", () => {
+test("backend metadata provider defaults to BrainzMash when unset", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
       ...(originalSettings.integrations || {}),
-      musicbrainz: {
-        email: "test@example.com",
-        provider: "aurralHosted",
-        customUrl: "",
+      metadata: {
+        provider: "brainzmash",
+        baseUrl: "",
+        userAgentSuffix: "",
+        enableNarrowFallbacks: true,
       },
     },
   });
 
-  assert.deepEqual(getMusicbrainzApiBaseUrls(), ["https://mb.lkly.net/ws/2"]);
-  assert.deepEqual(getCoverArtArchiveApiBaseUrls(), ["https://coverartarchive.org"]);
+  assert.equal(getMusicbrainzApiBaseUrl(), "https://lidarrapi.brainzmash.cc");
+  assert.deepEqual(getMusicbrainzApiBaseUrls(), [
+    "https://lidarrapi.brainzmash.cc",
+  ]);
 });
 
-test("automatic provider failover only changes the MusicBrainz base after hosted health degrades", () => {
+test("custom BrainzMash base URL is respected end to end", () => {
   dbOps.updateSettings({
     ...originalSettings,
     integrations: {
       ...(originalSettings.integrations || {}),
-      musicbrainz: {
-        email: "test@example.com",
-        provider: "aurralHosted",
-        customUrl: "",
+      metadata: {
+        provider: "brainzmash",
+        baseUrl: "https://brainzmash.example.net",
+        userAgentSuffix: "AurralTest",
+        enableNarrowFallbacks: false,
       },
     },
   });
 
-  __setMetadataProviderHealthStateForTests("musicbrainz", {
-    failoverActive: true,
-    consecutiveFailures: 3,
-    lastFailureReason: "HTTP 503",
-  });
-
-  assert.equal(getMusicbrainzApiBaseUrl(), "https://musicbrainz.org/ws/2");
-  assert.equal(getCoverArtArchiveApiBaseUrl(), "https://coverartarchive.org");
-
-  const snapshot = getMetadataProviderHealthSnapshot();
-  assert.equal(snapshot.musicbrainz.mode, "auto");
-  assert.equal(snapshot.musicbrainz.activeProvider, "official");
-  assert.equal(snapshot.musicbrainz.failoverActive, true);
-  assert.equal(snapshot.musicbrainz.lastFailureReason, "HTTP 503");
-});
-
-test("manual MusicBrainz provider selection bypasses automatic failover state", () => {
-  dbOps.updateSettings({
-    ...originalSettings,
-    integrations: {
-      ...(originalSettings.integrations || {}),
-      musicbrainz: {
-        email: "test@example.com",
-        provider: "official",
-        customUrl: "",
-      },
-    },
-  });
-
-  __setMetadataProviderHealthStateForTests("musicbrainz", {
-    failoverActive: true,
-    consecutiveFailures: 5,
-  });
-
-  assert.deepEqual(getMusicbrainzApiBaseUrls(), ["https://musicbrainz.org/ws/2"]);
+  assert.deepEqual(getMusicbrainzApiBaseUrls(), [
+    "https://brainzmash.example.net",
+  ]);
   assert.deepEqual(getCoverArtArchiveApiBaseUrls(), [
     "https://coverartarchive.org",
   ]);
+});
+
+test("provider health snapshot reports BrainzMash state", () => {
+  __setMetadataProviderHealthStateForTests("musicbrainz", {
+    failoverActive: true,
+    consecutiveFailures: 3,
+    lastFailureReason: "HTTP 403",
+  });
 
   const snapshot = getMetadataProviderHealthSnapshot();
-  assert.equal(snapshot.musicbrainz.mode, "manual");
-  assert.equal(snapshot.musicbrainz.activeProvider, "official");
-  assert.equal(snapshot.musicbrainz.failoverActive, false);
+  assert.ok(snapshot.brainzmash);
+  assert.equal(snapshot.brainzmash.configuredProvider, "brainzmash");
+  assert.equal(snapshot.brainzmash.activeBaseUrl, getMusicbrainzApiBaseUrl());
+  assert.equal(snapshot.brainzmash.failoverActive, false);
 });

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -113,6 +113,7 @@ export const UUID_REGEX =
 export const MUSICBRAINZ_API = "https://musicbrainz.org/ws/2";
 export const AURRAL_MUSICBRAINZ_API = "https://mb.lkly.net/ws/2";
 export const OFFICIAL_COVER_ART_ARCHIVE_API = "https://coverartarchive.org";
+export const DEFAULT_METADATA_BASE_URL = "https://lidarrapi.brainzmash.cc";
 export const LASTFM_API = "https://ws.audioscrobbler.com/2.0/";
 export const LISTENBRAINZ_API = "https://api.listenbrainz.org";
 export const APP_NAME = "Aurral";
@@ -197,10 +198,11 @@ export const defaultData = {
         defaultMonitorOption: "none",
         searchOnAdd: false,
       },
-      musicbrainz: {
-        email: "",
-        provider: "aurralHosted",
-        customUrl: "",
+      metadata: {
+        provider: "brainzmash",
+        baseUrl: DEFAULT_METADATA_BASE_URL,
+        userAgentSuffix: "",
+        enableNarrowFallbacks: true,
       },
       general: { authUser: "", authPassword: "" },
       gotify: {

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -2,18 +2,64 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import {
   getLastfmApiKey,
   lastfmRequest,
-  lastfmGetArtistNameByMbid,
-  getArtistBio,
   musicbrainzGetArtistReleaseGroups,
-  enrichReleaseGroupsWithLastfm,
   musicbrainzGetArtistNameByMbid,
 } from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { pendingArtistRequests } from "../utils.js";
+import { getArtistByMbid } from "../../../services/metadataProvider.js";
 
 export default function registerDetails(router) {
+  const toLegacyRelations = (metadataArtist) =>
+    Array.isArray(metadataArtist?.links)
+      ? metadataArtist.links
+          .filter((link) => link?.target)
+          .map((link) => ({
+            type: link.type || "external",
+            url: { resource: link.target },
+          }))
+      : [];
+
+  const getLastfmTags = async (mbid, artistName = "") => {
+    if (!getLastfmApiKey()) return [];
+    let data = await lastfmRequest("artist.getTopTags", { mbid }).catch(() => null);
+    if (!data?.toptags?.tag && artistName) {
+      data = await lastfmRequest("artist.getTopTags", { artist: artistName }).catch(
+        () => null,
+      );
+    }
+    const tags = data?.toptags?.tag
+      ? Array.isArray(data.toptags.tag)
+        ? data.toptags.tag
+        : [data.toptags.tag]
+      : [];
+    return tags
+      .map((tag) => ({
+        name: String(tag?.name || "").trim(),
+        count: Number(tag?.count || 0),
+      }))
+      .filter((tag) => tag.name);
+  };
+
+  const getArtistTagPayload = async (mbid, artistName = "", metadataArtist = null) => {
+    const lastfmTags = await getLastfmTags(mbid, artistName);
+    if (lastfmTags.length > 0) {
+      return {
+        tags: lastfmTags,
+        genres: lastfmTags.map((tag) => tag.name),
+      };
+    }
+    const fallbackGenres = Array.isArray(metadataArtist?.genres)
+      ? metadataArtist.genres.filter(Boolean)
+      : [];
+    return {
+      tags: fallbackGenres.map((genre) => ({ name: genre, count: 0 })),
+      genres: fallbackGenres,
+    };
+  };
+
   const parseSelectedReleaseTypes = (value) =>
     typeof value === "string" && value.trim()
       ? value
@@ -174,53 +220,44 @@ export default function registerDetails(router) {
       if (lidarrArtist) {
         const artistMbid =
           override?.musicbrainzId || lidarrArtist.foreignArtistId || mbid;
-        const [bio, tagsData] = coreOnly
-          ? [null, null]
-          : await Promise.all([
-              getArtistBio(lidarrArtist.artistName, artistMbid),
-              getLastfmApiKey()
-                ? lastfmRequest("artist.getTopTags", { mbid: artistMbid })
-                : null,
-            ]);
-        const tags = coreOnly
-          ? []
-          : tagsData?.toptags?.tag
-            ? (Array.isArray(tagsData.toptags.tag)
-                ? tagsData.toptags.tag
-                : [tagsData.toptags.tag]
-              ).map((t) => ({ name: t.name, count: t.count || 0 }))
-            : [];
+        const metadataArtist = coreOnly
+          ? null
+          : await getArtistByMbid(artistMbid).catch(() => null);
+        const releaseGroups = await musicbrainzGetArtistReleaseGroups(artistMbid, selectedReleaseTypes);
+        const tagPayload = coreOnly
+          ? { tags: [], genres: [] }
+          : await getArtistTagPayload(
+              artistMbid,
+              metadataArtist?.name || lidarrArtist.artistName,
+              metadataArtist,
+            );
         const payload = {
           id: artistMbid,
-          name: lidarrArtist.artistName,
-          "sort-name": lidarrArtist.artistName,
-          disambiguation: "",
+          name: metadataArtist?.name || lidarrArtist.artistName,
+          "sort-name":
+            metadataArtist?.sortName || metadataArtist?.name || lidarrArtist.artistName,
+          disambiguation: metadataArtist?.disambiguation || "",
           "type-id": null,
-          type: null,
+          type: metadataArtist?.type || null,
           country: null,
           "life-span": {
             begin: null,
             end: null,
             ended: false,
           },
-          tags,
-          genres: [],
-          "release-groups": lidarrAlbums.map((album) => ({
-            id: album.mbid,
-            title: album.albumName,
-            "first-release-date": album.releaseDate || null,
-            "primary-type": "Album",
-            "secondary-types": [],
-          })),
-          relations: [],
-          "release-group-count": lidarrAlbums.length,
-          "release-count": lidarrAlbums.length,
+          tags: tagPayload.tags,
+          genres: tagPayload.genres,
+          links: Array.isArray(metadataArtist?.links) ? metadataArtist.links : [],
+          "release-groups": releaseGroups,
+          relations: toLegacyRelations(metadataArtist),
+          "release-group-count": releaseGroups.length,
+          "release-count": releaseGroups.length,
           _lidarrData: {
             id: lidarrArtist.id,
             monitored: lidarrArtist.monitored,
             statistics: lidarrArtist.statistics,
           },
-          ...(bio ? { bio } : {}),
+          ...(metadataArtist?.overview ? { bio: metadataArtist.overview } : {}),
         };
 
         res.setHeader("Content-Type", "application/json");
@@ -229,53 +266,39 @@ export default function registerDetails(router) {
       }
 
       const fetchPromise = (async () => {
+        const metadataArtist = coreOnly
+          ? null
+          : await getArtistByMbid(resolvedMbid).catch(() => null);
         const name =
           (req.query.artistName || "").trim() ||
-          (getLastfmApiKey()
-            ? await lastfmGetArtistNameByMbid(resolvedMbid)
-            : null) ||
+          metadataArtist?.name ||
           (await musicbrainzGetArtistNameByMbid(resolvedMbid)) ||
           "Unknown Artist";
-        const tagsData =
-          !coreOnly && getLastfmApiKey()
-            ? await lastfmRequest("artist.getTopTags", { mbid: resolvedMbid })
-            : null;
-        const tags =
-          !coreOnly && tagsData?.toptags?.tag
-            ? (Array.isArray(tagsData.toptags.tag)
-                ? tagsData.toptags.tag
-                : [tagsData.toptags.tag]
-              ).map((t) => ({ name: t.name, count: t.count || 0 }))
-            : [];
+        const tagPayload = coreOnly
+          ? { tags: [], genres: [] }
+          : await getArtistTagPayload(resolvedMbid, name, metadataArtist);
         const releaseGroups =
           await musicbrainzGetArtistReleaseGroups(
             resolvedMbid,
             selectedReleaseTypes,
           );
-        if (!coreOnly && getLastfmApiKey()) {
-          await enrichReleaseGroupsWithLastfm(
-            releaseGroups,
-            name,
-            resolvedMbid,
-          );
-        }
-        const bio = coreOnly ? null : await getArtistBio(name, resolvedMbid);
         return {
           id: resolvedMbid,
           name,
-          "sort-name": name,
-          disambiguation: "",
+          "sort-name": metadataArtist?.sortName || name,
+          disambiguation: metadataArtist?.disambiguation || "",
           "type-id": null,
-          type: null,
+          type: metadataArtist?.type || null,
           country: null,
           "life-span": { begin: null, end: null, ended: false },
-          tags,
-          genres: [],
+          tags: tagPayload.tags,
+          genres: tagPayload.genres,
+          links: Array.isArray(metadataArtist?.links) ? metadataArtist.links : [],
           "release-groups": releaseGroups,
-          relations: [],
+          relations: toLegacyRelations(metadataArtist),
           "release-group-count": releaseGroups.length,
           "release-count": releaseGroups.length,
-          bio: bio || undefined,
+          bio: metadataArtist?.overview || undefined,
         };
       })();
 
@@ -298,6 +321,7 @@ export default function registerDetails(router) {
           "life-span": { begin: null, end: null, ended: false },
           tags: [],
           genres: [],
+          links: [],
           "release-groups": [],
           relations: [],
           "release-group-count": 0,

--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -1,12 +1,11 @@
 import { UUID_REGEX } from "../../../config/constants.js";
-import {
-  fetchItunesAlbumArt,
-  fetchCoverArtArchiveReleaseGroup,
-  musicbrainzRequest,
-} from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { warmImageProxy } from "../../../services/imageProxyService.js";
+import {
+  getAlbumByMbid,
+  getAlbumTracksByAlbumMbid,
+} from "../../../services/metadataProvider.js";
 
 const LEGACY_COVER_HOST_PATTERN =
   /https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org|archive\.org|[\w-]+\.ca\.archive\.org)\//i;
@@ -67,32 +66,10 @@ export default function registerReleaseGroup(router) {
       }
 
       try {
-        let resolvedArtistName = artistName;
-        let albumTitle = albumTitleFromQuery;
-
-        if (!resolvedArtistName || !albumTitle) {
-          const rgData = await musicbrainzRequest(`/release-group/${mbid}`, {
-            inc: "artist-credits",
-          });
-          if (!resolvedArtistName) {
-            resolvedArtistName = Array.isArray(rgData?.["artist-credit"])
-              ? rgData["artist-credit"]
-                  .map((credit) => credit?.name || credit?.artist?.name || "")
-                  .join(" ")
-                  .trim()
-              : "";
-          }
-          if (!albumTitle) {
-            albumTitle = String(rgData?.title || "").trim();
-          }
-        }
-
-        const itunesImageUrl = await fetchItunesAlbumArt(
-          resolvedArtistName,
-          albumTitle,
-        );
-        if (itunesImageUrl) {
-          const cachedImage = await warmImageProxy(itunesImageUrl);
+        const album = await getAlbumByMbid(mbid);
+        const image = Array.isArray(album?.images) ? album.images[0] : null;
+        if (image?.url) {
+          const cachedImage = await warmImageProxy(image.url);
           dbOps.setImage(cacheKey, cachedImage.localUrl);
           res.set("Cache-Control", "public, max-age=31536000, immutable");
           return res.json({
@@ -100,33 +77,14 @@ export default function registerReleaseGroup(router) {
               {
                 image: cachedImage.localUrl,
                 front: true,
-                types: ["Front"],
+                types: [image.kind || "Front"],
               },
             ],
           });
         }
-
-        const cover = await fetchCoverArtArchiveReleaseGroup(mbid);
-        if (cover?.imageUrl) {
-          const cachedImage = await warmImageProxy(cover.imageUrl);
-          dbOps.setImage(cacheKey, cachedImage.localUrl);
-
-          res.set("Cache-Control", "public, max-age=31536000, immutable");
-          return res.json({
-            images: [
-              {
-                image: cachedImage.localUrl,
-                front: true,
-                types: cover.types,
-              },
-            ],
-          });
-        }
-        if (cover?.notFound) {
-          dbOps.setImage(cacheKey, "NOT_FOUND");
-          res.set("Cache-Control", "public, max-age=3600");
-          return res.json({ images: [] });
-        }
+        dbOps.setImage(cacheKey, "NOT_FOUND");
+        res.set("Cache-Control", "public, max-age=3600");
+        return res.json({ images: [] });
       } catch (e) {}
 
       res.set("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
@@ -148,42 +106,18 @@ export default function registerReleaseGroup(router) {
         return res.status(400).json({ error: "Invalid MBID format" });
       }
 
-      const rgData = await musicbrainzRequest(`/release-group/${mbid}`, {
-        inc: "releases",
-      });
-
-      if (!rgData.releases || rgData.releases.length === 0) {
-        return res.json([]);
-      }
-
-      const releaseId = rgData.releases[0].id;
-      const releaseData = await musicbrainzRequest(`/release/${releaseId}`, {
-        inc: "recordings",
-      });
-
-      const tracks = [];
-      if (releaseData.media && releaseData.media.length > 0) {
-        for (const medium of releaseData.media) {
-          if (medium.tracks) {
-            for (const track of medium.tracks) {
-              const recording = track.recording;
-              if (recording) {
-                tracks.push({
-                  id: recording.id,
-                  mbid: recording.id,
-                  title: recording.title,
-                  trackName: recording.title,
-                  trackNumber: track.position || 0,
-                  position: track.position || 0,
-                  length: recording.length || null,
-                });
-              }
-            }
-          }
-        }
-      }
-
-      res.json(tracks);
+      const tracks = await getAlbumTracksByAlbumMbid(mbid);
+      res.json(
+        tracks.map((track) => ({
+          id: track.recordingId || track.id,
+          mbid: track.recordingId || track.id,
+          title: track.title,
+          trackName: track.title,
+          trackNumber: track.trackPosition || track.trackNumber || 0,
+          position: track.trackPosition || track.trackNumber || 0,
+          length: track.durationMs || null,
+        })),
+      );
     } catch (error) {
       console.error("Error fetching release group tracks:", error);
       res.status(500).json({

--- a/backend/routes/artists/handlers/similar.js
+++ b/backend/routes/artists/handlers/similar.js
@@ -2,7 +2,6 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import {
   getLastfmApiKey,
   lastfmRequest,
-  lastfmGetArtistNameByMbid,
   musicbrainzGetArtistNameByMbid,
 } from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
@@ -36,7 +35,6 @@ export default function registerSimilar(router) {
       if (!data?.similarartists?.artist) {
         const fallbackArtistName =
           artistNameParam ||
-          (await lastfmGetArtistNameByMbid(resolvedMbid).catch(() => null)) ||
           (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(() => null)) ||
           "";
 

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -2,10 +2,7 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import {
   getLastfmApiKey,
   lastfmRequest,
-  lastfmGetArtistNameByMbid,
-  getArtistBio,
   musicbrainzGetArtistReleaseGroups,
-  enrichReleaseGroupsWithLastfm,
   musicbrainzGetArtistNameByMbid,
 } from "../../../services/apiClients.js";
 import { dbOps } from "../../../config/db-helpers.js";
@@ -14,6 +11,7 @@ import { verifyTokenAuth } from "../../../middleware/auth.js";
 import { sendSSE, pendingArtistRequests } from "../utils.js";
 import { getArtistImage } from "../../../services/imageService.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
+import { getArtistByMbid } from "../../../services/metadataProvider.js";
 
 export default function registerStream(router) {
   router.get("/:mbid/stream", noCache, async (req, res) => {
@@ -60,17 +58,71 @@ export default function registerStream(router) {
 
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
+      const toLegacyRelations = (metadataArtist) =>
+        Array.isArray(metadataArtist?.links)
+          ? metadataArtist.links
+              .filter((link) => link?.target)
+              .map((link) => ({
+                type: link.type || "external",
+                url: { resource: link.target },
+              }))
+          : [];
+      const getLastfmTags = async (artistMbid, artistName = "") => {
+        if (!getLastfmApiKey()) return [];
+        let data = await lastfmRequest("artist.getTopTags", { mbid: artistMbid }).catch(
+          () => null,
+        );
+        if (!data?.toptags?.tag && artistName) {
+          data = await lastfmRequest("artist.getTopTags", {
+            artist: artistName,
+          }).catch(() => null);
+        }
+        const tags = data?.toptags?.tag
+          ? Array.isArray(data.toptags.tag)
+            ? data.toptags.tag
+            : [data.toptags.tag]
+          : [];
+        return tags
+          .map((tag) => ({
+            name: String(tag?.name || "").trim(),
+            count: Number(tag?.count || 0),
+          }))
+          .filter((tag) => tag.name);
+      };
+      const getArtistTagPayload = async (
+        artistMbid,
+        artistName = "",
+        metadataArtist = null,
+      ) => {
+        const lastfmTags = await getLastfmTags(artistMbid, artistName);
+        if (lastfmTags.length > 0) {
+          return {
+            tags: lastfmTags,
+            genres: lastfmTags.map((tag) => tag.name),
+          };
+        }
+        const fallbackGenres = Array.isArray(metadataArtist?.genres)
+          ? metadataArtist.genres.filter(Boolean)
+          : [];
+        return {
+          tags: fallbackGenres.map((genre) => ({ name: genre, count: 0 })),
+          genres: fallbackGenres,
+        };
+      };
       const initialName = streamArtistName || "Unknown Artist";
-      const buildArtistBase = (name) => ({
+      const buildArtistBase = (name, metadataArtist = null) => ({
         id: resolvedMbid,
-        name,
-        "sort-name": name,
-        disambiguation: "",
+        name: metadataArtist?.name || name,
+        "sort-name": metadataArtist?.sortName || metadataArtist?.name || name,
+        disambiguation: metadataArtist?.disambiguation || "",
         "type-id": null,
-        type: null,
+        type: metadataArtist?.type || null,
         country: null,
         "life-span": { begin: null, end: null, ended: false },
-        relations: [],
+        genres: Array.isArray(metadataArtist?.genres) ? metadataArtist.genres : [],
+        links: Array.isArray(metadataArtist?.links) ? metadataArtist.links : [],
+        relations: toLegacyRelations(metadataArtist),
+        ...(metadataArtist?.overview ? { bio: metadataArtist.overview } : {}),
       });
       const sendArtist = (payload) => {
         if (!isClientConnected()) return;
@@ -92,6 +144,7 @@ export default function registerStream(router) {
         const pendingPromise = pendingArtistRequests.has(mbid)
           ? pendingArtistRequests.get(mbid)
           : null;
+        const metadataArtistPromise = getArtistByMbid(resolvedMbid).catch(() => null);
         const namePromise = pendingPromise
           ? streamArtistName
             ? Promise.resolve(streamArtistName)
@@ -101,15 +154,31 @@ export default function registerStream(router) {
                 )
                 .catch(() => streamArtistName || "Unknown Artist")
           : (async () => {
+              const metadataArtist = await metadataArtistPromise;
+              if (metadataArtist?.name) return metadataArtist.name;
               if (streamArtistName) return streamArtistName;
               const name =
                 (await musicbrainzGetArtistNameByMbid(resolvedMbid)) ||
-                (getLastfmApiKey()
-                  ? await lastfmGetArtistNameByMbid(resolvedMbid)
-                  : null) ||
                 "Unknown Artist";
               return name;
             })();
+        tasks.push(
+          Promise.all([metadataArtistPromise, namePromise]).then(
+            async ([metadataArtist, name]) => {
+              if (!metadataArtist || !isClientConnected()) return;
+              const tagPayload = await getArtistTagPayload(
+                resolvedMbid,
+                name,
+                metadataArtist,
+              );
+              sendArtist({
+                ...buildArtistBase(name, metadataArtist),
+                tags: tagPayload.tags,
+                genres: tagPayload.genres,
+              });
+            },
+          ),
+        );
 
         const libraryTask = (async () => {
           const { lidarrClient } =
@@ -136,9 +205,10 @@ export default function registerStream(router) {
             console.log(
               `[Artists Stream] Found artist in Lidarr: ${lidarrArtist.artistName}`,
             );
+            const metadataArtist = await metadataArtistPromise;
 
             sendArtist({
-              ...buildArtistBase(lidarrArtist.artistName),
+              ...buildArtistBase(lidarrArtist.artistName, metadataArtist),
               _lidarrData: {
                 id: lidarrArtist.id,
                 monitored: lidarrArtist.monitored,
@@ -213,99 +283,41 @@ export default function registerStream(router) {
             resolvedMbid,
             selectedReleaseTypes,
           ).catch(() => []);
+          const metadataCorePromise = Promise.all([
+            metadataArtistPromise,
+            namePromise,
+            releaseGroupsPromise,
+          ]).then(async ([metadataArtist, name, releaseGroups]) => {
+            const tagPayload = await getArtistTagPayload(
+              resolvedMbid,
+              name,
+              metadataArtist,
+            );
+            return {
+              ...buildArtistBase(name, metadataArtist),
+              tags: tagPayload.tags,
+              genres: tagPayload.genres,
+              "release-groups": releaseGroups,
+              "release-group-count": releaseGroups.length,
+              "release-count": releaseGroups.length,
+            };
+          });
 
           tasks.push(
-            releaseGroupsPromise.then((releaseGroups) => {
+            metadataCorePromise.then((artistPayload) => {
               if (!isClientConnected()) return;
-              sendArtist({
-                id: resolvedMbid,
-                "release-groups": releaseGroups,
-                "release-group-count": releaseGroups.length,
-                "release-count": releaseGroups.length,
-              });
+              sendArtist(artistPayload);
             }),
           );
 
-          const enrichedReleaseGroupsPromise = Promise.all([
-            releaseGroupsPromise,
-            namePromise,
-          ])
-            .then(async ([releaseGroups, name]) => {
-              if (!releaseGroups.length) return { releaseGroups, name };
-              if (getLastfmApiKey()) {
-                await enrichReleaseGroupsWithLastfm(
-                  releaseGroups,
-                  name,
-                  resolvedMbid,
-                );
-              }
-              return { releaseGroups, name };
-            })
-            .then(({ releaseGroups, name }) => {
-              if (!isClientConnected()) return;
-              sendArtist({
-                id: resolvedMbid,
-                name,
-                "sort-name": name,
-                "release-groups": releaseGroups,
-                "release-group-count": releaseGroups.length,
-                "release-count": releaseGroups.length,
-              });
-              return releaseGroups;
-            });
-
-          const tagsPromise = getLastfmApiKey()
-            ? lastfmRequest("artist.getTopTags", { mbid: resolvedMbid })
-                .then((tagsData) => {
-                  const tags = tagsData?.toptags?.tag
-                    ? (Array.isArray(tagsData.toptags.tag)
-                        ? tagsData.toptags.tag
-                        : [tagsData.toptags.tag]
-                      ).map((t) => ({ name: t.name, count: t.count || 0 }))
-                    : [];
-                  if (!isClientConnected()) return tags;
-                  sendArtist({ id: resolvedMbid, tags });
-                  return tags;
-                })
-                .catch(() => [])
-            : Promise.resolve([]);
-
-          const bioPromise = getArtistBio(null, resolvedMbid)
-            .catch(() => null)
-            .then((bio) => {
-              if (!bio || !isClientConnected()) return bio;
-              sendArtist({ id: resolvedMbid, bio });
-              return bio;
-            });
-
-          tasks.push(enrichedReleaseGroupsPromise, tagsPromise, bioPromise);
-
-          fullArtistPromise = Promise.all([
-            namePromise,
-            enrichedReleaseGroupsPromise,
-            tagsPromise,
-            bioPromise,
-          ])
-            .then(([name, releaseGroups, tags, bio]) => ({
-              ...buildArtistBase(name),
-              tags,
-              genres: [],
-              "release-groups": releaseGroups,
-              relations: [],
-              "release-group-count": releaseGroups.length,
-              "release-count": releaseGroups.length,
-              ...(bio ? { bio } : {}),
-            }))
+          fullArtistPromise = metadataCorePromise
+            .then((artistPayload) => artistPayload)
             .catch(() => null);
 
           pendingArtistRequests.set(mbid, fullArtistPromise);
-          fullArtistPromise
-            .then((artistData) => {
-              if (artistData) sendArtist(artistData);
-            })
-            .finally(() => {
-              pendingArtistRequests.delete(mbid);
-            });
+          fullArtistPromise.finally(() => {
+            pendingArtistRequests.delete(mbid);
+          });
 
         }
         const coverTask = (async () => {
@@ -363,10 +375,8 @@ export default function registerStream(router) {
               if (!similarData?.similarartists?.artist) {
                 const fallbackArtistName =
                   streamArtistName ||
+                  (await metadataArtistPromise.catch(() => null))?.name ||
                   (await namePromise.catch(() => null)) ||
-                  (await lastfmGetArtistNameByMbid(resolvedMbid).catch(
-                    () => null,
-                  )) ||
                   (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(
                     () => null,
                   )) ||

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -41,9 +41,8 @@ function buildBootstrapPayload(req) {
     lidarrConfigured,
     lastfmConfigured: !!getLastfmApiKey(),
     ticketmasterConfigured: !!getTicketmasterApiKey(),
-    musicbrainzConfigured: !!(
-      settings.integrations?.musicbrainz?.email || process.env.CONTACT_EMAIL
-    ),
+    musicbrainzConfigured: !!settings.integrations?.metadata?.baseUrl,
+    metadataConfigured: !!settings.integrations?.metadata?.baseUrl,
     metadataProviders: getMetadataProviderHealthSnapshot(),
   };
 

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -66,7 +66,7 @@ export default function registerAlbums(router) {
           if (!mbid) {
             return res.status(400).json({
               error:
-                "Could not find MusicBrainz release group for this album. Try adding the artist to Lidarr first or use a different album.",
+                "Could not resolve metadata for this album. Try adding the artist to Lidarr first or use a different album.",
             });
           }
         }

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -1,5 +1,6 @@
 import { libraryManager } from "../../../services/libraryManager.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
+import { getAlbumTracksByAlbumMbid } from "../../../services/metadataProvider.js";
 
 export default function registerTracks(router) {
   router.get("/tracks", cacheMiddleware(120), async (req, res) => {
@@ -27,52 +28,25 @@ export default function registerTracks(router) {
             addedAt: new Date().toISOString(),
           }));
         } else {
-          const { musicbrainzRequest } = await import(
-            "../../../services/apiClients.js"
-          );
           try {
-            const rgData = await musicbrainzRequest(
-              `/release-group/${releaseGroupMbid}`,
-              { inc: "releases" }
-            );
-
-            if (rgData.releases && rgData.releases.length > 0) {
-              const releaseId = rgData.releases[0].id;
-              const releaseData = await musicbrainzRequest(
-                `/release/${releaseId}`,
-                {
-                  inc: "recordings",
-                }
-              );
-
-              if (releaseData.media && releaseData.media.length > 0) {
-                tracks = [];
-                for (const medium of releaseData.media) {
-                  if (medium.tracks) {
-                    for (const track of medium.tracks) {
-                      const recording = track.recording;
-                      if (recording) {
-                        tracks.push({
-                          id: recording.id,
-                          mbid: recording.id,
-                          trackName: recording.title,
-                          trackNumber: track.position || 0,
-                          title: recording.title,
-                          path: null,
-                          hasFile: false,
-                          size: 0,
-                          quality: null,
-                          addedAt: new Date().toISOString(),
-                        });
-                      }
-                    }
-                  }
-                }
-              }
+            const metadataTracks = await getAlbumTracksByAlbumMbid(releaseGroupMbid);
+            if (metadataTracks.length > 0) {
+              tracks = metadataTracks.map((track) => ({
+                id: track.recordingId || track.id,
+                mbid: track.recordingId || track.id,
+                trackName: track.title,
+                trackNumber: track.trackPosition || track.trackNumber || 0,
+                title: track.title,
+                path: null,
+                hasFile: false,
+                size: 0,
+                quality: null,
+                addedAt: new Date().toISOString(),
+              }));
             }
           } catch (mbError) {
             console.warn(
-              `[Library] Failed to fetch tracks from MusicBrainz: ${mbError.message}`
+              `[Library] Failed to fetch tracks from metadata provider: ${mbError.message}`
             );
           }
         }

--- a/backend/routes/onboarding.js
+++ b/backend/routes/onboarding.js
@@ -83,7 +83,7 @@ router.post("/navidrome/test", async (req, res) => {
 
 router.post("/complete", async (req, res) => {
   try {
-    const { authUser, authPassword, lidarr, musicbrainz, navidrome, lastfm } =
+    const { authUser, authPassword, lidarr, metadata, navidrome, lastfm } =
       req.body;
     if (authPassword != null && String(authPassword).length > 0) {
       const passwordValidation = requirePasswordStrength(authPassword);
@@ -110,13 +110,24 @@ router.post("/complete", async (req, res) => {
         lidarr && (lidarr.url || lidarr.apiKey)
           ? { ...(current.integrations?.lidarr || {}), ...lidarr }
           : current.integrations?.lidarr,
-      musicbrainz:
-        musicbrainz && musicbrainz.email != null
+      metadata:
+        metadata && (metadata.baseUrl || metadata.userAgentSuffix)
           ? {
-              ...(current.integrations?.musicbrainz || {}),
-              email: String(musicbrainz.email).trim(),
+              ...(current.integrations?.metadata || {}),
+              provider: "brainzmash",
+              baseUrl:
+                metadata.baseUrl != null
+                  ? String(metadata.baseUrl).trim().replace(/\/+$/, "")
+                  : current.integrations?.metadata?.baseUrl ||
+                    "https://lidarrapi.brainzmash.cc",
+              userAgentSuffix:
+                metadata.userAgentSuffix != null
+                  ? String(metadata.userAgentSuffix).trim()
+                  : current.integrations?.metadata?.userAgentSuffix || "",
+              enableNarrowFallbacks:
+                metadata.enableNarrowFallbacks !== false,
             }
-          : current.integrations?.musicbrainz,
+          : current.integrations?.metadata,
       navidrome:
         navidrome && (navidrome.url || navidrome.username)
           ? { ...(current.integrations?.navidrome || {}), ...navidrome }

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -15,7 +15,7 @@ router.get("/", noCache, async (req, res) => {
       scope = "artist",
       limit = 24,
       offset = 0,
-      tagScope = "recommended",
+      tagScope = "all",
       releaseTypes = "",
     } = req.query;
 

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -15,6 +15,20 @@ router.get("/", noCache, (req, res) => {
     if (settings?.integrations?.coverArtArchive) {
       delete settings.integrations.coverArtArchive;
     }
+    if (settings?.integrations?.musicbrainz) {
+      delete settings.integrations.musicbrainz;
+    }
+    if (!settings?.integrations?.metadata) {
+      const legacyMusicbrainz = dbOps.getSettings()?.integrations?.musicbrainz || {};
+      settings.integrations.metadata = {
+        provider: "brainzmash",
+        baseUrl:
+          String(legacyMusicbrainz.customUrl || "").trim().replace(/\/ws\/2\/?$/, "") ||
+          "https://lidarrapi.brainzmash.cc",
+        userAgentSuffix: "",
+        enableNarrowFallbacks: true,
+      };
+    }
     res.json(settings);
   } catch (error) {
     console.error("Settings GET error:", error);
@@ -43,50 +57,26 @@ router.post("/", async (req, res) => {
       }
     }
 
-    const musicbrainzProvider = integrations?.musicbrainz?.provider;
-    const validMusicbrainzProviders = new Set([
-      "aurralHosted",
-      "official",
-      "custom",
-    ]);
-    if (
-      musicbrainzProvider !== undefined &&
-      !validMusicbrainzProviders.has(musicbrainzProvider)
-    ) {
-      return res.status(400).json({
-        error:
-          "Invalid MusicBrainz provider. Expected aurralHosted, official, or custom.",
-      });
-    }
-
-    if (integrations?.musicbrainz) {
-      const nextMusicbrainz = {
-        ...(currentSettings.integrations?.musicbrainz || {}),
-        ...integrations.musicbrainz,
+    if (integrations?.metadata) {
+      const nextMetadata = {
+        ...(currentSettings.integrations?.metadata || {}),
+        ...integrations.metadata,
       };
-      const provider = validMusicbrainzProviders.has(nextMusicbrainz.provider)
-        ? nextMusicbrainz.provider
-        : "aurralHosted";
-      nextMusicbrainz.provider = provider;
-
-      if (provider === "custom") {
-        const customUrlValidation = validateExternalUrl(
-          nextMusicbrainz.customUrl || "",
-        );
-        if (!customUrlValidation.valid) {
-          return res.status(400).json({
-            error: `Invalid custom MusicBrainz URL: ${customUrlValidation.error}`,
-          });
-        }
-        nextMusicbrainz.customUrl = customUrlValidation.url;
-      } else {
-        nextMusicbrainz.customUrl =
-          typeof nextMusicbrainz.customUrl === "string"
-            ? nextMusicbrainz.customUrl.trim()
-            : "";
+      nextMetadata.provider = "brainzmash";
+      const baseUrlValidation = validateExternalUrl(nextMetadata.baseUrl || "");
+      if (!baseUrlValidation.valid) {
+        return res.status(400).json({
+          error: `Invalid metadata base URL: ${baseUrlValidation.error}`,
+        });
       }
-
-      integrations.musicbrainz = nextMusicbrainz;
+      nextMetadata.baseUrl = baseUrlValidation.url.replace(/\/+$/, "");
+      nextMetadata.userAgentSuffix =
+        typeof nextMetadata.userAgentSuffix === "string"
+          ? nextMetadata.userAgentSuffix.trim()
+          : "";
+      nextMetadata.enableNarrowFallbacks =
+        nextMetadata.enableNarrowFallbacks !== false;
+      integrations.metadata = nextMetadata;
     }
     if (integrations?.coverArtArchive) {
       delete integrations.coverArtArchive;
@@ -128,12 +118,12 @@ router.post("/", async (req, res) => {
               ...integrations.ticketmaster,
             }
           : mergedIntegrations.ticketmaster,
-        musicbrainz: integrations.musicbrainz
+        metadata: integrations.metadata
           ? {
-              ...(mergedIntegrations.musicbrainz || {}),
-              ...integrations.musicbrainz,
+              ...(mergedIntegrations.metadata || {}),
+              ...integrations.metadata,
             }
-          : mergedIntegrations.musicbrainz,
+          : mergedIntegrations.metadata,
         general: integrations.general
           ? {
               ...(mergedIntegrations.general || {}),
@@ -179,6 +169,9 @@ router.post("/", async (req, res) => {
 
     if (updatedSettings?.integrations?.coverArtArchive) {
       delete updatedSettings.integrations.coverArtArchive;
+    }
+    if (updatedSettings?.integrations?.musicbrainz) {
+      delete updatedSettings.integrations.musicbrainz;
     }
 
     dbOps.updateSettings(updatedSettings);

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -11,6 +11,16 @@ import {
   APP_NAME,
   APP_VERSION,
 } from "../config/constants.js";
+import {
+  getAlbumByMbid as getMetadataAlbumByMbid,
+  getArtistNameByMbid as getMetadataArtistNameByMbid,
+  getMetadataBaseUrl,
+  getMetadataProviderHealthSnapshot as getBrainzmashHealthSnapshot,
+  legacyMusicbrainzRequest,
+  listArtistAlbums as listMetadataArtistAlbums,
+  resolveAlbumByArtistAndTitle,
+  resolveArtistByName as resolveMetadataArtistByName,
+} from "./metadataProvider.js";
 
 const mbCache = new NodeCache({ stdTTL: 300, checkperiod: 60, maxKeys: 500 });
 const lastfmCache = new NodeCache({
@@ -276,14 +286,10 @@ const ensureMetadataProviderProbeLoop = () => {
   });
 };
 
-const getMusicbrainzProvider = () => {
-  const settings = dbOps.getSettings();
-  return settings.integrations?.musicbrainz?.provider || "aurralHosted";
-};
+const getMusicbrainzProvider = () => "brainzmash";
 
 export const getMusicbrainzApiBaseUrl = () => {
-  ensureMetadataProviderProbeLoop();
-  return getMetadataProviderSelection("musicbrainz").activeBaseUrl;
+  return getMetadataBaseUrl();
 };
 
 export const getMusicbrainzApiBaseUrls = () => {
@@ -299,28 +305,7 @@ export const getCoverArtArchiveApiBaseUrls = () => {
 };
 
 export const getMetadataProviderHealthSnapshot = () => {
-  const musicbrainzSelection = getMetadataProviderSelection("musicbrainz");
-
-  return {
-    musicbrainz: {
-      mode: musicbrainzSelection.mode,
-      configuredProvider: musicbrainzSelection.provider,
-      activeProvider: musicbrainzSelection.activeProvider,
-      activeBaseUrl: musicbrainzSelection.activeBaseUrl,
-      failoverActive:
-        musicbrainzSelection.mode === "auto"
-          ? metadataProviderHealth.musicbrainz.failoverActive
-          : false,
-      consecutiveFailures: metadataProviderHealth.musicbrainz.consecutiveFailures,
-      consecutiveSuccesses:
-        metadataProviderHealth.musicbrainz.consecutiveSuccesses,
-      lastCheckedAt: metadataProviderHealth.musicbrainz.lastCheckedAt,
-      lastSuccessAt: metadataProviderHealth.musicbrainz.lastSuccessAt,
-      lastFailureAt: metadataProviderHealth.musicbrainz.lastFailureAt,
-      lastFailureReason: metadataProviderHealth.musicbrainz.lastFailureReason,
-      lastTransitionAt: metadataProviderHealth.musicbrainz.lastTransitionAt,
-    },
-  };
+  return getBrainzmashHealthSnapshot();
 };
 
 export const __setMetadataProviderHealthStateForTests = (serviceKey, patch = {}) => {
@@ -332,7 +317,7 @@ export const __setMetadataProviderHealthStateForTests = (serviceKey, patch = {})
   );
 };
 
-ensureMetadataProviderProbeLoop();
+// Legacy MusicBrainz probing is intentionally disabled on the BrainzMash-native path.
 
 const requestMusicbrainz = async (
   baseUrl,
@@ -535,25 +520,8 @@ const musicbrainzRequestWithRetry = async (
   throw error;
 };
 
-export const musicbrainzRequest = async (endpoint, params = {}) => {
-  const cacheKey = getProviderRequestCacheKey("mb", endpoint, params);
-  const cached = mbCache.get(cacheKey);
-  if (cached) return cached;
-
-  const inflight = musicbrainzInflightRequests.get(cacheKey);
-  if (inflight) return inflight;
-
-  await configureMusicbrainzLimiter();
-  const requestPromise = mbLimiter.schedule(() =>
-    musicbrainzRequestWithRetry(endpoint, params),
-  );
-  musicbrainzInflightRequests.set(cacheKey, requestPromise);
-  try {
-    return await requestPromise;
-  } finally {
-    musicbrainzInflightRequests.delete(cacheKey);
-  }
-};
+export const musicbrainzRequest = async (endpoint, params = {}) =>
+  legacyMusicbrainzRequest(endpoint, params);
 
 const normalizeItunesArtworkUrl = (url) =>
   String(url || "")
@@ -562,160 +530,26 @@ const normalizeItunesArtworkUrl = (url) =>
     .replace(/\/\d+x\d+([a-z]+)(?=[/?#]|$)/i, "/600x600$1");
 
 export async function fetchItunesAlbumArt(artistName, albumName) {
-  const normalizedArtist = String(artistName || "").trim();
-  const normalizedAlbum = String(albumName || "").trim();
-  if (!normalizedArtist || !normalizedAlbum) return null;
-
-  const cacheKey = `${normalizedArtist.toLowerCase()}::${normalizedAlbum.toLowerCase()}`;
-  const cached = itunesAlbumArtCache.get(cacheKey);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  try {
-    const response = await itunesLimiter.schedule(() =>
-      axios.get("https://itunes.apple.com/search", {
-        params: {
-          term: `${normalizedArtist} ${normalizedAlbum}`,
-          media: "music",
-          entity: "album",
-          limit: 5,
-        },
-        timeout: 3000,
-      }),
-    );
-
-    const results = Array.isArray(response?.data?.results)
-      ? response.data.results
-      : [];
-
-    const normalizedAlbumTitle = normalizeTitle(normalizedAlbum);
-    const normalizedArtistTitle = normalizeTitle(normalizedArtist);
-    const exactMatch =
-      results.find((item) => {
-        const itemAlbum = normalizeTitle(item?.collectionName || "");
-        const itemArtist = normalizeTitle(item?.artistName || "");
-        return itemAlbum === normalizedAlbumTitle && itemArtist === normalizedArtistTitle;
-      }) || results[0];
-
-    const artworkUrl = normalizeItunesArtworkUrl(exactMatch?.artworkUrl100 || "");
-    const value = artworkUrl || null;
-    itunesAlbumArtCache.set(cacheKey, value);
-    return value;
-  } catch {
-    return null;
-  }
+  const _artist = artistName;
+  const _album = albumName;
+  return null;
 }
 
 export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
   if (!releaseGroupMbid) return null;
-  const baseUrl = getCoverArtArchiveApiBaseUrl();
-  const directUrl = `${baseUrl}/release-group/${releaseGroupMbid}/front`;
-  let sawTransientError = false;
-
-  const fetchReleaseFront = async (releaseMbid) => {
-    if (!releaseMbid) return null;
-    const releaseDirectUrl = `${baseUrl}/release/${releaseMbid}/front`;
-    try {
-      const response = await axios.head(releaseDirectUrl, {
-        timeout: 2000,
-        maxRedirects: 0,
-        validateStatus: (status) =>
-          status === 200 || status === 301 || status === 302 || status === 307,
-      });
-      if (response.status >= 200 && response.status < 400) {
-        return {
-          imageUrl: releaseDirectUrl,
-          types: ["Front"],
-        };
-      }
-    } catch (error) {
-      const status = error?.response?.status;
-      if (status === 404) return { imageUrl: null, notFound: true, types: [] };
-      if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
-        sawTransientError = true;
-      }
-    }
-    return null;
-  };
-
   try {
-    const response = await axios.head(directUrl, {
-      timeout: 2000,
-      maxRedirects: 0,
-      validateStatus: (status) =>
-        status === 200 || status === 301 || status === 302 || status === 307,
-    });
-
-    if (response.status >= 200 && response.status < 400) {
+    const album = await getMetadataAlbumByMbid(releaseGroupMbid);
+    const image = Array.isArray(album?.images) ? album.images[0] : null;
+    if (image?.url) {
       return {
-        imageUrl: directUrl,
-        types: ["Front"],
+        imageUrl: image.url,
+        types: [image.kind || "Front"],
       };
     }
-  } catch (error) {
-    const status = error?.response?.status;
-    if (status === 404) {
-      return { imageUrl: null, types: [], notFound: true };
-    }
-    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
-      sawTransientError = true;
-    }
-  }
-
-  try {
-    const response = await axios.get(
-      `${baseUrl}/release-group/${releaseGroupMbid}`,
-      {
-        headers: { Accept: "application/json" },
-        timeout: 2000,
-      },
-    );
-    const images = Array.isArray(response?.data?.images)
-      ? response.data.images
-      : [];
-    if (!images.length) {
-      return { imageUrl: null, types: [], notFound: true };
-    }
-
-    const frontImage = images.find((img) => img.front) || images[0];
-    return {
-      imageUrl: directUrl,
-      types: frontImage?.types || ["Front"],
-    };
-  } catch (error) {
-    const status = error?.response?.status;
-    if (status === 404) {
-      return { imageUrl: null, types: [], notFound: true };
-    }
-    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
-      sawTransientError = true;
-    }
-  }
-
-  try {
-    const rgData = await musicbrainzRequest(`/release-group/${releaseGroupMbid}`, {
-      inc: "releases",
-    });
-    const releases = Array.isArray(rgData?.releases) ? rgData.releases : [];
-    for (const release of releases.slice(0, 8)) {
-      const cover = await fetchReleaseFront(release?.id);
-      if (cover?.imageUrl) {
-        return cover;
-      }
-    }
-  } catch (error) {
-    const status = error?.response?.status;
-    if ([408, 425, 429, 500, 502, 503, 504].includes(status) || error?.code) {
-      sawTransientError = true;
-    }
-  }
-
-  if (sawTransientError) {
+    return { imageUrl: null, types: [], notFound: true };
+  } catch {
     return { imageUrl: null, types: [], transientError: true };
   }
-
-  return { imageUrl: null, types: [], notFound: true };
 }
 
 export const lastfmRequest = lastfmLimiter.wrap(
@@ -1326,116 +1160,37 @@ export async function musicbrainzGetArtistReleaseGroups(
   mbid,
   selectedReleaseTypes = null,
 ) {
-  const normalizedSelection = normalizeArtistReleaseTypeSelection(
-    selectedReleaseTypes,
-  );
-  const shouldOptimizeQuery =
-    normalizedSelection.primaryTypes.length > 0 &&
-    (normalizedSelection.primaryTypes.length < PRIMARY_RELEASE_TYPES.length ||
-      normalizedSelection.secondaryTypes.length === 0);
-  const cacheKey = `full:${mbid}:${JSON.stringify(
-    normalizedSelection.primaryTypes,
-  )}:${JSON.stringify(normalizedSelection.secondaryTypes)}`;
+  const cacheKey = `full:${mbid}:${JSON.stringify(selectedReleaseTypes || [])}`;
   const cached = musicbrainzReleaseGroupsCache.get(cacheKey);
   if (cached) return cached;
   try {
-    const raw = [];
-    const limit = 100;
-    let offset = 0;
-    let totalCount = 0;
-
-    if (shouldOptimizeQuery) {
-      const query = buildArtistReleaseGroupQuery(
-        mbid,
-        normalizedSelection.primaryTypes,
-        normalizedSelection.secondaryTypes,
-      );
-      do {
-        const data = await musicbrainzRequest("/release-group", {
-          query,
-          limit,
-          offset,
-        });
-        totalCount = Number(data?.count || 0);
-        const batch = Array.isArray(data?.["release-groups"])
-          ? data["release-groups"]
-          : [];
-        raw.push(...batch);
-        offset += limit;
-      } while (offset < totalCount);
-    } else {
-      do {
-        const data = await musicbrainzRequest("/release-group", {
-          artist: mbid,
-          limit,
-          offset,
-        });
-        totalCount = data["release-group-count"] || 0;
-        const batch = data["release-groups"] || [];
-        raw.push(...batch);
-        offset += limit;
-      } while (offset < totalCount);
-    }
-
-    const filtered = raw
-      .filter(
-        (rg) =>
-          rg.id &&
-          ALLOWED_PRIMARY_TYPES.has((rg["primary-type"] || "").toLowerCase()),
-      )
-      .map((rg) => ({
-        id: rg.id,
-        title: rg.title || "",
-        "first-release-date": rg["first-release-date"] || null,
-        "primary-type":
-          rg["primary-type"] === "EP"
-            ? "EP"
-            : rg["primary-type"] === "Single"
-              ? "Single"
-              : "Album",
-        "secondary-types": Array.isArray(rg["secondary-types"])
-          ? rg["secondary-types"]
-          : [],
-      }))
-      .filter((rg) => {
-        if (!selectedReleaseTypes || !Array.isArray(selectedReleaseTypes)) {
-          return true;
-        }
-        const { primaryTypes, secondaryTypes } = normalizedSelection;
-        const primaryType = rg["primary-type"];
-        const rgSecondaryTypes = Array.isArray(rg["secondary-types"])
-          ? rg["secondary-types"]
-          : [];
-        if (primaryTypes.length > 0 && !primaryTypes.includes(primaryType)) {
-          return false;
-        }
-        if (secondaryTypes.length === 0 && rgSecondaryTypes.length > 0) {
-          return false;
-        }
-        if (secondaryTypes.length > 0 && rgSecondaryTypes.length > 0) {
-          const normalizedRgSecondaryTypes = [
-            ...new Set(
-              rgSecondaryTypes.map((secondaryType) =>
-                SECONDARY_RELEASE_TYPES.includes(secondaryType)
-                  ? secondaryType
-                  : "Other",
-              ),
-            ),
-          ];
-          return normalizedRgSecondaryTypes.every((secondaryType) =>
-            secondaryTypes.includes(secondaryType),
-          );
-        }
-        return true;
-      })
-      .sort((a, b) => {
-        const dateA = a["first-release-date"] || "";
-        const dateB = b["first-release-date"] || "";
-        return dateB.localeCompare(dateA);
-      });
-    musicbrainzReleaseGroupsCache.set(cacheKey, filtered);
-    return filtered;
-  } catch (e) {
+    const items = await listMetadataArtistAlbums(mbid, {
+      releaseTypes: selectedReleaseTypes || [],
+      includeTrackCounts: true,
+    });
+    const mapped = items.map((item) => ({
+      id: item.id,
+      title: item.title || "",
+      "first-release-date": item.firstReleaseDate || null,
+      "primary-type": item.type || "Album",
+      "secondary-types": Array.isArray(item.secondaryTypes)
+        ? item.secondaryTypes
+        : [],
+      rating: item.rating || null,
+      "artist-credit": item.artistName
+        ? [
+            {
+              name: item.artistName,
+              artist: item.artistId
+                ? { id: item.artistId, name: item.artistName }
+                : { name: item.artistName },
+            },
+          ]
+        : [],
+    }));
+    musicbrainzReleaseGroupsCache.set(cacheKey, mapped);
+    return mapped;
+  } catch {
     return [];
   }
 }
@@ -1445,48 +1200,8 @@ export async function musicbrainzGetArtistReleaseGroupsPreview(mbid, limit = 50)
   const parsedLimit = Number.parseInt(limit, 10);
   const safeLimit =
     Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(100, parsedLimit) : 50;
-  const cacheKey = `preview:${mbid}:${safeLimit}`;
-  const cached = musicbrainzReleaseGroupsCache.get(cacheKey);
-  if (cached) return cached;
-  try {
-    const data = await musicbrainzRequest("/release-group", {
-      artist: mbid,
-      limit: safeLimit,
-      offset: 0,
-    });
-    const releaseGroups = Array.isArray(data?.["release-groups"])
-      ? data["release-groups"]
-      : [];
-    const result = releaseGroups
-      .filter(
-        (rg) =>
-          rg?.id &&
-          ALLOWED_PRIMARY_TYPES.has((rg["primary-type"] || "").toLowerCase()),
-      )
-      .map((rg) => ({
-        id: rg.id,
-        title: rg.title || "",
-        "first-release-date": rg["first-release-date"] || null,
-        "primary-type":
-          rg["primary-type"] === "EP"
-            ? "EP"
-            : rg["primary-type"] === "Single"
-              ? "Single"
-              : "Album",
-        "secondary-types": Array.isArray(rg["secondary-types"])
-          ? rg["secondary-types"]
-          : [],
-      }))
-      .sort((a, b) => {
-        const dateA = a["first-release-date"] || "";
-        const dateB = b["first-release-date"] || "";
-        return dateB.localeCompare(dateA);
-      });
-    musicbrainzReleaseGroupsCache.set(cacheKey, result);
-    return result;
-  } catch (e) {
-    return [];
-  }
+  const items = await musicbrainzGetArtistReleaseGroups(mbid);
+  return items.slice(0, safeLimit);
 }
 
 /**
@@ -1691,8 +1406,7 @@ export async function musicbrainzGetArtistNameByMbid(mbid) {
   const cached = musicbrainzArtistNameCache.get(mbid);
   if (cached !== undefined) return cached;
   try {
-    const data = await musicbrainzRequest(`/artist/${mbid}`);
-    const name = data?.name;
+    const name = await getMetadataArtistNameByMbid(mbid);
     const normalized =
       name && typeof name === "string" ? name.trim() : null;
     musicbrainzArtistNameCache.set(mbid, normalized);
@@ -1737,38 +1451,8 @@ export async function musicbrainzResolveArtistMbidByName(artistName) {
       return cached.mbid || null;
     }
   }
-  const queryName = rawName.replace(/"/g, '\\"');
   try {
-    const data = await musicbrainzRequest("/artist", {
-      query: `artist:"${queryName}"`,
-      limit: 5,
-    });
-    const artists = Array.isArray(data?.artists) ? data.artists : [];
-    const candidates = artists
-      .map((artist) => ({
-        id: artist.id,
-        name: artist.name || "",
-        type: artist.type || "",
-        disambiguation: artist.disambiguation || "",
-        score: parseInt(artist.score || 0),
-        normalized: String(artist.name || "").toLowerCase(),
-      }))
-      .filter((artist) => artist.id);
-    if (!candidates.length) return null;
-    candidates.sort((a, b) => {
-      const aExact = a.normalized === normalized ? 1 : 0;
-      const bExact = b.normalized === normalized ? 1 : 0;
-      if (aExact !== bExact) return bExact - aExact;
-      const aPerson = a.type.toLowerCase() === "person" ? 1 : 0;
-      const bPerson = b.type.toLowerCase() === "person" ? 1 : 0;
-      if (aPerson !== bPerson) return bPerson - aPerson;
-      const aDisambig = a.disambiguation ? 1 : 0;
-      const bDisambig = b.disambiguation ? 1 : 0;
-      if (aDisambig !== bDisambig) return bDisambig - aDisambig;
-      if (a.score !== b.score) return b.score - a.score;
-      return a.name.localeCompare(b.name);
-    });
-    const resolved = candidates[0]?.id || null;
+    const resolved = await resolveMetadataArtistByName(rawName);
     dbOps.setMusicbrainzArtistMbidCache(normalized, resolved);
     return resolved;
   } catch (e) {
@@ -1800,20 +1484,15 @@ export async function resolveDeezerAlbumToMbid(
     dbOps.getDeezerMbidCache(dzKey) || dbOps.getDeezerMbidCache(aaKey);
   if (cached) return cached;
 
-  const artist = String(artistName || "")
-    .trim()
-    .replace(/"/g, '\\"');
-  const album = String(albumName || "")
-    .trim()
-    .replace(/"/g, '\\"');
+  const artist = String(artistName || "").trim();
+  const album = String(albumName || "").trim();
   if (!artist || !album) return null;
 
   try {
-    const data = await musicbrainzRequest("/release-group", {
-      query: `artist:"${artist}" AND releasegroup:"${album}"`,
-      limit: 1,
+    const id = await resolveAlbumByArtistAndTitle({
+      artistName: artist,
+      albumTitle: album,
     });
-    const id = data?.["release-groups"]?.[0]?.id;
     if (!id) return null;
     dbOps.setDeezerMbidCache(dzKey, id);
     dbOps.setDeezerMbidCache(aaKey, id);

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -1,11 +1,10 @@
 import { dbOps } from "../config/db-helpers.js";
 import {
-  fetchItunesAlbumArt,
-  fetchCoverArtArchiveReleaseGroup,
   musicbrainzGetArtistNameByMbid,
   musicbrainzGetArtistReleaseGroupsPreview,
 } from "./apiClients.js";
 import { warmImageProxy } from "./imageProxyService.js";
+import { getAlbumByMbid, getArtistByMbid } from "./metadataProvider.js";
 
 const MAX_NEGATIVE_CACHE = 1000;
 const MAX_PENDING_REQUESTS = 100;
@@ -65,42 +64,28 @@ export const fetchReleaseGroupCoverUrl = async (
   releaseGroupMbid,
   { artistName = "", albumTitle = "" } = {},
 ) => {
+  const _artistName = artistName;
+  const _albumTitle = albumTitle;
   const cacheKey = `rg:${releaseGroupMbid}`;
   const cached = getCachedUrl(cacheKey);
   if (cached !== undefined) {
     return { imageUrl: cached, notFound: cached === null, transientError: false };
   }
   try {
-    const itunesImageUrl = await fetchItunesAlbumArt(artistName, albumTitle);
-    if (itunesImageUrl) {
-      const cachedImage = await warmImageProxy(itunesImageUrl);
+    const album = await getAlbumByMbid(releaseGroupMbid);
+    const image = Array.isArray(album?.images) ? album.images[0] : null;
+    if (image?.url) {
+      const cachedImage = await warmImageProxy(image.url);
       dbOps.setImage(cacheKey, cachedImage.localUrl);
       return {
         imageUrl: cachedImage.localUrl,
-        types: ["Front"],
+        types: [image.kind || "Front"],
         notFound: false,
         transientError: false,
       };
     }
-
-    const cover = await fetchCoverArtArchiveReleaseGroup(releaseGroupMbid);
-    if (cover?.imageUrl) {
-      const cachedImage = await warmImageProxy(cover.imageUrl);
-      dbOps.setImage(cacheKey, cachedImage.localUrl);
-      return {
-        imageUrl: cachedImage.localUrl,
-        types: cover.types || ["Front"],
-        notFound: false,
-        transientError: false,
-      };
-    }
-    if (cover?.notFound) {
-      dbOps.setImage(cacheKey, "NOT_FOUND");
-      return { imageUrl: null, types: [], notFound: true, transientError: false };
-    }
-    if (cover?.transientError) {
-      return { imageUrl: null, types: [], notFound: false, transientError: true };
-    }
+    dbOps.setImage(cacheKey, "NOT_FOUND");
+    return { imageUrl: null, types: [], notFound: true, transientError: false };
   } catch (e) {}
   return { imageUrl: null, types: [], notFound: false, transientError: true };
 };
@@ -184,6 +169,27 @@ export const getArtistImage = async (
     try {
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
+      const metadataArtist = await getArtistByMbid(resolvedMbid).catch(() => null);
+      const directArtistImage = Array.isArray(metadataArtist?.images)
+        ? metadataArtist.images.find((image) => image?.url)
+        : null;
+
+      if (directArtistImage?.url) {
+        const cachedImage = await warmImageProxy(directArtistImage.url);
+        negativeImageCache.delete(mbid);
+        dbOps.setImage(mbid, cachedImage.localUrl);
+        return {
+          url: cachedImage.localUrl,
+          images: [
+            {
+              image: cachedImage.localUrl,
+              front: true,
+              types: [directArtistImage.kind || "Artist"],
+            },
+          ],
+        };
+      }
+
       const resolvedArtistName =
         artistName ||
         (await musicbrainzGetArtistNameByMbid(resolvedMbid).catch(() => null));

--- a/backend/services/metadataProvider.js
+++ b/backend/services/metadataProvider.js
@@ -1,0 +1,17 @@
+export {
+  findArtistsByGenre,
+  getAlbumByMbid,
+  getAlbumTracksByAlbumMbid,
+  getArtistByMbid,
+  getArtistGenres,
+  getArtistNameByMbid,
+  getMetadataBaseUrl,
+  getMetadataProvider,
+  getMetadataProviderHealthSnapshot,
+  legacyMusicbrainzRequest,
+  listArtistAlbums,
+  resolveAlbumByArtistAndTitle,
+  resolveArtistByName,
+  searchAlbums,
+  searchArtists,
+} from "./providers/brainzmashProvider.js";

--- a/backend/services/providers/brainzmashMappers.js
+++ b/backend/services/providers/brainzmashMappers.js
@@ -1,0 +1,323 @@
+import { getNormalizedText } from "./brainzmashRanking.js";
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeString(value) {
+  return String(value || "").trim();
+}
+
+function normalizeType(value) {
+  const normalized = normalizeString(value);
+  if (normalized === "Album" || normalized === "EP" || normalized === "Single") {
+    return normalized;
+  }
+  return normalized || "Album";
+}
+
+function normalizeImageKind(value) {
+  const normalized = normalizeString(value);
+  return normalized || "Cover";
+}
+
+export function toNormalizedArtistImage(image) {
+  const url = normalizeString(image?.Url || image?.url);
+  if (!url) return null;
+  return {
+    kind: normalizeImageKind(image?.CoverType || image?.kind),
+    url,
+  };
+}
+
+export function toNormalizedArtistLink(link) {
+  const target = normalizeString(link?.target || link?.url);
+  if (!target) return null;
+  return {
+    type: normalizeString(link?.type) || "external",
+    target,
+  };
+}
+
+export function toNormalizedArtist(raw) {
+  const images = normalizeArray(raw?.images)
+    .map(toNormalizedArtistImage)
+    .filter(Boolean);
+  const links = normalizeArray(raw?.links)
+    .map(toNormalizedArtistLink)
+    .filter(Boolean);
+  return {
+    id: normalizeString(raw?.id),
+    name: normalizeString(raw?.artistname || raw?.name),
+    sortName:
+      normalizeString(raw?.sortname || raw?.sortName || raw?.artistname || raw?.name),
+    type: normalizeString(raw?.type) || null,
+    status: normalizeString(raw?.status) || null,
+    disambiguation: normalizeString(raw?.disambiguation) || "",
+    overview: normalizeString(raw?.overview) || "",
+    genres: normalizeArray(raw?.genres)
+      .map((genre) => normalizeString(genre))
+      .filter(Boolean),
+    aliases: normalizeArray(raw?.artistaliases)
+      .map((alias) => normalizeString(alias))
+      .filter(Boolean),
+    images,
+    links,
+    rating:
+      raw?.rating && raw.rating.Value != null
+        ? {
+            count: Number.parseInt(raw.rating.Count, 10) || 0,
+            value:
+              raw.rating.Value != null && Number.isFinite(Number(raw.rating.Value))
+                ? Number(raw.rating.Value)
+                : null,
+          }
+        : null,
+  };
+}
+
+export function toNormalizedTrack(raw) {
+  return {
+    id: normalizeString(raw?.id),
+    recordingId: normalizeString(raw?.recordingid || raw?.recordingId || raw?.id),
+    title: normalizeString(raw?.trackname || raw?.title),
+    trackNumber:
+      raw?.trackposition != null && Number.isFinite(Number(raw.trackposition))
+        ? Number(raw.trackposition)
+        : raw?.trackNumber != null && Number.isFinite(Number(raw.trackNumber))
+          ? Number(raw.trackNumber)
+          : null,
+    trackPosition:
+      raw?.trackposition != null && Number.isFinite(Number(raw.trackposition))
+        ? Number(raw.trackposition)
+        : null,
+    mediumNumber:
+      raw?.mediumnumber != null && Number.isFinite(Number(raw.mediumnumber))
+        ? Number(raw.mediumnumber)
+        : null,
+    durationMs:
+      raw?.durationms != null && Number.isFinite(Number(raw.durationms))
+        ? Number(raw.durationms)
+        : null,
+    artistId: normalizeString(raw?.artistid) || null,
+  };
+}
+
+export function toNormalizedRelease(raw) {
+  const tracks = normalizeArray(raw?.tracks).map(toNormalizedTrack).filter(Boolean);
+  return {
+    id: normalizeString(raw?.id),
+    title: normalizeString(raw?.title),
+    status: normalizeString(raw?.status) || null,
+    country: normalizeArray(raw?.country)
+      .map((entry) => normalizeString(entry))
+      .filter(Boolean),
+    label: normalizeArray(raw?.label)
+      .map((entry) => normalizeString(entry))
+      .filter(Boolean),
+    media: normalizeArray(raw?.media).map((entry) => ({
+      format: normalizeString(entry?.Format || entry?.format),
+      name: normalizeString(entry?.Name || entry?.name),
+      position:
+        entry?.Position != null && Number.isFinite(Number(entry.Position))
+          ? Number(entry.Position)
+          : null,
+    })),
+    trackCount:
+      raw?.track_count != null && Number.isFinite(Number(raw.track_count))
+        ? Number(raw.track_count)
+        : tracks.length,
+    tracks,
+    releaseDate: normalizeString(raw?.releasedate || raw?.releaseDate) || null,
+    disambiguation: normalizeString(raw?.disambiguation) || "",
+  };
+}
+
+export function toNormalizedAlbum(raw) {
+  const artists = normalizeArray(raw?.artists)
+    .map(toNormalizedArtist)
+    .filter((artist) => artist?.id);
+  const images = normalizeArray(raw?.images)
+    .map(toNormalizedArtistImage)
+    .filter(Boolean);
+  const links = normalizeArray(raw?.links)
+    .map(toNormalizedArtistLink)
+    .filter(Boolean);
+  const releases = normalizeArray(raw?.releases)
+    .map(toNormalizedRelease)
+    .filter((release) => release?.id);
+  return {
+    id: normalizeString(raw?.id),
+    title: normalizeString(raw?.title),
+    artistId: normalizeString(raw?.artistid) || artists[0]?.id || null,
+    artists,
+    type: normalizeType(raw?.type),
+    secondaryTypes: normalizeArray(raw?.secondarytypes)
+      .map((value) => normalizeString(value))
+      .filter(Boolean),
+    releaseDate: normalizeString(raw?.releasedate) || null,
+    genres: normalizeArray(raw?.genres)
+      .map((value) => normalizeString(value))
+      .filter(Boolean),
+    aliases: normalizeArray(raw?.aliases)
+      .map((value) => normalizeString(value))
+      .filter(Boolean),
+    overview: normalizeString(raw?.overview) || "",
+    images,
+    links,
+    releases,
+    rating:
+      raw?.rating && raw.rating.Value != null
+        ? {
+            count: Number.parseInt(raw.rating.Count, 10) || 0,
+            value:
+              raw.rating.Value != null && Number.isFinite(Number(raw.rating.Value))
+                ? Number(raw.rating.Value)
+                : null,
+          }
+        : null,
+  };
+}
+
+export function toNormalizedArtistAlbum(raw) {
+  return {
+    id: normalizeString(raw?.Id || raw?.id),
+    title: normalizeString(raw?.Title || raw?.title),
+    type: normalizeType(raw?.Type || raw?.type),
+    secondaryTypes: normalizeArray(raw?.SecondaryTypes || raw?.secondaryTypes)
+      .map((value) => normalizeString(value))
+      .filter(Boolean),
+    releaseStatuses: normalizeArray(raw?.ReleaseStatuses || raw?.releaseStatuses)
+      .map((value) => normalizeString(value))
+      .filter(Boolean),
+    firstReleaseDate: normalizeString(raw?.FirstReleaseDate || raw?.firstReleaseDate) || null,
+    coverImages: normalizeArray(raw?.images).map(toNormalizedArtistImage).filter(Boolean),
+    rating: null,
+  };
+}
+
+export function toLegacyArtist(normalizedArtist) {
+  return {
+    id: normalizedArtist.id,
+    name: normalizedArtist.name,
+    "sort-name": normalizedArtist.sortName,
+    type: normalizedArtist.type,
+    status: normalizedArtist.status,
+    disambiguation: normalizedArtist.disambiguation || "",
+    genres: normalizedArtist.genres,
+    aliases: normalizedArtist.aliases.map((name) => ({ name })),
+    relations: normalizedArtist.links.map((link) => ({
+      type: link.type,
+      url: { resource: link.target },
+    })),
+    overview: normalizedArtist.overview,
+  };
+}
+
+export function toLegacyReleaseGroupSummary(
+  album,
+  artist = null,
+  { score = 0 } = {},
+) {
+  const artistName = artist?.name || album?.artistName || "";
+  const artistId = artist?.id || album?.artistId || null;
+  return {
+    id: album.id,
+    title: album.title,
+    "primary-type": album.type || "Album",
+    "secondary-types": album.secondaryTypes || [],
+    "first-release-date": album.releaseDate || album.firstReleaseDate || null,
+    rating: album.rating || null,
+    score,
+    "artist-credit": artistName
+      ? [
+          {
+            name: artistName,
+            artist: artistId ? { id: artistId, name: artistName } : { name: artistName },
+          },
+        ]
+      : [],
+    releases: normalizeArray(album.releases).map((release) => ({
+      id: release.id,
+      status: release.status || null,
+      date: release.releaseDate || null,
+      title: release.title || album.title,
+    })),
+  };
+}
+
+export function toLegacyRelease(release) {
+  return {
+    id: release.id,
+    title: release.title,
+    status: release.status,
+    date: release.releaseDate,
+    media: normalizeArray(release.media).map((medium) => ({
+      format: medium.format,
+      name: medium.name,
+      position: medium.position,
+      tracks: normalizeArray(release.tracks)
+        .filter(
+          (track) =>
+            medium.position == null ||
+            track.mediumNumber == null ||
+            track.mediumNumber === medium.position,
+        )
+        .map((track) => ({
+          id: track.id,
+          title: track.title,
+          length: track.durationMs,
+          position: track.trackPosition || track.trackNumber || 0,
+          number:
+            track.trackNumber != null ? String(track.trackNumber) : null,
+          recording: {
+            id: track.recordingId || track.id,
+            title: track.title,
+            length: track.durationMs,
+          },
+        })),
+    })),
+  };
+}
+
+export function toLegacySearchArtistResult(normalizedArtist, score = 0) {
+  return {
+    id: normalizedArtist.id,
+    name: normalizedArtist.name,
+    "sort-name": normalizedArtist.sortName,
+    type: normalizedArtist.type,
+    disambiguation: normalizedArtist.disambiguation || "",
+    genres: normalizedArtist.genres,
+    score,
+  };
+}
+
+export function toLegacySearchAlbumResult(item) {
+  const normalizedArtistName = normalizeString(item?.artistName) || "Unknown Artist";
+  return {
+    id: item.id,
+    title: item.title,
+    "primary-type": item.type || "Album",
+    "secondary-types": item.secondaryTypes || [],
+    "first-release-date": item.releaseDate || null,
+    score: Number(item?.score || 0),
+    "artist-credit": normalizedArtistName
+      ? [
+          {
+            name: normalizedArtistName,
+            artist: item?.artistId
+              ? { id: item.artistId, name: normalizedArtistName }
+              : { name: normalizedArtistName },
+          },
+        ]
+      : [],
+  };
+}
+
+export function matchesGenreQuery(artist, query) {
+  const normalizedQuery = getNormalizedText(query);
+  if (!normalizedQuery) return false;
+  return normalizeArray(artist?.genres).some((genre) =>
+    getNormalizedText(genre).includes(normalizedQuery),
+  );
+}

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -1,0 +1,486 @@
+import axios from "axios";
+import NodeCache from "node-cache";
+import { dbOps } from "../../config/db-helpers.js";
+import {
+  APP_NAME,
+  APP_VERSION,
+  MUSICBRAINZ_API,
+} from "../../config/constants.js";
+import {
+  rankAlbumCandidates,
+  rankArtistCandidates,
+} from "./brainzmashRanking.js";
+import {
+  matchesGenreQuery,
+  toLegacyArtist,
+  toLegacyRelease,
+  toLegacyReleaseGroupSummary,
+  toLegacySearchAlbumResult,
+  toLegacySearchArtistResult,
+  toNormalizedAlbum,
+  toNormalizedArtist,
+  toNormalizedArtistAlbum,
+} from "./brainzmashMappers.js";
+
+const providerCache = new NodeCache({
+  stdTTL: 300,
+  checkperiod: 60,
+  maxKeys: 2000,
+});
+const releaseCache = new NodeCache({
+  stdTTL: 300,
+  checkperiod: 60,
+  maxKeys: 5000,
+});
+
+const healthState = {
+  configuredProvider: "brainzmash",
+  activeBaseUrl: null,
+  failoverActive: false,
+  lastCheckedAt: null,
+  lastSuccessAt: null,
+  lastFailureAt: null,
+  lastFailureReason: "",
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function getSettingsMetadata() {
+  const settings = dbOps.getSettings();
+  return settings.integrations?.metadata || {};
+}
+
+function isNarrowFallbacksEnabled() {
+  const metadata = getSettingsMetadata();
+  return metadata.enableNarrowFallbacks !== false;
+}
+
+export function getMetadataBaseUrl() {
+  const metadata = getSettingsMetadata();
+  const raw = String(
+    metadata.baseUrl ||
+      process.env.BRAINZMASH_BASE_URL ||
+      "https://lidarrapi.brainzmash.cc",
+  ).trim();
+  try {
+    const parsed = new URL(raw);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return "https://lidarrapi.brainzmash.cc";
+  }
+}
+
+export function getMetadataProvider() {
+  return "brainzmash";
+}
+
+function getUserAgent() {
+  const metadata = getSettingsMetadata();
+  const suffix = String(metadata.userAgentSuffix || "").trim();
+  const base = `Lidarr/2.0 Tubifarry/1.0 Aurral/${APP_VERSION}`;
+  return suffix ? `${base} ${suffix}` : base;
+}
+
+async function request(path, params = {}) {
+  const baseUrl = getMetadataBaseUrl();
+  const cacheKey = `${path}:${JSON.stringify(params)}`;
+  const cached = providerCache.get(cacheKey);
+  if (cached) return cached;
+
+  healthState.activeBaseUrl = baseUrl;
+  healthState.lastCheckedAt = nowIso();
+
+  try {
+    const response = await axios.get(`${baseUrl}${path}`, {
+      params,
+      timeout: 8000,
+      headers: {
+        "User-Agent": getUserAgent(),
+      },
+    });
+    providerCache.set(cacheKey, response.data);
+    healthState.lastSuccessAt = healthState.lastCheckedAt;
+    healthState.lastFailureReason = "";
+    return response.data;
+  } catch (error) {
+    healthState.lastFailureAt = healthState.lastCheckedAt;
+    healthState.lastFailureReason =
+      error?.response?.status != null
+        ? `HTTP ${error.response.status}`
+        : error?.code || error?.message || "Unknown error";
+    throw error;
+  }
+}
+
+function applyReleaseTypeFilter(albums, releaseTypes = []) {
+  const normalizedSet = new Set(
+    (Array.isArray(releaseTypes)
+      ? releaseTypes
+      : String(releaseTypes || "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter(Boolean)
+    ).map((value) => String(value)),
+  );
+  if (normalizedSet.size === 0) return albums;
+  return albums.filter((album) => {
+    if (normalizedSet.has(album.type)) return true;
+    return (album.secondaryTypes || []).some((entry) => normalizedSet.has(entry));
+  });
+}
+
+function selectedReleaseForAlbum(album) {
+  const releases = Array.isArray(album?.releases) ? album.releases : [];
+  return (
+    releases.find(
+      (release) =>
+        String(release?.status || "").toLowerCase() === "official" &&
+        Array.isArray(release?.tracks) &&
+        release.tracks.length > 0,
+    ) ||
+    releases.find(
+      (release) => Array.isArray(release?.tracks) && release.tracks.length > 0,
+    ) ||
+    releases[0] ||
+    null
+  );
+}
+
+function storeAlbumReleaseMappings(album) {
+  for (const release of album?.releases || []) {
+    releaseCache.set(
+      release.id,
+      JSON.parse(JSON.stringify({ albumId: album.id, release })),
+    );
+  }
+}
+
+export async function getArtistByMbid(mbid) {
+  const data = await request(`/artist/${mbid}`);
+  return toNormalizedArtist(data);
+}
+
+export async function getAlbumByMbid(albumMbid) {
+  const data = await request(`/album/${albumMbid}`);
+  const normalized = toNormalizedAlbum(data);
+  storeAlbumReleaseMappings(normalized);
+  return normalized;
+}
+
+export async function getAlbumTracksByAlbumMbid(albumMbid) {
+  const album = await getAlbumByMbid(albumMbid);
+  const release = selectedReleaseForAlbum(album);
+  return Array.isArray(release?.tracks) ? release.tracks : [];
+}
+
+export async function searchArtists(query, { limit = 24, offset = 0 } = {}) {
+  const data = await request("/search/artist", {
+    query,
+    limit,
+  });
+  const source = Array.isArray(data) ? data : [];
+  const items = source.map((entry, index) => ({
+    ...toNormalizedArtist(entry),
+    score: Math.max(0, 100 - index),
+  }));
+  return {
+    query,
+    count: items.length,
+    offset,
+    items: items.slice(offset, offset + limit),
+  };
+}
+
+export async function searchAlbums(
+  query,
+  { artistName = "", limit = 24, offset = 0, releaseTypes = [], sort = "relevance" } = {},
+) {
+  const requestedLimit = Math.max(limit + offset, limit);
+  let items = [];
+
+  try {
+    const data = await request("/search/album", {
+      query,
+      limit: requestedLimit,
+      ...(artistName ? { artist: artistName } : {}),
+    });
+    const source = Array.isArray(data) ? data : [];
+    items = source.map((entry, index) => {
+      const artists = Array.isArray(entry?.artists) ? entry.artists : [];
+      const primaryArtist = artists[0] ? toNormalizedArtist(artists[0]) : null;
+      return {
+        id: entry?.id,
+        title: entry?.title || "Untitled Release",
+        artistName: primaryArtist?.name || artistName || "Unknown Artist",
+        artistId: entry?.artistid || primaryArtist?.id || null,
+        type: entry?.type || "Album",
+        secondaryTypes: Array.isArray(entry?.secondarytypes) ? entry.secondarytypes : [],
+        releaseDate: entry?.releasedate || null,
+        coverUrl:
+          Array.isArray(entry?.images) && entry.images[0]?.Url
+            ? String(entry.images[0].Url).trim()
+            : null,
+        images: Array.isArray(entry?.images) ? entry.images : [],
+        inLibrary: false,
+        score: Math.max(0, 100 - index),
+        releaseStatuses: [],
+      };
+    });
+  } catch {}
+
+  if (items.length === 0 && isNarrowFallbacksEnabled()) {
+    const mbQuery = artistName
+      ? `artist:"${artistName.replace(/"/g, '\\"')}" AND releasegroup:"${String(query || "").replace(/"/g, '\\"')}"`
+      : String(query || "").trim();
+    const response = await axios.get(`${MUSICBRAINZ_API}/release-group`, {
+      params: {
+        fmt: "json",
+        query: mbQuery,
+        limit: requestedLimit,
+        offset: 0,
+      },
+      timeout: 8000,
+      headers: {
+        "User-Agent": `${APP_NAME}/${APP_VERSION} (metadata album fallback)`,
+      },
+    });
+    const source = Array.isArray(response?.data?.["release-groups"])
+      ? response.data["release-groups"]
+      : [];
+    items = source.map((entry, index) => {
+      const artistCredit = Array.isArray(entry?.["artist-credit"])
+        ? entry["artist-credit"]
+        : [];
+      const primaryArtist = artistCredit[0]?.artist || {};
+      return {
+        id: entry?.id,
+        title: entry?.title || "Untitled Release",
+        artistName:
+          artistCredit[0]?.name || primaryArtist?.name || artistName || "Unknown Artist",
+        artistId: primaryArtist?.id || null,
+        type: entry?.["primary-type"] || "Album",
+        secondaryTypes: Array.isArray(entry?.["secondary-types"])
+          ? entry["secondary-types"]
+          : [],
+        releaseDate: entry?.["first-release-date"] || null,
+        coverUrl: null,
+        images: [],
+        inLibrary: false,
+        score: Number(entry?.score || entry?.["ext:score"] || Math.max(0, 100 - index)) || 0,
+        releaseStatuses: [],
+      };
+    });
+  }
+
+  items = applyReleaseTypeFilter(items, releaseTypes);
+
+  if (sort === "relevance") {
+    items = rankAlbumCandidates(query, items, { artistName });
+  } else if (sort === "artistAsc") {
+    items.sort((left, right) =>
+      String(left.artistName || "").localeCompare(String(right.artistName || "")) ||
+      String(left.title || "").localeCompare(String(right.title || "")),
+    );
+  } else if (sort === "titleAsc") {
+    items.sort((left, right) =>
+      String(left.title || "").localeCompare(String(right.title || "")) ||
+      String(left.artistName || "").localeCompare(String(right.artistName || "")),
+    );
+  } else if (sort === "dateDesc") {
+    items.sort(
+      (left, right) =>
+        String(right.releaseDate || "").localeCompare(String(left.releaseDate || "")) ||
+        String(left.title || "").localeCompare(String(right.title || "")),
+    );
+  }
+
+  return {
+    query,
+    count: items.length,
+    offset,
+    items: items.slice(offset, offset + limit),
+  };
+}
+
+export async function resolveArtistByName(name) {
+  const result = await searchArtists(name, { limit: 10, offset: 0 });
+  const ranked = rankArtistCandidates(name, result.items);
+  return ranked[0]?.id || null;
+}
+
+export async function resolveAlbumByArtistAndTitle({
+  artistName = "",
+  albumTitle = "",
+  releaseYear = null,
+}) {
+  const firstPass = await searchAlbums(albumTitle, {
+    artistName,
+    limit: 10,
+    offset: 0,
+  });
+  let ranked = rankAlbumCandidates(albumTitle, firstPass.items, {
+    artistName,
+    releaseYear,
+  });
+  if (ranked[0]?.id) return ranked[0].id;
+
+  const secondPass = await searchAlbums(albumTitle, {
+    artistName: "",
+    limit: 10,
+    offset: 0,
+  });
+  ranked = rankAlbumCandidates(albumTitle, secondPass.items, {
+    artistName,
+    releaseYear,
+  });
+  return ranked[0]?.id || null;
+}
+
+export async function listArtistAlbums(
+  artistMbid,
+  { releaseTypes = [], includeTrackCounts = false } = {},
+) {
+  const rawArtist = await request(`/artist/${artistMbid}`);
+  const artist = toNormalizedArtist(rawArtist);
+  let albums = (Array.isArray(rawArtist?.Albums) ? rawArtist.Albums : []).map((entry) =>
+    toNormalizedArtistAlbum(entry),
+  );
+  albums = applyReleaseTypeFilter(albums, releaseTypes);
+  albums.sort((left, right) => {
+    const leftBootleg = (left.releaseStatuses || []).includes("Bootleg") ? 1 : 0;
+    const rightBootleg = (right.releaseStatuses || []).includes("Bootleg") ? 1 : 0;
+    if (leftBootleg !== rightBootleg) return leftBootleg - rightBootleg;
+    const typeOrder = { Album: 0, EP: 1, Single: 2 };
+    const leftType = typeOrder[left.type] ?? 9;
+    const rightType = typeOrder[right.type] ?? 9;
+    if (leftType !== rightType) return leftType - rightType;
+    return String(left.title || "").localeCompare(String(right.title || ""));
+  });
+
+  if (includeTrackCounts) {
+    await Promise.all(
+      albums.slice(0, 30).map(async (album) => {
+        try {
+          const hydrated = await getAlbumByMbid(album.id);
+          album.firstReleaseDate = hydrated.releaseDate || album.firstReleaseDate;
+          album.rating = hydrated.rating || null;
+        } catch {}
+      }),
+    );
+  }
+
+  return albums.map((album) => ({
+    ...album,
+    artistName: artist.name,
+    artistId: artist.id,
+  }));
+}
+
+export async function getArtistGenres(artistMbid) {
+  const artist = await getArtistByMbid(artistMbid);
+  return artist.genres || [];
+}
+
+export async function getArtistNameByMbid(artistMbid) {
+  const artist = await getArtistByMbid(artistMbid);
+  return artist.name || null;
+}
+
+export function getMetadataProviderHealthSnapshot() {
+  return {
+    brainzmash: {
+      configuredProvider: healthState.configuredProvider,
+      activeBaseUrl: getMetadataBaseUrl(),
+      failoverActive: healthState.failoverActive,
+      lastCheckedAt: healthState.lastCheckedAt,
+      lastSuccessAt: healthState.lastSuccessAt,
+      lastFailureAt: healthState.lastFailureAt,
+      lastFailureReason: healthState.lastFailureReason,
+    },
+  };
+}
+
+export async function legacyMusicbrainzRequest(endpoint, params = {}) {
+  const normalizedEndpoint = String(endpoint || "").trim();
+  if (normalizedEndpoint.startsWith("/artist/")) {
+    const mbid = normalizedEndpoint.replace(/^\/artist\//, "").trim();
+    const artist = await getArtistByMbid(mbid);
+    return toLegacyArtist(artist);
+  }
+
+  if (normalizedEndpoint === "/artist") {
+    const result = await searchArtists(String(params.query || "").trim(), {
+      limit: params.limit || 24,
+      offset: params.offset || 0,
+    });
+    return {
+      count: result.count,
+      offset: result.offset,
+      artists: result.items.map((item) => toLegacySearchArtistResult(item, item.score)),
+    };
+  }
+
+  if (normalizedEndpoint.startsWith("/release-group/")) {
+    const mbid = normalizedEndpoint.replace(/^\/release-group\//, "").trim();
+    const album = await getAlbumByMbid(mbid);
+    return toLegacyReleaseGroupSummary(album, album.artists[0], { score: 100 });
+  }
+
+  if (normalizedEndpoint === "/release-group") {
+    if (params.artist) {
+      const items = await listArtistAlbums(String(params.artist).trim(), {
+        releaseTypes: [],
+      });
+      const offset = Number.parseInt(params.offset, 10) || 0;
+      const limit = Number.parseInt(params.limit, 10) || items.length;
+      const paged = items.slice(offset, offset + limit);
+      return {
+        "release-group-count": items.length,
+        "release-groups": paged.map((item) =>
+          toLegacyReleaseGroupSummary(item, {
+            id: item.artistId,
+            name: item.artistName,
+          }),
+        ),
+      };
+    }
+    const result = await searchAlbums(String(params.query || "").trim(), {
+      artistName: "",
+      limit: params.limit || 24,
+      offset: params.offset || 0,
+      releaseTypes: [],
+    });
+    return {
+      count: result.count,
+      "release-group-count": result.count,
+      "release-groups": result.items.map((item) => toLegacySearchAlbumResult(item)),
+    };
+  }
+
+  if (normalizedEndpoint.startsWith("/release/")) {
+    const releaseId = normalizedEndpoint.replace(/^\/release\//, "").trim();
+    const cached = releaseCache.get(releaseId);
+    if (!cached?.release) {
+      throw new Error(`Release ${releaseId} not found in BrainzMash cache`);
+    }
+    return toLegacyRelease(cached.release);
+  }
+
+  throw new Error(`Unsupported legacy metadata endpoint: ${normalizedEndpoint}`);
+}
+
+export async function findArtistsByGenre(query, { limit = 24, offset = 0 } = {}) {
+  const result = await searchArtists(query, { limit: Math.max(limit * 3, 60), offset: 0 });
+  const filtered = result.items.filter((artist) => matchesGenreQuery(artist, query));
+  return {
+    query,
+    count: filtered.length,
+    offset,
+    items: filtered.slice(offset, offset + limit),
+  };
+}

--- a/backend/services/providers/brainzmashRanking.js
+++ b/backend/services/providers/brainzmashRanking.js
@@ -1,0 +1,137 @@
+function normalizeText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitWords(value) {
+  return normalizeText(value)
+    .split(" ")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function getNormalizedText(value) {
+  return normalizeText(value);
+}
+
+export function scoreTextMatch(left, right) {
+  const a = normalizeText(left);
+  const b = normalizeText(right);
+  if (!a || !b) return 0;
+  if (a === b) return 100;
+  if (a.includes(b) || b.includes(a)) return 92;
+  const leftWords = new Set(splitWords(a));
+  const rightWords = new Set(splitWords(b));
+  if (leftWords.size === 0 || rightWords.size === 0) return 0;
+  let overlap = 0;
+  for (const word of leftWords) {
+    if (rightWords.has(word)) overlap += 1;
+  }
+  const ratio =
+    (2 * overlap) / Math.max(1, leftWords.size + rightWords.size);
+  return Math.round(ratio * 100);
+}
+
+function getYear(value) {
+  const match = String(value || "").match(/\b(19\d{2}|20\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function typeRank(value) {
+  if (value === "Album") return 0;
+  if (value === "EP") return 1;
+  if (value === "Single") return 2;
+  return 3;
+}
+
+function bootlegPenalty(item) {
+  const statuses = Array.isArray(item?.releaseStatuses) ? item.releaseStatuses : [];
+  return statuses.some((status) => String(status || "").toLowerCase() === "bootleg")
+    ? 1
+    : 0;
+}
+
+export function rankArtistCandidates(query, candidates = []) {
+  const normalizedQuery = normalizeText(query);
+  return [...candidates].sort((left, right) => {
+    const leftName = String(left?.name || "").trim();
+    const rightName = String(right?.name || "").trim();
+    const leftExact = normalizeText(leftName) === normalizedQuery ? 1 : 0;
+    const rightExact = normalizeText(rightName) === normalizedQuery ? 1 : 0;
+    if (leftExact !== rightExact) return rightExact - leftExact;
+
+    const leftScore = Number(left?.score || 0);
+    const rightScore = Number(right?.score || 0);
+    if (leftScore !== rightScore) return rightScore - leftScore;
+
+    const leftType = left?.type ? 1 : 0;
+    const rightType = right?.type ? 1 : 0;
+    if (leftType !== rightType) return rightType - leftType;
+
+    const leftDisambiguation = left?.disambiguation ? 1 : 0;
+    const rightDisambiguation = right?.disambiguation ? 1 : 0;
+    if (leftDisambiguation !== rightDisambiguation) {
+      return rightDisambiguation - leftDisambiguation;
+    }
+
+    return leftName.localeCompare(rightName);
+  });
+}
+
+export function rankAlbumCandidates(
+  albumTitle,
+  candidates = [],
+  { artistName = "", releaseYear = null } = {},
+) {
+  const normalizedArtist = normalizeText(artistName);
+  const targetYear = getYear(releaseYear);
+  return [...candidates].sort((left, right) => {
+    const leftTitleScore = scoreTextMatch(left?.title, albumTitle);
+    const rightTitleScore = scoreTextMatch(right?.title, albumTitle);
+    if (leftTitleScore !== rightTitleScore) {
+      return rightTitleScore - leftTitleScore;
+    }
+
+    const leftArtistScore = normalizedArtist
+      ? scoreTextMatch(left?.artistName, artistName)
+      : 0;
+    const rightArtistScore = normalizedArtist
+      ? scoreTextMatch(right?.artistName, artistName)
+      : 0;
+    if (leftArtistScore !== rightArtistScore) {
+      return rightArtistScore - leftArtistScore;
+    }
+
+    const leftYear = getYear(left?.releaseDate);
+    const rightYear = getYear(right?.releaseDate);
+    const leftYearScore =
+      targetYear && leftYear === targetYear ? 1 : targetYear && leftYear ? -1 : 0;
+    const rightYearScore =
+      targetYear && rightYear === targetYear
+        ? 1
+        : targetYear && rightYear
+          ? -1
+          : 0;
+    if (leftYearScore !== rightYearScore) {
+      return rightYearScore - leftYearScore;
+    }
+
+    const leftTypeRank = typeRank(left?.type);
+    const rightTypeRank = typeRank(right?.type);
+    if (leftTypeRank !== rightTypeRank) return leftTypeRank - rightTypeRank;
+
+    const leftBootleg = bootlegPenalty(left);
+    const rightBootleg = bootlegPenalty(right);
+    if (leftBootleg !== rightBootleg) return leftBootleg - rightBootleg;
+
+    const leftScore = Number(left?.score || 0);
+    const rightScore = Number(right?.score || 0);
+    if (leftScore !== rightScore) return rightScore - leftScore;
+
+    return String(left?.title || "").localeCompare(String(right?.title || ""));
+  });
+}

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -1,11 +1,12 @@
 import NodeCache from "node-cache";
-import axios from "axios";
-import { dbOps } from "../config/db-helpers.js";
-import { getMusicbrainzApiBaseUrl, musicbrainzRequest } from "./apiClients.js";
 import { getDiscoveryCache } from "./discoveryService.js";
-import { primeArtistImageCache } from "./artistImageHydration.js";
+import { getLastfmApiKey, lastfmRequest } from "./apiClients.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
 import { lidarrClient } from "./lidarrClient.js";
+import {
+  searchAlbums as providerSearchAlbums,
+  searchArtists as providerSearchArtists,
+} from "./metadataProvider.js";
 
 const PRIMARY_RELEASE_TYPES = new Set(["Album", "EP", "Single"]);
 const SECONDARY_RELEASE_TYPES = new Set([
@@ -22,67 +23,15 @@ const ALL_RELEASE_TYPES = new Set([
   ...PRIMARY_RELEASE_TYPES,
   ...SECONDARY_RELEASE_TYPES,
 ]);
-const ALBUM_SEARCH_SORT_OPTIONS = new Set([
-  "relevance",
-  "dateDesc",
-  "artistAsc",
-  "titleAsc",
-]);
-const ALBUM_SORT_WINDOW = 120;
-const ALBUM_SORT_PAGE_SIZE = 50;
-const ALBUM_SORT_MAX_PAGES = 6;
-const ALBUM_SORT_COLLATOR = new Intl.Collator(undefined, {
-  sensitivity: "base",
-  numeric: true,
-});
-const SECONDARY_TYPE_PENALTIES = new Map([
-  ["Live", 1],
-  ["Demo", 2],
-  ["Remix", 3],
-  ["Compilation", 4],
-  ["Soundtrack", 5],
-  ["Broadcast", 6],
-  ["Spokenword", 7],
-  ["Other", 8],
-]);
 const albumLibraryLookupCache = new NodeCache({
   stdTTL: 60,
   checkperiod: 60,
   maxKeys: 10,
 });
-const MUSICBRAINZ_TAG_PAGE_CACHE_TTL_SECONDS = 15 * 60;
-const musicbrainzTagPageCache = new NodeCache({
-  stdTTL: MUSICBRAINZ_TAG_PAGE_CACHE_TTL_SECONDS,
-  checkperiod: 120,
-  maxKeys: 500,
-});
 
 function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function escapeMusicbrainzQueryTerm(value) {
-  return String(value || "").replace(/["\\]/g, "\\$&");
-}
-
-function normalizeTagValue(value) {
-  return String(value || "").trim().toLowerCase();
-}
-
-function decodeHtmlEntities(value) {
-  return String(value || "")
-    .replace(/&amp;/g, "&")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
-      String.fromCodePoint(Number.parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/g, (_, dec) =>
-      String.fromCodePoint(Number.parseInt(dec, 10)),
-    );
 }
 
 function normalizeSearchText(value) {
@@ -94,496 +43,12 @@ function normalizeSearchText(value) {
     .trim();
 }
 
-function getMusicbrainzSiteBaseUrl() {
-  const apiBaseUrl = String(getMusicbrainzApiBaseUrl() || "").trim();
-  if (!apiBaseUrl) {
-    return "https://mb.lkly.net";
-  }
-
-  try {
-    const parsed = new URL(apiBaseUrl);
-    parsed.pathname = parsed.pathname.replace(/\/ws\/2\/?$/, "") || "/";
-    parsed.search = "";
-    parsed.hash = "";
-    return parsed.toString().replace(/\/+$/, "");
-  } catch {
-    return "https://mb.lkly.net";
-  }
-}
-
 function normalizePercentOfTracks(value) {
   const raw = Number(value);
   if (!Number.isFinite(raw) || raw <= 0) return 0;
   if (raw > 1 && raw <= 100) return Math.round(raw);
   if (raw <= 1) return Math.round(raw * 100);
   return Math.min(100, Math.round(raw / 10));
-}
-
-function normalizeArtistImage(cachedImage) {
-  return cachedImage?.imageUrl && cachedImage.imageUrl !== "NOT_FOUND"
-    ? cachedImage.imageUrl
-    : null;
-}
-
-function normalizeReleaseGroupCover(cachedImage) {
-  return cachedImage?.imageUrl && cachedImage.imageUrl !== "NOT_FOUND"
-    ? buildImageProxyUrl(cachedImage.imageUrl) || cachedImage.imageUrl
-    : null;
-}
-
-export function normalizeArtistSearchItem(artist, cachedImages = {}) {
-  const rawImageUrl = normalizeArtistImage(cachedImages[artist.id]);
-  const imageUrl = rawImageUrl
-    ? buildImageProxyUrl(rawImageUrl) || rawImageUrl
-    : null;
-  const areaName =
-    artist?.area?.name || artist?.["begin-area"]?.name || artist?.area || null;
-  const lifeSpan = artist?.["life-span"] || artist?.lifeSpan || null;
-  const begin = lifeSpan?.begin || null;
-  const end = lifeSpan?.end || null;
-  return {
-    type: "artist",
-    id: artist.id,
-    name: artist.name,
-    sortName: artist["sort-name"] || artist.name,
-    image: imageUrl,
-    imageUrl,
-    artistType: artist.type || null,
-    country: artist.country || null,
-    area: areaName,
-    begin,
-    end,
-    disambiguation: artist.disambiguation || null,
-    inLibrary: false,
-  };
-}
-
-function normalizeArtistCredit(artistCredit) {
-  const credits = Array.isArray(artistCredit) ? artistCredit : [];
-  let artistName = "";
-  let artistMbid = null;
-
-  for (const credit of credits) {
-    if (typeof credit === "string") {
-      artistName += credit;
-      continue;
-    }
-    if (!credit || typeof credit !== "object") continue;
-    const name = credit.name || credit.artist?.name || "";
-    const joinPhrase = credit.joinphrase || "";
-    artistName += `${name}${joinPhrase}`;
-    if (!artistMbid && credit.artist?.id) {
-      artistMbid = credit.artist.id;
-    }
-  }
-
-  return {
-    artistName: artistName.trim() || null,
-    artistMbid,
-  };
-}
-
-function getReleaseGroupArtistName(releaseGroup) {
-  return normalizeArtistCredit(releaseGroup?.["artist-credit"]).artistName || "";
-}
-
-function getReleaseGroupScore(releaseGroup) {
-  return Number.parseInt(releaseGroup?.score, 10) || 0;
-}
-
-function getReleaseGroupDateSortValue(releaseGroup) {
-  const value = String(releaseGroup?.["first-release-date"] || "").trim();
-  if (!value) return -1;
-  const [yearPart = "", monthPart = "", dayPart = ""] = value.split("-");
-  const year = Number.parseInt(yearPart, 10);
-  if (!Number.isFinite(year) || year <= 0) return -1;
-  const month = Number.parseInt(monthPart, 10);
-  const day = Number.parseInt(dayPart, 10);
-  const normalizedMonth =
-    Number.isFinite(month) && month >= 1 && month <= 12 ? month : 0;
-  const normalizedDay =
-    Number.isFinite(day) && day >= 1 && day <= 31 ? day : 0;
-  return year * 10000 + normalizedMonth * 100 + normalizedDay;
-}
-
-function isVariousArtistsReleaseGroup(releaseGroup) {
-  return normalizeSearchText(getReleaseGroupArtistName(releaseGroup)) ===
-    "various artists";
-}
-
-function getPrimaryTypeRank(releaseGroup) {
-  const primaryType = String(releaseGroup?.["primary-type"] || "");
-  if (primaryType === "Album") return 0;
-  if (primaryType === "EP") return 1;
-  if (primaryType === "Single") return 2;
-  return 3;
-}
-
-function getSecondaryTypePenalty(releaseGroup) {
-  const secondaryTypes = Array.isArray(releaseGroup?.["secondary-types"])
-    ? releaseGroup["secondary-types"]
-    : [];
-  if (secondaryTypes.length === 0) return 0;
-  return secondaryTypes.reduce((highestPenalty, secondaryType) => {
-    const normalizedType = SECONDARY_RELEASE_TYPES.has(secondaryType)
-      ? secondaryType
-      : "Other";
-    const penalty = SECONDARY_TYPE_PENALTIES.get(normalizedType) || 8;
-    return Math.max(highestPenalty, penalty);
-  }, 0);
-}
-
-function getTitleMatchRank(releaseGroup, normalizedQuery) {
-  if (!normalizedQuery) return 3;
-  const normalizedTitle = normalizeSearchText(releaseGroup?.title);
-  if (!normalizedTitle) return 3;
-  if (normalizedTitle === normalizedQuery) return 0;
-  if (normalizedTitle.startsWith(normalizedQuery)) return 1;
-  if (normalizedTitle.includes(normalizedQuery)) return 2;
-  return 3;
-}
-
-function compareStrings(left, right) {
-  return ALBUM_SORT_COLLATOR.compare(String(left || ""), String(right || ""));
-}
-
-function compareReleaseDatesDesc(left, right) {
-  const leftValue = getReleaseGroupDateSortValue(left);
-  const rightValue = getReleaseGroupDateSortValue(right);
-  if (leftValue === rightValue) return 0;
-  if (leftValue < 0) return 1;
-  if (rightValue < 0) return -1;
-  return rightValue - leftValue;
-}
-
-function compareReleaseGroupsByRelevance(left, right, normalizedQuery) {
-  const leftTitleMatchRank = getTitleMatchRank(left, normalizedQuery);
-  const rightTitleMatchRank = getTitleMatchRank(right, normalizedQuery);
-  if (leftTitleMatchRank !== rightTitleMatchRank) {
-    return leftTitleMatchRank - rightTitleMatchRank;
-  }
-
-  const leftScore = getReleaseGroupScore(left);
-  const rightScore = getReleaseGroupScore(right);
-  if (leftScore !== rightScore) {
-    return rightScore - leftScore;
-  }
-
-  const leftPrimaryTypeRank = getPrimaryTypeRank(left);
-  const rightPrimaryTypeRank = getPrimaryTypeRank(right);
-  if (leftPrimaryTypeRank !== rightPrimaryTypeRank) {
-    return leftPrimaryTypeRank - rightPrimaryTypeRank;
-  }
-
-  const leftSecondaryPenalty = getSecondaryTypePenalty(left);
-  const rightSecondaryPenalty = getSecondaryTypePenalty(right);
-  if (leftSecondaryPenalty !== rightSecondaryPenalty) {
-    return leftSecondaryPenalty - rightSecondaryPenalty;
-  }
-
-  const leftVariousArtists = isVariousArtistsReleaseGroup(left) ? 1 : 0;
-  const rightVariousArtists = isVariousArtistsReleaseGroup(right) ? 1 : 0;
-  if (leftVariousArtists !== rightVariousArtists) {
-    return leftVariousArtists - rightVariousArtists;
-  }
-
-  const dateComparison = compareReleaseDatesDesc(left, right);
-  if (dateComparison !== 0) {
-    return dateComparison;
-  }
-
-  const artistComparison = compareStrings(
-    getReleaseGroupArtistName(left),
-    getReleaseGroupArtistName(right),
-  );
-  if (artistComparison !== 0) {
-    return artistComparison;
-  }
-
-  const titleComparison = compareStrings(left?.title, right?.title);
-  if (titleComparison !== 0) {
-    return titleComparison;
-  }
-
-  return compareStrings(left?.id, right?.id);
-}
-
-export function normalizeAlbumSearchSort(value) {
-  const normalized = String(value || "").trim();
-  return ALBUM_SEARCH_SORT_OPTIONS.has(normalized) ? normalized : "relevance";
-}
-
-export function sortAlbumSearchResults(
-  releaseGroups,
-  query,
-  sort = "relevance",
-) {
-  const normalizedQuery = normalizeSearchText(query);
-  const normalizedSort = normalizeAlbumSearchSort(sort);
-  const source = Array.isArray(releaseGroups) ? [...releaseGroups] : [];
-
-  return source.sort((left, right) => {
-    if (normalizedSort === "dateDesc") {
-      const dateComparison = compareReleaseDatesDesc(left, right);
-      if (dateComparison !== 0) return dateComparison;
-      const titleComparison = compareStrings(left?.title, right?.title);
-      if (titleComparison !== 0) return titleComparison;
-      const artistComparison = compareStrings(
-        getReleaseGroupArtistName(left),
-        getReleaseGroupArtistName(right),
-      );
-      if (artistComparison !== 0) return artistComparison;
-      return compareStrings(left?.id, right?.id);
-    }
-
-    if (normalizedSort === "artistAsc") {
-      const artistComparison = compareStrings(
-        getReleaseGroupArtistName(left),
-        getReleaseGroupArtistName(right),
-      );
-      if (artistComparison !== 0) return artistComparison;
-      const titleComparison = compareStrings(left?.title, right?.title);
-      if (titleComparison !== 0) return titleComparison;
-      const dateComparison = compareReleaseDatesDesc(left, right);
-      if (dateComparison !== 0) return dateComparison;
-      return compareStrings(left?.id, right?.id);
-    }
-
-    if (normalizedSort === "titleAsc") {
-      const titleComparison = compareStrings(left?.title, right?.title);
-      if (titleComparison !== 0) return titleComparison;
-      const artistComparison = compareStrings(
-        getReleaseGroupArtistName(left),
-        getReleaseGroupArtistName(right),
-      );
-      if (artistComparison !== 0) return artistComparison;
-      const dateComparison = compareReleaseDatesDesc(left, right);
-      if (dateComparison !== 0) return dateComparison;
-      return compareStrings(left?.id, right?.id);
-    }
-
-    return compareReleaseGroupsByRelevance(left, right, normalizedQuery);
-  });
-}
-
-export function normalizeAlbumSearchItem(
-  releaseGroup,
-  lookup = null,
-  cachedCovers = {},
-) {
-  const artistCredit = normalizeArtistCredit(releaseGroup["artist-credit"]);
-  const coverUrl = normalizeReleaseGroupCover(cachedCovers[releaseGroup.id]);
-  return {
-    type: "album",
-    id: releaseGroup.id,
-    title: releaseGroup.title || "Untitled Release",
-    artistName: artistCredit.artistName || "Unknown Artist",
-    artistMbid: artistCredit.artistMbid,
-    releaseDate: releaseGroup["first-release-date"] || null,
-    primaryType: releaseGroup["primary-type"] || null,
-    secondaryTypes: Array.isArray(releaseGroup["secondary-types"])
-      ? releaseGroup["secondary-types"]
-      : [],
-    coverUrl,
-    inLibrary: !!lookup,
-    libraryAlbumId: lookup?.libraryAlbumId || null,
-    libraryArtistId: lookup?.libraryArtistId || null,
-    status: lookup?.status || "missing",
-  };
-}
-
-export function normalizeAlbumReleaseTypesFilter(releaseTypes) {
-  const values = Array.isArray(releaseTypes)
-    ? releaseTypes
-    : String(releaseTypes || "")
-        .split(",")
-        .map((value) => value.trim())
-        .filter(Boolean);
-  return [...new Set(values.filter((value) => ALL_RELEASE_TYPES.has(value)))];
-}
-
-export function matchesAlbumReleaseTypeFilter(
-  releaseGroup,
-  selectedReleaseTypes,
-) {
-  const normalizedSelection =
-    normalizeAlbumReleaseTypesFilter(selectedReleaseTypes);
-  if (
-    normalizedSelection.length === 0 ||
-    normalizedSelection.length === ALL_RELEASE_TYPES.size
-  ) {
-    return true;
-  }
-
-  const selected = new Set(normalizedSelection);
-  const primaryType = releaseGroup?.["primary-type"];
-  const secondaryTypes = Array.isArray(releaseGroup?.["secondary-types"])
-    ? releaseGroup["secondary-types"]
-    : [];
-
-  if (!selected.has(primaryType)) return false;
-  if (secondaryTypes.length === 0) return true;
-
-  const normalizedSecondaryTypes = [
-    ...new Set(
-      secondaryTypes.map((secondaryType) =>
-        SECONDARY_RELEASE_TYPES.has(secondaryType) ? secondaryType : "Other",
-      ),
-    ),
-  ];
-
-  return normalizedSecondaryTypes.every((secondaryType) =>
-    selected.has(secondaryType),
-  );
-}
-
-function buildAlbumSearchQuery(query, selectedReleaseTypes) {
-  const normalizedQuery = String(query || "").trim();
-  const normalizedSelection =
-    normalizeAlbumReleaseTypesFilter(selectedReleaseTypes);
-  const primarySelection = normalizedSelection.filter((value) =>
-    PRIMARY_RELEASE_TYPES.has(value),
-  );
-  const secondarySelection = normalizedSelection.filter((value) =>
-    SECONDARY_RELEASE_TYPES.has(value),
-  );
-
-  if (
-    primarySelection.length === 0 ||
-    primarySelection.length === PRIMARY_RELEASE_TYPES.size
-  ) {
-    return normalizedQuery;
-  }
-
-  const primaryClauses = primarySelection.map(
-    (value) => `primarytype:${value.toLowerCase()}`,
-  );
-  const escapedQuery = escapeMusicbrainzQueryTerm(normalizedQuery);
-  const clauses = [`"${escapedQuery}"`, `(${primaryClauses.join(" OR ")})`];
-
-  if (secondarySelection.length === 0) {
-    clauses.push("-secondarytype:*");
-  }
-
-  return clauses.join(" AND ");
-}
-
-async function fetchMusicbrainzTagArtistPage(tag, page) {
-  const cacheKey = `tag-page:${normalizeTagValue(tag)}:${page}`;
-  const cached = musicbrainzTagPageCache.get(cacheKey);
-  if (cached) return cached;
-  const normalizedTag = encodeURIComponent(String(tag || "").trim());
-  const url = `${getMusicbrainzSiteBaseUrl()}/tag/${normalizedTag}/artist?page=${page}`;
-  const response = await axios.get(url, {
-    timeout: 15000,
-    headers: {
-      "User-Agent": "Aurral Tag Search",
-      Accept: "text/html,application/xhtml+xml",
-    },
-  });
-  const html = String(response.data || "");
-  const countMatch = html.match(/<p>([\d,]+)\s+artists found<\/p>/i);
-  const totalCount = Number.parseInt(
-    String(countMatch?.[1] || "0").replace(/,/g, ""),
-    10,
-  ) || 0;
-  const itemPattern =
-    /<li>(\d+)\s*-\s*<a href="\/artist\/([0-9a-f-]+)" title="([^"]*)"><bdi>(.*?)<\/bdi><\/a>(?:\s*<span class="comment">\(<bdi>(.*?)<\/bdi>\)<\/span>)?<\/li>/gisu;
-  const items = [];
-  let match;
-  while ((match = itemPattern.exec(html)) !== null) {
-    items.push({
-      id: match[2],
-      name: decodeHtmlEntities(match[4] || match[3] || ""),
-      sortName: decodeHtmlEntities(match[4] || match[3] || ""),
-      disambiguation: decodeHtmlEntities(match[5] || ""),
-      tagCount: Number.parseInt(match[1], 10) || 0,
-      type: "artist",
-    });
-  }
-
-  const result = {
-    totalCount,
-    items,
-    pageSize: items.length,
-  };
-  musicbrainzTagPageCache.set(cacheKey, result);
-  return result;
-}
-
-async function searchTagsAllFallbackViaArtistSearch(tag, limitInt, offsetInt) {
-  const mbData = await musicbrainzRequest("/artist", {
-    query: `tag:"${escapeMusicbrainzQueryTerm(tag)}"`,
-    limit: limitInt,
-    offset: offsetInt,
-  });
-  const artists = Array.isArray(mbData?.artists) ? mbData.artists : [];
-  const filteredArtists = artists.filter((artist) => artist?.id);
-  const cachedImages = dbOps.getImages(filteredArtists.map((artist) => artist.id));
-  const items = filteredArtists.map((artist) => ({
-    ...normalizeArtistSearchItem(artist, cachedImages),
-    tags: [tag],
-  }));
-  primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
-    () => {},
-  );
-  return {
-    scope: "tag",
-    query: tag,
-    count: Number.parseInt(mbData?.count, 10) || items.length,
-    hasMore:
-      (Number.parseInt(mbData?.count, 10) || items.length) >
-      offsetInt + items.length,
-    offset: offsetInt,
-    items,
-  };
-}
-
-function canUseDirectPrimaryTypeSearch(selectedReleaseTypes) {
-  const normalizedSelection =
-    normalizeAlbumReleaseTypesFilter(selectedReleaseTypes);
-  if (
-    normalizedSelection.length === 0 ||
-    normalizedSelection.length === ALL_RELEASE_TYPES.size
-  ) {
-    return false;
-  }
-
-  return normalizedSelection.every((value) => PRIMARY_RELEASE_TYPES.has(value));
-}
-
-function normalizeTagArtistItem(artist, tag) {
-  let imageUrl =
-    typeof artist.imageUrl === "string" && artist.imageUrl.trim()
-      ? artist.imageUrl.trim()
-      : typeof artist.image === "string" && artist.image.trim()
-        ? artist.image.trim()
-        : null;
-  if (!imageUrl && Array.isArray(artist.image)) {
-    const img =
-      artist.image.find((entry) => entry.size === "extralarge") ||
-      artist.image.find((entry) => entry.size === "large") ||
-      artist.image.slice(-1)[0];
-    if (
-      img?.["#text"] &&
-      !img["#text"].includes("2a96cbd8b46e442fc41c2b86b821562f")
-    ) {
-      imageUrl = img["#text"];
-    }
-  }
-
-  const proxiedImageUrl = imageUrl ? buildImageProxyUrl(imageUrl) || imageUrl : null;
-
-  return {
-    type: "artist",
-    id: artist.id || artist.mbid,
-    name: artist.name,
-    sortName: artist.sortName || artist.name,
-    image: proxiedImageUrl,
-    imageUrl: proxiedImageUrl,
-    inLibrary: false,
-    tags: [tag],
-  };
 }
 
 async function getAlbumLibraryLookup(albumMbids) {
@@ -593,7 +58,7 @@ async function getAlbumLibraryLookup(albumMbids) {
   }
 
   try {
-    let lidarrAlbums = albumLibraryLookupCache.get("lidarrAlbums");
+    const lidarrAlbums = albumLibraryLookupCache.get("lidarrAlbums");
     if (!lidarrAlbums) {
       return lookup;
     }
@@ -624,30 +89,152 @@ async function getAlbumLibraryLookup(albumMbids) {
   return lookup;
 }
 
+export function normalizeAlbumReleaseTypesFilter(releaseTypes) {
+  const values = Array.isArray(releaseTypes)
+    ? releaseTypes
+    : String(releaseTypes || "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+  return [...new Set(values.filter((value) => ALL_RELEASE_TYPES.has(value)))];
+}
+
+export function normalizeAlbumSearchSort(value) {
+  const normalized = String(value || "").trim();
+  return ["relevance", "dateDesc", "artistAsc", "titleAsc"].includes(normalized)
+    ? normalized
+    : "relevance";
+}
+
+function normalizeArtistItem(item) {
+  return {
+    type: "artist",
+    id: item.id,
+    name: item.name,
+    sortName: item.sortName || item.name,
+    image: item.images?.[0]?.url || null,
+    imageUrl: item.images?.[0]?.url || null,
+    artistType: item.type || null,
+    country: null,
+    area: null,
+    begin: null,
+    end: null,
+    disambiguation: item.disambiguation || null,
+    tags: Array.isArray(item.genres) ? item.genres : [],
+    genres: Array.isArray(item.genres) ? item.genres : [],
+    inLibrary: false,
+    score: item.score || 0,
+  };
+}
+
+export function normalizeArtistSearchItem(item, imageCache = {}) {
+  const normalized = normalizeArtistItem({
+    id: item?.id,
+    name: item?.name,
+    sortName: item?.sortName || item?.["sort-name"] || item?.name,
+    type: item?.type || null,
+    disambiguation: item?.disambiguation || null,
+    genres: item?.genres || item?.tags || [],
+    images: imageCache?.[item?.id]?.imageUrl
+      ? [{ url: imageCache[item.id].imageUrl }]
+      : item?.imageUrl || item?.image
+        ? [{ url: item.imageUrl || item.image }]
+        : [],
+    score: item?.score || 0,
+  });
+  return normalized;
+}
+
+function normalizeAlbumItem(item, lookup = null) {
+  return {
+    type: "album",
+    id: item.id,
+    title: item.title || "Untitled Release",
+    artistName: item.artistName || "Unknown Artist",
+    artistMbid: item.artistId || null,
+    releaseDate: item.releaseDate || null,
+    primaryType: item.type || null,
+    secondaryTypes: Array.isArray(item.secondaryTypes) ? item.secondaryTypes : [],
+    coverUrl: item.coverUrl || null,
+    inLibrary: !!lookup,
+    libraryAlbumId: lookup?.libraryAlbumId || null,
+    libraryArtistId: lookup?.libraryArtistId || null,
+    status: lookup?.status || "missing",
+    score: item.score || 0,
+  };
+}
+
+export function normalizeAlbumSearchItem(item, lookup = {}) {
+  const artistCredit = Array.isArray(item?.["artist-credit"])
+    ? item["artist-credit"]
+    : [];
+  const primaryCredit = artistCredit[0] || {};
+  const artist = primaryCredit.artist || {};
+  const normalized = normalizeAlbumItem(
+    {
+      id: item?.id,
+      title: item?.title,
+      artistName: primaryCredit.name || artist.name || item?.artistName,
+      artistId: artist.id || item?.artistMbid || item?.artistId || null,
+      type: item?.type || item?.["primary-type"] || null,
+      secondaryTypes:
+        item?.secondaryTypes || item?.["secondary-types"] || [],
+      releaseDate: item?.releaseDate || item?.["first-release-date"] || null,
+      coverUrl: item?.coverUrl || null,
+      score: item?.score || 0,
+    },
+    lookup?.inLibrary || lookup?.libraryAlbumId || lookup?.libraryArtistId
+      ? lookup
+      : null,
+  );
+  delete normalized.score;
+  return normalized;
+}
+
+export function matchesAlbumReleaseTypeFilter(item, selectedReleaseTypes = []) {
+  const selected = normalizeAlbumReleaseTypesFilter(selectedReleaseTypes);
+  if (selected.length === 0) return true;
+
+  const primaryType = String(item?.primaryType || item?.["primary-type"] || "").trim();
+  const secondaryTypes = Array.isArray(
+    item?.secondaryTypes || item?.["secondary-types"],
+  )
+    ? item.secondaryTypes || item["secondary-types"]
+    : [];
+
+  const primaryMatches = selected.filter((value) => PRIMARY_RELEASE_TYPES.has(value));
+  const secondaryMatches = selected.filter((value) =>
+    SECONDARY_RELEASE_TYPES.has(value),
+  );
+
+  if (primaryMatches.length > 0 && !primaryMatches.includes(primaryType)) {
+    return false;
+  }
+
+  if (!secondaryMatches.every((value) => secondaryTypes.includes(value))) {
+    return false;
+  }
+
+  if (secondaryMatches.length > 0 && secondaryTypes.length !== secondaryMatches.length) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function searchArtists(query, limit = 24, offset = 0) {
   const limitInt = parsePositiveInt(limit, 24);
   const offsetInt = Math.max(0, Number.parseInt(offset, 10) || 0);
-  const mbData = await musicbrainzRequest("/artist", {
-    query,
+  const result = await providerSearchArtists(String(query || "").trim(), {
     limit: limitInt,
     offset: offsetInt,
   });
-  const artists = Array.isArray(mbData?.artists) ? mbData.artists : [];
-  const filteredArtists = artists.filter((artist) => artist?.id);
-  const cachedImages = dbOps.getImages(filteredArtists.map((artist) => artist.id));
-  const items = filteredArtists.map((artist) =>
-    normalizeArtistSearchItem(artist, cachedImages),
-  );
-  primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
-    () => {},
-  );
-
   return {
     scope: "artist",
     query,
-    count: Number.parseInt(mbData?.count, 10) || items.length,
-    offset: offsetInt,
-    items,
+    count: result.count,
+    offset: result.offset,
+    items: result.items.map(normalizeArtistItem),
   };
 }
 
@@ -676,98 +263,32 @@ export async function searchAlbums(
 ) {
   const limitInt = parsePositiveInt(limit, 24);
   const offsetInt = Math.max(0, Number.parseInt(offset, 10) || 0);
-  const selectedReleaseTypes = normalizeAlbumReleaseTypesFilter(releaseTypes);
   const normalizedSort = normalizeAlbumSearchSort(sort);
-  const useDirectPrimaryTypeSearch =
-    canUseDirectPrimaryTypeSearch(selectedReleaseTypes);
-  const shouldFilterByReleaseType =
-    !useDirectPrimaryTypeSearch &&
-    selectedReleaseTypes.length > 0 &&
-    selectedReleaseTypes.length < ALL_RELEASE_TYPES.size;
-  const musicbrainzQuery = buildAlbumSearchQuery(query, selectedReleaseTypes);
-  const candidateWindow = Math.max(limitInt + offsetInt, ALBUM_SORT_WINDOW);
-  let pagesFetched = 0;
-  const rawPageSize = Math.max(limitInt, ALBUM_SORT_PAGE_SIZE);
-  let rawOffset = 0;
-  let rawCount = 0;
-  const candidateReleaseGroups = [];
-
-  while (candidateReleaseGroups.length < candidateWindow) {
-    if (pagesFetched >= ALBUM_SORT_MAX_PAGES) {
-      break;
-    }
-    const mbData = await musicbrainzRequest("/release-group", {
-      query: musicbrainzQuery,
-      limit: rawPageSize,
-      offset: rawOffset,
-    });
-    pagesFetched += 1;
-    rawCount =
-      Number.parseInt(mbData?.count, 10) ||
-      Number.parseInt(mbData?.["release-group-count"], 10) ||
-      rawCount;
-    const releaseGroups = Array.isArray(mbData?.["release-groups"])
-      ? mbData["release-groups"]
-      : [];
-    const validReleaseGroups = releaseGroups.filter(
-      (releaseGroup) => releaseGroup?.id && releaseGroup?.title,
-    );
-
-    for (const releaseGroup of validReleaseGroups) {
-      if (
-        shouldFilterByReleaseType &&
-        !matchesAlbumReleaseTypeFilter(releaseGroup, selectedReleaseTypes)
-      ) {
-        continue;
-      }
-      candidateReleaseGroups.push(releaseGroup);
-      if (candidateReleaseGroups.length >= candidateWindow) {
-        break;
-      }
-    }
-
-    if (candidateReleaseGroups.length >= candidateWindow) {
-      break;
-    }
-    if (validReleaseGroups.length === 0) {
-      break;
-    }
-    rawOffset += releaseGroups.length;
-    if (rawCount > 0 && rawOffset >= rawCount) {
-      break;
-    }
-  }
-
-  const sortedReleaseGroups = sortAlbumSearchResults(
-    candidateReleaseGroups,
-    query,
-    normalizedSort,
-  );
-  const pagedReleaseGroups = sortedReleaseGroups.slice(
-    offsetInt,
-    offsetInt + limitInt,
-  );
-  const albumLookup = await getAlbumLibraryLookup(
-    pagedReleaseGroups.map((releaseGroup) => releaseGroup.id),
-  );
-  const cachedCovers = dbOps.getImages(
-    pagedReleaseGroups.map((releaseGroup) => `rg:${releaseGroup.id}`),
-  );
-
+  const selectedReleaseTypes = normalizeAlbumReleaseTypesFilter(releaseTypes);
+  const result = await providerSearchAlbums(String(query || "").trim(), {
+    limit: limitInt,
+    offset: offsetInt,
+    releaseTypes: selectedReleaseTypes,
+    sort: normalizedSort,
+  });
+  const albumLookup = await getAlbumLibraryLookup(result.items.map((item) => item.id));
   return {
     scope: "album",
     query,
     sort: normalizedSort,
-    count: sortedReleaseGroups.length,
-    offset: offsetInt,
-    hasMore: offsetInt + pagedReleaseGroups.length < sortedReleaseGroups.length,
-    items: pagedReleaseGroups.map((releaseGroup) =>
-      normalizeAlbumSearchItem(
-        releaseGroup,
-        albumLookup.get(releaseGroup.id),
-        cachedCovers,
-      ),
+    count: result.count,
+    offset: result.offset,
+    hasMore: result.offset + result.items.length < result.count,
+    items: result.items.map((item) =>
+      normalizeAlbumItem(item, albumLookup.get(item.id)),
     ),
+  };
+}
+
+function normalizeTagArtistItem(artist, tag) {
+  return {
+    ...artist,
+    tags: [tag],
   };
 }
 
@@ -792,74 +313,120 @@ export async function searchTags(
   }
 
   if (tagScope === "all") {
-    try {
-      const firstPageNumber = Math.floor(offsetInt / 100) + 1;
-      const pages = [];
-      let totalCount = 0;
-      let pageSize = 100;
-      let currentPage = firstPageNumber;
-      let combined = [];
-
-      while (combined.length < limitInt + (offsetInt % pageSize || 0)) {
-        const pageData = await fetchMusicbrainzTagArtistPage(tag, currentPage);
-        totalCount = pageData.totalCount;
-        pageSize = pageData.pageSize || pageSize;
-        if (pageData.items.length === 0) break;
-        pages.push(pageData);
-        combined = pages.flatMap((entry) => entry.items);
-        currentPage += 1;
-        if (pageData.items.length < pageSize) break;
-        const absoluteLoaded =
-          (firstPageNumber - 1) * pageSize + combined.length;
-        if (totalCount > 0 && absoluteLoaded >= totalCount) break;
-      }
-
-      const withinPageOffset = offsetInt - (firstPageNumber - 1) * pageSize;
-      const pageArtists = combined.slice(
-        withinPageOffset,
-        withinPageOffset + limitInt,
-      );
-      const cachedImages = dbOps.getImages(pageArtists.map((artist) => artist.id));
-      const items = pageArtists.map((artist) => ({
-        ...normalizeArtistSearchItem(artist, cachedImages),
-        tags: [tag],
-      }));
-      primeArtistImageCache(items.slice(0, Math.min(items.length, limitInt))).catch(
-        () => {},
-      );
+    if (getLastfmApiKey()) {
+      const page = Math.floor(offsetInt / limitInt) + 1;
+      const data = await lastfmRequest("tag.getTopArtists", {
+        tag,
+        limit: limitInt,
+        page,
+      });
+      const artists = Array.isArray(data?.topartists?.artist)
+        ? data.topartists.artist
+        : data?.topartists?.artist
+          ? [data.topartists.artist]
+          : [];
+      const items = artists
+        .map((artist) => {
+          let imageUrl = null;
+          if (Array.isArray(artist?.image)) {
+            const img =
+              artist.image.find((entry) => entry.size === "extralarge") ||
+              artist.image.find((entry) => entry.size === "large") ||
+              artist.image.slice(-1)[0];
+            if (
+              img?.["#text"] &&
+              !String(img["#text"]).includes("2a96cbd8b46e442fc41c2b86b821562f")
+            ) {
+              imageUrl = img["#text"];
+            }
+          }
+          return normalizeTagArtistItem(
+            {
+              type: "artist",
+              id: artist?.mbid || null,
+              name: artist?.name || "Unknown Artist",
+              sortName: artist?.name || "Unknown Artist",
+              image: buildImageProxyUrl(imageUrl) || imageUrl,
+              imageUrl: buildImageProxyUrl(imageUrl) || imageUrl,
+              artistType: null,
+              country: null,
+              area: null,
+              begin: null,
+              end: null,
+              disambiguation: null,
+              tags: [tag],
+              genres: [tag],
+              inLibrary: false,
+              score: 0,
+            },
+            tag,
+          );
+        })
+        .filter((artist) => artist.id);
 
       return {
         scope: "tag",
         query: tag,
-        count: totalCount || items.length,
-        hasMore: totalCount > offsetInt + items.length,
+        count:
+          Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length,
         offset: offsetInt,
         items,
       };
-    } catch (error) {
-      console.warn(
-        `MusicBrainz tag page fetch failed for "${tag}", falling back to artist search:`,
-        error.message,
-      );
-      return searchTagsAllFallbackViaArtistSearch(tag, limitInt, offsetInt);
     }
+
+    const discoveryCache = getDiscoveryCache();
+    const tagLower = normalizeSearchText(tag);
+    const pool = [
+      ...(Array.isArray(discoveryCache.recommendations)
+        ? discoveryCache.recommendations
+        : []),
+      ...(Array.isArray(discoveryCache.globalTop) ? discoveryCache.globalTop : []),
+      ...(Array.isArray(discoveryCache.basedOn) ? discoveryCache.basedOn : []),
+    ];
+    const seen = new Set();
+    const matches = pool.filter((artist) => {
+      const artistId = String(artist?.id || artist?.mbid || "").trim().toLowerCase();
+      const artistName = String(artist?.name || "").trim().toLowerCase();
+      const key = artistId || artistName;
+      if (!key || seen.has(key)) return false;
+      const tags = Array.isArray(artist.tags) ? artist.tags : [];
+      const genres = Array.isArray(artist.genres) ? artist.genres : [];
+      const matched = [...tags, ...genres].some(
+        (entry) => normalizeSearchText(entry) === tagLower,
+      );
+      if (!matched) return false;
+      seen.add(key);
+      return true;
+    });
+
+    return {
+      scope: "tag",
+      query: tag,
+      count: matches.length,
+      offset: offsetInt,
+      items: matches
+        .slice(offsetInt, offsetInt + limitInt)
+        .map((artist) => normalizeTagArtistItem(artist, tag)),
+    };
   }
 
   const discoveryCache = getDiscoveryCache();
-  const tagLower = tag.toLowerCase();
+  const tagLower = normalizeSearchText(tag);
   const matches = (discoveryCache.recommendations || []).filter((artist) => {
     const tags = Array.isArray(artist.tags) ? artist.tags : [];
-    return tags.some((entry) => String(entry).toLowerCase() === tagLower);
+    const genres = Array.isArray(artist.genres) ? artist.genres : [];
+    return [...tags, ...genres].some(
+      (entry) => normalizeSearchText(entry) === tagLower,
+    );
   });
-  const items = matches
-    .slice(offsetInt, offsetInt + limitInt)
-    .map((artist) => normalizeTagArtistItem(artist, tag));
 
   return {
     scope: "tag",
     query: tag,
     count: matches.length,
     offset: offsetInt,
-    items,
+    items: matches
+      .slice(offsetInt, offsetInt + limitInt)
+      .map((artist) => normalizeTagArtistItem(artist, tag)),
   };
 }

--- a/backend/services/weeklyFlowTrackResolver.js
+++ b/backend/services/weeklyFlowTrackResolver.js
@@ -1,19 +1,17 @@
 import {
   lastfmRequest,
-  musicbrainzRequest,
   musicbrainzResolveArtistMbidByName,
 } from "./apiClients.js";
+import {
+  getArtistByMbid,
+  getAlbumByMbid,
+  listArtistAlbums,
+  resolveAlbumByArtistAndTitle,
+} from "./metadataProvider.js";
 
 const artistAliasCache = new Map();
 const releaseGroupSearchCache = new Map();
 const releaseContextCache = new Map();
-
-function escapeMbQuery(value) {
-  return String(value || "")
-    .trim()
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"');
-}
 
 function normalizeText(value) {
   return String(value || "")
@@ -98,10 +96,10 @@ async function fetchArtistAliases(artistMbid) {
   }
   const promise = (async () => {
     try {
-      const data = await musicbrainzRequest(`/artist/${key}`, { inc: "aliases" });
-      const aliases = Array.isArray(data?.aliases)
-        ? data.aliases
-            .map((entry) => String(entry?.name || "").trim())
+      const artist = await getArtistByMbid(key);
+      const aliases = Array.isArray(artist?.aliases)
+        ? artist.aliases
+            .map((entry) => String(entry || "").trim())
             .filter(Boolean)
         : [];
       return [...new Set(aliases)].slice(0, 8);
@@ -125,35 +123,32 @@ async function resolveReleaseGroup(artistName, artistMbid, albumName, releaseYea
     return releaseGroupSearchCache.get(cacheKey);
   }
   const promise = (async () => {
-    const escapedAlbum = escapeMbQuery(safeAlbum);
-    const searchQueries = [];
-    if (safeMbid) {
-      searchQueries.push(`arid:${safeMbid} AND releasegroup:"${escapedAlbum}"`);
-    }
-    if (safeArtist) {
-      searchQueries.push(
-        `artist:"${escapeMbQuery(safeArtist)}" AND releasegroup:"${escapedAlbum}"`,
-      );
-    }
-    for (const query of searchQueries) {
-      try {
-        const data = await musicbrainzRequest("/release-group", {
-          query,
-          limit: 5,
-        });
-        const releaseGroups = Array.isArray(data?.["release-groups"])
-          ? data["release-groups"]
-          : [];
-        const best = pickBestCandidate(releaseGroups, safeAlbum, releaseYear);
-        if (best?.id) {
-          return {
-            id: String(best.id),
-            title: String(best.title || safeAlbum).trim() || safeAlbum,
-            releaseYear: getYear(best["first-release-date"]),
-          };
-        }
-      } catch {}
-    }
+    try {
+      const resolvedId = await resolveAlbumByArtistAndTitle({
+        artistName: safeArtist,
+        artistMbid: safeMbid,
+        albumTitle: safeAlbum,
+        releaseYear,
+      });
+      if (!resolvedId) return null;
+      const album = await getAlbumByMbid(resolvedId).catch(() => null);
+      return {
+        id: String(resolvedId),
+        title: String(album?.title || safeAlbum).trim() || safeAlbum,
+        releaseYear: getYear(album?.releaseDate),
+      };
+    } catch {}
+    try {
+      const candidates = safeMbid ? await listArtistAlbums(safeMbid) : [];
+      const best = pickBestCandidate(candidates, safeAlbum, releaseYear);
+      if (best?.Id || best?.id) {
+        return {
+          id: String(best?.Id || best?.id),
+          title: String(best?.Title || best?.title || safeAlbum).trim() || safeAlbum,
+          releaseYear: getYear(best?.FirstReleaseDate || best?.firstReleaseDate),
+        };
+      }
+    } catch {}
     return null;
   })();
   releaseGroupSearchCache.set(cacheKey, promise);
@@ -215,33 +210,33 @@ async function fetchReleaseContext(albumMbid) {
   }
   const promise = (async () => {
     try {
-      const releaseGroupData = await musicbrainzRequest(`/release-group/${key}`, {
-        inc: "releases",
-      });
-      const releases = Array.isArray(releaseGroupData?.releases)
-        ? releaseGroupData.releases
-        : [];
+      const album = await getAlbumByMbid(key);
+      const releases = Array.isArray(album?.releases) ? album.releases : [];
       const pickedRelease =
         releases.find((release) => String(release?.status || "").toLowerCase() === "official") ||
+        releases.find((release) => Array.isArray(release?.tracks) && release.tracks.length > 0) ||
         releases[0] ||
         null;
-      if (!pickedRelease?.id) {
+      if (!pickedRelease) {
         return {
-          releaseYear: getYear(releaseGroupData?.["first-release-date"]),
+          releaseYear: getYear(album?.releaseDate),
           albumTrackCount: null,
           albumTrackTitles: [],
           tracks: [],
         };
       }
-      const releaseData = await musicbrainzRequest(`/release/${pickedRelease.id}`, {
-        inc: "recordings+artist-credits",
-      });
-      const tracks = flattenReleaseTracks(releaseData);
+      const tracks = Array.isArray(pickedRelease?.tracks)
+        ? pickedRelease.tracks.map((track) => ({
+            title: track.title,
+            trackNumber: track.trackPosition || track.trackNumber || null,
+            durationMs: track.durationMs || null,
+            recordingId: track.recordingId || null,
+          }))
+        : [];
       return {
         releaseYear:
-          getYear(pickedRelease?.date) ||
-          getYear(releaseData?.date) ||
-          getYear(releaseGroupData?.["first-release-date"]),
+          getYear(pickedRelease?.releaseDate) ||
+          getYear(album?.releaseDate),
         albumTrackCount: tracks.length > 0 ? tracks.length : null,
         albumTrackTitles: tracks.map((track) => track.title),
         tracks,

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import {
   Loader,
@@ -17,8 +17,9 @@ import {
   MoreHorizontal,
   Volume2,
   VolumeX,
+  ChevronUp,
 } from "lucide-react";
-import { getCoverImage, getTagColor, formatLifeSpan, getArtistType } from "../utils";
+import { getCoverImage, getTagColor, formatLifeSpan } from "../utils";
 import AddToLibraryButton from "../../../components/AddToLibraryButton";
 import lidarrLogo from "../../../../images/logos/lidarr.svg?raw";
 import lastFmLogo from "../../../../images/logos/last-fm.svg?raw";
@@ -31,6 +32,57 @@ const toCurrentColorSvg = (svg) =>
     .replace(/fill="#fff"/gi, 'fill="currentColor"')
     .replace(/fill:#ffffff/gi, "fill:currentColor")
     .replace(/fill="#ffffff"/gi, 'fill="currentColor"');
+
+const normalizeExternalHref = (value) => {
+  const href = String(value || "").trim();
+  if (!href) return null;
+  try {
+    return new URL(href).toString();
+  } catch {
+    return null;
+  }
+};
+
+const hostnameLabel = (href) => {
+  try {
+    return new URL(href).hostname.replace(/^www\./, "");
+  } catch {
+    return href;
+  }
+};
+
+const buildRelationLinks = (artist) => {
+  const directLinks = Array.isArray(artist?.links)
+    ? artist.links
+    : [];
+  if (directLinks.length > 0) {
+    return directLinks
+      .map((link, index) => {
+        const href = normalizeExternalHref(link?.target || link?.url);
+        if (!href) return null;
+        return {
+          key: `brainzmash-link-${index}`,
+          label: link?.type || hostnameLabel(href),
+          href,
+        };
+      })
+      .filter(Boolean);
+  }
+
+  return Array.isArray(artist?.relations)
+    ? artist.relations
+        .map((relation, index) => {
+          const href = normalizeExternalHref(relation?.url?.resource);
+          if (!href) return null;
+          return {
+            key: `relation-link-${index}`,
+            label: relation?.type || hostnameLabel(href),
+            href,
+          };
+        })
+        .filter(Boolean)
+    : [];
+};
 
 export function ArtistDetailsHero({
   artist,
@@ -77,6 +129,16 @@ export function ArtistDetailsHero({
   const lifeSpan = formatLifeSpan(artist["life-span"]);
   const [showHeroMenu, setShowHeroMenu] = useState(false);
   const [coverFailed, setCoverFailed] = useState(false);
+  const [showAllTags, setShowAllTags] = useState(false);
+  const [showAllSecondaryLinks, setShowAllSecondaryLinks] = useState(false);
+  const [collapsedTagCount, setCollapsedTagCount] = useState(8);
+  const [collapsedSecondaryLinkCount, setCollapsedSecondaryLinkCount] = useState(6);
+  const tagsRowRef = useRef(null);
+  const tagsMeasureRef = useRef(null);
+  const tagsToggleMeasureRef = useRef(null);
+  const secondaryLinksRowRef = useRef(null);
+  const secondaryLinksMeasureRef = useRef(null);
+  const secondaryLinksToggleMeasureRef = useRef(null);
   const lidarrArtistId =
     artist?.id ||
     libraryArtist?.foreignArtistId ||
@@ -97,15 +159,11 @@ export function ArtistDetailsHero({
   useEffect(() => {
     setCoverFailed(false);
   }, [coverImage]);
+  useEffect(() => {
+    setShowAllTags(false);
+    setShowAllSecondaryLinks(false);
+  }, [artist?.id]);
   const metadataItems = [
-    artist.type
-      ? {
-          key: "type",
-          icon: Music,
-          label: "Type",
-          value: getArtistType(artist.type),
-        }
-      : null,
     lifeSpan
       ? {
           key: "active",
@@ -141,7 +199,8 @@ export function ArtistDetailsHero({
       name: typeof tag === "string" ? tag : tag?.name,
     })),
   ].filter((tag) => tag.name);
-  const externalLinks = [
+  const visibleTags = showAllTags ? tags : tags.slice(0, collapsedTagCount);
+  const primaryExternalLinks = [
     lidarrArtistLink
       ? {
           key: "lidarr",
@@ -183,6 +242,91 @@ export function ArtistDetailsHero({
         }
       : null,
   ].filter(Boolean);
+  const secondaryExternalLinks = buildRelationLinks(artist).map((link) => ({
+    ...link,
+    color: "#a8acb8",
+  }));
+  const uniquePrimaryExternalLinks = [];
+  const uniqueSecondaryExternalLinks = [];
+  const seenExternalHrefs = new Set();
+  for (const link of primaryExternalLinks) {
+    const href = normalizeExternalHref(link?.href);
+    if (!href || seenExternalHrefs.has(href)) continue;
+    seenExternalHrefs.add(href);
+    uniquePrimaryExternalLinks.push({ ...link, href });
+  }
+  for (const link of secondaryExternalLinks) {
+    const href = normalizeExternalHref(link?.href);
+    if (!href || seenExternalHrefs.has(href)) continue;
+    seenExternalHrefs.add(href);
+    uniqueSecondaryExternalLinks.push({ ...link, href });
+  }
+  const visibleSecondaryLinks = showAllSecondaryLinks
+    ? uniqueSecondaryExternalLinks
+    : uniqueSecondaryExternalLinks.slice(0, collapsedSecondaryLinkCount);
+
+  useEffect(() => {
+    const GAP = 8;
+
+    const measureFitCount = ({
+      rowRef,
+      itemsRef,
+      toggleRef,
+      itemCount,
+      setCount,
+      fallbackCount,
+    }) => {
+      const row = rowRef.current;
+      const items = itemsRef.current?.children
+        ? Array.from(itemsRef.current.children)
+        : [];
+      const toggle = toggleRef.current;
+      if (!row || items.length === 0) {
+        setCount(fallbackCount);
+        return;
+      }
+      const rowWidth = row.clientWidth;
+      const toggleWidth = itemCount > 0 && toggle ? toggle.offsetWidth + GAP : 0;
+      const available = Math.max(0, rowWidth - toggleWidth);
+      let used = 0;
+      let count = 0;
+      for (const item of items) {
+        const width = item.offsetWidth;
+        const next = count === 0 ? width : used + GAP + width;
+        if (next > available) break;
+        used = next;
+        count += 1;
+      }
+      setCount(Math.max(1, count || fallbackCount));
+    };
+
+    const runMeasurements = () => {
+      measureFitCount({
+        rowRef: tagsRowRef,
+        itemsRef: tagsMeasureRef,
+        toggleRef: tagsToggleMeasureRef,
+        itemCount: tags.length,
+        setCount: setCollapsedTagCount,
+        fallbackCount: Math.min(8, Math.max(1, tags.length)),
+      });
+      measureFitCount({
+        rowRef: secondaryLinksRowRef,
+        itemsRef: secondaryLinksMeasureRef,
+        toggleRef: secondaryLinksToggleMeasureRef,
+        itemCount: uniqueSecondaryExternalLinks.length,
+        setCount: setCollapsedSecondaryLinkCount,
+        fallbackCount: Math.min(6, Math.max(1, uniqueSecondaryExternalLinks.length)),
+      });
+    };
+
+    runMeasurements();
+    const observer = new ResizeObserver(() => {
+      runMeasurements();
+    });
+    if (tagsRowRef.current) observer.observe(tagsRowRef.current);
+    if (secondaryLinksRowRef.current) observer.observe(secondaryLinksRowRef.current);
+    return () => observer.disconnect();
+  }, [tags, uniqueSecondaryExternalLinks, artist?.id]);
 
   const renderLibraryAction = () => {
     if (loadingLibrary) {
@@ -598,16 +742,6 @@ export function ArtistDetailsHero({
                         {artist.name}
                       </h1>
                     </div>
-                    {artist["sort-name"] && artist["sort-name"] !== artist.name && (
-                      <p className="mt-2 text-sm sm:text-base" style={{ color: "#c1c1c3" }}>
-                        {artist["sort-name"]}
-                      </p>
-                    )}
-                    {artist.disambiguation && (
-                      <p className="mt-3 max-w-2xl text-sm italic sm:text-base" style={{ color: "#d5d6db" }}>
-                        {artist.disambiguation}
-                      </p>
-                    )}
                   </div>
 
                   {renderHeroMenu()}
@@ -649,34 +783,88 @@ export function ArtistDetailsHero({
               </div>
             </div>
 
-            <div className="mt-5 flex gap-2 overflow-x-auto whitespace-nowrap pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:flex-wrap md:overflow-visible">
-              {tags.length > 0 ? (
-                tags.map((tag) => (
-                  <button
-                    key={tag.key}
-                    onClick={() =>
-                      onNavigate(`/search?q=${encodeURIComponent(`#${tag.name}`)}&type=tag`)
-                    }
-                    className="badge genre-tag-pill shrink-0 px-3 py-1.5 text-sm cursor-pointer"
-                    style={{
-                      backgroundColor: getTagColor(tag.name),
-                      color: "#fff",
-                    }}
-                    title={`View artists with tag: ${tag.name}`}
-                  >
-                    #{tag.name}
-                  </button>
-                ))
-              ) : (
-                <span className="text-sm" style={{ color: "#c1c1c3" }}>
-                  No tags
-                </span>
-              )}
+            <div className="mt-5 flex items-start gap-2">
+              <div className="absolute -left-[9999px] top-auto invisible pointer-events-none whitespace-nowrap">
+                <div ref={tagsMeasureRef} className="flex gap-2">
+                  {tags.map((tag) => (
+                    <span
+                      key={`measure-${tag.key}`}
+                      className="badge genre-tag-pill shrink-0 px-3 py-1.5 text-sm"
+                    >
+                      #{tag.name}
+                    </span>
+                  ))}
+                </div>
+                <button
+                  ref={tagsToggleMeasureRef}
+                  type="button"
+                  className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-sm"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+              </div>
+              <div
+                ref={tagsRowRef}
+                className={`min-w-0 flex-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
+                  showAllTags
+                    ? "overflow-visible whitespace-normal"
+                    : "overflow-x-auto whitespace-nowrap"
+                }`}
+              >
+                <div className={`flex gap-2 ${showAllTags ? "flex-wrap" : ""}`}>
+                  {tags.length > 0 ? (
+                    visibleTags.map((tag) => (
+                      <button
+                        key={tag.key}
+                        onClick={() =>
+                          onNavigate(`/search?q=${encodeURIComponent(`#${tag.name}`)}&type=tag`)
+                        }
+                        className="badge genre-tag-pill shrink-0 px-3 py-1.5 text-sm cursor-pointer"
+                        style={{
+                          backgroundColor: getTagColor(tag.name),
+                          color: "#fff",
+                        }}
+                        title={`View artists with tag: ${tag.name}`}
+                      >
+                        #{tag.name}
+                      </button>
+                    ))
+                  ) : (
+                    <span className="text-sm" style={{ color: "#c1c1c3" }}>
+                      No tags
+                    </span>
+                  )}
+                </div>
+              </div>
+              {tags.length > visibleTags.length ? (
+                <button
+                  type="button"
+                  onClick={() => setShowAllTags(true)}
+                  className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-sm transition-colors hover:bg-white/[0.08]"
+                  style={{ color: "#c1c1c3" }}
+                  aria-label="Show all tags"
+                  title="Show all tags"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+              ) : null}
+              {showAllTags && tags.length > collapsedTagCount ? (
+                <button
+                  type="button"
+                  onClick={() => setShowAllTags(false)}
+                  className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-sm transition-colors hover:bg-white/[0.08]"
+                  style={{ color: "#c1c1c3" }}
+                  aria-label="Collapse tags"
+                  title="Collapse tags"
+                >
+                  <ChevronUp className="h-4 w-4" />
+                </button>
+              ) : null}
             </div>
 
-            {externalLinks.length > 0 && (
+            {uniquePrimaryExternalLinks.length > 0 && (
               <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
-                {externalLinks.map((link) => (
+                {uniquePrimaryExternalLinks.map((link) => (
                   <a
                     key={link.key}
                     href={link.href}
@@ -685,15 +873,100 @@ export function ArtistDetailsHero({
                     className="inline-flex items-center gap-2 text-sm transition-opacity hover:opacity-100"
                     style={{ color: "#d5d6db", opacity: 0.92 }}
                   >
-                    <span
-                      className="flex h-4 w-4 flex-shrink-0 items-center justify-center [&_svg]:h-full [&_svg]:w-full"
-                      style={{ color: link.color }}
-                      aria-hidden="true"
-                      dangerouslySetInnerHTML={{ __html: link.logo }}
-                    />
+                    {link.logo ? (
+                      <span
+                        className="flex h-4 w-4 flex-shrink-0 items-center justify-center [&_svg]:h-full [&_svg]:w-full"
+                        style={{ color: link.color }}
+                        aria-hidden="true"
+                        dangerouslySetInnerHTML={{ __html: link.logo }}
+                      />
+                    ) : link.icon ? (
+                      <span
+                        className="flex h-4 w-4 flex-shrink-0 items-center justify-center"
+                        style={{ color: link.color }}
+                        aria-hidden="true"
+                      >
+                        <link.icon className="h-4 w-4" />
+                      </span>
+                    ) : null}
                     <span>{link.label}</span>
                   </a>
                 ))}
+              </div>
+            )}
+
+            {uniqueSecondaryExternalLinks.length > 0 && (
+              <div className="mt-2 flex items-start gap-2">
+                <div className="absolute -left-[9999px] top-auto invisible pointer-events-none whitespace-nowrap">
+                  <div ref={secondaryLinksMeasureRef} className="flex gap-x-3 gap-y-1.5">
+                    {uniqueSecondaryExternalLinks.map((link) => (
+                      <span
+                        key={`measure-${link.key}`}
+                        className="inline-flex items-center rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-xs"
+                      >
+                        {link.label}
+                      </span>
+                    ))}
+                  </div>
+                  <button
+                    ref={secondaryLinksToggleMeasureRef}
+                    type="button"
+                    className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-xs"
+                  >
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                <div
+                  ref={secondaryLinksRowRef}
+                  className={`min-w-0 flex-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
+                    showAllSecondaryLinks
+                      ? "overflow-visible whitespace-normal"
+                      : "overflow-x-auto whitespace-nowrap"
+                  }`}
+                >
+                  <div
+                    className={`flex gap-x-3 gap-y-1.5 ${
+                      showAllSecondaryLinks ? "flex-wrap whitespace-normal" : "whitespace-nowrap"
+                    }`}
+                  >
+                    {visibleSecondaryLinks.map((link) => (
+                      <a
+                        key={link.key}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-xs transition-colors hover:bg-white/[0.08]"
+                        style={{ color: "#a8acb8", opacity: 0.9 }}
+                      >
+                        <span>{link.label}</span>
+                      </a>
+                    ))}
+                  </div>
+                </div>
+                {uniqueSecondaryExternalLinks.length > visibleSecondaryLinks.length ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllSecondaryLinks(true)}
+                    className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-xs transition-colors hover:bg-white/[0.08]"
+                    style={{ color: "#a8acb8" }}
+                    aria-label="Show all links"
+                    title="Show all links"
+                  >
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+                {showAllSecondaryLinks && uniqueSecondaryExternalLinks.length > collapsedSecondaryLinkCount ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllSecondaryLinks(false)}
+                    className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-xs transition-colors hover:bg-white/[0.08]"
+                    style={{ color: "#a8acb8" }}
+                    aria-label="Collapse links"
+                    title="Collapse links"
+                  >
+                    <ChevronUp className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
               </div>
             )}
           </div>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -603,6 +603,14 @@ export function ArtistDetailsLibraryAlbums({
                         </span>
                       </div>
                       <div className="flex flex-shrink-0 items-center gap-2">
+                        {track.length && (
+                          <span className="text-xs" style={{ color: "#c1c1c3" }}>
+                            {Math.floor(track.length / 60000)}:
+                            {Math.floor((track.length % 60000) / 1000)
+                              .toString()
+                              .padStart(2, "0")}
+                          </span>
+                        )}
                         {onAddTrackToPlaylist ? (
                           <button
                             type="button"
@@ -626,14 +634,6 @@ export function ArtistDetailsLibraryAlbums({
                             </span>
                           </button>
                         ) : null}
-                        {track.length && (
-                          <span className="text-xs" style={{ color: "#c1c1c3" }}>
-                            {Math.floor(track.length / 60000)}:
-                            {Math.floor((track.length % 60000) / 1000)
-                              .toString()
-                              .padStart(2, "0")}
-                          </span>
-                        )}
                         {track.hasFile ||
                         libraryAlbum?.statistics?.percentOfTracks >= 100 ||
                         libraryAlbum?.statistics?.sizeOnDisk > 0 ? (

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -4,6 +4,7 @@ import {
   ArrowDownWideNarrow,
   ArrowUpDown,
   ArrowUpWideNarrow,
+  Star,
   Loader,
   Music,
   CheckCircle,
@@ -22,7 +23,6 @@ import {
   Pause,
 } from "lucide-react";
 import AddAlbumButton from "../../../components/AddAlbumButton";
-import { getPopularityScale, segmentsFromScale } from "../utils";
 import { matchesReleaseTypeFilter } from "../utils";
 
 export function ArtistDetailsReleaseGroups({
@@ -260,15 +260,26 @@ export function ArtistDetailsReleaseGroups({
     .filter((rg) => !isReleaseGroupDownloadedInLibrary(rg.id));
   const visibleCoverSourceKey = filtered.map((rg) => rg.id).join(",");
   const visibleCount = filtered.length;
-  const { pivot: popularityPivot } = getPopularityScale(releaseGroups);
+  const getReleaseMetric = (releaseGroup) => {
+    const ratingValue =
+      releaseGroup?.rating?.value != null &&
+      Number.isFinite(Number(releaseGroup.rating.value))
+        ? Number(releaseGroup.rating.value)
+        : null;
+    if (ratingValue != null) {
+      return { type: "rating", sortValue: ratingValue };
+    }
+    const fans = typeof releaseGroup?.fans === "number" ? releaseGroup.fans : 0;
+    return { type: "fans", sortValue: fans };
+  };
   const sortedReleaseGroups = [...filtered].sort((a, b) => {
-    const fansA = typeof a?.fans === "number" ? a.fans : 0;
-    const fansB = typeof b?.fans === "number" ? b.fans : 0;
+    const metricA = getReleaseMetric(a).sortValue;
+    const metricB = getReleaseMetric(b).sortValue;
     if (sortMode === "popularityAsc") {
-      const diff = fansA - fansB;
+      const diff = metricA - metricB;
       if (diff !== 0) return diff;
     } else if (sortMode === "popularityDesc") {
-      const diff = fansB - fansA;
+      const diff = metricB - metricA;
       if (diff !== 0) return diff;
     }
     const dateA = a["first-release-date"] || "";
@@ -643,33 +654,41 @@ export function ArtistDetailsReleaseGroups({
                             </span>
                           )}
                         {(() => {
+                          const ratingValue =
+                            releaseGroup?.rating?.value != null &&
+                            Number.isFinite(Number(releaseGroup.rating.value))
+                              ? Number(releaseGroup.rating.value)
+                              : null;
+                          const ratingCount =
+                            releaseGroup?.rating?.count != null &&
+                            Number.isFinite(Number(releaseGroup.rating.count))
+                              ? Number(releaseGroup.rating.count)
+                              : 0;
                           const fans =
-                            typeof releaseGroup.fans === "number"
+                            typeof releaseGroup?.fans === "number"
                               ? releaseGroup.fans
                               : 0;
-                          const segments = segmentsFromScale(
-                            fans,
-                            popularityPivot,
-                            10,
-                          );
+                          if (ratingValue == null && fans <= 0) return null;
                           return (
                             <span
-                              className="flex items-center gap-0.5 ml-1"
-                              title={`Popularity: ${segments}/10 · ${fans.toLocaleString()} listeners`}
+                              className="ml-1 inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/15 px-2 py-0.5"
+                              title={
+                                ratingValue != null
+                                  ? `Rating: ${ratingValue.toFixed(1)}${ratingCount > 0 ? ` (${ratingCount} votes)` : ""}`
+                                  : `Popularity fallback: ${fans.toLocaleString()} listeners`
+                              }
                             >
-                              {Array.from({ length: 10 }, (_, i) => {
-                                const n = i + 1;
-                                return (
-                                  <span
-                                    key={n}
-                                    className="w-1 h-3 rounded-sm flex-shrink-0"
-                                    style={{
-                                      backgroundColor:
-                                        n <= segments ? "#eab308" : "#4b5563",
-                                    }}
-                                  />
-                                );
-                              })}
+                              <Star className="h-3.5 w-3.5" style={{ color: "#eab308" }} />
+                              <span style={{ color: "#fff" }}>
+                                {ratingValue != null
+                                  ? ratingValue.toFixed(1)
+                                  : `${fans.toLocaleString()}`}
+                              </span>
+                              {ratingValue != null && ratingCount > 0 ? (
+                                <span style={{ color: "#c1c1c3" }}>
+                                  ({ratingCount})
+                                </span>
+                              ) : null}
                             </span>
                           );
                         })()}
@@ -926,6 +945,12 @@ export function ArtistDetailsReleaseGroups({
                                   </span>
                                 </div>
                                 <div className="flex items-center gap-2 flex-shrink-0">
+                                  <span
+                                    className="text-xs w-10 text-right tabular-nums"
+                                    style={{ color: "#c1c1c3" }}
+                                  >
+                                    {durationLabel}
+                                  </span>
                                   {onAddTrackToPlaylist ? (
                                     <button
                                       type="button"
@@ -976,12 +1001,6 @@ export function ArtistDetailsReleaseGroups({
                                       )}
                                     </button>
                                   )}
-                                  <span
-                                    className="text-xs w-10 text-right tabular-nums"
-                                    style={{ color: "#c1c1c3" }}
-                                  >
-                                    {durationLabel}
-                                  </span>
                                   {track.hasFile ||
                                   status?.albumInfo?.statistics
                                     ?.percentOfTracks >= 100 ||
@@ -992,13 +1011,6 @@ export function ArtistDetailsReleaseGroups({
                                       style={{ color: "#c1c1c3" }}
                                     >
                                       <CheckCircle className="w-4 h-4 text-green-500" />
-                                    </span>
-                                  ) : status?.libraryId ? (
-                                    <span
-                                      className="text-xs w-12 text-right"
-                                      style={{ color: "#c1c1c3" }}
-                                    >
-                                      Missing
                                     </span>
                                   ) : (
                                     <span className="w-12" />

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -26,7 +26,7 @@ const STEPS = [
   "welcome",
   "admin",
   "lidarr",
-  "musicbrainz",
+  "metadata",
   "navidrome",
   "lastfm",
   "done",
@@ -39,7 +39,9 @@ function Onboarding() {
   const [authPasswordConfirm, setAuthPasswordConfirm] = useState("");
   const [lidarrUrl, setLidarrUrl] = useState("");
   const [lidarrApiKey, setLidarrApiKey] = useState("");
-  const [musicbrainzEmail, setMusicbrainzEmail] = useState("");
+  const [metadataBaseUrl, setMetadataBaseUrl] = useState(
+    "https://lidarrapi.brainzmash.cc",
+  );
   const [navidromeUrl, setNavidromeUrl] = useState("");
   const [navidromeUsername, setNavidromeUsername] = useState("");
   const [navidromePassword, setNavidromePassword] = useState("");
@@ -71,7 +73,7 @@ function Onboarding() {
     currentStep === "done" ||
     (currentStep === "admin" && adminComplete) ||
     (currentStep === "lidarr" && lidarrTestSuccess) ||
-    (currentStep === "musicbrainz" && musicbrainzEmail.trim()) ||
+    (currentStep === "metadata" && metadataBaseUrl.trim()) ||
     (currentStep === "navidrome" && (!hasNavidrome || navidromeTestSuccess)) ||
     currentStep === "lastfm";
   const isPrimaryDisabled =
@@ -168,8 +170,8 @@ function Onboarding() {
                 apiKey: lidarrApiKey.trim(),
               }
             : undefined,
-        musicbrainz: musicbrainzEmail.trim()
-          ? { email: musicbrainzEmail.trim() }
+        metadata: metadataBaseUrl.trim()
+          ? { baseUrl: metadataBaseUrl.trim() }
           : undefined,
         navidrome:
           navidromeUrl.trim() && navidromeUsername.trim() && navidromePassword
@@ -237,9 +239,9 @@ function Onboarding() {
                 Welcome to Aurral
               </h2>
               <p className="text-sm" style={{ color: "#c1c1c3" }}>
-                Set up your admin account, connect Lidarr, and add your
-                MusicBrainz email. Navidrome and Last.fm are optional but
-                recommended.
+                Set up your admin account, connect Lidarr, and confirm the
+                BrainzMash metadata endpoint. Navidrome and Last.fm are optional
+                but recommended.
               </p>
             </div>
           </>
@@ -329,24 +331,25 @@ function Onboarding() {
           </>
         )}
 
-        {currentStep === "musicbrainz" && (
+        {currentStep === "metadata" && (
           <>
             <div className="flex items-center gap-2 mb-4">
               <h2 className="text-xl font-bold" style={{ color: "#fff" }}>
-                MusicBrainz email
+                Metadata endpoint
               </h2>
             </div>
             <p className="text-sm mb-4" style={{ color: "#c1c1c3" }}>
-              Used for API etiquette when fetching metadata. Not shared.
+              Aurral uses this BrainzMash-compatible metadata base URL for artist
+              and album data during local testing.
             </p>
             <input
-              type="email"
+              type="url"
               autoComplete="off"
               className={inputClass}
               style={inputStyle}
-              placeholder="your@email.com"
-              value={musicbrainzEmail}
-              onChange={(e) => setMusicbrainzEmail(e.target.value)}
+              placeholder="https://lidarrapi.brainzmash.cc"
+              value={metadataBaseUrl}
+              onChange={(e) => setMetadataBaseUrl(e.target.value)}
             />
           </>
         )}

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
-  ArrowLeft,
   ArrowUpDown,
   ChevronDown,
   Disc,
@@ -155,7 +154,7 @@ function SearchResultsPage() {
   }, [type, trimmedQuery]);
   const isTagSearch = normalizedType === "tag";
   const isAlbumSearch = normalizedType === "album";
-  const tagScope = searchParams.get("scope") || "recommended";
+  const tagScope = searchParams.get("scope") || "all";
   const albumSort = searchParams.get("sort") || DEFAULT_ALBUM_SORT;
   const showAllTagResults = isTagSearch && tagScope === "all";
   const canAddArtist = hasPermission("addArtist");
@@ -177,11 +176,7 @@ function SearchResultsPage() {
   const updateTagScope = useCallback(
     (nextScope) => {
       const params = new URLSearchParams(searchParams);
-      if (nextScope === "all") {
-        params.set("scope", "all");
-      } else {
-        params.delete("scope");
-      }
+      params.set("scope", nextScope === "all" ? "all" : "recommended");
       setSearchParams(params);
     },
     [searchParams, setSearchParams],
@@ -337,7 +332,7 @@ function SearchResultsPage() {
   ]);
 
   useEffect(() => {
-    if (isAlbumSearch || isTagSearch || results.length === 0) return undefined;
+    if (isAlbumSearch || results.length === 0) return undefined;
 
     let cancelled = false;
     const pendingArtists = results.filter((artist) => {
@@ -390,7 +385,7 @@ function SearchResultsPage() {
     return () => {
       cancelled = true;
     };
-  }, [artistImages, isAlbumSearch, isTagSearch, results]);
+  }, [artistImages, isAlbumSearch, results]);
 
   useEffect(() => {
     if (isAlbumSearch) return undefined;
@@ -749,10 +744,6 @@ function SearchResultsPage() {
   const showContent =
     !loading && (query || normalizedType === "recommended" || normalizedType === "trending");
   const isEmpty = displayedResults.length === 0;
-  const showBackButton =
-    normalizedType === "recommended" ||
-    normalizedType === "trending" ||
-    !!trimmedQuery;
   const showLoadMore =
     hasMore &&
     (normalizedType === "recommended" || normalizedType === "trending"
@@ -783,16 +774,6 @@ function SearchResultsPage() {
   return (
     <div className="animate-fade-in">
       <div className="mb-6">
-        {showBackButton && (
-          <button
-            onClick={() => navigate(-1)}
-            className="btn btn-secondary mb-6 hidden items-center sm:inline-flex"
-          >
-            <ArrowLeft className="mr-2 h-5 w-5" />
-            Back
-          </button>
-        )}
-
         <div className="flex flex-wrap items-center gap-4">
           <h1 className="text-2xl font-bold" style={{ color: "#fff" }}>
             {normalizedType === "recommended"

--- a/frontend/src/pages/Settings/MetadataProvidersPage.jsx
+++ b/frontend/src/pages/Settings/MetadataProvidersPage.jsx
@@ -39,7 +39,8 @@ function MetadataProvidersPage() {
             Metadata Providers
           </h1>
           <p style={{ color: "#c1c1c3" }}>
-            Advanced controls for MusicBrainz and Cover Art Archive routing.
+            Configure the BrainzMash-native metadata backend used for local
+            testing.
           </p>
         </div>
 

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -39,12 +39,10 @@ export function SettingsIntegrationsTab({
   const [ticketmasterEditing, setTicketmasterEditing] = useState(false);
   const [navidromeEditing, setNavidromeEditing] = useState(false);
   const [lastfmEditing, setLastfmEditing] = useState(false);
-  const [musicbrainzContactEditing, setMusicbrainzContactEditing] = useState(false);
   const [collapsedSections, setCollapsedSections] = useState({
     lidarr: false,
     lastfm: true,
     ticketmaster: true,
-    musicbrainzContact: true,
     navidrome: true,
   });
   const [lidarrTestLatencyMs, setLidarrTestLatencyMs] = useState(null);
@@ -1013,97 +1011,6 @@ export function SettingsIntegrationsTab({
                 }
               />
             </label>
-          </fieldset>
-          )}
-        </div>
-        <div
-          className="p-6 rounded-lg space-y-4"
-          style={{
-            backgroundColor: "#1a1a1e",
-            border: "1px solid #2a2a2e",
-          }}
-        >
-          <div className="flex items-center justify-between mb-2">
-            <h3
-              className="text-lg font-medium flex items-center"
-              style={{ color: "#fff" }}
-            >
-              <button
-                type="button"
-                onClick={() => toggleSection("musicbrainzContact")}
-                className="flex items-center gap-2 text-left"
-                style={{ color: "#fff" }}
-                aria-expanded={!collapsedSections.musicbrainzContact}
-              >
-                <ChevronDown
-                  className={`w-4 h-4 transition-transform ${
-                    collapsedSections.musicbrainzContact ? "-rotate-90" : ""
-                  }`}
-                />
-                <span>Metadata Client</span>
-              </button>
-            </h3>
-            <div className="flex items-center gap-2">
-              {health?.musicbrainzConfigured && (
-                <span className="flex items-center text-sm text-green-400">
-                  <CheckCircle className="w-4 h-4 mr-1" />
-                  Configured
-                </span>
-              )}
-              <button
-                type="button"
-                className={`btn ${
-                  musicbrainzContactEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setMusicbrainzContactEditing((value) => !value)}
-                aria-label={
-                  musicbrainzContactEditing
-                    ? "Lock metadata client settings"
-                    : "Edit metadata client settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
-          {!collapsedSections.musicbrainzContact && (
-          <fieldset
-            disabled={!musicbrainzContactEditing}
-            className={`space-y-4 ${
-              musicbrainzContactEditing ? "" : "opacity-60"
-            }`}
-          >
-            <div>
-              <label
-                className="block text-sm font-medium mb-1"
-                style={{ color: "#fff" }}
-              >
-                User-Agent Suffix
-              </label>
-              <input
-                type="text"
-                className="input"
-                placeholder="Aurral Local Test"
-                autoComplete="off"
-                value={settings.integrations?.metadata?.userAgentSuffix || ""}
-                onChange={(e) =>
-                  updateSettings({
-                    ...settings,
-                    integrations: {
-                      ...settings.integrations,
-                      metadata: {
-                        ...(settings.integrations?.metadata || {}),
-                        userAgentSuffix: e.target.value,
-                      },
-                    },
-                  })
-                }
-              />
-              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Optional text appended to the BrainzMash request user agent for
-                easier tracing during local testing.
-              </p>
-            </div>
           </fieldset>
           )}
         </div>

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -1040,7 +1040,7 @@ export function SettingsIntegrationsTab({
                     collapsedSections.musicbrainzContact ? "-rotate-90" : ""
                   }`}
                 />
-                <span>MusicBrainz Contact</span>
+                <span>Metadata Client</span>
               </button>
             </h3>
             <div className="flex items-center gap-2">
@@ -1058,8 +1058,8 @@ export function SettingsIntegrationsTab({
                 onClick={() => setMusicbrainzContactEditing((value) => !value)}
                 aria-label={
                   musicbrainzContactEditing
-                    ? "Lock MusicBrainz contact settings"
-                    : "Edit MusicBrainz contact settings"
+                    ? "Lock metadata client settings"
+                    : "Edit metadata client settings"
                 }
               >
                 <Pencil className="w-4 h-4" />
@@ -1078,30 +1078,30 @@ export function SettingsIntegrationsTab({
                 className="block text-sm font-medium mb-1"
                 style={{ color: "#fff" }}
               >
-                Contact Email
+                User-Agent Suffix
               </label>
               <input
-                type="email"
+                type="text"
                 className="input"
-                placeholder="contact@example.com"
+                placeholder="Aurral Local Test"
                 autoComplete="off"
-                value={settings.integrations?.musicbrainz?.email || ""}
+                value={settings.integrations?.metadata?.userAgentSuffix || ""}
                 onChange={(e) =>
                   updateSettings({
                     ...settings,
                     integrations: {
                       ...settings.integrations,
-                      musicbrainz: {
-                        ...(settings.integrations?.musicbrainz || {}),
-                        email: e.target.value,
+                      metadata: {
+                        ...(settings.integrations?.metadata || {}),
+                        userAgentSuffix: e.target.value,
                       },
                     },
                   })
                 }
               />
               <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Used for the MusicBrainz user agent. This is needed if the app
-                falls back to the public MusicBrainz API.
+                Optional text appended to the BrainzMash request user agent for
+                easier tracing during local testing.
               </p>
             </div>
           </fieldset>

--- a/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
@@ -1,19 +1,5 @@
-import { useState } from "react";
-import { CheckCircle, Pencil } from "lucide-react";
+import { CheckCircle } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
-
-function ProviderStatusNote({ providerHealth, activeLabel }) {
-  if (!providerHealth) return null;
-
-  return (
-    <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-      Active route: {activeLabel}.
-      {providerHealth.failoverActive
-        ? " Narrow fallback is active because the primary BrainzMash endpoint failed recently."
-        : " BrainzMash is serving metadata directly."}
-    </p>
-  );
-}
 
 export function SettingsMetadataTab({
   settings,
@@ -23,9 +9,6 @@ export function SettingsMetadataTab({
   saving,
   handleSaveSettings,
 }) {
-  const [metadataEditing, setMetadataEditing] = useState(false);
-  const providerHealth = health?.metadataProviders || {};
-
   return (
     <div className="card animate-fade-in">
       <div className="flex items-center justify-between mb-6">
@@ -58,53 +41,16 @@ export function SettingsMetadataTab({
               className="text-lg font-medium flex items-center"
               style={{ color: "#fff" }}
             >
-              BrainzMash
+              Metadata Server
             </h3>
-            <div className="flex items-center gap-2">
-              {health?.metadataConfigured && (
-                <span className="flex items-center text-sm text-green-400">
-                  <CheckCircle className="w-4 h-4 mr-1" />
-                  Configured
-                </span>
-              )}
-              <button
-                type="button"
-                className={`btn ${
-                  metadataEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setMetadataEditing((value) => !value)}
-                aria-label={
-                  metadataEditing
-                    ? "Lock metadata settings"
-                    : "Edit metadata settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
-            </div>
+            {health?.metadataConfigured && (
+              <span className="flex items-center text-sm text-green-400">
+                <CheckCircle className="w-4 h-4 mr-1" />
+                Configured
+              </span>
+            )}
           </div>
-          <fieldset
-            disabled={!metadataEditing}
-            className={`space-y-4 ${metadataEditing ? "" : "opacity-60"}`}
-          >
-            <div>
-              <label
-                className="block text-sm font-medium mb-1"
-                style={{ color: "#fff" }}
-              >
-                Provider
-              </label>
-              <input className="input" value="BrainzMash" disabled />
-              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                This branch uses a BrainzMash-compatible metadata backend and no
-                longer routes normal metadata reads through the old
-                MusicBrainz mirror path.
-              </p>
-              <ProviderStatusNote
-                providerHealth={providerHealth.brainzmash}
-                activeLabel="BrainzMash"
-              />
-            </div>
+          <div className="space-y-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"
@@ -133,39 +79,7 @@ export function SettingsMetadataTab({
                 }
               />
             </div>
-            <div>
-              <label
-                className="flex items-center gap-2 text-sm font-medium"
-                style={{ color: "#fff" }}
-              >
-                <input
-                  type="checkbox"
-                  checked={
-                    settings.integrations?.metadata?.enableNarrowFallbacks !== false
-                  }
-                  onChange={(e) =>
-                    updateSettings({
-                      ...settings,
-                      integrations: {
-                        ...settings.integrations,
-                        metadata: {
-                          ...(settings.integrations?.metadata || {}),
-                          provider: "brainzmash",
-                          enableNarrowFallbacks: e.target.checked,
-                        },
-                      },
-                    })
-                  }
-                />
-                Enable narrow fallbacks
-              </label>
-              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Keep the BrainzMash-native path primary, but allow isolated
-                fallback behavior if a required metadata read cannot be
-                satisfied.
-              </p>
-            </div>
-          </fieldset>
+          </div>
         </div>
       </form>
     </div>

--- a/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsMetadataTab.jsx
@@ -2,31 +2,15 @@ import { useState } from "react";
 import { CheckCircle, Pencil } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 
-function ProviderStatusNote({ providerHealth, hostedLabel, officialLabel }) {
+function ProviderStatusNote({ providerHealth, activeLabel }) {
   if (!providerHealth) return null;
-
-  const activeLabel =
-    providerHealth.activeProvider === "aurralHosted"
-      ? hostedLabel
-      : providerHealth.activeProvider === "official"
-        ? officialLabel
-        : "Custom provider";
-
-  if (providerHealth.mode !== "auto") {
-    return (
-      <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-        Using {activeLabel}. Automatic hosted failover is disabled while a
-        manual provider is selected.
-      </p>
-    );
-  }
 
   return (
     <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
       Active route: {activeLabel}.
       {providerHealth.failoverActive
-        ? " Hosted health checks failed repeatedly, so requests are temporarily using the official endpoint until the hosted route recovers."
-        : " Hosted mode stays pinned to the hosted cache and only fails over after repeated background health check failures."}
+        ? " Narrow fallback is active because the primary BrainzMash endpoint failed recently."
+        : " BrainzMash is serving metadata directly."}
     </p>
   );
 }
@@ -39,7 +23,7 @@ export function SettingsMetadataTab({
   saving,
   handleSaveSettings,
 }) {
-  const [musicbrainzEditing, setMusicbrainzEditing] = useState(false);
+  const [metadataEditing, setMetadataEditing] = useState(false);
   const providerHealth = health?.metadataProviders || {};
 
   return (
@@ -74,10 +58,10 @@ export function SettingsMetadataTab({
               className="text-lg font-medium flex items-center"
               style={{ color: "#fff" }}
             >
-              MusicBrainz
+              BrainzMash
             </h3>
             <div className="flex items-center gap-2">
-              {health?.musicbrainzConfigured && (
+              {health?.metadataConfigured && (
                 <span className="flex items-center text-sm text-green-400">
                   <CheckCircle className="w-4 h-4 mr-1" />
                   Configured
@@ -86,13 +70,13 @@ export function SettingsMetadataTab({
               <button
                 type="button"
                 className={`btn ${
-                  musicbrainzEditing ? "btn-primary" : "btn-secondary"
+                  metadataEditing ? "btn-primary" : "btn-secondary"
                 } px-2 py-1`}
-                onClick={() => setMusicbrainzEditing((value) => !value)}
+                onClick={() => setMetadataEditing((value) => !value)}
                 aria-label={
-                  musicbrainzEditing
-                    ? "Lock MusicBrainz settings"
-                    : "Edit MusicBrainz settings"
+                  metadataEditing
+                    ? "Lock metadata settings"
+                    : "Edit metadata settings"
                 }
               >
                 <Pencil className="w-4 h-4" />
@@ -100,86 +84,87 @@ export function SettingsMetadataTab({
             </div>
           </div>
           <fieldset
-            disabled={!musicbrainzEditing}
-            className={`space-y-4 ${musicbrainzEditing ? "" : "opacity-60"}`}
+            disabled={!metadataEditing}
+            className={`space-y-4 ${metadataEditing ? "" : "opacity-60"}`}
           >
             <div>
               <label
                 className="block text-sm font-medium mb-1"
                 style={{ color: "#fff" }}
               >
-                Metadata source
+                Provider
               </label>
-              <select
+              <input className="input" value="BrainzMash" disabled />
+              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
+                This branch uses a BrainzMash-compatible metadata backend and no
+                longer routes normal metadata reads through the old
+                MusicBrainz mirror path.
+              </p>
+              <ProviderStatusNote
+                providerHealth={providerHealth.brainzmash}
+                activeLabel="BrainzMash"
+              />
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium mb-1"
+                style={{ color: "#fff" }}
+              >
+                Base URL
+              </label>
+              <input
+                type="url"
                 className="input"
-                value={
-                  settings.integrations?.musicbrainz?.provider ||
-                  "aurralHosted"
-                }
+                placeholder="https://lidarrapi.brainzmash.cc"
+                autoComplete="off"
+                value={settings.integrations?.metadata?.baseUrl || ""}
                 onChange={(e) =>
                   updateSettings({
                     ...settings,
                     integrations: {
                       ...settings.integrations,
-                      musicbrainz: {
-                        ...(settings.integrations?.musicbrainz || {}),
-                        provider: e.target.value,
+                      metadata: {
+                        ...(settings.integrations?.metadata || {}),
+                        provider: "brainzmash",
+                        baseUrl: e.target.value,
                       },
                     },
                   })
                 }
-              >
-                <option value="aurralHosted">
-                  Aurral-hosted MusicBrainz mirror
-                </option>
-                <option value="official">Official MusicBrainz API</option>
-                <option value="custom">Custom self-hosted instance</option>
-              </select>
-              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                Aurral-hosted is quicker but may have downtime. Official is
-                slower but usually steadier. Custom lets users point at their
-                own MusicBrainz API.
-              </p>
-              <ProviderStatusNote
-                providerHealth={providerHealth.musicbrainz}
-                hostedLabel="Aurral-hosted MusicBrainz mirror"
-                officialLabel="Official MusicBrainz API"
               />
             </div>
-            {(settings.integrations?.musicbrainz?.provider || "aurralHosted") ===
-              "custom" && (
-              <div>
-                <label
-                  className="block text-sm font-medium mb-1"
-                  style={{ color: "#fff" }}
-                >
-                  Custom API URL
-                </label>
+            <div>
+              <label
+                className="flex items-center gap-2 text-sm font-medium"
+                style={{ color: "#fff" }}
+              >
                 <input
-                  type="url"
-                  className="input"
-                  placeholder="https://musicbrainz.example.com/ws/2"
-                  autoComplete="off"
-                  value={settings.integrations?.musicbrainz?.customUrl || ""}
+                  type="checkbox"
+                  checked={
+                    settings.integrations?.metadata?.enableNarrowFallbacks !== false
+                  }
                   onChange={(e) =>
                     updateSettings({
                       ...settings,
                       integrations: {
                         ...settings.integrations,
-                        musicbrainz: {
-                          ...(settings.integrations?.musicbrainz || {}),
-                          customUrl: e.target.value,
+                        metadata: {
+                          ...(settings.integrations?.metadata || {}),
+                          provider: "brainzmash",
+                          enableNarrowFallbacks: e.target.checked,
                         },
                       },
                     })
                   }
                 />
-                <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
-                  Enter the MusicBrainz API base URL. If you omit `/ws/2`, it
-                  will be added automatically.
-                </p>
-              </div>
-            )}
+                Enable narrow fallbacks
+              </label>
+              <p className="mt-1 text-xs" style={{ color: "#c1c1c3" }}>
+                Keep the BrainzMash-native path primary, but allow isolated
+                fallback behavior if a required metadata read cannot be
+                satisfied.
+              </p>
+            </div>
           </fieldset>
         </div>
       </form>

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -47,10 +47,11 @@ const defaultSettings = {
       defaultMonitorOption: "none",
       searchOnAdd: false,
     },
-    musicbrainz: {
-      email: "",
-      provider: "aurralHosted",
-      customUrl: "",
+    metadata: {
+      provider: "brainzmash",
+      baseUrl: "https://lidarrapi.brainzmash.cc",
+      userAgentSuffix: "",
+      enableNarrowFallbacks: true,
     },
     general: { authUser: "", authPassword: "" },
     gotify: {

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -3,6 +3,8 @@ import { allReleaseTypes } from "./constants";
 export const normalizeSettings = (savedSettings) => {
   const lidarr = savedSettings.integrations?.lidarr || {};
   const lastfm = savedSettings.integrations?.lastfm || {};
+  const legacyMusicbrainz = savedSettings.integrations?.musicbrainz || {};
+  const metadata = savedSettings.integrations?.metadata || {};
   const parsedAutoRefreshHours = parseInt(lastfm.discoveryAutoRefreshHours, 10);
   const normalizedAutoRefreshHours = [24, 168, 720].includes(
     parsedAutoRefreshHours,
@@ -62,11 +64,17 @@ export const normalizeSettings = (savedSettings) => {
         localDiscoveryIncludeTrending: true,
         ...(savedSettings.integrations?.ticketmaster || {}),
       },
-      musicbrainz: {
-        email: "",
-        provider: "aurralHosted",
-        customUrl: "",
-        ...(savedSettings.integrations?.musicbrainz || {}),
+      metadata: {
+        provider: "brainzmash",
+        baseUrl:
+          metadata.baseUrl ||
+          String(legacyMusicbrainz.customUrl || "")
+            .trim()
+            .replace(/\/ws\/2\/?$/, "") ||
+          "https://lidarrapi.brainzmash.cc",
+        userAgentSuffix: "",
+        enableNarrowFallbacks: true,
+        ...metadata,
       },
       general: {
         authUser: "",

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -259,7 +259,7 @@ export const searchCatalog = async (
   {
     limit = 24,
     offset = 0,
-    tagScope = "recommended",
+    tagScope = "all",
     releaseTypes = [],
   } = {},
 ) => {


### PR DESCRIPTION
## Summary
- Replaced the legacy MusicBrainz-centric metadata flow with a BrainzMash-backed metadata provider.
- Updated artist, release-group, search, onboarding, and settings flows to read from the new `metadata` integration config.
- Simplified metadata settings UI and defaulted new installs to the BrainzMash endpoint.
- Added provider mapping, ranking, and metadata provider service layers to centralize metadata lookups and fallbacks.

## Testing
- Not run
- Added and updated metadata provider unit coverage in `./.tests/metadata-providers.test.js`
- Manually verified the new default metadata settings shape and provider health snapshot behavior in code paths touched by the refactor