### PR TITLE
Merge tag search results and simplify feedback

### DIFF
--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -15,7 +15,7 @@ router.get("/", noCache, async (req, res) => {
       scope = "artist",
       limit = 24,
       offset = 0,
-      tagScope = "all",
+      tagScope = "merged",
       releaseTypes = "",
     } = req.query;
 

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -292,11 +292,136 @@ function normalizeTagArtistItem(artist, tag) {
   };
 }
 
+function getTagArtistKey(artist) {
+  const artistId = String(artist?.id || artist?.mbid || "").trim().toLowerCase();
+  if (artistId) return `id:${artistId}`;
+  const artistName = String(artist?.name || "").trim().toLowerCase();
+  return artistName ? `name:${artistName}` : null;
+}
+
+function matchesTagSearch(artist, normalizedTag) {
+  const tags = Array.isArray(artist?.tags) ? artist.tags : [];
+  const genres = Array.isArray(artist?.genres) ? artist.genres : [];
+  return [...tags, ...genres].some(
+    (entry) => normalizeSearchText(entry) === normalizedTag,
+  );
+}
+
+function dedupeTagArtists(artists) {
+  const seen = new Set();
+  const output = [];
+  for (const artist of Array.isArray(artists) ? artists : []) {
+    const key = getTagArtistKey(artist);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    output.push(artist);
+  }
+  return output;
+}
+
+function getTagSourceMap(artists) {
+  const sourceMap = new Map();
+  for (const artist of Array.isArray(artists) ? artists : []) {
+    const key = getTagArtistKey(artist);
+    if (!key || sourceMap.has(key)) continue;
+    sourceMap.set(key, artist?.tagResultSource || "all");
+  }
+  return sourceMap;
+}
+
+function normalizeLastfmTagArtist(artist, tag) {
+  let imageUrl = null;
+  if (Array.isArray(artist?.image)) {
+    const img =
+      artist.image.find((entry) => entry.size === "extralarge") ||
+      artist.image.find((entry) => entry.size === "large") ||
+      artist.image.slice(-1)[0];
+    if (
+      img?.["#text"] &&
+      !String(img["#text"]).includes("2a96cbd8b46e442fc41c2b86b821562f")
+    ) {
+      imageUrl = img["#text"];
+    }
+  }
+
+  return normalizeTagArtistItem(
+    {
+      type: "artist",
+      id: artist?.mbid || null,
+      name: artist?.name || "Unknown Artist",
+      sortName: artist?.name || "Unknown Artist",
+      image: buildImageProxyUrl(imageUrl) || imageUrl,
+      imageUrl: buildImageProxyUrl(imageUrl) || imageUrl,
+      artistType: null,
+      country: null,
+      area: null,
+      begin: null,
+      end: null,
+      disambiguation: null,
+      tags: [tag],
+      genres: [tag],
+      inLibrary: false,
+      score: 0,
+      tagResultSource: "all",
+    },
+    tag,
+  );
+}
+
+async function fetchMergedLastfmTagArtists(tag, limitInt, offsetInt, recommendedItems) {
+  const pageSize = 50;
+  const requiredCount = offsetInt + limitInt;
+  const supplementalItems = [];
+  const seen = new Set(recommendedItems.map((artist) => getTagArtistKey(artist)).filter(Boolean));
+  let page = 1;
+  let exhausted = false;
+
+  while (!exhausted && recommendedItems.length + supplementalItems.length < requiredCount) {
+    const data = await lastfmRequest("tag.getTopArtists", {
+      tag,
+      limit: pageSize,
+      page,
+    });
+    const artists = Array.isArray(data?.topartists?.artist)
+      ? data.topartists.artist
+      : data?.topartists?.artist
+        ? [data.topartists.artist]
+        : [];
+
+    if (artists.length === 0) {
+      exhausted = true;
+      break;
+    }
+
+    for (const artist of artists) {
+      const normalized = normalizeLastfmTagArtist(artist, tag);
+      const key = getTagArtistKey(normalized);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      supplementalItems.push(normalized);
+    }
+
+    const reportedTotal = Number.parseInt(data?.topartists?.["@attr"]?.total, 10);
+    const totalPages = Number.isFinite(reportedTotal)
+      ? Math.ceil(reportedTotal / pageSize)
+      : null;
+    exhausted =
+      artists.length < pageSize ||
+      (Number.isFinite(totalPages) && page >= totalPages);
+    page += 1;
+  }
+
+  return {
+    items: [...recommendedItems, ...supplementalItems],
+    exhausted,
+  };
+}
+
 export async function searchTags(
   query,
   limit = 24,
   offset = 0,
-  tagScope = "recommended",
+  tagScope = "merged",
 ) {
   const tag = String(query || "").trim().replace(/^#/, "");
   const limitInt = parsePositiveInt(limit, 24);
@@ -309,6 +434,33 @@ export async function searchTags(
       count: 0,
       offset: offsetInt,
       items: [],
+    };
+  }
+
+  const discoveryCache = getDiscoveryCache();
+  const tagLower = normalizeSearchText(tag);
+  const recommendedMatches = dedupeTagArtists(
+    (discoveryCache.recommendations || [])
+      .filter((artist) => matchesTagSearch(artist, tagLower))
+      .map((artist) =>
+        normalizeTagArtistItem(
+          {
+            ...artist,
+            tagResultSource: "recommended",
+          },
+          tag,
+        ),
+      ),
+  );
+
+  if (tagScope === "recommended") {
+    return {
+      scope: "tag",
+      query: tag,
+      count: recommendedMatches.length,
+      offset: offsetInt,
+      hasMore: offsetInt + limitInt < recommendedMatches.length,
+      items: recommendedMatches.slice(offsetInt, offsetInt + limitInt),
     };
   }
 
@@ -326,42 +478,7 @@ export async function searchTags(
           ? [data.topartists.artist]
           : [];
       const items = artists
-        .map((artist) => {
-          let imageUrl = null;
-          if (Array.isArray(artist?.image)) {
-            const img =
-              artist.image.find((entry) => entry.size === "extralarge") ||
-              artist.image.find((entry) => entry.size === "large") ||
-              artist.image.slice(-1)[0];
-            if (
-              img?.["#text"] &&
-              !String(img["#text"]).includes("2a96cbd8b46e442fc41c2b86b821562f")
-            ) {
-              imageUrl = img["#text"];
-            }
-          }
-          return normalizeTagArtistItem(
-            {
-              type: "artist",
-              id: artist?.mbid || null,
-              name: artist?.name || "Unknown Artist",
-              sortName: artist?.name || "Unknown Artist",
-              image: buildImageProxyUrl(imageUrl) || imageUrl,
-              imageUrl: buildImageProxyUrl(imageUrl) || imageUrl,
-              artistType: null,
-              country: null,
-              area: null,
-              begin: null,
-              end: null,
-              disambiguation: null,
-              tags: [tag],
-              genres: [tag],
-              inLibrary: false,
-              score: 0,
-            },
-            tag,
-          );
-        })
+        .map((artist) => normalizeLastfmTagArtist(artist, tag))
         .filter((artist) => artist.id);
 
       return {
@@ -370,63 +487,85 @@ export async function searchTags(
         count:
           Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length,
         offset: offsetInt,
+        hasMore:
+          offsetInt + items.length <
+          (Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length),
         items,
       };
     }
 
-    const discoveryCache = getDiscoveryCache();
-    const tagLower = normalizeSearchText(tag);
-    const pool = [
+    const sourceMap = getTagSourceMap(recommendedMatches);
+    const poolItems = dedupeTagArtists([
       ...(Array.isArray(discoveryCache.recommendations)
         ? discoveryCache.recommendations
         : []),
       ...(Array.isArray(discoveryCache.globalTop) ? discoveryCache.globalTop : []),
       ...(Array.isArray(discoveryCache.basedOn) ? discoveryCache.basedOn : []),
-    ];
-    const seen = new Set();
-    const matches = pool.filter((artist) => {
-      const artistId = String(artist?.id || artist?.mbid || "").trim().toLowerCase();
-      const artistName = String(artist?.name || "").trim().toLowerCase();
-      const key = artistId || artistName;
-      if (!key || seen.has(key)) return false;
-      const tags = Array.isArray(artist.tags) ? artist.tags : [];
-      const genres = Array.isArray(artist.genres) ? artist.genres : [];
-      const matched = [...tags, ...genres].some(
-        (entry) => normalizeSearchText(entry) === tagLower,
+    ])
+      .filter((artist) => matchesTagSearch(artist, tagLower))
+      .map((artist) =>
+        normalizeTagArtistItem(
+          {
+            ...artist,
+            tagResultSource: sourceMap.get(getTagArtistKey(artist)) || "all",
+          },
+          tag,
+        ),
       );
-      if (!matched) return false;
-      seen.add(key);
-      return true;
-    });
 
     return {
       scope: "tag",
       query: tag,
-      count: matches.length,
+      count: poolItems.length,
       offset: offsetInt,
-      items: matches
-        .slice(offsetInt, offsetInt + limitInt)
-        .map((artist) => normalizeTagArtistItem(artist, tag)),
+      hasMore: offsetInt + limitInt < poolItems.length,
+      items: poolItems.slice(offsetInt, offsetInt + limitInt),
     };
   }
 
-  const discoveryCache = getDiscoveryCache();
-  const tagLower = normalizeSearchText(tag);
-  const matches = (discoveryCache.recommendations || []).filter((artist) => {
-    const tags = Array.isArray(artist.tags) ? artist.tags : [];
-    const genres = Array.isArray(artist.genres) ? artist.genres : [];
-    return [...tags, ...genres].some(
-      (entry) => normalizeSearchText(entry) === tagLower,
+  if (getLastfmApiKey()) {
+    const merged = await fetchMergedLastfmTagArtists(
+      tag,
+      limitInt,
+      offsetInt,
+      recommendedMatches,
     );
-  });
+    const items = merged.items.slice(offsetInt, offsetInt + limitInt);
+    return {
+      scope: "tag",
+      query: tag,
+      count: merged.exhausted
+        ? merged.items.length
+        : offsetInt + items.length + (merged.items.length > offsetInt + items.length ? 1 : 0),
+      offset: offsetInt,
+      hasMore: !merged.exhausted || offsetInt + items.length < merged.items.length,
+      items,
+    };
+  }
+
+  const mergedItems = dedupeTagArtists([
+    ...recommendedMatches,
+    ...(Array.isArray(discoveryCache.globalTop) ? discoveryCache.globalTop : []),
+    ...(Array.isArray(discoveryCache.basedOn) ? discoveryCache.basedOn : []),
+  ])
+    .filter((artist) => matchesTagSearch(artist, tagLower))
+    .map((artist) =>
+      normalizeTagArtistItem(
+        {
+          ...artist,
+          tagResultSource:
+            artist.tagResultSource === "recommended" ? "recommended" : "all",
+        },
+        tag,
+      ),
+    );
 
   return {
     scope: "tag",
     query: tag,
-    count: matches.length,
+    count: mergedItems.length,
     offset: offsetInt,
-    items: matches
-      .slice(offsetInt, offsetInt + limitInt)
-      .map((artist) => normalizeTagArtistItem(artist, tag)),
+    hasMore: offsetInt + limitInt < mergedItems.length,
+    items: mergedItems.slice(offsetInt, offsetInt + limitInt),
   };
 }

--- a/frontend/src/components/SearchArtistResults.jsx
+++ b/frontend/src/components/SearchArtistResults.jsx
@@ -7,6 +7,7 @@ import {
   Library,
   Loader2,
   MoreVertical,
+  Star,
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
@@ -235,6 +236,8 @@ function SearchArtistResults({
     <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
       {artists.map((artist, index) => {
         const artistId = getArtistId(artist);
+        const isRecommendedTagResult =
+          type === "tag" && artist.tagResultSource === "recommended";
         const artistTypeLabel = normalizeArtistType(artist);
         const lifeSpan = formatLifeSpan(artist);
         const area = normalizeArea(artist);
@@ -290,6 +293,23 @@ function SearchArtistResults({
                 showLoading={false}
                 enableBackendFallback={false}
               />
+              {isRecommendedTagResult && (
+                <div className="pointer-events-none absolute right-2 top-2">
+                  <div
+                    className="flex h-5 w-5 items-center justify-center rounded-full"
+                    style={{
+                      backgroundColor: "rgba(20, 19, 24, 0.72)",
+                      boxShadow: "0 3px 10px rgba(0, 0, 0, 0.22)",
+                      backdropFilter: "blur(6px)",
+                    }}
+                  >
+                    <Star
+                      className="h-3 w-3"
+                      style={{ color: "#f4c430", fill: "#f4c430" }}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="flex min-w-0 items-start gap-2">

--- a/frontend/src/components/SearchArtistResults.jsx
+++ b/frontend/src/components/SearchArtistResults.jsx
@@ -257,6 +257,10 @@ function SearchArtistResults({
         ]
           .filter(Boolean)
           .join(" • ");
+        const feedbackHandler =
+          type === "tag" && artist.tagResultSource !== "recommended"
+            ? undefined
+            : onArtistFeedback;
 
         return (
           <div
@@ -341,7 +345,7 @@ function SearchArtistResults({
                   canAddArtist={canAddArtist}
                   onAddToLibrary={onAddArtistToLibrary}
                   onAddToBlocklist={onAddArtistToBlocklist}
-                  onFeedback={onArtistFeedback}
+                  onFeedback={feedbackHandler}
                 />
               )}
             </div>

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -9,6 +9,7 @@ import {
   FileMusic,
   Loader,
   Music,
+  Star,
 } from "lucide-react";
 import {
   addArtistToLibrary,
@@ -859,9 +860,19 @@ function SearchResultsPage() {
           <p style={{ color: "#c1c1c3" }}>Trending artists right now</p>
         )}
         {isTagSearch && trimmedQuery && (
-          <p style={{ color: "#c1c1c3" }}>
-            {`Artists for tag "${trimmedQuery.replace(/^#/, "")}"`}
-          </p>
+          <div
+            className="flex flex-wrap items-center gap-x-3 gap-y-2"
+            style={{ color: "#c1c1c3" }}
+          >
+            <p>{`Artists for tag "${trimmedQuery.replace(/^#/, "")}"`}</p>
+            <div className="ml-auto flex items-center gap-1.5 text-sm">
+              <Star
+                className="h-3.5 w-3.5"
+                style={{ color: "#f4c430", fill: "#f4c430" }}
+              />
+              <span>= recommended</span>
+            </div>
+          </div>
         )}
         {isAlbumSearch && trimmedQuery && (
           <div className="space-y-3">

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -24,7 +24,6 @@ import {
   searchCatalog,
   updateBlocklist,
 } from "../utils/api";
-import PillToggle from "../components/PillToggle";
 import SearchAlbumResults from "../components/SearchAlbumResults";
 import SearchArtistResults from "../components/SearchArtistResults";
 import { useAuth } from "../contexts/AuthContext";
@@ -155,11 +154,9 @@ function SearchResultsPage() {
   }, [type, trimmedQuery]);
   const isTagSearch = normalizedType === "tag";
   const isAlbumSearch = normalizedType === "album";
-  const tagScope = searchParams.get("scope") || "all";
   const albumSort = searchParams.get("sort") || DEFAULT_ALBUM_SORT;
-  const showAllTagResults = isTagSearch && tagScope === "all";
   const supportsDiscoveryFeedback =
-    normalizedType === "recommended" || (isTagSearch && !showAllTagResults);
+    normalizedType === "recommended" || isTagSearch;
   const canAddArtist = hasPermission("addArtist");
   const canAddAlbum = hasPermission("addAlbum");
   const hasActiveReleaseTypeFilters = useMemo(() => {
@@ -174,15 +171,6 @@ function SearchResultsPage() {
         (typeName) => !selectedReleaseTypes.includes(typeName),
       ).length,
     [allReleaseTypes, selectedReleaseTypes],
-  );
-
-  const updateTagScope = useCallback(
-    (nextScope) => {
-      const params = new URLSearchParams(searchParams);
-      params.set("scope", nextScope === "all" ? "all" : "recommended");
-      setSearchParams(params);
-    },
-    [searchParams, setSearchParams],
   );
 
   const updateAlbumSort = useCallback(
@@ -286,7 +274,6 @@ function SearchResultsPage() {
         const data = await searchCatalog(searchQuery, normalizedType, {
           limit: PAGE_SIZE,
           offset: 0,
-          tagScope,
           releaseTypes: isAlbumSearch ? selectedReleaseTypes : [],
         });
         const nextResults = isAlbumSearch
@@ -328,7 +315,6 @@ function SearchResultsPage() {
   }, [
     trimmedQuery,
     normalizedType,
-    tagScope,
     isAlbumSearch,
     isTagSearch,
     selectedReleaseTypes,
@@ -573,7 +559,6 @@ function SearchResultsPage() {
       const data = await searchCatalog(searchQuery, normalizedType, {
         limit: PAGE_SIZE,
         offset: results.length,
-        tagScope,
         releaseTypes: isAlbumSearch ? selectedReleaseTypes : [],
       });
       const newItems = data.items || [];
@@ -610,7 +595,6 @@ function SearchResultsPage() {
     results,
     searchTotalCount,
     selectedReleaseTypes,
-    tagScope,
     trimmedQuery,
     visibleCount,
   ]);
@@ -821,9 +805,7 @@ function SearchResultsPage() {
       : isAlbumSearch
         ? `We couldn't find any albums matching "${trimmedQuery}"`
         : isTagSearch
-          ? `We couldn't find any ${
-              showAllTagResults ? "artists" : "recommended artists"
-            } for tag "${trimmedQuery.replace(/^#/, "")}"`
+          ? `We couldn't find any artists for tag "${trimmedQuery.replace(/^#/, "")}"`
           : `We couldn't find any artists matching "${trimmedQuery}"`;
 
   return (
@@ -846,36 +828,15 @@ function SearchResultsPage() {
                       : "Search Results"}
           </h1>
 
-          {isTagSearch && (
-            <div className="ml-auto inline-flex items-center gap-3">
-              <span
-                className="text-sm"
-                style={{ color: showAllTagResults ? "#8a8a8f" : "#fff" }}
-              >
-                Recommended
-              </span>
-              <PillToggle
-                checked={showAllTagResults}
-                onChange={(event) =>
-                  updateTagScope(event.target.checked ? "all" : "recommended")
-                }
-              />
-              <span
-                className="text-sm"
-                style={{ color: showAllTagResults ? "#fff" : "#8a8a8f" }}
-              >
-                All
-              </span>
-            </div>
-          )}
         </div>
 
-        {isTagSearch && !showAllTagResults && lastfmConfigured === false && (
+        {isTagSearch && lastfmConfigured === false && (
           <div className="mt-4 bg-yellow-500/20 p-4">
             <div className="flex flex-wrap items-center gap-3">
               <p className="text-sm text-yellow-300">
-                Recommended tag results use the hydrated Last.fm discovery
-                cache. Add an API key to enable that path.
+                Tag results are currently limited to the hydrated discovery
+                cache. Add a Last.fm API key to pull broader top-artist matches
+                for this tag.
               </p>
               <button
                 type="button"
@@ -899,7 +860,7 @@ function SearchResultsPage() {
         )}
         {isTagSearch && trimmedQuery && (
           <p style={{ color: "#c1c1c3" }}>
-            {`${showAllTagResults ? "Top artists" : "Recommended artists"} for tag "${trimmedQuery.replace(/^#/, "")}"`}
+            {`Artists for tag "${trimmedQuery.replace(/^#/, "")}"`}
           </p>
         )}
         {isAlbumSearch && trimmedQuery && (
@@ -1124,15 +1085,6 @@ function SearchResultsPage() {
                 No Results Found
               </h3>
               <p style={{ color: "#c1c1c3" }}>{emptyMessage}</p>
-              {isTagSearch && !showAllTagResults && (
-                <button
-                  type="button"
-                  className="btn btn-primary mt-6"
-                  onClick={() => updateTagScope("all")}
-                >
-                  Try searching all
-                </button>
-              )}
             </div>
           ) : (
             <>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -259,7 +259,7 @@ export const searchCatalog = async (
   {
     limit = 24,
     offset = 0,
-    tagScope = "all",
+    tagScope = "merged",
     releaseTypes = [],
   } = {},
 ) => {
@@ -721,11 +721,11 @@ export const searchArtistsByTag = async (
   tag,
   limit = 24,
   offset = 0,
-  scope = "recommended",
+  scope = "merged",
 ) => {
   const params = { tag, limit, offset };
-  if (scope === "all") {
-    params.scope = "all";
+  if (scope !== "merged") {
+    params.scope = scope;
   }
   const response = await api.get("/discover/by-tag", {
     params,


### PR DESCRIPTION
## Summary
- Merge tag search into a single default flow that combines recommended discovery results with broader top-artist matches.
- Remove the tag scope toggle from the search results UI and update tag messaging to reflect the unified behavior.
- Only allow feedback actions on recommended tag results, while suppressing feedback for merged/non-recommended tag entries.
- Align API defaults so tag searches now use `merged` unless a different scope is explicitly requested.

## Testing
- Not run (no tests requested).
- Verified the diff for backend tag search merging, frontend tag UI cleanup, and API default scope changes.