### PR TITLE
Scope weekly flow access by user ownership

### DIFF
--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -84,6 +84,7 @@ const getAllListeningHistoryUsersStmt = db.prepare(
 );
 
 const DEFAULT_PERMISSIONS = {
+  accessFlow: false,
   addArtist: true,
   addAlbum: true,
   changeMonitoring: false,

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -97,7 +97,6 @@ function buildPermissions(role, permissions) {
     ...userOps.getDefaultPermissions(),
     ...(permissions || {}),
     accessSettings: false,
-    accessFlow: false,
   };
 }
 

--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -18,6 +18,7 @@ import { noCache } from "../middleware/cache.js";
 import { hasPermission, verifyTokenAuth } from "../middleware/auth.js";
 import {
   requireAuth,
+  requireAdmin,
   requirePermission,
 } from "../middleware/requirePermission.js";
 
@@ -304,6 +305,9 @@ router.get("/stream/:jobId", noCache, async (req, res) => {
   if (!job) {
     return res.status(404).json({ error: "Track not found" });
   }
+  if (!canAccessPlaylistType(req.user, job.playlistType)) {
+    return res.status(404).json({ error: "Track not found" });
+  }
   if (job.status !== "done" || !job.finalPath) {
     return res.status(400).json({ error: "Track is not ready to stream" });
   }
@@ -367,6 +371,9 @@ router.get("/artwork/:playlistId", noCache, async (req, res) => {
   }
 
   const { playlistId } = req.params;
+  if (!canAccessPlaylistType(req.user, playlistId)) {
+    return res.status(404).json({ error: "Playlist artwork not found" });
+  }
   const playlistName = playlistManager.getPlaylistName(playlistId);
   if (!playlistName) {
     return res.status(404).json({ error: "Playlist artwork not found" });
@@ -456,6 +463,38 @@ const pauseSharedPlaylistRetryCycle = async (playlistId) => {
     await restartWorkerIfPending();
   }
   return cancelledJobs;
+};
+
+const getAccessibleFlow = (user, flowId) =>
+  flowPlaylistConfig.getFlowForUser(user, flowId);
+
+const getAccessibleSharedPlaylist = (user, playlistId) =>
+  flowPlaylistConfig.getSharedPlaylistForUser(user, playlistId);
+
+const canAccessPlaylistType = (user, playlistType) => {
+  const key = String(playlistType || "").trim();
+  if (!key) return false;
+  const flow = flowPlaylistConfig.getFlow(key);
+  if (flow) {
+    return flowPlaylistConfig.canUserAccessFlow(user, flow);
+  }
+  const sharedPlaylist = flowPlaylistConfig.getSharedPlaylist(key);
+  if (sharedPlaylist) {
+    return flowPlaylistConfig.canUserAccessSharedPlaylist(user, sharedPlaylist);
+  }
+  return false;
+};
+
+const filterJobsForUser = (user, jobs) =>
+  (Array.isArray(jobs) ? jobs : []).filter((job) =>
+    canAccessPlaylistType(user, job?.playlistType),
+  );
+
+const sanitizeSoulseekStatus = (user, status) => {
+  if (user?.role === "admin") return status;
+  if (!status || typeof status !== "object") return status;
+  const { credential, ...rest } = status;
+  return rest;
 };
 
 const queueFlowEnableRefresh = (flowId, mutationVersion) => {
@@ -549,7 +588,7 @@ router.post("/start/:flowId", async (req, res) => {
   try {
     const { flowId } = req.params;
     const { limit } = req.body;
-    const flow = flowPlaylistConfig.getFlow(flowId);
+    const flow = getAccessibleFlow(req.user, flowId);
     if (!flow) {
       return res.status(404).json({ error: "Flow not found" });
     }
@@ -569,7 +608,7 @@ router.post("/start/:flowId", async (req, res) => {
           return { cancelled: true };
         }
 
-        const latestFlow = flowPlaylistConfig.getFlow(flowId);
+        const latestFlow = getAccessibleFlow(req.user, flowId);
         if (!latestFlow) {
           return { missing: true };
         }
@@ -653,13 +692,16 @@ router.get("/status", (req, res) => {
     Number.isFinite(parsedLimit) && parsedLimit > 0
       ? Math.min(Math.floor(parsedLimit), 500)
       : null;
-  res.json(
-    getWeeklyFlowStatusSnapshot({
-      includeJobs,
-      flowId,
-      jobsLimit,
-    }),
-  );
+  const snapshot = getWeeklyFlowStatusSnapshot({
+    user: req.user,
+    includeJobs,
+    flowId,
+    jobsLimit,
+  });
+  res.json({
+    ...snapshot,
+    soulseek: sanitizeSoulseekStatus(req.user, snapshot.soulseek),
+  });
 });
 
 router.post("/flows", async (req, res) => {
@@ -689,6 +731,7 @@ router.post("/flows", async (req, res) => {
       relatedArtists,
       scheduleDays,
       scheduleTime,
+      ownerUserId: req.user.id,
     });
     await playlistManager.ensureSmartPlaylists();
     res.json({ success: true, flow });
@@ -709,7 +752,7 @@ router.post("/flows", async (req, res) => {
 router.put("/flows/:flowId", async (req, res) => {
   try {
     const { flowId } = req.params;
-    const existingFlow = flowPlaylistConfig.getFlow(flowId);
+    const existingFlow = getAccessibleFlow(req.user, flowId);
     if (!existingFlow) {
       return res.status(404).json({ error: "Flow not found" });
     }
@@ -764,6 +807,9 @@ router.put("/flows/:flowId", async (req, res) => {
 router.delete("/flows/:flowId", async (req, res) => {
   try {
     const { flowId } = req.params;
+    if (!getAccessibleFlow(req.user, flowId)) {
+      return res.status(404).json({ error: "Flow not found" });
+    }
     const mutationVersion = (flowEnableMutationVersion.get(flowId) || 0) + 1;
     flowEnableMutationVersion.set(flowId, mutationVersion);
     const deleted = await weeklyFlowOperationQueue.enqueue(
@@ -816,7 +862,7 @@ router.put("/flows/:flowId/enabled", async (req, res) => {
       return res.status(400).json({ error: "enabled must be a boolean" });
     }
 
-    const flow = flowPlaylistConfig.getFlow(flowId);
+    const flow = getAccessibleFlow(req.user, flowId);
     if (!flow) {
       return res.status(404).json({ error: "Flow not found" });
     }
@@ -869,7 +915,7 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
   let playlist = null;
   try {
     const { flowId } = req.params;
-    const flow = flowPlaylistConfig.getFlow(flowId);
+    const flow = getAccessibleFlow(req.user, flowId);
     if (!flow) {
       return res.status(404).json({ error: "Flow not found" });
     }
@@ -915,6 +961,7 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       sourceName: flow.name,
       sourceFlowId: flowId,
       tracks,
+      ownerUserId: flow.ownerUserId ?? req.user.id,
     });
 
     const targetRoot = path.resolve(
@@ -1015,6 +1062,7 @@ router.post("/shared-playlists", async (req, res) => {
       sourceName,
       sourceFlowId,
       tracks: normalizedTracks,
+      ownerUserId: req.user.id,
     });
 
     let tracksQueued = 0;
@@ -1082,6 +1130,7 @@ router.post("/shared-playlists/import", async (req, res) => {
       sourceName,
       sourceFlowId,
       tracks: normalizedTracks,
+      ownerUserId: req.user.id,
     });
 
     const jobIds = downloadTracker.addJobs(normalizedTracks, playlist.id);
@@ -1116,7 +1165,7 @@ router.post("/shared-playlists/import", async (req, res) => {
 router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
   try {
     const { playlistId } = req.params;
-    const playlist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+    const playlist = getAccessibleSharedPlaylist(req.user, playlistId);
     if (!playlist) {
       return res.status(404).json({ error: "Shared playlist not found" });
     }
@@ -1222,7 +1271,7 @@ router.put("/shared-playlists/:playlistId", async (req, res) => {
         error: "At least one playlist field is required",
       });
     }
-    const currentPlaylist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+    const currentPlaylist = getAccessibleSharedPlaylist(req.user, playlistId);
     if (!currentPlaylist) {
       return res.status(404).json({ error: "Shared playlist not found" });
     }
@@ -1347,7 +1396,7 @@ router.delete(
   async (req, res) => {
     try {
       const { playlistId, jobId } = req.params;
-      const playlist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+      const playlist = getAccessibleSharedPlaylist(req.user, playlistId);
       if (!playlist) {
         return res.status(404).json({ error: "Shared playlist not found" });
       }
@@ -1422,7 +1471,7 @@ router.post(
   async (req, res) => {
     try {
       const { playlistId, jobId } = req.params;
-      const playlist = flowPlaylistConfig.getSharedPlaylist(playlistId);
+      const playlist = getAccessibleSharedPlaylist(req.user, playlistId);
       if (!playlist) {
         return res.status(404).json({ error: "Shared playlist not found" });
       }
@@ -1478,7 +1527,7 @@ router.post(
 router.delete("/shared-playlists/:playlistId", async (req, res) => {
   try {
     const { playlistId } = req.params;
-    const exists = flowPlaylistConfig.getSharedPlaylist(playlistId);
+    const exists = getAccessibleSharedPlaylist(req.user, playlistId);
     if (!exists) {
       return res.status(404).json({ error: "Shared playlist not found" });
     }
@@ -1512,20 +1561,27 @@ router.delete("/shared-playlists/:playlistId", async (req, res) => {
 
 router.get("/jobs/:flowId", (req, res) => {
   const { flowId } = req.params;
+  if (!canAccessPlaylistType(req.user, flowId)) {
+    return res.status(404).json({ error: "Playlist not found" });
+  }
   const parsedLimit = Number(req.query.limit);
   const limit =
     Number.isFinite(parsedLimit) && parsedLimit > 0
       ? Math.min(Math.floor(parsedLimit), 500)
       : 200;
-  const jobs = downloadTracker.getByPlaylistType(flowId, limit);
+  const jobs = filterJobsForUser(
+    req.user,
+    downloadTracker.getByPlaylistType(flowId, limit),
+  );
   res.json(jobs);
 });
 
 router.get("/jobs", (req, res) => {
   const { status } = req.query;
-  const jobs = status
-    ? downloadTracker.getByStatus(status)
-    : downloadTracker.getAll();
+  const jobs = filterJobsForUser(
+    req.user,
+    status ? downloadTracker.getByStatus(status) : downloadTracker.getAll(),
+  );
   res.json(jobs);
 });
 
@@ -1538,7 +1594,7 @@ router.put("/playlists/:playlistId/retry-cycle", async (req, res) => {
         error: "paused must be a boolean",
       });
     }
-    const shared = flowPlaylistConfig.getSharedPlaylist(playlistId);
+    const shared = getAccessibleSharedPlaylist(req.user, playlistId);
     if (!shared) {
       return res.status(404).json({
         error: "Static playlist not found",
@@ -1563,11 +1619,11 @@ router.put("/playlists/:playlistId/retry-cycle", async (req, res) => {
   }
 });
 
-router.get("/worker/settings", (req, res) => {
+router.get("/worker/settings", requireAdmin, (req, res) => {
   res.json(weeklyFlowWorker.getWorkerSettings());
 });
 
-router.put("/worker/settings", async (req, res) => {
+router.put("/worker/settings", requireAdmin, async (req, res) => {
   const {
     concurrency,
     preferredFormat,
@@ -1626,7 +1682,7 @@ router.put("/worker/settings", async (req, res) => {
   return res.json({ success: true, settings });
 });
 
-router.post("/worker/soulseek/rotate", async (req, res) => {
+router.post("/worker/soulseek/rotate", requireAdmin, async (req, res) => {
   try {
     const result = await soulseekClient.regenerateCredentials({
       reason: "manual_rotate",
@@ -1645,7 +1701,7 @@ router.post("/worker/soulseek/rotate", async (req, res) => {
   }
 });
 
-router.post("/worker/start", async (req, res) => {
+router.post("/worker/start", requireAdmin, async (req, res) => {
   try {
     await weeklyFlowWorker.start();
     res.json({ success: true, message: "Worker started" });
@@ -1657,7 +1713,7 @@ router.post("/worker/start", async (req, res) => {
   }
 });
 
-router.post("/worker/stop", async (req, res) => {
+router.post("/worker/stop", requireAdmin, async (req, res) => {
   try {
     await weeklyFlowWorker.stopAndDrain();
     res.json({ success: true, message: "Worker stopped" });
@@ -1669,17 +1725,17 @@ router.post("/worker/stop", async (req, res) => {
   }
 });
 
-router.delete("/jobs/completed", (req, res) => {
+router.delete("/jobs/completed", requireAdmin, (req, res) => {
   const count = downloadTracker.clearCompleted();
   res.json({ success: true, cleared: count });
 });
 
-router.delete("/jobs/all", (req, res) => {
+router.delete("/jobs/all", requireAdmin, (req, res) => {
   const count = downloadTracker.clearAll();
   res.json({ success: true, cleared: count });
 });
 
-router.post("/reset", async (req, res) => {
+router.post("/reset", requireAdmin, async (req, res) => {
   try {
     const { flowIds } = req.body;
     const types =
@@ -1707,7 +1763,7 @@ router.post("/reset", async (req, res) => {
   }
 });
 
-router.post("/playlist/:playlistType/create", async (req, res) => {
+router.post("/playlist/:playlistType/create", requireAdmin, async (req, res) => {
   try {
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
@@ -1724,7 +1780,7 @@ router.post("/playlist/:playlistType/create", async (req, res) => {
   }
 });
 
-router.get("/test/soulseek", async (req, res) => {
+router.get("/test/soulseek", requireAdmin, async (req, res) => {
   try {
     if (!soulseekClient.isConfigured()) {
       return res.status(400).json({

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -477,9 +477,13 @@ if (
   };
 }
 
-export const getDiscoveryCache = (lastfmUsername = null) => {
-  if (lastfmUsername) {
-    const userDbData = dbOps.getDiscoveryCache(lastfmUsername);
+export const getDiscoveryCache = (listenHistoryProfile = null) => {
+  const cacheNamespace =
+    typeof listenHistoryProfile === "string"
+      ? String(listenHistoryProfile).trim() || null
+      : getListenHistoryCacheNamespace(listenHistoryProfile);
+  if (cacheNamespace) {
+    const userDbData = dbOps.getDiscoveryCache(cacheNamespace);
     const hasUserData =
       userDbData.recommendations?.length > 0 ||
       userDbData.basedOn?.length > 0;

--- a/backend/services/listeningHistory.js
+++ b/backend/services/listeningHistory.js
@@ -22,25 +22,32 @@ export function normalizeListenHistoryUsername(value) {
 }
 
 export function getListenHistoryProfile(source = {}) {
+  const safeSource =
+    source && typeof source === "object" && !Array.isArray(source)
+      ? source
+      : {};
   const explicitUsername =
-    source.listenHistoryUsername ?? source.listen_history_username;
-  const legacyLastfmUsername = source.lastfmUsername ?? source.lastfm_username;
+    safeSource.listenHistoryUsername ?? safeSource.listen_history_username;
+  const legacyLastfmUsername =
+    safeSource.lastfmUsername ?? safeSource.lastfm_username;
   const username = normalizeListenHistoryUsername(
     explicitUsername != null ? explicitUsername : legacyLastfmUsername,
   );
   const hasExplicitProvider =
-    source.listenHistoryProvider !== undefined ||
-    source.listen_history_provider !== undefined;
+    safeSource.listenHistoryProvider !== undefined ||
+    safeSource.listen_history_provider !== undefined;
   const provider = username
     ? hasExplicitProvider
       ? normalizeListenHistoryProvider(
-          source.listenHistoryProvider ?? source.listen_history_provider,
+          safeSource.listenHistoryProvider ??
+            safeSource.listen_history_provider,
         )
       : legacyLastfmUsername != null
         ? "lastfm"
         : DEFAULT_LISTEN_HISTORY_PROVIDER
     : normalizeListenHistoryProvider(
-        source.listenHistoryProvider ?? source.listen_history_provider,
+        safeSource.listenHistoryProvider ??
+          safeSource.listen_history_provider,
       );
 
   return {

--- a/backend/services/websocketService.js
+++ b/backend/services/websocketService.js
@@ -35,6 +35,7 @@ class WebSocketService {
   }
 
   handleConnection(ws, req) {
+    let sessionUser = null;
     if (isAuthRequired()) {
       const requestUrl = new URL(req.url || "", "http://localhost");
       const token = requestUrl.searchParams.get("token");
@@ -43,6 +44,7 @@ class WebSocketService {
         ws.close(4401, "Unauthorized");
         return;
       }
+      sessionUser = session.user;
     }
 
     const clientId = this.generateClientId();
@@ -50,6 +52,7 @@ class WebSocketService {
     const client = {
       id: clientId,
       ws,
+      user: sessionUser,
       subscriptions: new Set(['status']),
       connectedAt: Date.now(),
     };
@@ -147,6 +150,31 @@ class WebSocketService {
       }
     }
 
+    return sent;
+  }
+
+  broadcastPerClient(channel, buildData) {
+    let sent = 0;
+    for (const client of this.clients) {
+      if (!(client.subscriptions.has(channel) || client.subscriptions.has('*'))) {
+        continue;
+      }
+      if (client.ws.readyState !== 1) {
+        continue;
+      }
+      const payload = buildData(client);
+      if (!payload) {
+        continue;
+      }
+      client.ws.send(
+        JSON.stringify({
+          channel,
+          timestamp: Date.now(),
+          ...payload,
+        }),
+      );
+      sent++;
+    }
     return sent;
   }
 

--- a/backend/services/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlowPlaylistConfig.js
@@ -343,6 +343,10 @@ const normalizeFlow = (flow) => {
   return {
     id: flow?.id || randomUUID(),
     name: name || "Flow",
+    ownerUserId:
+      flow?.ownerUserId != null && Number.isFinite(Number(flow.ownerUserId))
+        ? Math.trunc(Number(flow.ownerUserId))
+        : null,
     enabled: flow?.enabled === true,
     scheduleDays: normalizeScheduleDays(flow?.scheduleDays),
     scheduleTime: normalizeScheduleTime(flow?.scheduleTime),
@@ -466,6 +470,11 @@ const normalizeSharedPlaylist = (playlist) => {
   return {
     id: playlist?.id || randomUUID(),
     name: name || "Shared Playlist",
+    ownerUserId:
+      playlist?.ownerUserId != null &&
+      Number.isFinite(Number(playlist.ownerUserId))
+        ? Math.trunc(Number(playlist.ownerUserId))
+        : null,
     sourceName: String(playlist?.sourceName || "").trim() || null,
     sourceFlowId: String(playlist?.sourceFlowId || "").trim() || null,
     importedAt:
@@ -631,6 +640,12 @@ const assertUniqueFlowName = (flows, nextName, exceptFlowId = null) => {
   }
 };
 
+const canUserAccessOwnerScopedEntity = (user, ownerUserId) => {
+  if (user?.role === "admin") return true;
+  if (!user || ownerUserId == null) return false;
+  return Number(user.id) === Number(ownerUserId);
+};
+
 const assertUniqueSharedPlaylistName = (
   playlists,
   nextName,
@@ -649,12 +664,29 @@ const assertUniqueSharedPlaylistName = (
 };
 
 export const flowPlaylistConfig = {
+  canUserAccessFlow(user, flow) {
+    return canUserAccessOwnerScopedEntity(user, flow?.ownerUserId ?? null);
+  },
+
+  canUserAccessSharedPlaylist(user, playlist) {
+    return canUserAccessOwnerScopedEntity(user, playlist?.ownerUserId ?? null);
+  },
+
   getFlows() {
     return getStoredFlows();
   },
 
+  getFlowsForUser(user) {
+    return getStoredFlows().filter((flow) => this.canUserAccessFlow(user, flow));
+  },
+
   getFlow(flowId) {
     return getStoredFlows().find((flow) => flow.id === flowId) || null;
+  },
+
+  getFlowForUser(user, flowId) {
+    const flow = this.getFlow(flowId);
+    return this.canUserAccessFlow(user, flow) ? flow : null;
   },
 
   isEnabled(flowId) {
@@ -672,6 +704,7 @@ export const flowPlaylistConfig = {
     relatedArtists,
     scheduleDays,
     scheduleTime,
+    ownerUserId = null,
   }) {
     const flows = getStoredFlows();
     assertUniqueFlowName(flows, name);
@@ -686,6 +719,7 @@ export const flowPlaylistConfig = {
       relatedArtists,
       scheduleDays,
       scheduleTime,
+      ownerUserId,
       enabled: false,
       nextRunAt: null,
     });
@@ -810,10 +844,17 @@ export const flowPlaylistConfig = {
     return getStoredSharedPlaylists();
   },
 
+  getSharedPlaylistsForUser(user) {
+    return getStoredSharedPlaylists().filter((playlist) =>
+      this.canUserAccessSharedPlaylist(user, playlist),
+    );
+  },
+
   getSharedPlaylistSummaries() {
     return getStoredSharedPlaylists().map((playlist) => ({
       id: playlist.id,
       name: playlist.name,
+      ownerUserId: playlist.ownerUserId,
       sourceName: playlist.sourceName,
       sourceFlowId: playlist.sourceFlowId,
       importedAt: playlist.importedAt,
@@ -830,12 +871,24 @@ export const flowPlaylistConfig = {
     );
   },
 
-  createSharedPlaylist({ name, sourceName, sourceFlowId, tracks = [] }) {
+  getSharedPlaylistForUser(user, playlistId) {
+    const playlist = this.getSharedPlaylist(playlistId);
+    return this.canUserAccessSharedPlaylist(user, playlist) ? playlist : null;
+  },
+
+  createSharedPlaylist({
+    name,
+    sourceName,
+    sourceFlowId,
+    tracks = [],
+    ownerUserId = null,
+  }) {
     const playlists = getStoredSharedPlaylists();
     assertUniqueSharedPlaylistName(playlists, name);
     const playlist = normalizeSharedPlaylist({
       id: randomUUID(),
       name,
+      ownerUserId,
       sourceName,
       sourceFlowId,
       tracks,

--- a/backend/services/weeklyFlowPlaylistSource.js
+++ b/backend/services/weeklyFlowPlaylistSource.js
@@ -305,16 +305,16 @@ export class WeeklyFlowPlaylistSource {
     };
   }
 
-  _getRecommendedArtists() {
-    const discoveryCache = getDiscoveryCache();
+  _getRecommendedArtists(listenHistoryProfile = null) {
+    const discoveryCache = getDiscoveryCache(listenHistoryProfile);
     return Array.isArray(discoveryCache.recommendations)
       ? discoveryCache.recommendations
       : [];
   }
 
-  _getRecommendedArtistSet() {
+  _getRecommendedArtistSet(listenHistoryProfile = null) {
     const set = new Set();
-    for (const artist of this._getRecommendedArtists()) {
+    for (const artist of this._getRecommendedArtists(listenHistoryProfile)) {
       if (artist?.id) {
         set.add(this._artistKey(artist.id));
       }
@@ -328,9 +328,9 @@ export class WeeklyFlowPlaylistSource {
     return set;
   }
 
-  _getRecommendedArtistMap() {
+  _getRecommendedArtistMap(listenHistoryProfile = null) {
     const map = new Map();
-    for (const artist of this._getRecommendedArtists()) {
+    for (const artist of this._getRecommendedArtists(listenHistoryProfile)) {
       if (!artist) continue;
       const keys = this._artistKeysFromArtist(artist);
       for (const key of keys) {
@@ -342,11 +342,11 @@ export class WeeklyFlowPlaylistSource {
     return map;
   }
 
-  _getRecommendedArtistsByTags(tags, match) {
+  _getRecommendedArtistsByTags(tags, match, listenHistoryProfile = null) {
     const wanted = tags.map((tag) => String(tag).trim().toLowerCase()).filter(Boolean);
     if (wanted.length === 0) return [];
     const requiredAll = match === "all";
-    return this._getRecommendedArtists().filter((artist) => {
+    return this._getRecommendedArtists(listenHistoryProfile).filter((artist) => {
       const artistTags = Array.isArray(artist.tags)
         ? artist.tags.map((t) => String(t).toLowerCase())
         : [];
@@ -1454,6 +1454,7 @@ export class WeeklyFlowPlaylistSource {
     }
     const harvestLimitFor = (count) =>
       Math.min(150, Math.max(Number(count || 0) * 6, 24));
+    const listenHistoryProfile = options?.listenHistoryProfile || null;
     const [discoverTracks, mixTracks, trendingTracks, focusCandidates] = await Promise.all([
       combinedTargets.discover > 0
         ? this.getDiscoverTracks(harvestLimitFor(combinedTargets.discover), {
@@ -1461,6 +1462,7 @@ export class WeeklyFlowPlaylistSource {
             reason: "From discovery recommendations",
             blocklist,
             excludeArtistKeys: nonLibraryExcludeArtistKeys,
+            listenHistoryProfile,
           }).catch(() => [])
         : [],
       combinedTargets.mix > 0
@@ -1476,6 +1478,7 @@ export class WeeklyFlowPlaylistSource {
             reason: "From trending artists",
             blocklist,
             excludeArtistKeys: nonLibraryExcludeArtistKeys,
+            listenHistoryProfile,
           }).catch(() => [])
         : [],
       combinedTargets.focus > 0
@@ -1601,7 +1604,7 @@ export class WeeklyFlowPlaylistSource {
       throw new Error("Last.fm API key not configured");
     }
 
-    const discoveryCache = getDiscoveryCache();
+    const discoveryCache = getDiscoveryCache(options?.listenHistoryProfile);
     const recommendations = this._filterArtistsByBlocklist(
       discoveryCache.recommendations || [],
       options?.blocklist,
@@ -1671,7 +1674,7 @@ export class WeeklyFlowPlaylistSource {
     if (!getLastfmApiKey()) {
       throw new Error("Last.fm API key not configured");
     }
-    const discoveryCache = getDiscoveryCache();
+    const discoveryCache = getDiscoveryCache(options?.listenHistoryProfile);
     const globalTop = this._filterArtistsByBlocklist(
       discoveryCache.globalTop || [],
       options?.blocklist,
@@ -1858,7 +1861,7 @@ export class WeeklyFlowPlaylistSource {
   }
 
   async getRecommendedTracks(limit, options = {}) {
-    const discoveryCache = getDiscoveryCache();
+    const discoveryCache = getDiscoveryCache(options?.listenHistoryProfile);
     const recommendations = this._filterArtistsByBlocklist(
       discoveryCache.recommendations || [],
       options?.blocklist,

--- a/backend/services/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlowStatusSnapshot.js
@@ -3,6 +3,7 @@ import { weeklyFlowWorker } from "./weeklyFlowWorker.js";
 import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 import { weeklyFlowOperationQueue } from "./weeklyFlowOperationQueue.js";
 import { soulseekClient } from "./simpleSoulseekClient.js";
+import { userOps } from "../config/db-helpers.js";
 
 function formatNextRunMessage(flows) {
   const nextRunAt = (Array.isArray(flows) ? flows : [])
@@ -52,23 +53,68 @@ function aggregateStats(statsByType, ids) {
   return base;
 }
 
+function buildOwnerMap(flows, sharedPlaylists) {
+  const ownerIds = new Set();
+  for (const item of [...(Array.isArray(flows) ? flows : []), ...(Array.isArray(sharedPlaylists) ? sharedPlaylists : [])]) {
+    const ownerUserId = Number(item?.ownerUserId);
+    if (Number.isFinite(ownerUserId)) {
+      ownerIds.add(ownerUserId);
+    }
+  }
+  const ownerMap = new Map();
+  for (const ownerUserId of ownerIds) {
+    const owner = userOps.getUserById(ownerUserId);
+    if (owner?.username) {
+      ownerMap.set(ownerUserId, owner.username);
+    }
+  }
+  return ownerMap;
+}
+
 export function getWeeklyFlowStatusSnapshot({
   includeJobs = false,
   flowId = null,
   jobsLimit = null,
+  user = null,
 } = {}) {
   const workerStatus = weeklyFlowWorker.getStatus();
-  const flows = flowPlaylistConfig.getFlows();
-  const sharedPlaylists = flowPlaylistConfig.getSharedPlaylistSummaries();
-  const flowIds = flows.map((flow) => flow.id);
-  const sharedPlaylistIds = sharedPlaylists.map((playlist) => playlist.id);
+  const flows = user
+    ? flowPlaylistConfig.getFlowsForUser(user)
+    : flowPlaylistConfig.getFlows();
+  const sharedPlaylists = (
+    user
+      ? flowPlaylistConfig.getSharedPlaylistsForUser(user)
+      : flowPlaylistConfig.getSharedPlaylists()
+  ).map((playlist) => ({
+    id: playlist.id,
+    name: playlist.name,
+    ownerUserId: playlist.ownerUserId ?? null,
+    sourceName: playlist.sourceName,
+    sourceFlowId: playlist.sourceFlowId,
+    importedAt: playlist.importedAt,
+    createdAt: playlist.createdAt,
+    trackCount: playlist.trackCount,
+  }));
+  const ownerMap = buildOwnerMap(flows, sharedPlaylists);
+  const flowsWithOwners = flows.map((flow) => ({
+    ...flow,
+    ownerUsername:
+      ownerMap.get(Number(flow?.ownerUserId)) || null,
+  }));
+  const sharedPlaylistsWithOwners = sharedPlaylists.map((playlist) => ({
+    ...playlist,
+    ownerUsername:
+      ownerMap.get(Number(playlist?.ownerUserId)) || null,
+  }));
+  const flowIds = flowsWithOwners.map((flow) => flow.id);
+  const sharedPlaylistIds = sharedPlaylistsWithOwners.map((playlist) => playlist.id);
   const scopedStats = downloadTracker.getStatsByPlaylistType([
     ...flowIds,
     ...sharedPlaylistIds,
   ]);
   const stats = aggregateStats(scopedStats, flowIds);
   const sharedStats = aggregateStats(scopedStats, sharedPlaylistIds);
-  const nextRunMessage = formatNextRunMessage(flows);
+  const nextRunMessage = formatNextRunMessage(flowsWithOwners);
   const operationQueue = weeklyFlowOperationQueue.getStatus();
   const queueLabel = String(operationQueue?.currentLabel || "");
   let phase = "idle";
@@ -124,9 +170,14 @@ export function getWeeklyFlowStatusSnapshot({
   ]);
   let jobs;
   if (includeJobs) {
+    const allowedPlaylistTypes = new Set([...flowIds, ...sharedPlaylistIds]);
     const sourceJobs = flowId
-      ? downloadTracker.getByPlaylistType(flowId)
-      : downloadTracker.getAll();
+      ? allowedPlaylistTypes.has(flowId)
+        ? downloadTracker.getByPlaylistType(flowId)
+        : []
+      : downloadTracker
+          .getAll()
+          .filter((job) => allowedPlaylistTypes.has(String(job?.playlistType || "")));
     jobs = jobsLimit ? sourceJobs.slice(0, jobsLimit) : sourceJobs;
   }
   return {
@@ -140,8 +191,8 @@ export function getWeeklyFlowStatusSnapshot({
     sharedStats,
     sharedPlaylistStats,
     jobs,
-    flows,
-    sharedPlaylists,
+    flows: flowsWithOwners,
+    sharedPlaylists: sharedPlaylistsWithOwners,
     retryCyclePausedByPlaylist,
     retryCycleScheduledByPlaylist,
     operationQueue,

--- a/backend/services/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlowWorker.js
@@ -5,8 +5,9 @@ import { soulseekClient } from "./simpleSoulseekClient.js";
 import { playlistManager } from "./weeklyFlowPlaylistManager.js";
 import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 import { playlistSource } from "./weeklyFlowPlaylistSource.js";
-import { dbOps } from "../config/db-helpers.js";
+import { dbOps, userOps } from "../config/db-helpers.js";
 import { resolveWeeklyFlowTrackContext } from "./weeklyFlowTrackResolver.js";
+import { getListenHistoryProfile } from "./listeningHistory.js";
 import {
   buildFlowSearchQueries,
   rankFlowSearchResults,
@@ -645,6 +646,13 @@ export class WeeklyFlowWorker {
     };
   }
 
+  _getFlowListenHistoryProfile(flow) {
+    const ownerUserId = Number(flow?.ownerUserId);
+    if (!Number.isFinite(ownerUserId)) return null;
+    const owner = userOps.getUserById(ownerUserId);
+    return owner ? getListenHistoryProfile(owner) : null;
+  }
+
   async seedFlowRun(playlistType, flow, options = {}) {
     const key = String(playlistType || "").trim();
     if (!key || !flow) {
@@ -656,6 +664,9 @@ export class WeeklyFlowWorker {
         : null;
     const plan = await playlistSource.buildFlowRunPlan(
       sizeOverride ? { ...flow, size: sizeOverride } : flow,
+      {
+        listenHistoryProfile: this._getFlowListenHistoryProfile(flow),
+      },
     );
     this.clearPlaylistRunState(key);
     this.setPlaylistRunPlan(key, plan);
@@ -926,6 +937,7 @@ export class WeeklyFlowWorker {
           reserveSize: Math.max(Math.ceil(target * 0.25), 4),
           excludeArtistKeys: existingArtistKeys,
           excludeTrackKeys: existingKeys,
+          listenHistoryProfile: this._getFlowListenHistoryProfile(flow),
         },
       )
       .catch(() => null)

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -26,6 +26,7 @@ import {
   CreatePlaylistModal,
   PlaylistTrackModal,
 } from "../components/PlaylistModals";
+import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
 import {
@@ -636,6 +637,7 @@ function FlowPage() {
   const [playlistTrackError, setPlaylistTrackError] = useState("");
   const lastFlowWsMessageAtRef = useRef(0);
   const importInputRef = useRef(null);
+  const { user } = useAuth();
   const { showSuccess, showError } = useToast();
 
   const fetchStatus = useCallback(async () => {
@@ -1212,6 +1214,7 @@ function FlowPage() {
   };
 
   const handleOpenWorkerSettings = () => {
+    if (user?.role !== "admin") return;
     const current = getCurrentWorkerSettings();
     setWorkerSettingsBaseline(current);
     setWorkerSettingsDraft(current);
@@ -1760,14 +1763,16 @@ function FlowPage() {
           <h2 className="text-base font-semibold text-white">Playlists / Flows</h2>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <button
-            type="button"
-            onClick={handleOpenWorkerSettings}
-            className="btn btn-secondary btn-sm p-2 opacity-80 hover:opacity-100"
-            aria-label="Open flow worker settings"
-          >
-            <Settings className="w-4 h-4" />
-          </button>
+          {user?.role === "admin" && (
+            <button
+              type="button"
+              onClick={handleOpenWorkerSettings}
+              className="btn btn-secondary btn-sm p-2 opacity-80 hover:opacity-100"
+              aria-label="Open flow worker settings"
+            >
+              <Settings className="w-4 h-4" />
+            </button>
+          )}
           <button
             type="button"
             onClick={handleOpenImportPicker}
@@ -1817,6 +1822,7 @@ function FlowPage() {
               <SharedPlaylistCard
                 key={playlist.id}
                 playlist={playlist}
+                isAdminView={user?.role === "admin"}
                 stats={getPlaylistStats(playlist.id)}
                 currentJob={status?.worker?.currentJob}
                 isEditing={editingId === playlist.id}
@@ -1908,6 +1914,7 @@ function FlowPage() {
             <FlowCard
               key={flow.id}
               flow={flow}
+              isAdminView={user?.role === "admin"}
               enabled={enabled}
               state={state}
               stats={displayStats}
@@ -1982,21 +1989,23 @@ function FlowPage() {
         onCancel={() => setConfirmDisable(null)}
         onConfirm={handleConfirmDisable}
       />
-      <FlowWorkerSettingsModal
-        isOpen={isWorkerSettingsOpen}
-        settings={workerSettingsDraft}
-        soulseekCredential={status?.soulseek?.credential || null}
-        hasChanges={hasWorkerSettingsChanges}
-        saving={savingWorkerSettings}
-        rotatingSoulseekCredential={rotatingSoulseekCredential}
-        onCancel={() => {
-          if (savingWorkerSettings || rotatingSoulseekCredential) return;
-          setIsWorkerSettingsOpen(false);
-        }}
-        onChange={setWorkerSettingsDraft}
-        onRotateSoulseekCredential={handleRotateSoulseekCredential}
-        onSave={handleSaveWorkerSettings}
-      />
+      {user?.role === "admin" && (
+        <FlowWorkerSettingsModal
+          isOpen={isWorkerSettingsOpen}
+          settings={workerSettingsDraft}
+          soulseekCredential={status?.soulseek?.credential || null}
+          hasChanges={hasWorkerSettingsChanges}
+          saving={savingWorkerSettings}
+          rotatingSoulseekCredential={rotatingSoulseekCredential}
+          onCancel={() => {
+            if (savingWorkerSettings || rotatingSoulseekCredential) return;
+            setIsWorkerSettingsOpen(false);
+          }}
+          onChange={setWorkerSettingsDraft}
+          onRotateSoulseekCredential={handleRotateSoulseekCredential}
+          onSave={handleSaveWorkerSettings}
+        />
+      )}
       <FlowImportReviewModal
         importReview={importReview}
         importing={importing}

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -1413,6 +1413,7 @@ const shouldHandleMobileCardTap = (event) => {
 
 export function FlowCard({
   flow,
+  isAdminView = false,
   artworkUrl,
   enabled,
   state,
@@ -1543,6 +1544,9 @@ export function FlowCard({
   }
   const typeLabel = enabled ? "Flow" : "Flow Draft";
   const statusSummary = enabled ? "" : "Flow ready when enabled";
+  const ownerLabel = isAdminView && flow?.ownerUsername
+    ? `Owner: ${flow.ownerUsername}`
+    : null;
 
   const handleMobileTrackToggle = (event) => {
     if (!shouldHandleMobileCardTap(event)) return;
@@ -1569,6 +1573,11 @@ export function FlowCard({
                   <span className="rounded-full bg-white/5 px-2 py-0.5 text-[11px] text-[#c6c6cb]">
                     {flow.size} tracks
                   </span>
+                  {ownerLabel ? (
+                    <span className="rounded-full border border-[#90a07d]/25 bg-[#90a07d]/10 px-2 py-0.5 text-[11px] text-[#d8e5cc]">
+                      {ownerLabel}
+                    </span>
+                  ) : null}
                   {state === "running" && (
                     <span className="badge badge-success badge-sm gap-1.5 pl-1.5 pr-2">
                       <Loader2 className="w-3 h-3 animate-spin" />
@@ -2363,6 +2372,7 @@ export function FlowEmptyState({ onCreate, creating }) {
 
 export function SharedPlaylistCard({
   playlist,
+  isAdminView = false,
   stats,
   currentJob,
   artworkUrl,
@@ -2411,6 +2421,9 @@ export function SharedPlaylistCard({
     currentJob?.playlistType === playlist.id &&
     currentJob?.artistName &&
     currentJob?.trackName;
+  const ownerLabel = isAdminView && playlist?.ownerUsername
+    ? `Owner: ${playlist.ownerUsername}`
+    : null;
 
   const handleMobileTrackToggle = (event) => {
     if (!shouldHandleMobileCardTap(event)) return;
@@ -2434,6 +2447,11 @@ export function SharedPlaylistCard({
                 <span className="rounded-full bg-white/5 px-2 py-0.5 text-[11px] text-[#c6c6cb]">
                   {playlist.trackCount} tracks
                 </span>
+                {ownerLabel ? (
+                  <span className="rounded-full border border-[#90a07d]/25 bg-[#90a07d]/10 px-2 py-0.5 text-[11px] text-[#d8e5cc]">
+                    {ownerLabel}
+                  </span>
+                ) : null}
               </div>
               <div className="flex shrink-0 items-center justify-end gap-1 self-end min-[420px]:self-start">
                 <button

--- a/frontend/src/pages/Settings/constants.js
+++ b/frontend/src/pages/Settings/constants.js
@@ -12,6 +12,7 @@ export const allReleaseTypes = [
 ];
 
 export const GRANULAR_PERMISSIONS = {
+  accessFlow: false,
   addArtist: true,
   addAlbum: true,
   changeMonitoring: false,
@@ -20,6 +21,7 @@ export const GRANULAR_PERMISSIONS = {
 };
 
 export const granularPerms = [
+  { key: "accessFlow", label: "Access flows and playlists" },
   { key: "addArtist", label: "Add artist" },
   { key: "addAlbum", label: "Add album" },
   { key: "changeMonitoring", label: "Change artist monitoring" },

--- a/server.js
+++ b/server.js
@@ -297,19 +297,30 @@ const broadcastDownloadStatuses = async () => {
 };
 
 const WEEKLY_FLOW_STATUS_INTERVAL_MS = 4000;
-let lastWeeklyFlowStatusPayload = null;
+const lastWeeklyFlowStatusPayloadByUser = new Map();
 const broadcastWeeklyFlowStatus = async () => {
   try {
     if (!hasWsSubscribers("weekly-flow")) return;
-    const status = getWeeklyFlowStatusSnapshot();
-    const payload = JSON.stringify(status);
-    if (payload !== lastWeeklyFlowStatusPayload) {
-      lastWeeklyFlowStatusPayload = payload;
-      websocketService.broadcast("weekly-flow", {
+    websocketService.broadcastPerClient("weekly-flow", (client) => {
+      const status = getWeeklyFlowStatusSnapshot({
+        user: client?.user || null,
+      });
+      const cacheKey =
+        client?.user?.role === "admin"
+          ? "admin"
+          : client?.user?.id != null
+            ? `user:${client.user.id}`
+            : `anon:${client?.id || "unknown"}`;
+      const payload = JSON.stringify(status);
+      if (lastWeeklyFlowStatusPayloadByUser.get(cacheKey) === payload) {
+        return null;
+      }
+      lastWeeklyFlowStatusPayloadByUser.set(cacheKey, payload);
+      return {
         type: "weekly_flow_status",
         status,
-      });
-    }
+      };
+    });
   } catch (error) {
     console.warn("Failed to broadcast weekly flow status:", error.message);
   }


### PR DESCRIPTION
## Summary
- Scoped flow and shared playlist access to the owning user, with admins retaining full access.
- Added owner tracking to flow/shared-playlist records and surfaced owner usernames in status snapshots and UI cards for admin views.
- Restricted weekly flow routes, job listings, stream/artwork endpoints, worker controls, and destructive actions to accessible resources or admin-only paths.
- Isolated discovery and playlist generation inputs by listen-history profile so per-user flows use the correct recommendation cache.
- Hid worker settings controls from non-admin users in the Flow page.

## Testing
- Not run (not requested).
- Review access checks for `/weekly-flow/*`, `/jobs/*`, `/shared-playlists/*`, and worker admin endpoints.
- Verify admin users can still see and manage all flows, playlists, and worker settings.
- Verify non-admin users only see their own flows/playlists and do not receive Soulseek credentials in status responses.