### PR TITLE
Add artist discovery feedback actions

### DIFF
--- a/frontend/src/components/SearchArtistResults.jsx
+++ b/frontend/src/components/SearchArtistResults.jsx
@@ -3,9 +3,12 @@ import PropTypes from "prop-types";
 import {
   Ban,
   CheckCircle2,
+  EyeOff,
   Library,
   Loader2,
   MoreVertical,
+  ThumbsDown,
+  ThumbsUp,
 } from "lucide-react";
 import ArtistImage from "./ArtistImage";
 
@@ -16,6 +19,7 @@ function ArtistActionsMenu({
   canAddArtist,
   onAddToLibrary,
   onAddToBlocklist,
+  onFeedback,
 }) {
   const [showMenu, setShowMenu] = useState(false);
   const [pendingAction, setPendingAction] = useState(null);
@@ -95,6 +99,66 @@ function ArtistActionsMenu({
             )}
             {isBlocked ? "In Blocklist" : "Blocklist Artist"}
           </button>
+          {onFeedback && (
+            <>
+              <button
+                type="button"
+                onClick={(event) =>
+                  handleAction(event, "more_like_this", (nextArtist) =>
+                    onFeedback(nextArtist, "more_like_this"),
+                  )
+                }
+                disabled={!!pendingAction}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ color: "#fff" }}
+              >
+                <ThumbsUp className="h-4 w-4" />
+                More like this
+              </button>
+              <button
+                type="button"
+                onClick={(event) =>
+                  handleAction(event, "less_like_this", (nextArtist) =>
+                    onFeedback(nextArtist, "less_like_this"),
+                  )
+                }
+                disabled={!!pendingAction}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ color: "#fff" }}
+              >
+                <ThumbsDown className="h-4 w-4" />
+                Less like this
+              </button>
+              <button
+                type="button"
+                onClick={(event) =>
+                  handleAction(event, "already_known", (nextArtist) =>
+                    onFeedback(nextArtist, "already_known"),
+                  )
+                }
+                disabled={!!pendingAction}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ color: "#fff" }}
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                Already know this
+              </button>
+              <button
+                type="button"
+                onClick={(event) =>
+                  handleAction(event, "hide_for_now", (nextArtist) =>
+                    onFeedback(nextArtist, "hide_for_now"),
+                  )
+                }
+                disabled={!!pendingAction}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ color: "#fca5a5" }}
+              >
+                <EyeOff className="h-4 w-4" />
+                Hide for now
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>
@@ -111,6 +175,7 @@ function SearchArtistResults({
   blockedArtists,
   onAddArtistToLibrary,
   onAddArtistToBlocklist,
+  onArtistFeedback,
 }) {
   const getArtistId = (artist) =>
     artist?.id || artist?.mbid || artist?.foreignArtistId;
@@ -268,7 +333,7 @@ function SearchArtistResults({
                 </div>
               </div>
 
-              {(canAddArtist || onAddArtistToBlocklist) && (
+              {(canAddArtist || onAddArtistToBlocklist || onArtistFeedback) && (
                 <ArtistActionsMenu
                   artist={artist}
                   isInLibrary={!!libraryLookup[artistId]}
@@ -276,6 +341,7 @@ function SearchArtistResults({
                   canAddArtist={canAddArtist}
                   onAddToLibrary={onAddArtistToLibrary}
                   onAddToBlocklist={onAddArtistToBlocklist}
+                  onFeedback={onArtistFeedback}
                 />
               )}
             </div>
@@ -296,6 +362,7 @@ SearchArtistResults.propTypes = {
   blockedArtists: PropTypes.arrayOf(PropTypes.object),
   onAddArtistToLibrary: PropTypes.func,
   onAddArtistToBlocklist: PropTypes.func,
+  onArtistFeedback: PropTypes.func,
 };
 
 ArtistActionsMenu.propTypes = {
@@ -305,6 +372,7 @@ ArtistActionsMenu.propTypes = {
   canAddArtist: PropTypes.bool,
   onAddToLibrary: PropTypes.func,
   onAddToBlocklist: PropTypes.func,
+  onFeedback: PropTypes.func,
 };
 
 export default SearchArtistResults;

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -262,6 +262,22 @@ const matchesBlockedArtist = (target, artist) => {
     (targetName && artistName && targetName === artistName);
 };
 
+const filterDiscoveryDataByBlockedArtists = (value, blockedArtists) => {
+  const normalized = normalizeDiscoveryData(value);
+  if (!normalized) return normalized;
+  const entries = Array.isArray(blockedArtists) ? blockedArtists : [];
+  if (entries.length === 0) return normalized;
+  return {
+    ...normalized,
+    recommendations: normalized.recommendations.filter(
+      (artist) => !isArtistInEntries(artist, entries),
+    ),
+    globalTop: normalized.globalTop.filter(
+      (artist) => !isArtistInEntries(artist, entries),
+    ),
+  };
+};
+
 const parseCalendarDate = (value) => {
   if (!value) return null;
   const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -1098,6 +1114,7 @@ function DiscoverPage() {
   const requestedReleaseCoversRef = useRef(new Set());
   const requestedArtistCoversRef = useRef(new Set());
   const lastDiscoveryWsMessageAtRef = useRef(0);
+  const blockedArtistsRef = useRef([]);
   const navigate = useNavigate();
   const { showSuccess, showError } = useToast();
   const canAddArtist = hasPermission("addArtist");
@@ -1123,8 +1140,12 @@ function DiscoverPage() {
               : "balanced",
           configured: true,
         };
-        setData(nextData);
-        writeStoredDiscoveryData(nextData, authUser?.id);
+        const filteredData = filterDiscoveryDataByBlockedArtists(
+          nextData,
+          blockedArtistsRef.current,
+        );
+        setData(filteredData);
+        writeStoredDiscoveryData(filteredData, authUser?.id);
       }
     },
   );
@@ -1134,8 +1155,12 @@ function DiscoverPage() {
     if (!data?.isUpdating && !data?.stale) return;
     getDiscovery()
       .then((discoveryData) => {
-        setData(discoveryData);
-        writeStoredDiscoveryData(discoveryData, authUser?.id);
+        const filteredData = filterDiscoveryDataByBlockedArtists(
+          discoveryData,
+          blockedArtistsRef.current,
+        );
+        setData(filteredData);
+        writeStoredDiscoveryData(filteredData, authUser?.id);
         setError(null);
       })
       .catch(() => {});
@@ -1149,8 +1174,12 @@ function DiscoverPage() {
     const pollDiscovery = () => {
       getDiscovery(true)
         .then((next) => {
-          setData(next);
-          writeStoredDiscoveryData(next, authUser?.id);
+          const filteredData = filterDiscoveryDataByBlockedArtists(
+            next,
+            blockedArtistsRef.current,
+          );
+          setData(filteredData);
+          writeStoredDiscoveryData(filteredData, authUser?.id);
           setError(null);
         })
         .catch(() => {});
@@ -1166,8 +1195,12 @@ function DiscoverPage() {
     const id = setTimeout(() => {
       getDiscovery(true)
         .then((next) => {
-          setData(next);
-          writeStoredDiscoveryData(next, authUser?.id);
+          const filteredData = filterDiscoveryDataByBlockedArtists(
+            next,
+            blockedArtistsRef.current,
+          );
+          setData(filteredData);
+          writeStoredDiscoveryData(filteredData, authUser?.id);
           setError(null);
         })
         .catch(() => {});
@@ -1185,8 +1218,12 @@ function DiscoverPage() {
   useEffect(() => {
     getDiscovery()
       .then((discoveryData) => {
-        setData(discoveryData);
-        writeStoredDiscoveryData(discoveryData, authUser?.id);
+        const filteredData = filterDiscoveryDataByBlockedArtists(
+          discoveryData,
+          blockedArtistsRef.current,
+        );
+        setData(filteredData);
+        writeStoredDiscoveryData(filteredData, authUser?.id);
         setError(null);
       })
       .catch((err) => {
@@ -1223,7 +1260,12 @@ function DiscoverPage() {
       try {
         const data = await getBlocklist();
         if (!cancelled) {
-          setBlockedArtists(normalizeBlocklistArtists(data?.artists));
+          const nextBlockedArtists = normalizeBlocklistArtists(data?.artists);
+          blockedArtistsRef.current = nextBlockedArtists;
+          setBlockedArtists(nextBlockedArtists);
+          setData((prev) =>
+            filterDiscoveryDataByBlockedArtists(prev, nextBlockedArtists),
+          );
         }
       } catch {}
     };
@@ -1671,9 +1713,11 @@ function DiscoverPage() {
           artists: nextArtists,
           tags: current?.tags || [],
         });
-        setBlockedArtists(
-          normalizeBlocklistArtists(response?.blocklist?.artists || nextArtists),
+        const savedBlockedArtists = normalizeBlocklistArtists(
+          response?.blocklist?.artists || nextArtists,
         );
+        blockedArtistsRef.current = savedBlockedArtists;
+        setBlockedArtists(savedBlockedArtists);
         setData((prev) =>
           prev
             ? {

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import {
   addArtistToLibrary,
+  addDiscoveryFeedback,
   getBlocklist,
   getDiscovery,
   getBootstrapStatus,
@@ -158,6 +159,8 @@ function SearchResultsPage() {
   const tagScope = searchParams.get("scope") || "recommended";
   const albumSort = searchParams.get("sort") || DEFAULT_ALBUM_SORT;
   const showAllTagResults = isTagSearch && tagScope === "all";
+  const supportsDiscoveryFeedback =
+    normalizedType === "recommended" || (isTagSearch && !showAllTagResults);
   const canAddArtist = hasPermission("addArtist");
   const canAddAlbum = hasPermission("addAlbum");
   const hasActiveReleaseTypeFilters = useMemo(() => {
@@ -741,6 +744,58 @@ function SearchResultsPage() {
     [showError, showSuccess],
   );
 
+  const handleArtistFeedback = useCallback(
+    async (artist, action) => {
+      try {
+        await addDiscoveryFeedback({
+          artistId: getArtistId(artist),
+          artistName: artist.name || null,
+          action,
+          sourceContext: artist.sourceType || artist.discoveryTier || null,
+          tagContext: artist.matchedTags || artist.tags || [],
+          seedContext: Array.isArray(artist.supportingSeeds)
+            ? artist.supportingSeeds.map((seed) => seed?.artistName).filter(Boolean)
+            : artist.sourceArtists || [],
+        });
+        if (action === "hide_for_now") {
+          setResults((prev) =>
+            prev.filter((entry) => !matchesBlockedArtist(entry, artist)),
+          );
+          setFullList((prev) =>
+            Array.isArray(prev) ? prev.filter((entry) => !matchesBlockedArtist(entry, artist)) : prev,
+          );
+          setSearchTotalCount((prev) => Math.max(0, prev - 1));
+          setHasMore((prev) => {
+            if (!prev) return false;
+            if (normalizedType === "recommended" || normalizedType === "trending") {
+              const nextFullListLength = Array.isArray(fullList)
+                ? fullList.filter((entry) => !matchesBlockedArtist(entry, artist)).length
+                : 0;
+              return nextFullListLength > visibleCount;
+            }
+            return true;
+          });
+        }
+        showSuccess(
+          action === "more_like_this"
+            ? "We’ll bias future picks toward this taste"
+            : action === "less_like_this"
+              ? "We’ll show less like this"
+              : action === "already_known"
+                ? "We’ll avoid obvious repeats like this"
+                : "Hidden from recommendations for now",
+        );
+        return true;
+      } catch (err) {
+        showError(
+          err.response?.data?.message || "Failed to save discovery feedback",
+        );
+        return false;
+      }
+    },
+    [fullList, normalizedType, showError, showSuccess, visibleCount],
+  );
+
   const displayedResults =
     normalizedType === "recommended" || normalizedType === "trending"
       ? results.slice(0, visibleCount)
@@ -1120,6 +1175,9 @@ function SearchResultsPage() {
                   blockedArtists={blockedArtists}
                   onAddArtistToLibrary={handleArtistAction}
                   onAddArtistToBlocklist={handleAddArtistToBlocklist}
+                  onArtistFeedback={
+                    supportsDiscoveryFeedback ? handleArtistFeedback : undefined
+                  }
                 />
               )}
 


### PR DESCRIPTION
## Summary
- Adds discovery feedback actions to artist menus: `More like this`, `Less like this`, `Already know this`, and `Hide for now`.
- Wires artist feedback from search results into `addDiscoveryFeedback` with context from source type, tags, and supporting seeds.
- Filters hidden artists out of search/discovery results and keeps discover page state aligned with the blocklist.
- Updates result counts and visible lists after hiding an artist so recommendations refresh immediately.

## Testing
- Not run (not requested).
- Verify artist actions still open from search/discovery result cards.
- Verify `Hide for now` removes the artist from the current results list and updates counts.
- Verify discovery pages re-filter results after blocklist changes.
- Verify feedback actions succeed and surface the expected success/error toast messages.