### PR TITLE
Add Lidarr existing-albums monitoring support

### DIFF
--- a/.tests/auth/lidarr-preferences.integration.test.js
+++ b/.tests/auth/lidarr-preferences.integration.test.js
@@ -257,7 +257,7 @@ async function saveLidarrSettings({
   apiKey = "fake-key",
   rootFolderPath = "/music/main",
   qualityProfileId = 7,
-  defaultMonitorOption,
+  defaultMonitorOption = "none",
 } = {}) {
   const { response, payload } = await apiFetch("/api/settings", {
     method: "POST",
@@ -268,7 +268,7 @@ async function saveLidarrSettings({
           url: fakeLidarr.url,
           apiKey,
           qualityProfileId,
-          ...(defaultMonitorOption ? { defaultMonitorOption } : {}),
+          defaultMonitorOption,
         },
       },
     }),
@@ -489,7 +489,7 @@ test("POST /library/artists falls back to global defaults when the user has no s
   assert.equal(posted.qualityProfileId, 7);
 });
 
-test("POST /library/artists preserves none monitoring defaults", async () => {
+test("POST /library/artists preserves artist-only none monitoring defaults", async () => {
   await saveLidarrSettings({ defaultMonitorOption: "none" });
 
   const mbid = "55555555-5555-5555-5555-555555555555";
@@ -504,7 +504,7 @@ test("POST /library/artists preserves none monitoring defaults", async () => {
   assert.equal(response.status, 202, JSON.stringify(payload));
 
   const posted = await waitForPostedArtist(mbid);
-  assert.equal(posted.monitored, false);
+  assert.equal(posted.monitored, true);
   assert.equal(posted.monitor, "none");
   assert.equal(posted.monitorNewItems, "none");
   assert.equal(posted.addOptions.monitor, "none");
@@ -553,6 +553,7 @@ test("POST /library/artists uses existing albums monitor from global defaults", 
 
 test("POST /library/artists only future-facing modes monitor new albums", async () => {
   const cases = [
+    ["none", "none", "none"],
     ["missing", "missing", "none"],
     ["latest", "latest", "none"],
     ["first", "first", "none"],

--- a/.tests/auth/lidarr-preferences.integration.test.js
+++ b/.tests/auth/lidarr-preferences.integration.test.js
@@ -58,7 +58,10 @@ async function startFakeLidarr() {
     tags: DEFAULT_TAGS.map((tag) => ({ ...tag })),
     metadataProfiles: [{ id: 1, name: "Standard" }],
     artists: [],
+    albums: [],
     postedArtists: [],
+    updatedArtists: [],
+    updatedAlbums: [],
     nextArtistId: 100,
   };
 
@@ -95,6 +98,27 @@ async function startFakeLidarr() {
       }
       return json(res, 200, artist);
     }
+    if (
+      req.method === "PUT" &&
+      url.pathname.startsWith("/api/v1/artist/") &&
+      url.pathname !== "/api/v1/artist/"
+    ) {
+      const artistId = url.pathname.split("/").pop();
+      const payload = await readJsonBody(req);
+      state.updatedArtists.push(payload);
+      const artistIndex = state.artists.findIndex(
+        (entry) => String(entry.id) === artistId,
+      );
+      if (artistIndex === -1) {
+        return json(res, 404, { message: "Artist not found" });
+      }
+      state.artists[artistIndex] = {
+        ...state.artists[artistIndex],
+        ...payload,
+        id: state.artists[artistIndex].id,
+      };
+      return json(res, 200, state.artists[artistIndex]);
+    }
     if (req.method === "POST" && url.pathname === "/api/v1/artist") {
       const payload = await readJsonBody(req);
       state.postedArtists.push(payload);
@@ -121,6 +145,46 @@ async function startFakeLidarr() {
       state.artists.push(artist);
       return json(res, 201, artist);
     }
+    if (req.method === "GET" && url.pathname === "/api/v1/album") {
+      const artistId = url.searchParams.get("artistId");
+      const albums = artistId
+        ? state.albums.filter((album) => String(album.artistId) === artistId)
+        : state.albums;
+      return json(res, 200, albums);
+    }
+    if (
+      req.method === "GET" &&
+      url.pathname.startsWith("/api/v1/album/") &&
+      url.pathname !== "/api/v1/album/"
+    ) {
+      const albumId = url.pathname.split("/").pop();
+      const album = state.albums.find((entry) => String(entry.id) === albumId);
+      if (!album) {
+        return json(res, 404, { message: "Album not found" });
+      }
+      return json(res, 200, album);
+    }
+    if (
+      req.method === "PUT" &&
+      url.pathname.startsWith("/api/v1/album/") &&
+      url.pathname !== "/api/v1/album/"
+    ) {
+      const albumId = url.pathname.split("/").pop();
+      const payload = await readJsonBody(req);
+      state.updatedAlbums.push(payload);
+      const albumIndex = state.albums.findIndex(
+        (entry) => String(entry.id) === albumId,
+      );
+      if (albumIndex === -1) {
+        return json(res, 404, { message: "Album not found" });
+      }
+      state.albums[albumIndex] = {
+        ...state.albums[albumIndex],
+        ...payload,
+        id: state.albums[albumIndex].id,
+      };
+      return json(res, 200, state.albums[albumIndex]);
+    }
 
     return json(res, 404, { message: "Not found" });
   });
@@ -143,7 +207,10 @@ async function startFakeLidarr() {
       state.tags = DEFAULT_TAGS.map((tag) => ({ ...tag }));
       state.metadataProfiles = [{ id: 1, name: "Standard" }];
       state.artists = [];
+      state.albums = [];
       state.postedArtists = [];
+      state.updatedArtists = [];
+      state.updatedAlbums = [];
       state.nextArtistId = 100;
     },
     async stop() {
@@ -186,7 +253,12 @@ async function loginAsAdmin() {
   return payload.token;
 }
 
-async function saveLidarrSettings({ apiKey = "fake-key", rootFolderPath = "/music/main", qualityProfileId = 7 } = {}) {
+async function saveLidarrSettings({
+  apiKey = "fake-key",
+  rootFolderPath = "/music/main",
+  qualityProfileId = 7,
+  defaultMonitorOption,
+} = {}) {
   const { response, payload } = await apiFetch("/api/settings", {
     method: "POST",
     body: JSON.stringify({
@@ -196,6 +268,7 @@ async function saveLidarrSettings({ apiKey = "fake-key", rootFolderPath = "/musi
           url: fakeLidarr.url,
           apiKey,
           qualityProfileId,
+          ...(defaultMonitorOption ? { defaultMonitorOption } : {}),
         },
       },
     }),
@@ -414,6 +487,209 @@ test("POST /library/artists falls back to global defaults when the user has no s
   const posted = await waitForPostedArtist(mbid);
   assert.equal(posted.rootFolderPath, "/music/main");
   assert.equal(posted.qualityProfileId, 7);
+});
+
+test("POST /library/artists preserves none monitoring defaults", async () => {
+  await saveLidarrSettings({ defaultMonitorOption: "none" });
+
+  const mbid = "55555555-5555-5555-5555-555555555555";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "None Monitor Artist",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.monitored, false);
+  assert.equal(posted.monitor, "none");
+  assert.equal(posted.monitorNewItems, "none");
+  assert.equal(posted.addOptions.monitor, "none");
+});
+
+test("POST /library/artists supports existing albums monitor option", async () => {
+  const mbid = "66666666-6666-6666-6666-666666666666";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Existing Monitor Artist",
+      monitorOption: "existing",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.monitored, true);
+  assert.equal(posted.monitor, "existing");
+  assert.equal(posted.monitorNewItems, "none");
+  assert.equal(posted.addOptions.monitor, "existing");
+});
+
+test("POST /library/artists uses existing albums monitor from global defaults", async () => {
+  await saveLidarrSettings({ defaultMonitorOption: "existing" });
+
+  const mbid = "77777777-7777-7777-7777-777777777777";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Default Existing Monitor Artist",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.monitored, true);
+  assert.equal(posted.monitor, "existing");
+  assert.equal(posted.monitorNewItems, "none");
+  assert.equal(posted.addOptions.monitor, "existing");
+});
+
+test("POST /library/artists only future-facing modes monitor new albums", async () => {
+  const cases = [
+    ["missing", "missing", "none"],
+    ["latest", "latest", "none"],
+    ["first", "first", "none"],
+    ["existing", "existing", "none"],
+    ["future", "future", "all"],
+    ["all", "all", "all"],
+  ];
+
+  for (const [
+    index,
+    [monitorOption, expectedMonitor, expectedMonitorNewItems],
+  ] of cases.entries()) {
+    const mbid = `88888888-8888-8888-8888-${String(index + 1).padStart(
+      12,
+      "0",
+    )}`;
+    const { response, payload } = await apiFetch("/api/library/artists", {
+      method: "POST",
+      body: JSON.stringify({
+        foreignArtistId: mbid,
+        artistName: `${monitorOption} Monitor Artist`,
+        monitorOption,
+      }),
+    });
+
+    assert.equal(response.status, 202, JSON.stringify(payload));
+
+    const posted = await waitForPostedArtist(mbid);
+    assert.equal(posted.monitored, true);
+    assert.equal(posted.monitor, expectedMonitor);
+    assert.equal(posted.monitorNewItems, expectedMonitorNewItems);
+    assert.equal(posted.addOptions.monitor, expectedMonitor);
+  }
+});
+
+test("PUT /library/artists/:mbid updates artist monitoring to existing albums", async () => {
+  const mbid = "99999999-9999-9999-9999-999999999999";
+  const addResult = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Updated Existing Monitor Artist",
+    }),
+  });
+  assert.equal(addResult.response.status, 202, JSON.stringify(addResult.payload));
+
+  await waitForPostedArtist(mbid);
+  const artist = fakeLidarr.state.artists.find(
+    (entry) => entry.foreignArtistId === mbid,
+  );
+  assert.ok(artist);
+  fakeLidarr.state.albums.push({
+    id: 900,
+    artistId: artist.id,
+    title: "Already Monitored",
+    foreignAlbumId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    monitored: true,
+    statistics: {
+      trackCount: 1,
+      sizeOnDisk: 0,
+      percentOfTracks: 0,
+    },
+  });
+
+  const { response, payload } = await apiFetch(`/api/library/artists/${mbid}`, {
+    method: "PUT",
+    body: JSON.stringify({
+      monitored: true,
+      monitorOption: "existing",
+    }),
+  });
+
+  assert.equal(response.status, 200, JSON.stringify(payload));
+  const updated = fakeLidarr.state.updatedArtists.at(-1);
+  assert.equal(updated.monitored, true);
+  assert.equal(updated.monitor, "existing");
+  assert.equal(updated.monitorNewItems, "none");
+  assert.equal(updated.addOptions.monitor, "existing");
+  assert.equal(payload.monitorOption, "existing");
+});
+
+test("POST /library/downloads/album monitors only the requested album", async () => {
+  const artist = {
+    id: 700,
+    artistName: "Pick And Choose Artist",
+    foreignArtistId: "abababab-abab-abab-abab-abababababab",
+    path: "/music/main/Pick And Choose Artist",
+    added: new Date().toISOString(),
+    monitored: false,
+    monitor: "none",
+    monitorNewItems: "none",
+    addOptions: {
+      monitor: "none",
+    },
+    qualityProfile: DEFAULT_QUALITY_PROFILES[0],
+    statistics: {
+      albumCount: 1,
+      trackCount: 0,
+      sizeOnDisk: 0,
+    },
+  };
+  const album = {
+    id: 701,
+    artistId: artist.id,
+    title: "Selected Album",
+    foreignAlbumId: "bcbcbcbc-bcbc-bcbc-bcbc-bcbcbcbcbcbc",
+    monitored: false,
+    statistics: {
+      trackCount: 10,
+      sizeOnDisk: 0,
+      percentOfTracks: 0,
+    },
+  };
+  fakeLidarr.state.artists.push(artist);
+  fakeLidarr.state.albums.push(album);
+
+  const { response, payload } = await apiFetch("/api/library/downloads/album", {
+    method: "POST",
+    body: JSON.stringify({
+      artistId: String(artist.id),
+      albumId: String(album.id),
+      artistMbid: artist.foreignArtistId,
+      artistName: artist.artistName,
+    }),
+  });
+
+  assert.equal(response.status, 200, JSON.stringify(payload));
+  assert.equal(fakeLidarr.state.updatedArtists.length, 0);
+  assert.equal(fakeLidarr.state.updatedAlbums.length, 1);
+  assert.equal(fakeLidarr.state.updatedAlbums[0].monitored, true);
+
+  const storedArtist = fakeLidarr.state.artists.find(
+    (entry) => entry.id === artist.id,
+  );
+  assert.equal(storedArtist.monitored, false);
+  assert.equal(storedArtist.monitor, "none");
+  assert.equal(storedArtist.monitorNewItems, "none");
 });
 
 test("POST /library/artists returns 409 when saved defaults are stale", async () => {

--- a/.tests/auth/lidarr-preferences.integration.test.js
+++ b/.tests/auth/lidarr-preferences.integration.test.js
@@ -62,7 +62,9 @@ async function startFakeLidarr() {
     postedArtists: [],
     updatedArtists: [],
     updatedAlbums: [],
+    commands: [],
     forceUnmonitoredArtistOnPost: false,
+    unmonitorAfterAlbumSearch: false,
     nextArtistId: 100,
   };
 
@@ -188,6 +190,27 @@ async function startFakeLidarr() {
       };
       return json(res, 200, state.albums[albumIndex]);
     }
+    if (req.method === "POST" && url.pathname === "/api/v1/command") {
+      const payload = await readJsonBody(req);
+      state.commands.push(payload);
+      if (payload.name === "AlbumSearch" && state.unmonitorAfterAlbumSearch) {
+        for (const albumId of payload.albumIds || []) {
+          const album = state.albums.find(
+            (entry) => String(entry.id) === String(albumId),
+          );
+          if (album) {
+            album.monitored = false;
+            const artist = state.artists.find(
+              (entry) => String(entry.id) === String(album.artistId),
+            );
+            if (artist) {
+              artist.monitored = false;
+            }
+          }
+        }
+      }
+      return json(res, 201, { id: state.commands.length, ...payload });
+    }
 
     return json(res, 404, { message: "Not found" });
   });
@@ -214,7 +237,9 @@ async function startFakeLidarr() {
       state.postedArtists = [];
       state.updatedArtists = [];
       state.updatedAlbums = [];
+      state.commands = [];
       state.forceUnmonitoredArtistOnPost = false;
+      state.unmonitorAfterAlbumSearch = false;
       state.nextArtistId = 100;
     },
     async stop() {
@@ -262,6 +287,7 @@ async function saveLidarrSettings({
   rootFolderPath = "/music/main",
   qualityProfileId = 7,
   defaultMonitorOption = "none",
+  searchOnAdd = false,
 } = {}) {
   const { response, payload } = await apiFetch("/api/settings", {
     method: "POST",
@@ -273,6 +299,7 @@ async function saveLidarrSettings({
           apiKey,
           qualityProfileId,
           defaultMonitorOption,
+          searchOnAdd,
         },
       },
     }),
@@ -721,6 +748,69 @@ test("POST /library/downloads/album checks artist and monitors only the requeste
   assert.equal(storedArtist.monitored, true);
   assert.equal(storedArtist.monitor, "none");
   assert.equal(storedArtist.monitorNewItems, "none");
+});
+
+test("POST /library/downloads/album repairs monitoring after Lidarr search flips it off", async () => {
+  await saveLidarrSettings({ defaultMonitorOption: "none", searchOnAdd: true });
+  fakeLidarr.state.unmonitorAfterAlbumSearch = true;
+  const artist = {
+    id: 710,
+    artistName: "Failed Search Artist",
+    foreignArtistId: "cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd",
+    path: "/music/main/Failed Search Artist",
+    added: new Date().toISOString(),
+    monitored: true,
+    monitor: "none",
+    monitorNewItems: "none",
+    addOptions: {
+      monitor: "none",
+    },
+    qualityProfile: DEFAULT_QUALITY_PROFILES[0],
+    statistics: {
+      albumCount: 1,
+      trackCount: 0,
+      sizeOnDisk: 0,
+    },
+  };
+  const album = {
+    id: 711,
+    artistId: artist.id,
+    title: "Hard To Find Album",
+    foreignAlbumId: "dededede-dede-dede-dede-dededededede",
+    monitored: true,
+    statistics: {
+      trackCount: 10,
+      sizeOnDisk: 0,
+      percentOfTracks: 0,
+    },
+  };
+  fakeLidarr.state.artists.push(artist);
+  fakeLidarr.state.albums.push(album);
+
+  const { response, payload } = await apiFetch("/api/library/downloads/album", {
+    method: "POST",
+    body: JSON.stringify({
+      artistId: String(artist.id),
+      albumId: String(album.id),
+      artistMbid: artist.foreignArtistId,
+      artistName: artist.artistName,
+    }),
+  });
+
+  assert.equal(response.status, 200, JSON.stringify(payload));
+  assert.equal(fakeLidarr.state.commands.length, 1);
+  assert.equal(fakeLidarr.state.commands[0].name, "AlbumSearch");
+
+  const storedArtist = fakeLidarr.state.artists.find(
+    (entry) => entry.id === artist.id,
+  );
+  const storedAlbum = fakeLidarr.state.albums.find(
+    (entry) => entry.id === album.id,
+  );
+  assert.equal(storedArtist.monitored, true);
+  assert.equal(storedArtist.monitor, "none");
+  assert.equal(storedArtist.monitorNewItems, "none");
+  assert.equal(storedAlbum.monitored, true);
 });
 
 test("POST /library/artists returns 409 when saved defaults are stale", async () => {

--- a/.tests/auth/lidarr-preferences.integration.test.js
+++ b/.tests/auth/lidarr-preferences.integration.test.js
@@ -62,6 +62,7 @@ async function startFakeLidarr() {
     postedArtists: [],
     updatedArtists: [],
     updatedAlbums: [],
+    forceUnmonitoredArtistOnPost: false,
     nextArtistId: 100,
   };
 
@@ -131,7 +132,9 @@ async function startFakeLidarr() {
         foreignArtistId: payload.foreignArtistId,
         path: `${payload.rootFolderPath}/${payload.artistName}`,
         added: new Date().toISOString(),
-        monitored: payload.monitored,
+        monitored: state.forceUnmonitoredArtistOnPost
+          ? false
+          : payload.monitored,
         monitor: payload.monitor,
         monitorNewItems: payload.monitorNewItems,
         addOptions: payload.addOptions,
@@ -211,6 +214,7 @@ async function startFakeLidarr() {
       state.postedArtists = [];
       state.updatedArtists = [];
       state.updatedAlbums = [];
+      state.forceUnmonitoredArtistOnPost = false;
       state.nextArtistId = 100;
     },
     async stop() {
@@ -510,6 +514,29 @@ test("POST /library/artists preserves artist-only none monitoring defaults", asy
   assert.equal(posted.addOptions.monitor, "none");
 });
 
+test("POST /library/artists repairs Lidarr artist checkbox when none add returns unmonitored", async () => {
+  fakeLidarr.state.forceUnmonitoredArtistOnPost = true;
+
+  const mbid = "56565656-5656-5656-5656-565656565656";
+  const { response, payload } = await apiFetch("/api/library/artists", {
+    method: "POST",
+    body: JSON.stringify({
+      foreignArtistId: mbid,
+      artistName: "Repaired None Monitor Artist",
+    }),
+  });
+
+  assert.equal(response.status, 202, JSON.stringify(payload));
+
+  const posted = await waitForPostedArtist(mbid);
+  assert.equal(posted.monitored, true);
+  assert.equal(fakeLidarr.state.updatedArtists.length, 1);
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitored, true);
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitor, "none");
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitorNewItems, "none");
+  assert.equal(fakeLidarr.state.updatedArtists[0].addOptions.monitor, "none");
+});
+
 test("POST /library/artists supports existing albums monitor option", async () => {
   const mbid = "66666666-6666-6666-6666-666666666666";
   const { response, payload } = await apiFetch("/api/library/artists", {
@@ -635,7 +662,7 @@ test("PUT /library/artists/:mbid updates artist monitoring to existing albums", 
   assert.equal(payload.monitorOption, "existing");
 });
 
-test("POST /library/downloads/album monitors only the requested album", async () => {
+test("POST /library/downloads/album checks artist and monitors only the requested album", async () => {
   const artist = {
     id: 700,
     artistName: "Pick And Choose Artist",
@@ -681,14 +708,17 @@ test("POST /library/downloads/album monitors only the requested album", async ()
   });
 
   assert.equal(response.status, 200, JSON.stringify(payload));
-  assert.equal(fakeLidarr.state.updatedArtists.length, 0);
+  assert.equal(fakeLidarr.state.updatedArtists.length, 1);
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitored, true);
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitor, "none");
+  assert.equal(fakeLidarr.state.updatedArtists[0].monitorNewItems, "none");
   assert.equal(fakeLidarr.state.updatedAlbums.length, 1);
   assert.equal(fakeLidarr.state.updatedAlbums[0].monitored, true);
 
   const storedArtist = fakeLidarr.state.artists.find(
     (entry) => entry.id === artist.id,
   );
-  assert.equal(storedArtist.monitored, false);
+  assert.equal(storedArtist.monitored, true);
   assert.equal(storedArtist.monitor, "none");
   assert.equal(storedArtist.monitorNewItems, "none");
 });

--- a/.tests/search/search-service.test.js
+++ b/.tests/search/search-service.test.js
@@ -309,7 +309,7 @@ test("requestAlbumFromSearch rejects when artist must be created without addArti
   }
 });
 
-test("addAlbum preserves artist monitoring state while monitoring only the requested album", async () => {
+test("addAlbum checks artist monitoring while monitoring only the requested album", async () => {
   const originalIsConfigured = lidarrClient.isConfigured;
   const originalGetArtist = lidarrClient.getArtist;
   const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
@@ -338,14 +338,26 @@ test("addAlbum preserves artist monitoring state while monitoring only the reque
       sizeOnDisk: 0,
     },
   });
-  lidarrClient.updateArtistMonitoring = async () => {
+  lidarrClient.updateArtistMonitoring = async (_artistId, monitorOption) => {
     updateArtistMonitoringCalls += 1;
+    assert.equal(monitorOption, "none");
+    return {
+      id: 7,
+      artistName: "Boards of Canada",
+      foreignArtistId: "artist-mbid",
+      monitored: true,
+      monitor: "none",
+      monitorNewItems: "none",
+      addOptions: {
+        monitor: "none",
+      },
+    };
   };
 
   try {
     const album = await libraryManager.addAlbum(7, "album-mbid", "Geogaddi");
     assert.equal(album.id, "42");
-    assert.equal(updateArtistMonitoringCalls, 0);
+    assert.equal(updateArtistMonitoringCalls, 1);
   } finally {
     lidarrClient.isConfigured = originalIsConfigured;
     lidarrClient.getArtist = originalGetArtist;
@@ -363,11 +375,13 @@ test("addAlbum monitors and searches the requested album after Lidarr conflict l
   const originalGetAlbum = lidarrClient.getAlbum;
   const originalMonitorAlbum = lidarrClient.monitorAlbum;
   const originalTriggerAlbumSearch = lidarrClient.triggerAlbumSearch;
+  const originalUpdateArtistMonitoring = lidarrClient.updateArtistMonitoring;
   const originalWaitForAlbumByMbidForArtist =
     libraryManager.waitForAlbumByMbidForArtist;
 
   let monitorCalls = 0;
   let searchCalls = 0;
+  let updateArtistMonitoringCalls = 0;
 
   lidarrClient.isConfigured = () => true;
   lidarrClient.getArtist = async () => ({
@@ -378,6 +392,17 @@ test("addAlbum monitors and searches the requested album after Lidarr conflict l
     monitor: "none",
   });
   lidarrClient.getAlbumByMbid = async () => null;
+  lidarrClient.updateArtistMonitoring = async (_artistId, monitorOption) => {
+    updateArtistMonitoringCalls += 1;
+    assert.equal(monitorOption, "none");
+    return {
+      id: 7,
+      artistName: "Boards of Canada",
+      foreignArtistId: "artist-mbid",
+      monitored: true,
+      monitor: "none",
+    };
+  };
   lidarrClient.addAlbum = async () => {
     throw new Error("AlbumExistsValidator: This album has already been added");
   };
@@ -420,6 +445,7 @@ test("addAlbum monitors and searches the requested album after Lidarr conflict l
 
     assert.equal(album.id, "42");
     assert.equal(album.monitored, true);
+    assert.equal(updateArtistMonitoringCalls, 1);
     assert.equal(monitorCalls, 1);
     assert.equal(searchCalls, 1);
   } finally {
@@ -430,6 +456,7 @@ test("addAlbum monitors and searches the requested album after Lidarr conflict l
     lidarrClient.getAlbum = originalGetAlbum;
     lidarrClient.monitorAlbum = originalMonitorAlbum;
     lidarrClient.triggerAlbumSearch = originalTriggerAlbumSearch;
+    lidarrClient.updateArtistMonitoring = originalUpdateArtistMonitoring;
     libraryManager.waitForAlbumByMbidForArtist =
       originalWaitForAlbumByMbidForArtist;
   }

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -524,18 +524,6 @@ export default function registerDownloads(router) {
         }
 
         try {
-          if (!artist.monitored || artist.monitorOption === "none") {
-            const artistMbidToUpdate = artist.mbid || artist.foreignArtistId;
-            if (artistMbidToUpdate) {
-              try {
-                await libraryManager.updateArtist(artistMbidToUpdate, {
-                  monitored: true,
-                  monitorOption: "missing",
-                });
-                artist = await libraryManager.getArtist(artistMbidToUpdate);
-              } catch {}
-            }
-          }
           if (!album.monitored) {
             await libraryManager.updateAlbum(albumId, { monitored: true });
           }

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -524,6 +524,7 @@ export default function registerDownloads(router) {
         }
 
         try {
+          artist = await libraryManager.ensureArtistMonitored(artist);
           if (!album.monitored) {
             await libraryManager.updateAlbum(albumId, { monitored: true });
           }

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -538,6 +538,14 @@ export default function registerDownloads(router) {
               name: "AlbumSearch",
               albumIds: [parseInt(albumId, 10)],
             });
+            await libraryManager.ensureRequestedAlbumMonitoring(
+              artist.id,
+              albumId,
+            );
+            libraryManager.scheduleRequestedAlbumMonitoringRepair(
+              artist.id,
+              albumId,
+            );
           }
           invalidateAllDownloadStatusesCache();
 
@@ -590,6 +598,13 @@ export default function registerDownloads(router) {
           return res.status(404).json({ error: "Album not found" });
         }
 
+        const artist = album.artistId
+          ? await libraryManager.getArtistById(album.artistId)
+          : null;
+        if (artist) {
+          await libraryManager.ensureArtistMonitored(artist);
+        }
+
         if (!album.monitored) {
           await libraryManager.updateAlbum(albumId, { monitored: true });
         }
@@ -598,6 +613,16 @@ export default function registerDownloads(router) {
           name: "AlbumSearch",
           albumIds: [parseInt(albumId, 10)],
         });
+        if (album.artistId) {
+          await libraryManager.ensureRequestedAlbumMonitoring(
+            album.artistId,
+            albumId,
+          );
+          libraryManager.scheduleRequestedAlbumMonitoringRepair(
+            album.artistId,
+            albumId,
+          );
+        }
         invalidateAllDownloadStatusesCache();
 
         res.json({

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -292,8 +292,8 @@ export class LibraryManager {
     });
 
     switch (artist.monitorOption) {
-      case "all":
       case "existing":
+      case "all":
         albumsToMonitor.push(...eligibleAlbums.filter((album) => !album.monitored));
         break;
       case "latest":
@@ -686,8 +686,7 @@ export class LibraryManager {
     const artistPath = lidarrArtist.path ?? null;
     const monitorOption =
       lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none";
-    const normalizedMonitorOption =
-      monitorOption === "existing" ? "all" : monitorOption;
+    const normalizedMonitorOption = monitorOption || "none";
     return {
       id: lidarrArtist.id?.toString() || lidarrArtist.foreignArtistId,
       mbid: lidarrArtist.foreignArtistId,
@@ -725,8 +724,7 @@ export class LibraryManager {
       ) {
         const monitorOption =
           updates.monitorOption || lidarrArtist.monitor || "none";
-        const normalizedMonitorOption =
-          monitorOption === "existing" ? "all" : monitorOption;
+        const normalizedMonitorOption = monitorOption || "none";
         await lidarr.updateArtistMonitoring(lidarrArtist.id, monitorOption);
         console.log(
           `[LibraryManager] Updated Lidarr monitoring for "${lidarrArtist.artistName}" to "${monitorOption}"`,

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -55,6 +55,10 @@ function removeCachedArtistByMbid(mbid) {
   );
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function getLidarrClient() {
   if (!lidarrClient) {
     try {
@@ -583,6 +587,47 @@ export class LibraryManager {
     return updated?.error ? artist : updated;
   }
 
+  async ensureRequestedAlbumMonitoring(artistId, albumId, options = {}) {
+    const normalizedArtistId = String(artistId || "").trim();
+    const normalizedAlbumId = String(albumId || "").trim();
+    if (!normalizedArtistId || !normalizedAlbumId) {
+      return { artist: null, album: null };
+    }
+
+    let artist = await this.getArtistById(normalizedArtistId);
+    if (artist?.monitored === false) {
+      artist = await this.ensureArtistMonitored(artist, options.monitorOption);
+    }
+
+    let album = await this.getAlbumById(normalizedAlbumId);
+    if (album?.monitored === false) {
+      album = await this.updateAlbum(normalizedAlbumId, { monitored: true });
+    }
+
+    return { artist, album };
+  }
+
+  scheduleRequestedAlbumMonitoringRepair(artistId, albumId, options = {}) {
+    const normalizedArtistId = String(artistId || "").trim();
+    const normalizedAlbumId = String(albumId || "").trim();
+    if (!normalizedArtistId || !normalizedAlbumId) return;
+
+    for (const delayMs of [1000, 3000, 8000, 15000]) {
+      const timeout = setTimeout(() => {
+        this.ensureRequestedAlbumMonitoring(
+          normalizedArtistId,
+          normalizedAlbumId,
+          options,
+        ).catch((error) => {
+          console.error(
+            `[LibraryManager] Failed to stabilize requested album monitoring: ${error.message}`,
+          );
+        });
+      }, delayMs);
+      timeout.unref?.();
+    }
+  }
+
   async getAllArtists() {
     try {
       const lidarr = await getLidarrClient();
@@ -835,7 +880,6 @@ export class LibraryManager {
           msg.includes("foreignalbumid")
         );
       };
-      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
       const settings = getSettings();
       const searchOnAdd = settings.integrations?.lidarr?.searchOnAdd ?? false;
       const shouldTriggerSearch =
@@ -848,6 +892,11 @@ export class LibraryManager {
         }
         if (shouldTriggerSearch) {
           await lidarr.triggerAlbumSearch(existingAlbum.id);
+          await this.ensureRequestedAlbumMonitoring(artistId, existingAlbum.id);
+          this.scheduleRequestedAlbumMonitoringRepair(
+            artistId,
+            existingAlbum.id,
+          );
         }
         const refreshedExisting = await lidarr
           .getAlbum(existingAlbum.id)
@@ -947,6 +996,13 @@ export class LibraryManager {
       }
       if (!lidarrAlbum) {
         return { error: "Failed to add album to Lidarr" };
+      }
+      if (shouldTriggerSearch) {
+        await this.ensureRequestedAlbumMonitoring(artistId, lidarrAlbum.id);
+        this.scheduleRequestedAlbumMonitoringRepair(artistId, lidarrAlbum.id);
+        lidarrAlbum = await lidarr
+          .getAlbum(lidarrAlbum.id)
+          .catch(() => lidarrAlbum);
       }
       const updatedArtist = await lidarr.getArtist(artistId);
       return this.mapLidarrAlbum(lidarrAlbum, updatedArtist);

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -46,6 +46,15 @@ function upsertCachedArtist(mappedArtist) {
   _cachedArtists.unshift(mappedArtist);
 }
 
+function removeCachedArtistByMbid(mbid) {
+  if (!mbid || !Array.isArray(_cachedArtists) || _cachedArtists.length === 0) {
+    return;
+  }
+  _cachedArtists = _cachedArtists.filter(
+    (artist) => artist?.mbid !== mbid && artist?.foreignArtistId !== mbid,
+  );
+}
+
 async function getLidarrClient() {
   if (!lidarrClient) {
     try {
@@ -552,6 +561,28 @@ export class LibraryManager {
     }
   }
 
+  async ensureArtistMonitored(artist, monitorOption = null) {
+    if (!artist || artist.monitored !== false) {
+      return artist;
+    }
+
+    const mbid = artist.mbid || artist.foreignArtistId;
+    if (!mbid) {
+      return artist;
+    }
+
+    const nextMonitorOption =
+      monitorOption ||
+      artist.monitorOption ||
+      artist.addOptions?.monitor ||
+      "none";
+    const updated = await this.updateArtist(mbid, {
+      monitored: true,
+      monitorOption: nextMonitorOption,
+    });
+    return updated?.error ? artist : updated;
+  }
+
   async getAllArtists() {
     try {
       const lidarr = await getLidarrClient();
@@ -769,6 +800,7 @@ export class LibraryManager {
       if (!lidarrArtist)
         return { success: false, error: "Artist not found in Lidarr" };
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
+      removeCachedArtistByMbid(mbid);
       console.log(
         `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`,
       );
@@ -845,6 +877,12 @@ export class LibraryManager {
         }
       }
       if (!lidarrArtist) return { error: "Artist not found in Lidarr" };
+      if (lidarrArtist.monitored === false) {
+        lidarrArtist = await lidarr.updateArtistMonitoring(
+          artistId,
+          lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none",
+        );
+      }
       const existing = await lidarr.getAlbumByMbid(releaseGroupMbid);
       const artistNumericId = parseInt(artistId, 10);
       const sameArtistExisting =
@@ -990,6 +1028,8 @@ export class LibraryManager {
       error.statusCode = 503;
       throw error;
     }
+
+    artist = await this.ensureArtistMonitored(artist);
 
     let existingAlbum = await lidarr.getAlbumByMbid(normalizedAlbumMbid);
     if (

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -927,9 +927,16 @@ export class LidarrClient {
       },
     };
 
+    const ensureArtistMonitored = async (artist) => {
+      if (!artist?.id || artist.monitored === true) {
+        return artist;
+      }
+      return this.updateArtistMonitoring(artist.id, monitoring.option);
+    };
+
     try {
       const result = await this.request("/artist", "POST", lidarrArtist);
-      return result;
+      return ensureArtistMonitored(result);
     } catch (error) {
       if (requestedMonitorOption !== "all") {
         throw error;
@@ -942,7 +949,8 @@ export class LidarrClient {
           monitor: "existing",
         },
       };
-      return this.request("/artist", "POST", fallbackArtist);
+      const result = await this.request("/artist", "POST", fallbackArtist);
+      return ensureArtistMonitored(result);
     }
   }
 
@@ -1051,17 +1059,29 @@ export class LidarrClient {
       throw new Error(`Artist with ID ${artistId} not found in Lidarr`);
     }
 
+    const effectiveArtist =
+      artist.monitored === true
+        ? artist
+        : await this.updateArtistMonitoring(
+            artistId,
+            artist.monitor || artist.addOptions?.monitor || "none",
+          );
+
     const lidarrAlbum = {
       title: albumName,
       foreignAlbumId: albumMbid,
       artistId: artistId,
-      artist: artist,
+      artist: effectiveArtist,
       monitored: options.monitored !== false,
       anyReleaseOk: true,
       images: [],
     };
 
-    const result = await this.request("/album", "POST", lidarrAlbum);
+    let result = await this.request("/album", "POST", lidarrAlbum);
+
+    if (options.monitored !== false && result?.id && result.monitored !== true) {
+      result = await this.monitorAlbum(result.id, true);
+    }
 
     if (options.triggerSearch === true) {
       await this.triggerAlbumSearch(result.id);
@@ -1163,7 +1183,11 @@ export class LidarrClient {
       params.append("deleteFiles", "true");
     }
     const query = params.toString() ? `?${params.toString()}` : "";
-    return this.request(`/artist/${artistId}${query}`, "DELETE");
+    const result = await this.request(`/artist/${artistId}${query}`, "DELETE");
+    this._artistListCache = null;
+    this._invalidateArtistIndexes();
+    this._albumCache.clear();
+    return result;
   }
 
   async deleteAlbum(albumId, deleteFiles = false) {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -46,7 +46,7 @@ function normalizeMonitorOption(value) {
 
 function getArtistMonitoringPayload(
   monitorOption,
-  { forceArtistMonitored = false } = {},
+  { forceArtistMonitored = true } = {},
 ) {
   const option = normalizeMonitorOption(monitorOption);
   const monitored = forceArtistMonitored || option !== "none";
@@ -887,7 +887,6 @@ export class LidarrClient {
       albumOnly && requestedMonitorOption === "none"
         ? "missing"
         : requestedMonitorOption,
-      { forceArtistMonitored: albumOnly },
     );
     const searchOnAdd = settings.integrations?.lidarr?.searchOnAdd ?? false;
 

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -13,6 +13,15 @@ const LIDARR_RETRY_ATTEMPTS = 2;
 const LIDARR_RETRY_DELAY_MS = 800;
 const LIDARR_STATUS_CACHE_MS = 10000;
 const LIDARR_ARTIST_INDEX_TTL_MS = 15 * 60 * 1000;
+const VALID_MONITOR_OPTIONS = new Set([
+  "none",
+  "existing",
+  "all",
+  "future",
+  "missing",
+  "latest",
+  "first",
+]);
 
 function normalizeRootFolderPath(value) {
   const normalized = String(value || "").trim();
@@ -28,6 +37,28 @@ function normalizeProfileId(value) {
     return null;
   }
   return Math.trunc(parsed);
+}
+
+function normalizeMonitorOption(value) {
+  const option = String(value || "none").trim();
+  return VALID_MONITOR_OPTIONS.has(option) ? option : "none";
+}
+
+function getArtistMonitoringPayload(
+  monitorOption,
+  { forceArtistMonitored = false } = {},
+) {
+  const option = normalizeMonitorOption(monitorOption);
+  const monitored = forceArtistMonitored || option !== "none";
+  const monitorNewItems =
+    option === "all" || option === "future" ? "all" : "none";
+
+  return {
+    option,
+    monitored,
+    monitor: option,
+    monitorNewItems,
+  };
 }
 
 function mapTags(tags) {
@@ -849,12 +880,16 @@ export class LidarrClient {
     });
 
     const albumOnly = options.albumOnly === true;
-    const monitorOption = options.monitorOption || options.monitor || "none";
-    const lidarrMonitorOption = monitorOption;
-    const artistMonitored = albumOnly || monitorOption !== "none";
-    const effectiveMonitor = albumOnly ? "missing" : lidarrMonitorOption;
+    const requestedMonitorOption = normalizeMonitorOption(
+      options.monitorOption || options.monitor || "none",
+    );
+    const monitoring = getArtistMonitoringPayload(
+      albumOnly && requestedMonitorOption === "none"
+        ? "missing"
+        : requestedMonitorOption,
+      { forceArtistMonitored: albumOnly },
+    );
     const searchOnAdd = settings.integrations?.lidarr?.searchOnAdd ?? false;
-    const monitorNewItems = monitorOption === "none" ? "none" : "all";
 
     const qualityProfileId = resolved.qualityProfileId;
     const defaultMetadataProfileId =
@@ -882,13 +917,13 @@ export class LidarrClient {
       rootFolderPath: resolved.rootFolderPath,
       qualityProfileId: qualityProfileId,
       metadataProfileId: metadataProfileId,
-      monitored: artistMonitored,
-      monitor: effectiveMonitor,
-      monitorNewItems: monitorNewItems,
+      monitored: monitoring.monitored,
+      monitor: monitoring.monitor,
+      monitorNewItems: monitoring.monitorNewItems,
       tags: tags,
       albumsToMonitor: [],
       addOptions: {
-        monitor: effectiveMonitor,
+        monitor: monitoring.monitor,
         searchForMissingAlbums: searchOnAdd,
       },
     };
@@ -897,7 +932,7 @@ export class LidarrClient {
       const result = await this.request("/artist", "POST", lidarrArtist);
       return result;
     } catch (error) {
-      if (monitorOption !== "all") {
+      if (requestedMonitorOption !== "all") {
         throw error;
       }
       const fallbackArtist = {
@@ -980,24 +1015,23 @@ export class LidarrClient {
 
   async updateArtistMonitoring(artistId, monitorOption) {
     const artist = await this.getArtist(artistId);
-    const lidarrMonitorOption = monitorOption;
-    const monitorNewItems = monitorOption === "none" ? "none" : "all";
+    const monitoring = getArtistMonitoringPayload(monitorOption);
 
     const updated = {
       ...artist,
-      monitored: monitorOption !== "none",
-      monitor: lidarrMonitorOption,
-      monitorNewItems: monitorNewItems,
+      monitored: monitoring.monitored,
+      monitor: monitoring.monitor,
+      monitorNewItems: monitoring.monitorNewItems,
       addOptions: {
         ...(artist.addOptions || {}),
-        monitor: lidarrMonitorOption,
+        monitor: monitoring.monitor,
       },
     };
 
     try {
       return await this.request(`/artist/${artistId}`, "PUT", updated);
     } catch (error) {
-      if (monitorOption !== "all") {
+      if (monitoring.option !== "all") {
         throw error;
       }
       const fallbackUpdated = {

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -426,6 +426,7 @@ export function ArtistDetailsHero({
                       <div className="my-1" />
                       {[
                         { value: "none", label: "None (Artist Only)" },
+                        { value: "existing", label: "Existing Albums" },
                         { value: "all", label: "All Albums" },
                         { value: "future", label: "Future Albums" },
                         { value: "missing", label: "Missing Albums" },

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -231,6 +231,7 @@ export function useArtistDetailsLibrary({
       setShowRemoveDropdown(false);
       const monitorLabels = {
         none: "None (Artist Only)",
+        existing: "Existing Albums",
         all: "All Albums",
         future: "Future Albums",
         missing: "Missing Albums",

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -215,7 +215,7 @@ export function useArtistDetailsLibrary({
     try {
       const updatedArtist = {
         ...libraryArtist,
-        monitored: newMonitorOption !== "none",
+        monitored: true,
         monitorOption: newMonitorOption,
         addOptions: {
           ...(libraryArtist.addOptions || {}),
@@ -355,9 +355,15 @@ export function useArtistDetailsLibrary({
       libraryArtist.monitorNewItems;
     if (
       monitorOption &&
-      ["none", "all", "future", "missing", "latest", "first"].includes(
-        monitorOption,
-      )
+      [
+        "none",
+        "existing",
+        "all",
+        "future",
+        "missing",
+        "latest",
+        "first",
+      ].includes(monitorOption)
     ) {
       return monitorOption;
     }

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -622,6 +622,7 @@ export function SettingsIntegrationsTab({
                 }
               >
                 <option value="none">None (Artist Only)</option>
+                <option value="existing">Existing Albums</option>
                 <option value="all">All Albums</option>
                 <option value="future">Future Albums</option>
                 <option value="missing">Missing Albums</option>


### PR DESCRIPTION
## Summary
- Add support for Lidarr's `existing` monitor option across library add and update flows.
- Preserve `existing` as a distinct monitoring mode instead of normalizing it to `all`, while keeping `monitorNewItems` behavior aligned with future-facing modes.
- Stop bulk-updating the artist when downloading a single album, so album downloads only monitor the requested album.
- Expose `Existing Albums` in the artist details UI and Lidarr integration settings.
- Extend integration tests to cover new artist creation, artist updates, and album-only download monitoring.

## Testing
- Added/updated integration coverage in `.tests/auth/lidarr-preferences.integration.test.js` for `existing`, `none`, and album-only monitoring paths.
- Verified the fake Lidarr server now handles artist and album `PUT` requests plus album lookup endpoints used by the new flows.
- Not run: full test suite.
- Not run: manual UI verification in the browser.