### PR TITLE
Allow the app to be embedded in frames

### DIFF
--- a/server.js
+++ b/server.js
@@ -105,10 +105,11 @@ app.use(
         connectSrc: ["'self'", "ws:", "wss:", "https://api.github.com"],
         mediaSrc: ["'self'", "https://*.dzcdn.net", "https://*.deezer.com"],
         frameSrc: ["'none'"],
+        frameAncestors: null,
         upgradeInsecureRequests: null,
       },
     },
-    frameguard: { action: "deny" },
+    frameguard: false,
   }),
 );
 app.use(express.json({ limit: JSON_BODY_LIMIT }));


### PR DESCRIPTION
## Summary
- Allow the app to be embedded in iframes by removing the `frame-ancestors` CSP restriction.
- Disable the `frameguard` header so browser frame embedding is no longer denied by middleware.
- Keep the rest of the security policy unchanged.

## Testing
- Not run (not requested).
- Reviewed the `server.js` middleware change to confirm only frame embedding restrictions were adjusted.