### PR TITLE
Select best album art from image sources

### DIFF
--- a/.tests/artist-images.test.js
+++ b/.tests/artist-images.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { selectBestArtistImage } from "../backend/services/imageService.js";
+import {
+  selectBestAlbumImage,
+  selectBestArtistImage,
+} from "../backend/services/imageService.js";
 
 test("artist image selection prefers poster art over banners for square displays", () => {
   const selected = selectBestArtistImage([
@@ -36,4 +39,22 @@ test("artist image selection keeps source order when image types tie", () => {
   ]);
 
   assert.equal(selected?.url, "https://example.test/first.jpg");
+});
+
+test("album image selection prefers cover art over disc art", () => {
+  const selected = selectBestAlbumImage([
+    { kind: "Disc", url: "https://example.test/disc.png" },
+    { kind: "Cover", url: "https://example.test/cover.jpg" },
+  ]);
+
+  assert.equal(selected?.url, "https://example.test/cover.jpg");
+});
+
+test("album image selection accepts raw BrainzMash image casing", () => {
+  const selected = selectBestAlbumImage([
+    { CoverType: "Disc", Url: "https://example.test/disc.png" },
+    { CoverType: "Cover", Url: "https://example.test/cover.jpg" },
+  ]);
+
+  assert.equal(selected?.Url, "https://example.test/cover.jpg");
 });

--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -2,6 +2,7 @@ import { UUID_REGEX } from "../../../config/constants.js";
 import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { warmImageProxy } from "../../../services/imageProxyService.js";
+import { selectBestAlbumImage } from "../../../services/imageService.js";
 import {
   getAlbumByMbid,
   getAlbumTracksByAlbumMbid,
@@ -67,7 +68,7 @@ export default function registerReleaseGroup(router) {
 
       try {
         const album = await getAlbumByMbid(mbid);
-        const image = Array.isArray(album?.images) ? album.images[0] : null;
+        const image = selectBestAlbumImage(album?.images);
         if (image?.url) {
           const cachedImage = await warmImageProxy(image.url);
           dbOps.setImage(cacheKey, cachedImage.localUrl);

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -21,6 +21,7 @@ import {
   resolveAlbumByArtistAndTitle,
   resolveArtistByName as resolveMetadataArtistByName,
 } from "./metadataProvider.js";
+import { selectBestAlbumImage } from "./imageService.js";
 
 const mbCache = new NodeCache({ stdTTL: 300, checkperiod: 60, maxKeys: 500 });
 const lastfmCache = new NodeCache({
@@ -539,7 +540,7 @@ export async function fetchCoverArtArchiveReleaseGroup(releaseGroupMbid) {
   if (!releaseGroupMbid) return null;
   try {
     const album = await getMetadataAlbumByMbid(releaseGroupMbid);
-    const image = Array.isArray(album?.images) ? album.images[0] : null;
+    const image = selectBestAlbumImage(album?.images);
     if (image?.url) {
       return {
         imageUrl: image.url,

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -26,21 +26,49 @@ const ARTIST_IMAGE_KIND_RANK = {
   clearlogo: 9,
 };
 
+const ALBUM_IMAGE_KIND_RANK = {
+  front: 0,
+  cover: 0,
+  albumcover: 0,
+  back: 4,
+  booklet: 5,
+  medium: 6,
+  tray: 6,
+  spine: 7,
+  disc: 8,
+  logo: 9,
+};
+
 const getArtistImageKindRank = (image) => {
   const kind = String(image?.kind || image?.CoverType || "").trim().toLowerCase();
   return ARTIST_IMAGE_KIND_RANK[kind] ?? 5;
 };
 
-export const selectBestArtistImage = (images = []) => {
+const getAlbumImageKindRank = (image) => {
+  const kind = String(image?.kind || image?.CoverType || "").trim().toLowerCase();
+  return ALBUM_IMAGE_KIND_RANK[kind] ?? 3;
+};
+
+const getImageUrl = (image) => image?.url || image?.Url || null;
+
+const selectBestImageByKind = (images = [], getKindRank) => {
   if (!Array.isArray(images)) return null;
   return images
-    .filter((image) => image?.url)
+    .filter((image) => getImageUrl(image))
     .map((image, index) => ({ image, index }))
     .sort((a, b) => {
-      const rankDiff = getArtistImageKindRank(a.image) - getArtistImageKindRank(b.image);
+      const rankDiff = getKindRank(a.image) - getKindRank(b.image);
       if (rankDiff !== 0) return rankDiff;
       return a.index - b.index;
     })[0]?.image || null;
+};
+
+export const selectBestArtistImage = (images = []) => {
+  return selectBestImageByKind(images, getArtistImageKindRank);
+};
+
+export const selectBestAlbumImage = (images = []) => {
+  return selectBestImageByKind(images, getAlbumImageKindRank);
 };
 
 const addToNegativeCache = (mbid) => {
@@ -101,7 +129,7 @@ export const fetchReleaseGroupCoverUrl = async (
   }
   try {
     const album = await getAlbumByMbid(releaseGroupMbid);
-    const image = Array.isArray(album?.images) ? album.images[0] : null;
+    const image = selectBestAlbumImage(album?.images);
     if (image?.url) {
       const cachedImage = await warmImageProxy(image.url);
       dbOps.setImage(cacheKey, cachedImage.localUrl);

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -23,6 +23,7 @@ import {
   toNormalizedArtist,
   toNormalizedArtistAlbum,
 } from "./brainzmashMappers.js";
+import { selectBestAlbumImage } from "../imageService.js";
 
 const providerCache = new NodeCache({
   stdTTL: 300,
@@ -216,6 +217,7 @@ export async function searchAlbums(
     items = source.map((entry, index) => {
       const artists = Array.isArray(entry?.artists) ? entry.artists : [];
       const primaryArtist = artists[0] ? toNormalizedArtist(artists[0]) : null;
+      const coverImage = selectBestAlbumImage(entry?.images);
       return {
         id: entry?.id,
         title: entry?.title || "Untitled Release",
@@ -224,10 +226,7 @@ export async function searchAlbums(
         type: entry?.type || "Album",
         secondaryTypes: Array.isArray(entry?.secondarytypes) ? entry.secondarytypes : [],
         releaseDate: entry?.releasedate || null,
-        coverUrl:
-          Array.isArray(entry?.images) && entry.images[0]?.Url
-            ? String(entry.images[0].Url).trim()
-            : null,
+        coverUrl: coverImage?.Url ? String(coverImage.Url).trim() : null,
         images: Array.isArray(entry?.images) ? entry.images : [],
         inLibrary: false,
         score: Math.max(0, 100 - index),

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -2,6 +2,7 @@ import NodeCache from "node-cache";
 import { getDiscoveryCache } from "./discoveryService.js";
 import { getLastfmApiKey, lastfmRequest } from "./apiClients.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
+import { selectBestArtistImage } from "./imageService.js";
 import { lidarrClient } from "./lidarrClient.js";
 import {
   searchAlbums as providerSearchAlbums,
@@ -111,13 +112,14 @@ export function normalizeAlbumSearchSort(value) {
 }
 
 function normalizeArtistItem(item) {
+  const image = selectBestArtistImage(item.images);
   return {
     type: "artist",
     id: item.id,
     name: item.name,
     sortName: item.sortName || item.name,
-    image: item.images?.[0]?.url || null,
-    imageUrl: item.images?.[0]?.url || null,
+    image: image?.url || null,
+    imageUrl: image?.url || null,
     artistType: item.type || null,
     country: null,
     area: null,


### PR DESCRIPTION
## Summary
- Add album image selection logic that ranks cover art ahead of disc, tray, and other variants.
- Normalize album image handling across release group lookup, cover art fetches, and BrainzMash search results.
- Update artist search normalization to pick the best available artist image instead of assuming the first entry.
- Add tests covering album image ranking and BrainzMash casing compatibility.

## Testing
- `node --test .tests/artist-images.test.js`
- Not run: broader backend test suite
- Not run: manual API verification for release group cover lookup and album search responses