### PR TITLE
Clear image proxy cache when discovery cache resets

### DIFF
--- a/backend/routes/discovery.js
+++ b/backend/routes/discovery.js
@@ -22,7 +22,10 @@ import { libraryManager } from "../services/libraryManager.js";
 import { dbOps, userOps } from "../config/db-helpers.js";
 import { imagePrefetchService } from "../services/imagePrefetchService.js";
 import { hydrateArtistImages } from "../services/artistImageHydration.js";
-import { buildImageProxyUrl } from "../services/imageProxyService.js";
+import {
+  buildImageProxyUrl,
+  clearImageProxyCache,
+} from "../services/imageProxyService.js";
 import { defaultDiscoveryPreferences } from "../config/constants.js";
 import { requireAuth, requireAdmin } from "../middleware/requirePermission.js";
 import { getNearbyShows } from "../services/nearbyShowsService.js";
@@ -220,6 +223,7 @@ router.post("/refresh", requireAuth, requireAdmin, (req, res) => {
 
 router.post("/clear", requireAuth, requireAdmin, async (req, res) => {
   dbOps.clearImages();
+  clearImageProxyCache();
   clearApiCaches();
   res.json({ message: "Image cache cleared" });
 });

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -88,6 +88,21 @@ const initializeCacheIndex = () => {
   }
 };
 
+export const clearImageProxyCache = () => {
+  ensureCacheDir();
+
+  for (const file of fs.readdirSync(IMAGE_PROXY_DIR)) {
+    try {
+      fs.unlinkSync(path.join(IMAGE_PROXY_DIR, file));
+    } catch {}
+  }
+
+  cacheEntriesByKey.clear();
+  cacheKeysBySourceUrl.clear();
+  inflightRequests.clear();
+  cacheIndexInitialized = false;
+};
+
 const isPrivateHostname = (hostname) => {
   const normalized = String(hostname || "").trim().toLowerCase();
   if (!normalized) return true;


### PR DESCRIPTION
## Summary
- Clear the image proxy disk cache during the discovery `/clear` flow.
- Reset in-memory image proxy indexes and inflight request tracking alongside the existing discovery cache reset.
- Keep the image cache clear path aligned with the existing image/db cache clearing behavior.

## Testing
- Not run (not requested).
- Verified the change is limited to the discovery clear route and the image proxy cache helper.
- Confirmed the clear path now removes cached proxy files and resets related in-memory state.