### PR TITLE
Add verbose console logging toggle for server diagnostics

### DIFF
--- a/.tests/helpers/console-logging.test.js
+++ b/.tests/helpers/console-logging.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+import {
+  isVerboseConsoleEnabled,
+  shouldEmitDefaultConsoleMessage,
+} from "../../backend/loadEnv.js";
+
+const runConsoleProbe = (env = {}) => {
+  const result = spawnSync("node", [".tests/helpers/consolePatchProbe.js"], {
+    cwd: new URL("../..", import.meta.url),
+    env: {
+      ...process.env,
+      AURRAL_VERBOSE_LOGS: "",
+      ...env,
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return `${result.stdout}${result.stderr}`;
+};
+
+test("verbose console mode accepts explicit truthy environment values", () => {
+  assert.equal(isVerboseConsoleEnabled({ AURRAL_VERBOSE_LOGS: "true" }), true);
+  assert.equal(isVerboseConsoleEnabled({ AURRAL_VERBOSE_LOGS: "1" }), true);
+  assert.equal(isVerboseConsoleEnabled({ AURRAL_VERBOSE_LOGS: "debug" }), true);
+});
+
+test("verbose console mode stays off unless explicitly enabled", () => {
+  assert.equal(isVerboseConsoleEnabled({}), false);
+  assert.equal(isVerboseConsoleEnabled({ AURRAL_VERBOSE_LOGS: "false" }), false);
+  assert.equal(isVerboseConsoleEnabled({ AURRAL_VERBOSE_LOGS: "0" }), false);
+});
+
+test("default server console keeps only important startup and problem output", () => {
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("log", ["Server running on port 3001"]),
+    true,
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("log", [
+      "Discovery cache needs update. Starting...",
+    ]),
+    false,
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("warn", [
+      "Failed to broadcast download statuses",
+    ]),
+    true,
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("error", [
+      "Unhandled Rejection:",
+      new Error("boom"),
+    ]),
+    true,
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("debug", ["Lidarr getArtistByMbid completed"]),
+    false,
+  );
+});
+
+test("patched default server console suppresses routine detail output", () => {
+  const output = runConsoleProbe();
+
+  assert.match(output, /Server running on port 3001/);
+  assert.match(output, /Unhandled Rejection: probe failure/);
+  assert.doesNotMatch(output, /Discovery cache needs update/);
+  assert.doesNotMatch(output, /debug detail/);
+});
+
+test("patched verbose server console includes full detail output", () => {
+  const output = runConsoleProbe({ AURRAL_VERBOSE_LOGS: "true" });
+
+  assert.match(output, /Discovery cache needs update/);
+  assert.match(output, /Server running on port 3001/);
+  assert.match(output, /debug detail/);
+  assert.match(output, /Unhandled Rejection:/);
+  assert.match(output, /probe failure/);
+});
+
+test("structured logger starts at debug level in verbose console mode", async () => {
+  const originalVerbose = process.env.AURRAL_VERBOSE_LOGS;
+  process.env.AURRAL_VERBOSE_LOGS = "true";
+
+  try {
+    const { LOG_LEVELS_EXPORT, logger } = await import(
+      `../../backend/services/logger.js?verbose-test=${Date.now()}`
+    );
+    assert.equal(logger.shouldLog(LOG_LEVELS_EXPORT.DEBUG), true);
+  } finally {
+    if (originalVerbose === undefined) {
+      delete process.env.AURRAL_VERBOSE_LOGS;
+    } else {
+      process.env.AURRAL_VERBOSE_LOGS = originalVerbose;
+    }
+  }
+});

--- a/.tests/helpers/consolePatchProbe.js
+++ b/.tests/helpers/consolePatchProbe.js
@@ -1,0 +1,8 @@
+process.argv[1] = new URL("../../backend/server.js", import.meta.url).pathname;
+
+await import("../../backend/loadEnv.js");
+
+console.log("Discovery cache needs update. Starting...");
+console.log("Server running on port 3001");
+console.debug("debug detail");
+console.error("Unhandled Rejection:", new Error("probe failure"));

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Most configuration is handled in the web UI, but these environment variables are
 | `PORT` | HTTP port | `3001` |
 | `TRUST_PROXY` | Express trust proxy setting (`true`, `false`, or number) | `1` |
 | `DOWNLOAD_FOLDER` | Flow root folder path used for Navidrome library creation | `${DL_FOLDER:-./data/downloads}` in the compose example |
+| `AURRAL_VERBOSE_LOGS` | Print full diagnostic console logs from the server when set to `true` | unset |
 | `PUID` / `PGID` | Run container as this UID and GID when starting as root | `1001` / `1001` |
 | `LIDARR_INSECURE` | Allow invalid TLS certificates | unset |
 | `LIDARR_TIMEOUT_MS` | Lidarr request timeout | `8000` |
@@ -302,6 +303,7 @@ Event triggers such as Discover updated and Weekly Flow done apply to all config
 <summary><strong>Troubleshooting</strong></summary>
 
 - Lidarr connection fails: confirm the Lidarr URL is reachable and the API key is correct in `Settings -> Integrations -> Lidarr`
+- Need detailed server logs: set `AURRAL_VERBOSE_LOGS=true` and restart Aurral
 - Discovery looks empty: add artists to Lidarr and configure Last.fm, then give the first recommendation refresh a little time
 - MusicBrainz is slow: MusicBrainz is rate-limited and first runs can take longer
 - Flows do not show in Navidrome: verify `DOWNLOAD_FOLDER` matches your host path mapping and Navidrome purge settings

--- a/backend/loadEnv.js
+++ b/backend/loadEnv.js
@@ -1,22 +1,92 @@
 import dotenv from "dotenv";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import { fileURLToPath } from "url";
+
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on", "verbose", "debug"]);
+const DEFAULT_VISIBLE_MESSAGES = [
+  /^Server running on port \d+/,
+  /^Port \d+ is already in use\./,
+  /^Frontend not built\./,
+  /^Uncaught Exception:/,
+  /^Unhandled Rejection:/,
+  /^Server error:/,
+];
+
+export const isVerboseConsoleEnabled = (env = process.env) =>
+  TRUE_ENV_VALUES.has(
+    String(env.AURRAL_VERBOSE_LOGS || "").trim().toLowerCase(),
+  );
+
+const isServerProcess = (argv = process.argv) =>
+  basename(argv[1] || "") === "server.js";
+
+const formatLogTimestamp = () =>
+  new Date().toISOString().replace("T", " ").slice(0, 19);
+
+const hasTimestampPrefix = (value) =>
+  typeof value === "string" &&
+  /^\[\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/.test(value);
+
+const toCompactConsoleValue = (value) => {
+  if (value == null) return "";
+  if (value instanceof Error) return value.message || value.name;
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  return "";
+};
+
+export const shouldEmitDefaultConsoleMessage = (method, args = []) => {
+  if (method === "debug") return false;
+  if (method === "warn" || method === "error") return true;
+
+  const first = args[0];
+  if (typeof first !== "string") return false;
+  return DEFAULT_VISIBLE_MESSAGES.some((pattern) => pattern.test(first));
+};
+
+const formatDefaultConsoleArgs = (args = []) => {
+  const values = args.map(toCompactConsoleValue).filter(Boolean);
+  if (values.length > 0) return [values.join(" ")];
+  if (args.length > 0) {
+    return ["Details hidden. Set AURRAL_VERBOSE_LOGS=true for full logs."];
+  }
+  return [""];
+};
 
 const patchConsoleWithTimestamp = () => {
   if (globalThis.__aurralConsoleTimestampPatched) return;
   globalThis.__aurralConsoleTimestampPatched = true;
-  const formatLogTimestamp = () =>
-    new Date().toISOString().replace("T", " ").slice(0, 19);
+  const verbose = isVerboseConsoleEnabled();
+  const compactServerConsole = isServerProcess() && !verbose;
+
   for (const method of ["log", "info", "warn", "error", "debug"]) {
     const original = console[method].bind(console);
     console[method] = (...args) => {
+      if (compactServerConsole && !shouldEmitDefaultConsoleMessage(method, args)) {
+        return;
+      }
+
+      const visibleArgs = compactServerConsole
+        ? formatDefaultConsoleArgs(args)
+        : args;
       const timestamp = `[${formatLogTimestamp()}]`;
-      if (args.length === 0) {
+      if (visibleArgs.length === 0) {
         original(timestamp);
         return;
       }
-      const [first, ...rest] = args;
+
+      const [first, ...rest] = visibleArgs;
       if (typeof first === "string") {
+        if (hasTimestampPrefix(first)) {
+          original(first, ...rest);
+          return;
+        }
         original(`${timestamp} ${first}`, ...rest);
         return;
       }
@@ -25,7 +95,7 @@ const patchConsoleWithTimestamp = () => {
   }
 };
 
-patchConsoleWithTimestamp();
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: join(__dirname, ".env") });
+dotenv.config({ path: join(__dirname, ".env"), quiet: true });
+
+patchConsoleWithTimestamp();

--- a/backend/services/logger.js
+++ b/backend/services/logger.js
@@ -1,4 +1,5 @@
 import { dbOps } from '../config/db-helpers.js';
+import { isVerboseConsoleEnabled } from '../loadEnv.js';
 
 const LOG_LEVELS = {
   DEBUG: 0,
@@ -17,7 +18,7 @@ const LOG_LEVEL_NAMES = {
 
 class Logger {
   constructor() {
-    this.level = LOG_LEVELS.INFO;
+    this.level = isVerboseConsoleEnabled() ? LOG_LEVELS.DEBUG : LOG_LEVELS.INFO;
     this.persistToDb = true;
     this.maxDbEntries = 1000;
     this.categories = new Map();


### PR DESCRIPTION
## Summary
- Adds `AURRAL_VERBOSE_LOGS` to enable full server console output when set to a truthy value.
- Keeps default server startup/runtime logs compact by suppressing routine debug chatter while preserving important startup and error messages.
- Starts the structured logger at `DEBUG` level in verbose mode.
- Documents the new environment variable and troubleshooting guidance in `README.md`.
- Adds tests covering verbose flag parsing, console patch behavior, and logger level selection.

## Testing
- Added automated Node test coverage in `.tests/helpers/console-logging.test.js` for verbose mode detection and console filtering behavior.
- Verified the console patch probe emits only the expected startup/error lines in default mode and full detail output when `AURRAL_VERBOSE_LOGS=true`.
- Verified the logger initializes at `DEBUG` when verbose console logging is enabled.
- Not run: full repository test suite.