### PR TITLE
Add trusted local-network auto-login for sole admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,22 @@ Navidrome should be configured to purge missing tracks so flow rotations do not 
 
 Aurral uses local user accounts created during onboarding. Authentication is HTTP Basic Auth at the API layer, so use HTTPS if you expose it publicly.
 
+### Local-network auto-login
+
+Aurral also supports an optional trusted local-network auto-login mode from `Settings -> Users`.
+
+- It is only available when exactly one stored user exists and that user is an `admin`.
+- When enabled, requests from the server's inferred trusted IPv4 local subnet are automatically resolved as that sole admin user.
+- If you add another user, Aurral disables local-network auto-login immediately.
+- If the installation later returns to a single admin user, the setting stays off until you re-enable it manually.
+- Anyone on that trusted subnet is treated as the admin while the feature is active.
+
+Notes:
+
+- V1 trusts only the server's inferred IPv4 local subnet plus loopback access.
+- If Aurral cannot infer a single trusted subnet, the feature remains unavailable.
+- Behind Docker or a reverse proxy, correct client IP forwarding is required for this to behave as expected.
+
 ### Reset forgotten admin password
 
 Set a specific password:

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -217,6 +217,11 @@ export const defaultData = {
         notifyWeeklyFlowDone: false,
       },
     },
+    security: {
+      localNetworkBypass: {
+        enabled: false,
+      },
+    },
     queueCleaner: {
       enabled: true,
       blocklist: true,

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -343,6 +343,9 @@ export const dbOps = {
     const queueCleaner = dbHelpers.parseJSON(
       getSettingStmt.get("queueCleaner")?.value
     );
+    const security = dbHelpers.parseJSON(
+      getSettingStmt.get("security")?.value
+    );
     const rootFolderPath = getSettingStmt.get("rootFolderPath")?.value;
     const releaseTypes = dbHelpers.parseJSON(
       getSettingStmt.get("releaseTypes")?.value
@@ -413,6 +416,10 @@ export const dbOps = {
       integrations: decryptIntegrations(integrations, encKey) || {},
       quality: quality || "standard",
       queueCleaner: queueCleaner || {},
+      security:
+        security && typeof security === "object"
+          ? security
+          : { localNetworkBypass: { enabled: false } },
       rootFolderPath: rootFolderPath || null,
       releaseTypes: releaseTypes || [],
       weeklyFlowPlaylists: merged,
@@ -455,6 +462,12 @@ export const dbOps = {
         upsertSettingStmt.run(
           "queueCleaner",
           dbHelpers.stringifyJSON(settings.queueCleaner)
+        );
+      }
+      if (settings.security !== undefined) {
+        upsertSettingStmt.run(
+          "security",
+          dbHelpers.stringifyJSON(settings.security)
         );
       }
       if (

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,12 +1,28 @@
 import basicAuth from "express-basic-auth";
 import bcrypt from "bcrypt";
 import crypto from "crypto";
+import os from "os";
 import { dbOps, userOps } from "../config/db-helpers.js";
 import { getSessionByToken } from "../config/session-helpers.js";
 
 const DEFAULT_PROXY_HEADER = "x-forwarded-user";
 const STREAM_TOKEN_TTL_MS = 2 * 60 * 1000;
 const streamTokenStore = new Map();
+const LOOPBACK_IPS = new Set(["127.0.0.1", "::1"]);
+
+const normalizeLocalNetworkBypassSettings = (settings = dbOps.getSettings()) => ({
+  enabled: settings?.security?.localNetworkBypass?.enabled === true,
+});
+
+const withLocalNetworkBypassDefaults = (settings = dbOps.getSettings()) => ({
+  ...settings,
+  security: {
+    ...(settings?.security || {}),
+    localNetworkBypass: {
+      enabled: settings?.security?.localNetworkBypass?.enabled === true,
+    },
+  },
+});
 
 export const getAuthUser = () => {
   const settings = dbOps.getSettings();
@@ -60,6 +76,109 @@ function normalizeIp(value) {
     : withoutBrackets;
 }
 
+function isLoopbackIp(ip) {
+  return LOOPBACK_IPS.has(normalizeIp(ip));
+}
+
+function isPrivateIpv4(ip) {
+  const parts = String(ip || "")
+    .trim()
+    .split(".")
+    .map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+function ipv4ToInt(ip) {
+  const parts = String(ip || "")
+    .trim()
+    .split(".")
+    .map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return null;
+  }
+  return (
+    ((parts[0] << 24) >>> 0) +
+    ((parts[1] << 16) >>> 0) +
+    ((parts[2] << 8) >>> 0) +
+    (parts[3] >>> 0)
+  ) >>> 0;
+}
+
+function parseNetmaskPrefix(netmask) {
+  const maskInt = ipv4ToInt(netmask);
+  if (maskInt == null) return null;
+  let prefix = 0;
+  let sawZero = false;
+  for (let bit = 31; bit >= 0; bit -= 1) {
+    const set = (maskInt & (1 << bit)) !== 0;
+    if (set && sawZero) return null;
+    if (set) {
+      prefix += 1;
+    } else {
+      sawZero = true;
+    }
+  }
+  return prefix;
+}
+
+function buildIpv4Subnet(address, netmask, interfaceName) {
+  const ipInt = ipv4ToInt(address);
+  const maskInt = ipv4ToInt(netmask);
+  const prefix = parseNetmaskPrefix(netmask);
+  if (ipInt == null || maskInt == null || prefix == null) return null;
+  const networkInt = (ipInt & maskInt) >>> 0;
+  return {
+    interfaceName,
+    address,
+    netmask,
+    prefix,
+    networkInt,
+    key: `${networkInt}/${prefix}`,
+  };
+}
+
+function getIpv4SubnetCandidates() {
+  const interfaces = os.networkInterfaces();
+  const candidates = [];
+  for (const [name, details] of Object.entries(interfaces)) {
+    for (const detail of details || []) {
+      if (!detail || detail.internal) continue;
+      if (detail.family !== "IPv4") continue;
+      const normalizedAddress = normalizeIp(detail.address);
+      if (!isPrivateIpv4(normalizedAddress)) continue;
+      const subnet = buildIpv4Subnet(
+        normalizedAddress,
+        detail.netmask,
+        name,
+      );
+      if (subnet) {
+        candidates.push(subnet);
+      }
+    }
+  }
+  candidates.sort((a, b) =>
+    `${a.interfaceName}:${a.address}`.localeCompare(
+      `${b.interfaceName}:${b.address}`,
+    ),
+  );
+  return candidates;
+}
+
+export function inferTrustedLocalSubnet() {
+  const candidates = getIpv4SubnetCandidates();
+  if (candidates.length === 0) return null;
+  const unique = new Map(candidates.map((candidate) => [candidate.key, candidate]));
+  if (unique.size !== 1) return null;
+  return Array.from(unique.values())[0];
+}
+
 function getRequestIps(req) {
   const ips = [
     req?.socket?.remoteAddress,
@@ -97,6 +216,16 @@ function buildPermissions(role, permissions) {
     ...userOps.getDefaultPermissions(),
     ...(permissions || {}),
     accessSettings: false,
+  };
+}
+
+function toResolvedUser(user) {
+  if (!user) return null;
+  return {
+    id: user.id,
+    username: user.username,
+    role: user.role,
+    permissions: buildPermissions(user.role, user.permissions),
   };
 }
 
@@ -146,7 +275,7 @@ export function sendUnauthorizedResponse(
   });
 }
 
-const resolveSessionUserFromToken = (token) => {
+export const resolveSessionUserFromToken = (token) => {
   if (!token) return null;
   return toSessionUser(getSessionByToken(token));
 };
@@ -160,6 +289,103 @@ export const isAuthRequiredByConfig = () => {
   return isProxyAuthEnabled() || users.length > 0 || legacyPasswords.length > 0;
 };
 
+export const getLocalNetworkBypassConfig = (settings = dbOps.getSettings()) =>
+  normalizeLocalNetworkBypassSettings(settings);
+
+export function getSoleAdminUser() {
+  const users = userOps.getAllUsers();
+  if (users.length !== 1) return null;
+  const [user] = users;
+  if (user?.role !== "admin") return null;
+  return user;
+}
+
+export function isRequestFromTrustedLocalSubnet(req) {
+  const requestIps = getRequestIps(req);
+  if (requestIps.some((ip) => isLoopbackIp(ip))) {
+    return true;
+  }
+  const subnet = inferTrustedLocalSubnet();
+  if (!subnet) return false;
+  return requestIps.some((ip) => {
+    if (!isPrivateIpv4(ip)) return false;
+    const ipInt = ipv4ToInt(ip);
+    if (ipInt == null) return false;
+    return (ipInt & ipv4ToInt(subnet.netmask)) >>> 0 === subnet.networkInt;
+  });
+}
+
+export function getLocalNetworkBypassStatus(req) {
+  const settings = dbOps.getSettings();
+  const config = getLocalNetworkBypassConfig(settings);
+  const onboardingDone = settings?.onboardingComplete === true;
+  const users = userOps.getAllUsers();
+  const soleUser = users.length === 1 ? users[0] : null;
+  const soleAdminUser = getSoleAdminUser();
+  const subnet = inferTrustedLocalSubnet();
+
+  let eligible = true;
+  let reason = null;
+
+  if (!onboardingDone) {
+    eligible = false;
+    reason = "not_onboarded";
+  } else if (users.length !== 1) {
+    eligible = false;
+    reason = "not_single_user";
+  } else if (!soleUser || soleUser.role !== "admin") {
+    eligible = false;
+    reason = "sole_user_not_admin";
+  } else if (!subnet) {
+    eligible = false;
+    reason = "not_trusted_network";
+  }
+
+  const active =
+    config.enabled &&
+    eligible &&
+    isRequestFromTrustedLocalSubnet(req) &&
+    !!soleAdminUser;
+
+  return {
+    enabled: config.enabled,
+    eligible,
+    active,
+    reason: reason || (config.enabled ? null : "disabled"),
+  };
+}
+
+export function reconcileLocalNetworkBypassSetting() {
+  const currentSettings = dbOps.getSettings();
+  const current = getLocalNetworkBypassConfig(currentSettings);
+  if (!current.enabled) {
+    return {
+      changed: false,
+      settings: withLocalNetworkBypassDefaults(currentSettings),
+    };
+  }
+  const status = getLocalNetworkBypassStatus({
+    headers: {},
+    socket: {},
+    connection: {},
+    ip: "",
+    ips: [],
+  });
+  if (status.eligible) {
+    return {
+      changed: false,
+      settings: withLocalNetworkBypassDefaults(currentSettings),
+    };
+  }
+  const nextSettings = withLocalNetworkBypassDefaults(currentSettings);
+  nextSettings.security.localNetworkBypass.enabled = false;
+  dbOps.updateSettings(nextSettings);
+  return {
+    changed: true,
+    settings: nextSettings,
+  };
+}
+
 function resolveProxyUser(req) {
   if (!isProxyAuthEnabled()) return null;
   if (!isTrustedProxy(req)) return null;
@@ -169,12 +395,7 @@ function resolveProxyUser(req) {
   if (!username) return null;
   const existing = userOps.getUserByUsername(username);
   if (existing) {
-    return {
-      id: existing.id,
-      username: existing.username,
-      role: existing.role,
-      permissions: buildPermissions(existing.role, existing.permissions),
-    };
+    return toResolvedUser(existing);
   }
   const adminUsers = parseCsv(process.env.AUTH_PROXY_ADMIN_USERS).map((u) =>
     u.toLowerCase(),
@@ -264,25 +485,33 @@ function legacyAuth(username, password) {
   };
 }
 
+export function resolveLocalNetworkBypassUser(req) {
+  const status = getLocalNetworkBypassStatus(req);
+  if (!status.active) return null;
+  return toResolvedUser(getSoleAdminUser());
+}
+
 export function resolveRequestUser(req) {
   const sessionUser = resolveSessionUserFromToken(getBearerToken(req));
   if (sessionUser) return sessionUser;
   const proxyUser = resolveProxyUser(req);
   if (proxyUser) return proxyUser;
   const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith("Basic ")) return null;
-  try {
-    const token = authHeader.substring(6);
-    const decoded = Buffer.from(token, "base64").toString("utf8");
-    const colon = decoded.indexOf(":");
-    const username = colon >= 0 ? decoded.slice(0, colon) : decoded;
-    const password = colon >= 0 ? decoded.slice(colon + 1) : "";
-    let user = resolveUser(username, password);
-    if (!user) user = legacyAuth(username, password);
-    return user;
-  } catch (e) {
-    return null;
+  if (authHeader && authHeader.startsWith("Basic ")) {
+    try {
+      const token = authHeader.substring(6);
+      const decoded = Buffer.from(token, "base64").toString("utf8");
+      const colon = decoded.indexOf(":");
+      const username = colon >= 0 ? decoded.slice(0, colon) : decoded;
+      const password = colon >= 0 ? decoded.slice(colon + 1) : "";
+      let user = resolveUser(username, password);
+      if (!user) user = legacyAuth(username, password);
+      if (user) return user;
+    } catch (e) {
+      return null;
+    }
   }
+  return resolveLocalNetworkBypassUser(req);
 }
 
 function pruneExpiredStreamTokens() {

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -10,6 +10,7 @@ import {
   getAuthUser,
   isAuthRequiredByConfig,
   issueStreamToken,
+  getLocalNetworkBypassStatus,
 } from "../middleware/auth.js";
 import { getDiscoveryCache } from "../services/discoveryService.js";
 import { getCachedArtistCount } from "../services/libraryManager.js";
@@ -28,6 +29,7 @@ function buildBootstrapPayload(req) {
   const authRequired = isAuthRequiredByConfig();
   const authUser = getAuthUser();
   const currentUser = resolveRequestUser(req);
+  const localNetworkBypass = getLocalNetworkBypassStatus(req);
   const lidarrConfigured = lidarrClient.isConfigured();
 
   const payload = {
@@ -44,6 +46,7 @@ function buildBootstrapPayload(req) {
     musicbrainzConfigured: !!settings.integrations?.metadata?.baseUrl,
     metadataConfigured: !!settings.integrations?.metadata?.baseUrl,
     metadataProviders: getMetadataProviderHealthSnapshot(),
+    localNetworkBypass,
   };
 
   if (currentUser) {

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -1,9 +1,11 @@
 import express from "express";
 import { dbOps } from "../config/db-helpers.js";
 import { DEFAULT_METADATA_BASE_URL, defaultData } from "../config/constants.js";
+import { reconcileLocalNetworkBypassSetting } from "../middleware/auth.js";
 import { noCache } from "../middleware/cache.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
 import { validateExternalUrl } from "../middleware/urlValidator.js";
+import { websocketService } from "../services/websocketService.js";
 
 const router = express.Router();
 router.use(requireAuth);
@@ -29,6 +31,12 @@ router.get("/", noCache, (req, res) => {
         enableNarrowFallbacks: true,
       };
     }
+    settings.security = {
+      ...(settings.security || {}),
+      localNetworkBypass: {
+        enabled: settings?.security?.localNetworkBypass?.enabled === true,
+      },
+    };
     res.json(settings);
   } catch (error) {
     console.error("Settings GET error:", error);
@@ -40,9 +48,12 @@ router.get("/", noCache, (req, res) => {
 
 router.post("/", async (req, res) => {
   try {
-    const { quality, releaseTypes, integrations, rootFolderPath } = req.body;
+    const { quality, releaseTypes, integrations, rootFolderPath, security } =
+      req.body;
 
     const currentSettings = dbOps.getSettings();
+    const localBypassWasEnabled =
+      currentSettings?.security?.localNetworkBypass?.enabled === true;
     const lidarrExternalUrl = integrations?.lidarr?.externalUrl;
     if (lidarrExternalUrl !== undefined) {
       const trimmedExternalUrl = String(lidarrExternalUrl).trim();
@@ -165,6 +176,24 @@ router.post("/", async (req, res) => {
           ? releaseTypes
           : currentSettings.releaseTypes || defaultData.settings.releaseTypes,
       integrations: mergedIntegrations,
+      security:
+        security !== undefined
+          ? {
+              ...(currentSettings.security || {}),
+              ...security,
+              localNetworkBypass: security.localNetworkBypass
+                ? {
+                    ...(
+                      currentSettings.security?.localNetworkBypass ||
+                      defaultData.settings.security.localNetworkBypass
+                    ),
+                    ...security.localNetworkBypass,
+                    enabled: security.localNetworkBypass.enabled === true,
+                  }
+                : currentSettings.security?.localNetworkBypass ||
+                  defaultData.settings.security.localNetworkBypass,
+            }
+          : currentSettings.security || defaultData.settings.security,
     };
 
     if (updatedSettings?.integrations?.coverArtArchive) {
@@ -175,7 +204,14 @@ router.post("/", async (req, res) => {
     }
 
     dbOps.updateSettings(updatedSettings);
-    res.json(updatedSettings);
+    const reconciled = reconcileLocalNetworkBypassSetting().settings;
+    if (
+      localBypassWasEnabled &&
+      reconciled?.security?.localNetworkBypass?.enabled !== true
+    ) {
+      websocketService.reconcileAuthState();
+    }
+    res.json(reconciled);
   } catch (error) {
     console.error("Settings POST error:", error);
     res

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -2,8 +2,10 @@ import express from "express";
 import bcrypt from "bcrypt";
 import { userOps, dbOps } from "../config/db-helpers.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
+import { reconcileLocalNetworkBypassSetting } from "../middleware/auth.js";
 import { requirePasswordStrength } from "../middleware/validation.js";
 import { deleteSessionsByUserId } from "../config/session-helpers.js";
+import { websocketService } from "../services/websocketService.js";
 import {
   getListenHistoryCacheNamespace,
   getListenHistoryProfile,
@@ -12,6 +14,14 @@ import {
 } from "../services/listeningHistory.js";
 
 const router = express.Router();
+
+const reconcileLocalBypassAfterUserMutation = () => {
+  const result = reconcileLocalNetworkBypassSetting();
+  if (result.changed) {
+    websocketService.reconcileAuthState();
+  }
+  return result;
+};
 
 const normalizeRootFolderPath = (value) => {
   const normalized = String(value || "").trim();
@@ -114,6 +124,7 @@ router.post("/", requireAuth, requireAdmin, (req, res) => {
     if (!created) {
       return res.status(500).json({ error: "Failed to create user" });
     }
+    reconcileLocalBypassAfterUserMutation();
     res
       .status(201)
       .json({
@@ -249,6 +260,7 @@ router.patch("/:id", requireAuth, (req, res) => {
       });
     }
     const updated = userOps.updateUser(id, updates);
+    reconcileLocalBypassAfterUserMutation();
     res.json(updated);
   } catch (e) {
     res
@@ -491,6 +503,7 @@ router.delete("/:id", requireAuth, requireAdmin, (req, res) => {
     }
     deleteSessionsByUserId(id);
     userOps.deleteUser(id);
+    reconcileLocalBypassAfterUserMutation();
     res.json({ success: true });
   } catch (e) {
     res

--- a/backend/services/websocketService.js
+++ b/backend/services/websocketService.js
@@ -1,7 +1,11 @@
 import { WebSocketServer } from 'ws';
 import { dbOps, userOps } from "../config/db-helpers.js";
-import { getAuthPassword, isProxyAuthEnabled } from "../middleware/auth.js";
-import { getSessionByToken } from "../config/session-helpers.js";
+import {
+  getAuthPassword,
+  isProxyAuthEnabled,
+  resolveLocalNetworkBypassUser,
+  resolveSessionUserFromToken,
+} from "../middleware/auth.js";
 
 const isAuthRequired = () => {
   const settings = dbOps.getSettings();
@@ -36,15 +40,29 @@ class WebSocketService {
 
   handleConnection(ws, req) {
     let sessionUser = null;
+    let authSource = null;
     if (isAuthRequired()) {
       const requestUrl = new URL(req.url || "", "http://localhost");
       const token = requestUrl.searchParams.get("token");
-      const session = getSessionByToken(token);
-      if (!session?.user) {
+      sessionUser = resolveSessionUserFromToken(token);
+      if (sessionUser) {
+        authSource = "session";
+      } else {
+        sessionUser = resolveLocalNetworkBypassUser({
+          headers: req.headers || {},
+          socket: req.socket || {},
+          connection: req.connection || {},
+          ip: req.socket?.remoteAddress || "",
+          ips: [],
+        });
+        if (sessionUser) {
+          authSource = "local-network-bypass";
+        }
+      }
+      if (!sessionUser) {
         ws.close(4401, "Unauthorized");
         return;
       }
-      sessionUser = session.user;
     }
 
     const clientId = this.generateClientId();
@@ -53,6 +71,7 @@ class WebSocketService {
       id: clientId,
       ws,
       user: sessionUser,
+      authSource,
       subscriptions: new Set(['status']),
       connectedAt: Date.now(),
     };
@@ -219,6 +238,20 @@ class WebSocketService {
       downloadId,
       ...result,
     });
+  }
+
+  reconcileAuthState() {
+    for (const client of this.clients) {
+      if (client.authSource !== "local-network-bypass") {
+        continue;
+      }
+      if (client.ws.readyState !== 1) {
+        continue;
+      }
+      try {
+        client.ws.close(4401, "Unauthorized");
+      } catch {}
+    }
   }
 
   emitDownloadFailed(downloadId, error) {

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -165,6 +165,11 @@ function SettingsPage() {
             updateUser={users.updateUser}
             deleteUser={users.deleteUser}
             changeMyPassword={users.changeMyPassword}
+            settings={data.settings}
+            updateSettings={data.updateSettings}
+            handleSaveSettings={data.handleSaveSettings}
+            health={data.health}
+            refreshSettingsData={data.fetchSettings}
             showSuccess={showSuccess}
             showError={showError}
           />

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -2,6 +2,76 @@ import { UserPlus, Lock, Pencil, Trash2, X } from "lucide-react";
 import { GRANULAR_PERMISSIONS, granularPerms } from "../constants";
 import { loginApi, setStoredAuth } from "../../../utils/api";
 
+function getLocalBypassStatus(status) {
+  if (!status) {
+    return {
+      title: "Unavailable: status unknown",
+      detail: "Aurral could not load the current local-network auto-login status.",
+      canToggle: false,
+    };
+  }
+  if (status.active) {
+    return {
+      title: "Active for this device",
+      detail:
+        "This device is currently being auto-signed in as the sole admin from the trusted local subnet.",
+      canToggle: true,
+    };
+  }
+  if (status.enabled) {
+    return {
+      title: "Enabled",
+      detail:
+        "Auto-login is enabled for the sole admin user. It will only activate from the server's trusted local subnet.",
+      canToggle: true,
+    };
+  }
+  switch (status.reason) {
+    case "disabled":
+      return {
+        title: "Disabled",
+        detail:
+          "Automatically sign in as the sole admin user when accessing Aurral from this server's local subnet. If additional users are added, this setting turns off automatically.",
+        canToggle: true,
+      };
+    case "not_single_user":
+      return {
+        title: "Unavailable: more than one user exists",
+        detail:
+          "Local-network auto-login is only available while exactly one stored user exists.",
+        canToggle: false,
+      };
+    case "sole_user_not_admin":
+      return {
+        title: "Unavailable: sole user is not admin",
+        detail:
+          "The only stored user must have the admin role before local-network auto-login can be enabled.",
+        canToggle: false,
+      };
+    case "not_trusted_network":
+      return {
+        title: "Unavailable: local subnet could not be determined",
+        detail:
+          "Aurral could not infer a single trusted IPv4 local subnet for this server, so local-network auto-login stays disabled.",
+        canToggle: false,
+      };
+    case "not_onboarded":
+      return {
+        title: "Unavailable: onboarding incomplete",
+        detail:
+          "Finish onboarding before enabling local-network auto-login.",
+        canToggle: false,
+      };
+    default:
+      return {
+        title: "Unavailable",
+        detail:
+          "Local-network auto-login is not currently available for this installation.",
+        canToggle: false,
+      };
+  }
+}
+
 export function SettingsUsersTab({
   authUser,
   usersList,
@@ -43,10 +113,18 @@ export function SettingsUsersTab({
   updateUser,
   deleteUser,
   changeMyPassword,
+  settings,
+  updateSettings,
+  handleSaveSettings,
+  health,
+  refreshSettingsData,
   showSuccess,
   showError,
 }) {
   const isSelfEdit = editUser && editUser.id === authUser?.id;
+  const localBypassStatus = getLocalBypassStatus(health?.localNetworkBypass);
+  const localBypassEnabled =
+    settings?.security?.localNetworkBypass?.enabled === true;
 
   return (
     <div className="card animate-fade-in space-y-6">
@@ -177,6 +255,56 @@ export function SettingsUsersTab({
         </div>
       ) : (
         <>
+          <div
+            className="p-5 rounded-lg space-y-4"
+            style={{
+              backgroundColor: "#1a1a1e",
+              boxShadow: "0 0 0 1px #2a2a2e",
+            }}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <h3 className="text-lg font-medium text-main">
+                  Auto-login from local network
+                </h3>
+                <p className="text-sm" style={{ color: "#c1c1c3" }}>
+                  {localBypassStatus.title}
+                </p>
+              </div>
+              <label className="inline-flex items-center gap-3">
+                <span className="text-sm text-sub">
+                  {localBypassEnabled ? "On" : "Off"}
+                </span>
+                <input
+                  type="checkbox"
+                  className="h-5 w-5 rounded border-gray-600 text-[#707e61] focus:ring-[#707e61]"
+                  checked={localBypassEnabled}
+                  disabled={!localBypassStatus.canToggle}
+                  onChange={async (e) => {
+                    const nextSettings = {
+                      ...settings,
+                      security: {
+                        ...(settings.security || {}),
+                        localNetworkBypass: {
+                          enabled: e.target.checked,
+                        },
+                      },
+                    };
+                    updateSettings(nextSettings);
+                    try {
+                      await handleSaveSettings(null, nextSettings);
+                    } catch {
+                      // handleSaveSettings already reports failure and resets local state.
+                    }
+                  }}
+                />
+              </label>
+            </div>
+            <p className="text-sm" style={{ color: "#8a8a8f" }}>
+              {localBypassStatus.detail}
+            </p>
+          </div>
+
           <div className="rounded-lg overflow-hidden">
             {loadingUsers ? (
               <div className="p-8 text-center">
@@ -326,7 +454,8 @@ export function SettingsUsersTab({
                         await deleteUser(deleteUserTarget.id);
                         showSuccess("User deleted");
                         setDeleteUserTarget(null);
-                        refreshUsers();
+                        await refreshUsers();
+                        await refreshSettingsData();
                       } catch (err) {
                         showError(
                           err.response?.data?.error || "Failed to delete"
@@ -376,18 +505,26 @@ export function SettingsUsersTab({
                     }
                     setCreatingUser(true);
                     try {
+                      const shouldWarnLocalBypass =
+                        health?.localNetworkBypass?.enabled === true &&
+                        usersList.length === 1;
                       await createUser(
                         newUserUsername.trim(),
                         newUserPassword,
                         "user",
                         newUserPermissions
                       );
-                      showSuccess("User created");
+                      showSuccess(
+                        shouldWarnLocalBypass
+                          ? "User created. Local-network auto-login was disabled."
+                          : "User created"
+                      );
                       setShowAddUserModal(false);
                       setNewUserUsername("");
                       setNewUserPassword("");
                       setNewUserPermissions({ ...GRANULAR_PERMISSIONS });
-                      refreshUsers();
+                      await refreshUsers();
+                      await refreshSettingsData();
                     } catch (err) {
                       showError(
                         err.response?.data?.error ||
@@ -569,7 +706,8 @@ export function SettingsUsersTab({
                       });
                       showSuccess("User updated");
                       setEditUser(null);
-                      refreshUsers();
+                      await refreshUsers();
+                      await refreshSettingsData();
                     } catch (err) {
                       showError(
                         err.response?.data?.error ||

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -67,6 +67,11 @@ const defaultSettings = {
       notifyWeeklyFlowDone: false,
     },
   },
+  security: {
+    localNetworkBypass: {
+      enabled: false,
+    },
+  },
 };
 
 export function useSettingsData(showSuccess, showError, showInfo) {
@@ -220,17 +225,21 @@ export function useSettingsData(showSuccess, showError, showInfo) {
       const toSave = settingsOverride ?? settings;
       setSaving(true);
       try {
-        await updateAppSettings(toSave);
-        setOriginalSettings(JSON.parse(JSON.stringify(toSave)));
+        const savedSettings = await updateAppSettings(toSave);
+        const normalizedSettings = normalizeSettings(savedSettings);
+        setSettingsState(normalizedSettings);
+        setOriginalSettings(JSON.parse(JSON.stringify(normalizedSettings)));
         setHasUnsavedChanges(false);
         showSuccess("Settings saved successfully!");
+        await refreshHealth();
       } catch (err) {
+        await fetchSettings();
         showError("Failed to save settings: " + err.message);
       } finally {
         setSaving(false);
       }
     },
-    [settings, showSuccess, showError],
+    [settings, showSuccess, showError, refreshHealth, fetchSettings],
   );
 
   const handleRefreshDiscovery = useCallback(async () => {

--- a/frontend/src/pages/Settings/hooks/useSettingsUsers.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsUsers.js
@@ -43,7 +43,10 @@ export function useSettingsUsers(authUser, showSuccess, showError, activeTab) {
   }, [activeTab, authUser?.role]);
 
   const refreshUsers = () => {
-    getUsers().then(setUsersList);
+    return getUsers().then((nextUsers) => {
+      setUsersList(nextUsers);
+      return nextUsers;
+    });
   };
 
   return {

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -17,6 +17,12 @@ export const normalizeSettings = (savedSettings) => {
     ...savedSettings,
     releaseTypes: savedSettings.releaseTypes || allReleaseTypes,
     quality: savedSettings.quality || "standard",
+    security: {
+      ...(savedSettings.security || {}),
+      localNetworkBypass: {
+        enabled: savedSettings?.security?.localNetworkBypass?.enabled === true,
+      },
+    },
     integrations: {
       lidarr: {
         url: "",


### PR DESCRIPTION
## Summary
- Add an optional local-network auto-login mode that resolves requests from the server’s inferred trusted IPv4 subnet to the sole admin user.
- Persist the new `settings.security.localNetworkBypass.enabled` flag and expose status/eligibility in the health bootstrap payload.
- Automatically disable the feature when a second user is added or the sole user stops qualifying, and close existing WebSocket sessions that were authenticated through the bypass.
- Add a Settings > Users toggle and UI messaging that reflects whether the feature is active, enabled, or unavailable.
- Update the README with the new behavior and operational notes.

## Testing
- Not run
- Verified the settings payload now normalizes `security.localNetworkBypass.enabled` on read/write paths.
- Verified user create, update, and delete flows reconcile the bypass state after mutations.
- Verified WebSocket connections authenticated via local-network bypass are tracked separately and can be invalidated when the setting is disabled.