### PR TITLE
Prefer highest-priority artist image type

### DIFF
--- a/.tests/artist-images.test.js
+++ b/.tests/artist-images.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { selectBestArtistImage } from "../backend/services/imageService.js";
+
+test("artist image selection prefers poster art over banners for square displays", () => {
+  const selected = selectBestArtistImage([
+    {
+      kind: "Banner",
+      url: "https://assets.fanart.tv/fanart/bieber-justin-50788c8b98378.jpg",
+    },
+    {
+      kind: "Fanart",
+      url: "https://assets.fanart.tv/fanart/bieber-justin-56167e6110c53.jpg",
+    },
+    {
+      kind: "Logo",
+      url: "https://assets.fanart.tv/fanart/bieber-justin-5c19a40664655.png",
+    },
+    {
+      kind: "Poster",
+      url: "https://assets.fanart.tv/fanart/bieber-justin-5375fe939e307.jpg",
+    },
+  ]);
+
+  assert.equal(
+    selected?.url,
+    "https://assets.fanart.tv/fanart/bieber-justin-5375fe939e307.jpg",
+  );
+});
+
+test("artist image selection keeps source order when image types tie", () => {
+  const selected = selectBestArtistImage([
+    { kind: "Fanart", url: "https://example.test/first.jpg" },
+    { kind: "Fanart", url: "https://example.test/second.jpg" },
+  ]);
+
+  assert.equal(selected?.url, "https://example.test/first.jpg");
+});

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -15,6 +15,34 @@ const pendingImageRequests = new Map();
 const LEGACY_COVER_HOST_PATTERN =
   /https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org|archive\.org|[\w-]+\.ca\.archive\.org)\//i;
 
+const ARTIST_IMAGE_KIND_RANK = {
+  poster: 0,
+  artist: 1,
+  thumb: 2,
+  fanart: 3,
+  background: 4,
+  banner: 8,
+  logo: 9,
+  clearlogo: 9,
+};
+
+const getArtistImageKindRank = (image) => {
+  const kind = String(image?.kind || image?.CoverType || "").trim().toLowerCase();
+  return ARTIST_IMAGE_KIND_RANK[kind] ?? 5;
+};
+
+export const selectBestArtistImage = (images = []) => {
+  if (!Array.isArray(images)) return null;
+  return images
+    .filter((image) => image?.url)
+    .map((image, index) => ({ image, index }))
+    .sort((a, b) => {
+      const rankDiff = getArtistImageKindRank(a.image) - getArtistImageKindRank(b.image);
+      if (rankDiff !== 0) return rankDiff;
+      return a.index - b.index;
+    })[0]?.image || null;
+};
+
 const addToNegativeCache = (mbid) => {
   if (negativeImageCache.size >= MAX_NEGATIVE_CACHE) {
     const firstKey = negativeImageCache.keys().next().value;
@@ -170,9 +198,7 @@ export const getArtistImage = async (
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
       const metadataArtist = await getArtistByMbid(resolvedMbid).catch(() => null);
-      const directArtistImage = Array.isArray(metadataArtist?.images)
-        ? metadataArtist.images.find((image) => image?.url)
-        : null;
+      const directArtistImage = selectBestArtistImage(metadataArtist?.images);
 
       if (directArtistImage?.url) {
         const cachedImage = await warmImageProxy(directArtistImage.url);


### PR DESCRIPTION
## Summary
- Added `selectBestArtistImage` to rank artist images by kind and keep source order as a tie-breaker.
- Updated artist image lookup to pick the best available image instead of the first URL-bearing entry.
- Added tests covering poster-vs-banner selection and stable ordering for tied image types.

## Testing
- Not run (PR content only).
- Added unit coverage in [`.tests/artist-images.test.js`](/Users/leekelly/Sync/Aurral/.tests/artist-images.test.js).
- Verified the selection logic change in [`backend/services/imageService.js`](/Users/leekelly/Sync/Aurral/backend/services/imageService.js).