### PR TITLE
Preserve empty discovery refresh state

### DIFF
--- a/.tests/discovery/discovery-cache-hydration.test.js
+++ b/.tests/discovery/discovery-cache-hydration.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "path";
+import { pathToFileURL } from "url";
+
+import {
+  createIsolatedStateDir,
+  applyIsolatedBackendEnv,
+  cleanupIsolatedState,
+  importFromRepo,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const isolatedState = await createIsolatedStateDir("discovery-cache-hydration");
+applyIsolatedBackendEnv(isolatedState);
+
+const [{ db }, { dbOps }] = await Promise.all([
+  importFromRepo("backend/config/db-sqlite.js"),
+  importFromRepo("backend/config/db-helpers.js"),
+]);
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("getDiscoveryCache preserves lastUpdated after an empty completed refresh", async () => {
+  resetDatabase(db);
+
+  dbOps.updateDiscoveryCache({
+    recommendations: [],
+    globalTop: [],
+    basedOn: [],
+    topTags: [],
+    topGenres: [],
+  });
+
+  const moduleUrl = pathToFileURL(
+    path.join(process.cwd(), "backend/services/discoveryService.js"),
+  ).href;
+  const { getDiscoveryCache } = await import(`${moduleUrl}?t=${Date.now()}`);
+  const cache = getDiscoveryCache();
+
+  assert.ok(cache.lastUpdated);
+  assert.deepEqual(cache.recommendations, []);
+  assert.deepEqual(cache.globalTop, []);
+  assert.deepEqual(cache.topGenres, []);
+  assert.equal(cache.isUpdating, false);
+});

--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -318,10 +318,11 @@ router.get("/", requireAuth, async (req, res) => {
     discoveryCache.recommendations?.length > 0 ||
     discoveryCache.globalTop?.length > 0 ||
     discoveryCache.topGenres?.length > 0;
+  const hasCompletedRefresh = !!discoveryCache.lastUpdated;
 
   let isUpdating = discoveryCache.isUpdating || false;
 
-  if (!hasData && !isUpdating) {
+  if (!hasData && !hasCompletedRefresh && !isUpdating) {
     lastDiscoveryRevalidateAt = Date.now();
     updateDiscoveryCache().catch((err) => {
       console.error("[Discover] Lazy discovery refresh failed:", err.message);

--- a/backend/services/discoveryService.js
+++ b/backend/services/discoveryService.js
@@ -462,6 +462,7 @@ let discoveryCache = { ...EMPTY_CACHE };
 
 const dbData = dbOps.getDiscoveryCache();
 if (
+  dbData.lastUpdated ||
   dbData.recommendations?.length > 0 ||
   dbData.globalTop?.length > 0 ||
   dbData.topGenres?.length > 0
@@ -502,6 +503,7 @@ export const getDiscoveryCache = (listenHistoryProfile = null) => {
 
   const dbData = dbOps.getDiscoveryCache();
   if (
+    (dbData.lastUpdated && !discoveryCache.lastUpdated) ||
     (dbData.recommendations?.length > 0 &&
       (!discoveryCache.recommendations ||
         discoveryCache.recommendations.length === 0)) ||


### PR DESCRIPTION
## Summary
- Preserve a completed discovery refresh in cache even when the refresh returns no recommendations.
- Treat `lastUpdated` as evidence of a completed refresh so the route does not keep triggering lazy refreshes for an intentionally empty cache.
- Add coverage for the empty-refresh hydration path in `getDiscoveryCache`.

## Testing
- Not run
- Added unit coverage in `.tests/discovery/discovery-cache-hydration.test.js` for an empty completed refresh retaining `lastUpdated`
- Verified route hydration logic now distinguishes between an empty cache and a completed empty refresh