### PR TITLE
Use filepath ordering for weekly flow playlists

### DIFF
--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -211,7 +211,8 @@ export class WeeklyFlowPlaylistManager {
             : [pathCondition];
         const payload = {
           all,
-          sort: "random",
+          // Keep playlist order stable as tracks are added over time.
+          sort: "filepath",
           limit: 1000,
         };
         await fs.writeFile(nspPath, JSON.stringify(payload), "utf8");


### PR DESCRIPTION
## Summary
- Switch weekly flow playlist generation from random ordering to filepath ordering.
- Keep playlist order stable as tracks are added over time.

## Testing
- Not run (not requested).
- Reviewed the diff to confirm only the weekly flow playlist payload sort field changed.