### PR TITLE
fix: resolve eslint 10 lint findings

### DIFF
--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -260,7 +260,7 @@ export function useArtistDetailsLibrary({
   ) => {
     if (!lookupArtist) return null;
     const lookupMbid = lookupArtist.mbid || lookupArtist.foreignArtistId;
-    let fullArtist = null;
+    let fullArtist;
     try {
       fullArtist = await getLibraryArtist(lookupMbid);
     } catch {

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -1700,7 +1700,7 @@ function FlowPage() {
         err.message ||
         "Failed to update static playlist tracklist";
       showError(message);
-      throw new Error(message);
+      throw new Error(message, { cause: err });
     } finally {
       setApplyingSharedPlaylistId(null);
     }


### PR DESCRIPTION
## Summary
- remove an unused initial assignment flagged by ESLint 10
- preserve the original caught error as the cause when rethrowing playlist track update failures

## Verification
- `npm run lint` from `frontend/`
- temporary ESLint 10 check: installed `eslint@10.4.0` and `@eslint/js@10.0.1` in a disposable worktree, then ran `npm run lint` from `frontend/`