### PR TITLE
Reuse existing files in weekly flows

### DIFF
--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs/promises";
+import path from "path";
+
+import {
+  createIsolatedStateDir,
+  applyIsolatedBackendEnv,
+  cleanupIsolatedState,
+  importFromRepo,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const isolatedState = await createIsolatedStateDir("weekly-flow-file-reuse");
+applyIsolatedBackendEnv(isolatedState);
+
+const [{ db }, trackerModule, reuseModule] = await Promise.all([
+  importFromRepo("backend/config/db-sqlite.js"),
+  importFromRepo("backend/services/weeklyFlowDownloadTracker.js"),
+  importFromRepo("backend/services/weeklyFlowFileReuse.js"),
+]);
+
+const { downloadTracker } = trackerModule;
+const {
+  normalizeExistingFileMode,
+  reuseTrackForPlaylist,
+  createPlaylistFileEntry,
+} = reuseModule;
+
+const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
+
+test.beforeEach(async () => {
+  await resetDatabase(db);
+  downloadTracker.clearAll();
+  await fs.rm(weeklyFlowRoot, { recursive: true, force: true });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("normalizeExistingFileMode accepts supported modes and defaults invalid values", () => {
+  assert.equal(normalizeExistingFileMode("download"), "download");
+  assert.equal(normalizeExistingFileMode("hardlink"), "hardlink");
+  assert.equal(normalizeExistingFileMode("copy"), "copy");
+  assert.equal(normalizeExistingFileMode(""), "hardlink");
+  assert.equal(normalizeExistingFileMode("unsupported"), "hardlink");
+});
+
+test("reuseTrackForPlaylist hardlinks a completed Aurral track into the target playlist", async () => {
+  const track = {
+    artistName: "System of a Down",
+    trackName: "Chop Suey",
+    albumName: "Toxicity",
+  };
+  const sourcePath = path.join(
+    weeklyFlowRoot,
+    "aurral-weekly-flow",
+    "source-playlist",
+    "System of a Down",
+    "Toxicity",
+    "Chop Suey.flac",
+  );
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.writeFile(sourcePath, "audio");
+  const sourceJobId = downloadTracker.addJob(track, "source-playlist");
+  downloadTracker.setDone(sourceJobId, sourcePath, track.albumName);
+
+  const result = await reuseTrackForPlaylist(track, "target-playlist", {
+    existingFileMode: "hardlink",
+    weeklyFlowRoot,
+  });
+
+  assert.equal(result.reused, true);
+  assert.equal(result.sourceType, "aurral");
+  assert.equal(result.linkType, "hardlink");
+  assert.notEqual(result.finalPath, sourcePath);
+  assert.equal(await fs.readFile(result.finalPath, "utf8"), "audio");
+
+  const sourceStat = await fs.stat(sourcePath);
+  const targetStat = await fs.stat(result.finalPath);
+  assert.equal(targetStat.ino, sourceStat.ino);
+
+  await fs.rm(result.finalPath, { force: true });
+  assert.equal(await fs.readFile(sourcePath, "utf8"), "audio");
+  assert.equal(downloadTracker.getJob(result.jobId)?.status, "done");
+});
+
+test("createPlaylistFileEntry can copy files directly", async () => {
+  const sourcePath = path.join(weeklyFlowRoot, "source.mp3");
+  const targetPath = path.join(weeklyFlowRoot, "target.mp3");
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.writeFile(sourcePath, "audio");
+
+  const result = await createPlaylistFileEntry(sourcePath, targetPath, "copy");
+
+  assert.equal(result.linked, true);
+  assert.equal(result.linkType, "copy");
+  assert.equal(await fs.readFile(targetPath, "utf8"), "audio");
+  const sourceStat = await fs.stat(sourcePath);
+  const targetStat = await fs.stat(targetPath);
+  assert.notEqual(targetStat.ino, sourceStat.ino);
+});
+
+test("reuseTrackForPlaylist does not inspect sources when reuse is disabled", async () => {
+  const result = await reuseTrackForPlaylist(
+    { artistName: "Artist", trackName: "Song", albumName: "Album" },
+    "target-playlist",
+    {
+      existingFileMode: "download",
+      weeklyFlowRoot,
+    },
+  );
+
+  assert.equal(result.reused, false);
+  assert.equal(downloadTracker.getAll().length, 0);
+});

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Relevant links:
 ### Imported Playlists
 
 - Import exported Aurral playlists, single playlist objects, raw track arrays, or multi-playlist bundles
+- Reuse existing Aurral or Lidarr files with hardlinks or copies to avoid repeated downloads
 - Retry the exact imported tracks on failures instead of replacing them
 - Pause or resume retry cycles for incomplete imported playlists
 - Export static playlists back to JSON for sharing
@@ -160,6 +161,23 @@ Mount a downloads folder for flows, imported playlists, and optional Navidrome i
 ### Main library safety
 
 Aurral does not write to your root music folder directly. Main collection changes happen through Lidarr add, monitor, request, and import actions.
+
+### Existing file reuse
+
+Worker Settings includes an `Existing Files` mode for flows and imported playlists:
+
+- `Download` always downloads a new file into the Aurral library.
+- `Hardlink` reuses completed Aurral tracks or existing Lidarr files with hardlinks, then falls back to copying when the filesystem does not support hardlinks.
+- `Copy` copies completed Aurral tracks or existing Lidarr files into the generated playlist library.
+
+Reused files still get a playlist-local entry under `/app/downloads/aurral-weekly-flow/<playlist-id>`, so deleting a playlist folder removes only that playlist entry. To reuse Lidarr files, Aurral must be able to read the exact file path Lidarr reports. For example, if Lidarr reports `/data/Musik/...`, mount that path into Aurral too:
+
+```yaml
+aurral:
+  volumes:
+    - /srv/mergerfs/Downloads/Musik/aurral:/app/downloads
+    - /srv/mergerfs/Musik:/data/Musik:ro
+```
 
 </details>
 
@@ -307,6 +325,7 @@ Event triggers such as Discover updated and Weekly Flow done apply to all config
 - Discovery looks empty: add artists to Lidarr and configure Last.fm, then give the first recommendation refresh a little time
 - MusicBrainz is slow: MusicBrainz is rate-limited and first runs can take longer
 - Flows do not show in Navidrome: verify `DOWNLOAD_FOLDER` matches your host path mapping and Navidrome purge settings
+- Existing Lidarr tracks are still downloaded: verify Aurral can read the same root path that Lidarr reports for track files
 - Permission errors writing `./data`: set `PUID` and `PGID` to match your host directory ownership
 
 </details>

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -241,6 +241,7 @@ export const defaultData = {
       preferredFormat: "flac",
       preferredFormatStrict: false,
       retryCycleMinutes: 15,
+      existingFileMode: "hardlink",
     },
   },
   blocklist: [],

--- a/backend/config/db-helpers.js
+++ b/backend/config/db-helpers.js
@@ -92,6 +92,13 @@ const DEFAULT_PERMISSIONS = {
   deleteAlbum: false,
 };
 
+const normalizeExistingFileMode = (value) => {
+  const normalized = String(value || "").trim().toLowerCase();
+  return ["download", "hardlink", "copy"].includes(normalized)
+    ? normalized
+    : "hardlink";
+};
+
 export const userOps = {
   getDefaultPermissions() {
     return { ...DEFAULT_PERMISSIONS };
@@ -394,6 +401,9 @@ export const dbOps = {
             .filter(Boolean),
         )]
       : [];
+    const existingFileMode = normalizeExistingFileMode(
+      weeklyFlowWorker?.existingFileMode,
+    );
 
     const defaultFlowPlaylists = {
       discover: { enabled: false, nextRunAt: null },
@@ -431,6 +441,7 @@ export const dbOps = {
         preferredFormatStrict,
         retryCycleMinutes,
         retryPausedPlaylistIds,
+        existingFileMode,
       },
       blocklist:
         blocklist && typeof blocklist === "object"

--- a/backend/routes/weeklyFlow.js
+++ b/backend/routes/weeklyFlow.js
@@ -14,6 +14,11 @@ import {
 } from "../services/weeklyFlowPlaylistConfig.js";
 import { weeklyFlowOperationQueue } from "../services/weeklyFlowOperationQueue.js";
 import { getWeeklyFlowStatusSnapshot } from "../services/weeklyFlowStatusSnapshot.js";
+import {
+  createPlaylistFileEntry,
+  normalizeExistingFileMode,
+  reuseTrackForPlaylist,
+} from "../services/weeklyFlowFileReuse.js";
 import { noCache } from "../middleware/cache.js";
 import { hasPermission, verifyTokenAuth } from "../middleware/auth.js";
 import {
@@ -25,6 +30,7 @@ import { getLastfmApiKey } from "../services/apiClients.js";
 
 const router = express.Router();
 const FLOW_WORKER_RETRY_CYCLE_OPTIONS_MINUTES = [15, 30, 60, 360, 720, 1440];
+const EXISTING_FILE_MODE_OPTIONS = ["download", "hardlink", "copy"];
 const AUDIO_CONTENT_TYPES = {
   ".mp3": "audio/mpeg",
   ".m4a": "audio/mp4",
@@ -233,75 +239,24 @@ const getPlaylistLibraryRoot = (playlistType) =>
     String(playlistType || "").trim(),
   );
 
-const buildReusableJobsByIdentity = (jobs) => {
-  const reusableJobsByIdentity = new Map();
-  for (const job of Array.isArray(jobs) ? jobs : []) {
-    if (job?.status !== "done" || typeof job?.finalPath !== "string") continue;
-    const identity = buildTrackIdentity(job);
-    const current = reusableJobsByIdentity.get(identity) || [];
-    current.push(job);
-    reusableJobsByIdentity.set(identity, current);
-  }
-  for (const [identity, jobsForIdentity] of reusableJobsByIdentity.entries()) {
-    reusableJobsByIdentity.set(identity, sortJobsForTrackReuse(jobsForIdentity));
-  }
-  return reusableJobsByIdentity;
-};
-
-const buildUniqueReuseTargetPath = async (sourceJob, targetPlaylistId) => {
-  const safeSourcePath = path.resolve(sourceJob.finalPath);
-  const sourceRoot = getPlaylistLibraryRoot(sourceJob.playlistType);
-  if (!isPathInsideRoot(safeSourcePath, sourceRoot)) {
-    throw new Error(`Track path is outside the playlist library: ${sourceJob.finalPath}`);
-  }
-  const sourceStat = await fsp.stat(safeSourcePath);
-  if (!sourceStat.isFile()) {
-    throw new Error(`Track file is missing: ${sourceJob.finalPath}`);
-  }
-
-  const relativePath = path.relative(sourceRoot, safeSourcePath);
-  const targetRoot = getPlaylistLibraryRoot(targetPlaylistId);
-  let targetPath = path.resolve(targetRoot, relativePath);
-  if (!isPathInsideRoot(targetPath, targetRoot)) {
-    throw new Error(`Target path is outside the playlist library: ${targetPath}`);
-  }
-
-  const parsed = path.parse(targetPath);
-  let suffix = 1;
-  while (true) {
-    try {
-      await fsp.access(targetPath);
-      targetPath = path.resolve(
-        parsed.dir,
-        `${parsed.name}-${suffix}${parsed.ext}`,
-      );
-      suffix += 1;
-    } catch {
-      break;
+const reuseTracksForPlaylist = async (tracks, playlistId) => {
+  const settings = weeklyFlowWorker.getWorkerSettings();
+  const existingFileMode = normalizeExistingFileMode(settings.existingFileMode);
+  const reusedJobIds = [];
+  const tracksToQueue = [];
+  for (const track of Array.isArray(tracks) ? tracks : []) {
+    const reuse = await reuseTrackForPlaylist(track, playlistId, {
+      existingFileMode,
+      weeklyFlowRoot: weeklyFlowWorker.weeklyFlowRoot,
+      targetPlaylistType: playlistId,
+    });
+    if (reuse.reused) {
+      reusedJobIds.push(reuse.jobId);
+    } else {
+      tracksToQueue.push(track);
     }
   }
-
-  await fsp.mkdir(path.dirname(targetPath), { recursive: true });
-  return { safeSourcePath, targetPath };
-};
-
-const reuseCompletedTrackForPlaylist = async (track, targetPlaylistId, sourceJob) => {
-  const { safeSourcePath, targetPath } = await buildUniqueReuseTargetPath(
-    sourceJob,
-    targetPlaylistId,
-  );
-  await fsp.copyFile(safeSourcePath, targetPath);
-  const jobId = downloadTracker.addJob(track, targetPlaylistId);
-  if (!jobId) {
-    await fsp.rm(targetPath, { force: true });
-    return null;
-  }
-  downloadTracker.setDone(
-    jobId,
-    targetPath,
-    sourceJob.albumName || track.albumName || null,
-  );
-  return jobId;
+  return { reusedJobIds, tracksToQueue };
 };
 
 router.get("/stream/:jobId", noCache, async (req, res) => {
@@ -998,6 +953,11 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       "aurral-weekly-flow",
       playlist.id,
     );
+    const existingFileMode = normalizeExistingFileMode(
+      weeklyFlowWorker.getWorkerSettings().existingFileMode,
+    );
+    const staticPlaylistLinkMode =
+      existingFileMode === "download" ? "hardlink" : existingFileMode;
     for (const job of uniqueCompletedJobs) {
       const safeSourcePath = path.resolve(job.finalPath);
       if (!isPathInsideRoot(safeSourcePath, sourceRoot)) {
@@ -1012,7 +972,14 @@ router.post("/flows/:flowId/static-playlist", async (req, res) => {
       const relativePath = path.relative(sourceRoot, safeSourcePath);
       const targetPath = path.join(targetRoot, relativePath);
       await fsp.mkdir(path.dirname(targetPath), { recursive: true });
-      await fsp.copyFile(safeSourcePath, targetPath);
+      const linked = await createPlaylistFileEntry(
+        safeSourcePath,
+        targetPath,
+        staticPlaylistLinkMode,
+      );
+      if (!linked.linked) {
+        await fsp.copyFile(safeSourcePath, targetPath);
+      }
 
       const jobId = downloadTracker.addJob(
         {
@@ -1095,12 +1062,20 @@ router.post("/shared-playlists", async (req, res) => {
     });
 
     let tracksQueued = 0;
+    let reusedJobIds = [];
+    let jobIds = [];
     if (normalizedTracks.length > 0) {
-      tracksQueued = downloadTracker.addJobs(normalizedTracks, playlist.id).length;
+      const reused = await reuseTracksForPlaylist(normalizedTracks, playlist.id);
+      reusedJobIds = reused.reusedJobIds;
+      jobIds = downloadTracker.addJobs(reused.tracksToQueue, playlist.id);
+      tracksQueued = jobIds.length;
     }
 
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
+    if (reusedJobIds.length > 0) {
+      await playlistManager.scanLibrary();
+    }
     if (tracksQueued > 0) {
       if (!weeklyFlowWorker.running) {
         await weeklyFlowWorker.start();
@@ -1113,6 +1088,8 @@ router.post("/shared-playlists", async (req, res) => {
       success: true,
       playlist,
       tracksQueued,
+      tracksReused: reusedJobIds.length,
+      jobIds: [...reusedJobIds, ...jobIds],
     });
   } catch (error) {
     if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
@@ -1162,9 +1139,13 @@ router.post("/shared-playlists/import", async (req, res) => {
       ownerUserId: req.user.id,
     });
 
-    const jobIds = downloadTracker.addJobs(normalizedTracks, playlist.id);
+    const reused = await reuseTracksForPlaylist(normalizedTracks, playlist.id);
+    const jobIds = downloadTracker.addJobs(reused.tracksToQueue, playlist.id);
     playlistManager.updateConfig(false);
     await playlistManager.ensureSmartPlaylists();
+    if (reused.reusedJobIds.length > 0) {
+      await playlistManager.scanLibrary();
+    }
     if (jobIds.length > 0 && !weeklyFlowWorker.running) {
       await weeklyFlowWorker.start();
     } else if (jobIds.length > 0) {
@@ -1175,7 +1156,8 @@ router.post("/shared-playlists/import", async (req, res) => {
       success: true,
       playlist,
       tracksQueued: jobIds.length,
-      jobIds,
+      tracksReused: reused.reusedJobIds.length,
+      jobIds: [...reused.reusedJobIds, ...jobIds],
     });
   } catch (error) {
     if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
@@ -1221,38 +1203,10 @@ router.post("/shared-playlists/:playlistId/tracks", async (req, res) => {
       playlistId,
       tracksToAdd,
     );
-    const reusableJobsByIdentity = buildReusableJobsByIdentity(
-      downloadTracker
-        .getAll()
-        .filter((job) => String(job?.playlistType || "") !== String(playlistId)),
+    const { reusedJobIds, tracksToQueue } = await reuseTracksForPlaylist(
+      tracksToAdd,
+      playlistId,
     );
-    const reusedJobIds = [];
-    const tracksToQueue = [];
-    for (const track of tracksToAdd) {
-      const reusableJob = (reusableJobsByIdentity.get(buildTrackIdentity(track)) || [])[0];
-      if (!reusableJob) {
-        tracksToQueue.push(track);
-        continue;
-      }
-      try {
-        const reusedJobId = await reuseCompletedTrackForPlaylist(
-          track,
-          playlistId,
-          reusableJob,
-        );
-        if (reusedJobId) {
-          reusedJobIds.push(reusedJobId);
-        } else {
-          tracksToQueue.push(track);
-        }
-      } catch (error) {
-        console.warn(
-          `[WeeklyFlow] Failed to reuse completed track for ${playlistId}:`,
-          error.message,
-        );
-        tracksToQueue.push(track);
-      }
-    }
     const jobIds = downloadTracker.addJobs(tracksToQueue, playlistId);
 
     playlistManager.updateConfig(false);
@@ -1353,7 +1307,7 @@ router.put("/shared-playlists/:playlistId", async (req, res) => {
         }
 
         const matchedJobIds = new Set();
-        const tracksToQueue = [];
+        const tracksNeedingWork = [];
         for (const track of normalizedTracks) {
           const identity = buildTrackIdentity(track);
           const reusableJobs = reusableJobsByIdentity.get(identity) || [];
@@ -1361,7 +1315,7 @@ router.put("/shared-playlists/:playlistId", async (req, res) => {
           if (matchedJob) {
             matchedJobIds.add(matchedJob.id);
           } else {
-            tracksToQueue.push(track);
+            tracksNeedingWork.push(track);
           }
         }
 
@@ -1385,6 +1339,10 @@ router.put("/shared-playlists/:playlistId", async (req, res) => {
           name: safeName,
           tracks: normalizedTracks,
         });
+        const { tracksToQueue } = await reuseTracksForPlaylist(
+          tracksNeedingWork,
+          playlistId,
+        );
         tracksQueued = downloadTracker.addJobs(
           tracksToQueue,
           playlistId,
@@ -1658,6 +1616,7 @@ router.put("/worker/settings", requireAdmin, async (req, res) => {
     preferredFormat,
     preferredFormatStrict,
     retryCycleMinutes,
+    existingFileMode,
   } = req.body || {};
   if (concurrency !== undefined) {
     const parsed = Number(concurrency);
@@ -1694,11 +1653,20 @@ router.put("/worker/settings", requireAdmin, async (req, res) => {
       });
     }
   }
+  if (existingFileMode !== undefined) {
+    const normalized = String(existingFileMode || "").trim().toLowerCase();
+    if (!EXISTING_FILE_MODE_OPTIONS.includes(normalized)) {
+      return res.status(400).json({
+        error: "existingFileMode must be one of: download, hardlink, copy",
+      });
+    }
+  }
   const settings = weeklyFlowWorker.updateWorkerSettings({
     concurrency,
     preferredFormat,
     preferredFormatStrict,
     retryCycleMinutes,
+    existingFileMode,
   });
   try {
     await soulseekClient.applyConfigChanges();

--- a/backend/services/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlowFileReuse.js
@@ -1,0 +1,355 @@
+import fs from "fs/promises";
+import path from "path";
+import { downloadTracker } from "./weeklyFlowDownloadTracker.js";
+import { buildSharedTrackIdentity } from "./weeklyFlowPlaylistConfig.js";
+import { libraryManager } from "./libraryManager.js";
+
+export const EXISTING_FILE_MODES = new Set(["download", "hardlink", "copy"]);
+const DEFAULT_EXISTING_FILE_MODE = "hardlink";
+const LINK_FALLBACK_CODES = new Set([
+  "EXDEV",
+  "EPERM",
+  "EACCES",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+]);
+const AUDIO_EXTENSIONS = new Set([
+  ".flac",
+  ".mp3",
+  ".m4a",
+  ".ogg",
+  ".wav",
+  ".aac",
+  ".opus",
+  ".alac",
+  ".ape",
+  ".wma",
+]);
+
+export function normalizeExistingFileMode(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return EXISTING_FILE_MODES.has(normalized)
+    ? normalized
+    : DEFAULT_EXISTING_FILE_MODE;
+}
+
+function normalizeText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/\(.*?\)|\[.*?\]/g, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sanitizePathPart(value, fallback = "Unknown") {
+  const sanitized = String(value || fallback)
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .trim();
+  return sanitized || fallback;
+}
+
+function isPathInsideRoot(candidatePath, rootPath) {
+  const relative = path.relative(rootPath, candidatePath);
+  return (
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+  );
+}
+
+function getPlaylistRoot(weeklyFlowRoot, playlistType) {
+  return path.resolve(
+    weeklyFlowRoot,
+    "aurral-weekly-flow",
+    String(playlistType || "").trim(),
+  );
+}
+
+function getAudioExtension(filePath) {
+  const ext = path.extname(String(filePath || "")).toLowerCase();
+  return AUDIO_EXTENSIONS.has(ext) ? ext : ".mp3";
+}
+
+async function fileExists(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function getUniqueTargetPath(targetPath) {
+  let candidate = path.resolve(targetPath);
+  const parsed = path.parse(candidate);
+  let suffix = 1;
+  while (await fileExists(candidate)) {
+    candidate = path.resolve(parsed.dir, `${parsed.name}-${suffix}${parsed.ext}`);
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function sortReusableJobs(jobs) {
+  return [...jobs].sort((left, right) => {
+    const leftCreated = Number(left?.createdAt || 0);
+    const rightCreated = Number(right?.createdAt || 0);
+    if (leftCreated !== rightCreated) return leftCreated - rightCreated;
+    return String(left?.id || "").localeCompare(String(right?.id || ""));
+  });
+}
+
+async function findAurralSource(track, options = {}) {
+  const weeklyFlowRoot = path.resolve(options.weeklyFlowRoot || "/app/downloads");
+  const targetPlaylistType = String(options.targetPlaylistType || "").trim();
+  const identity = buildSharedTrackIdentity(track);
+  const excludeJobIds = new Set(
+    (Array.isArray(options.excludeJobIds) ? options.excludeJobIds : [])
+      .map((id) => String(id || "").trim())
+      .filter(Boolean),
+  );
+  const candidates = [];
+  for (const job of downloadTracker.getAll()) {
+    if (!job || job.status !== "done") continue;
+    if (excludeJobIds.has(String(job.id || ""))) continue;
+    if (!job.finalPath || typeof job.finalPath !== "string") continue;
+    if (buildSharedTrackIdentity(job) !== identity) continue;
+    const sourcePath = path.resolve(job.finalPath);
+    if (!isPathInsideRoot(sourcePath, path.resolve(weeklyFlowRoot))) continue;
+    if (targetPlaylistType && String(job.playlistType || "") === targetPlaylistType) {
+      const targetRoot = getPlaylistRoot(weeklyFlowRoot, targetPlaylistType);
+      if (isPathInsideRoot(sourcePath, targetRoot)) continue;
+    }
+    if (!(await fileExists(sourcePath))) continue;
+    candidates.push(job);
+  }
+  const sourceJob = sortReusableJobs(candidates)[0];
+  if (!sourceJob) return null;
+  return {
+    sourceType: "aurral",
+    sourcePath: path.resolve(sourceJob.finalPath),
+    sourceJob,
+    albumName: sourceJob.albumName || track.albumName || null,
+  };
+}
+
+function findMatchingArtist(artists, track) {
+  const artistMbid = String(track?.artistMbid || "").trim();
+  if (artistMbid) {
+    const match = artists.find(
+      (artist) =>
+        String(artist?.mbid || "").trim() === artistMbid ||
+        String(artist?.foreignArtistId || "").trim() === artistMbid,
+    );
+    if (match) return match;
+  }
+  const artistKey = normalizeText(track?.artistName);
+  if (!artistKey) return null;
+  return (
+    artists.find((artist) => normalizeText(artist?.artistName || artist?.name) === artistKey) ||
+    null
+  );
+}
+
+function rankAlbums(albums, track) {
+  const albumMbid = String(track?.albumMbid || "").trim();
+  const albumKey = normalizeText(track?.albumName);
+  return [...albums].sort((left, right) => {
+    const score = (album) => {
+      let total = 0;
+      if (
+        albumMbid &&
+        (String(album?.mbid || "").trim() === albumMbid ||
+          String(album?.foreignAlbumId || "").trim() === albumMbid)
+      ) {
+        total += 100;
+      }
+      if (albumKey && normalizeText(album?.albumName || album?.title) === albumKey) {
+        total += 50;
+      }
+      if (album?.statistics?.sizeOnDisk > 0) total += 5;
+      return total;
+    };
+    return score(right) - score(left);
+  });
+}
+
+function findMatchingTrack(tracks, track) {
+  const trackMbid = String(track?.trackMbid || "").trim();
+  if (trackMbid) {
+    const match = tracks.find(
+      (entry) =>
+        String(entry?.mbid || "").trim() === trackMbid ||
+        String(entry?.foreignRecordingId || "").trim() === trackMbid ||
+        String(entry?.foreignTrackId || "").trim() === trackMbid,
+    );
+    if (match) return match;
+  }
+  const trackKey = normalizeText(track?.trackName);
+  if (!trackKey) return null;
+  return (
+    tracks.find((entry) => normalizeText(entry?.trackName || entry?.title) === trackKey) ||
+    null
+  );
+}
+
+async function findLidarrSource(track) {
+  let artists = [];
+  try {
+    artists = await libraryManager.getAllArtists();
+  } catch (error) {
+    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr artists:", error.message);
+    return null;
+  }
+  const artist = findMatchingArtist(Array.isArray(artists) ? artists : [], track);
+  if (!artist) return null;
+  const artistId = artist.id || artist.artistId;
+  if (!artistId) return null;
+
+  let albums = [];
+  try {
+    albums = await libraryManager.getAlbums(artistId);
+  } catch (error) {
+    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr albums:", error.message);
+    return null;
+  }
+
+  for (const album of rankAlbums(Array.isArray(albums) ? albums : [], track)) {
+    let tracks = [];
+    try {
+      tracks = await libraryManager.getTracks(album.id);
+    } catch (error) {
+      console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr tracks:", error.message);
+      continue;
+    }
+    const matchedTrack = findMatchingTrack(Array.isArray(tracks) ? tracks : [], track);
+    if (!matchedTrack || matchedTrack.hasFile !== true || !matchedTrack.path) continue;
+    const sourcePath = path.resolve(matchedTrack.path);
+    if (!(await fileExists(sourcePath))) {
+      console.warn(
+        `[WeeklyFlowReuse] Lidarr track exists but file is not accessible from Aurral: ${matchedTrack.path}`,
+      );
+      continue;
+    }
+    return {
+      sourceType: "lidarr",
+      sourcePath,
+      lidarrTrack: matchedTrack,
+      albumName: album.albumName || track.albumName || null,
+    };
+  }
+  return null;
+}
+
+function buildTargetPathForSource(source, track, playlistType, weeklyFlowRoot) {
+  const targetRoot = getPlaylistRoot(weeklyFlowRoot, playlistType);
+  if (source?.sourceType === "aurral" && source.sourceJob) {
+    const sourceRoot = getPlaylistRoot(weeklyFlowRoot, source.sourceJob.playlistType);
+    const sourcePath = path.resolve(source.sourcePath);
+    if (isPathInsideRoot(sourcePath, sourceRoot)) {
+      const relativePath = path.relative(sourceRoot, sourcePath);
+      return path.resolve(targetRoot, relativePath);
+    }
+  }
+
+  const artistDir = sanitizePathPart(track?.artistName, "Unknown Artist");
+  const albumDir = sanitizePathPart(source?.albumName || track?.albumName, "Unknown Album");
+  const fileName = `${sanitizePathPart(track?.trackName, "Unknown Track")}${getAudioExtension(source?.sourcePath)}`;
+  return path.resolve(targetRoot, artistDir, albumDir, fileName);
+}
+
+export async function createPlaylistFileEntry(sourcePath, targetPath, mode = "hardlink") {
+  const normalizedMode = normalizeExistingFileMode(mode);
+  if (normalizedMode === "download") {
+    return { linked: false, reason: "Existing file reuse is disabled" };
+  }
+  const safeSourcePath = path.resolve(sourcePath);
+  const safeTargetPath = path.resolve(targetPath);
+  await fs.mkdir(path.dirname(safeTargetPath), { recursive: true });
+
+  if (normalizedMode === "hardlink") {
+    try {
+      await fs.link(safeSourcePath, safeTargetPath);
+      return { linked: true, linkType: "hardlink" };
+    } catch (error) {
+      if (!LINK_FALLBACK_CODES.has(error?.code)) {
+        return { linked: false, reason: error.message };
+      }
+      console.warn(
+        `[WeeklyFlowReuse] Hardlink failed, copying file instead: ${error.code} ${error.message}`,
+      );
+    }
+  }
+
+  try {
+    await fs.copyFile(safeSourcePath, safeTargetPath);
+    return { linked: true, linkType: "copy" };
+  } catch (error) {
+    return { linked: false, reason: error.message };
+  }
+}
+
+export async function resolveReusableTrackSource(track, options = {}) {
+  const mode = normalizeExistingFileMode(options.existingFileMode);
+  if (mode === "download") {
+    return { source: null, reason: "Existing file reuse is disabled" };
+  }
+  const aurralSource = await findAurralSource(track, options);
+  if (aurralSource) return { source: aurralSource, reason: null };
+  const lidarrSource = await findLidarrSource(track);
+  if (lidarrSource) return { source: lidarrSource, reason: null };
+  return { source: null, reason: "No reusable Aurral or Lidarr file found" };
+}
+
+export async function reuseTrackForPlaylist(track, playlistType, options = {}) {
+  const mode = normalizeExistingFileMode(options.existingFileMode);
+  const weeklyFlowRoot = path.resolve(options.weeklyFlowRoot || "/app/downloads");
+  if (mode === "download") {
+    return { reused: false, reason: "Existing file reuse is disabled" };
+  }
+  const { source, reason } = await resolveReusableTrackSource(track, {
+    ...options,
+    existingFileMode: mode,
+    weeklyFlowRoot,
+    targetPlaylistType: playlistType,
+  });
+  if (!source) return { reused: false, reason };
+
+  const rawTargetPath = buildTargetPathForSource(
+    source,
+    track,
+    playlistType,
+    weeklyFlowRoot,
+  );
+  const targetRoot = getPlaylistRoot(weeklyFlowRoot, playlistType);
+  const targetPath = await getUniqueTargetPath(rawTargetPath);
+  if (!isPathInsideRoot(targetPath, targetRoot)) {
+    return { reused: false, reason: "Target path is outside playlist root" };
+  }
+  const link = await createPlaylistFileEntry(source.sourcePath, targetPath, mode);
+  if (!link.linked) {
+    console.warn(
+      `[WeeklyFlowReuse] Existing file reuse unavailable, falling back to download: ${link.reason}`,
+    );
+    return { reused: false, reason: link.reason };
+  }
+
+  const jobId = options.existingJobId || downloadTracker.addJob(track, playlistType);
+  if (!jobId) {
+    await fs.rm(targetPath, { force: true }).catch(() => {});
+    return { reused: false, reason: "Failed to create reuse job" };
+  }
+  downloadTracker.setDone(jobId, targetPath, source.albumName || track.albumName || null);
+  console.log(
+    `[WeeklyFlowReuse] Reused ${source.sourceType} track via ${link.linkType} for ${playlistType}: ${track.artistName} - ${track.trackName}`,
+  );
+  return {
+    reused: true,
+    jobId,
+    sourceType: source.sourceType,
+    linkType: link.linkType,
+    sourcePath: source.sourcePath,
+    finalPath: targetPath,
+    albumName: source.albumName || track.albumName || null,
+  };
+}

--- a/backend/services/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlowWorker.js
@@ -14,6 +14,10 @@ import {
   selectRankedMatchAttempts,
   validateDownloadedTrack,
 } from "./weeklyFlowSoulseekMatcher.js";
+import {
+  normalizeExistingFileMode,
+  reuseTrackForPlaylist,
+} from "./weeklyFlowFileReuse.js";
 
 const DEFAULT_CONCURRENCY = 3;
 const MIN_CONCURRENCY = 1;
@@ -441,6 +445,10 @@ export class WeeklyFlowWorker {
     return DEFAULT_RETRY_CYCLE_MINUTES;
   }
 
+  _normalizeExistingFileMode(value) {
+    return normalizeExistingFileMode(value);
+  }
+
   _getIncompleteRetryDelayMs() {
     const { retryCycleMinutes } = this.getWorkerSettings();
     return Math.max(1000, retryCycleMinutes * 60 * 1000);
@@ -491,6 +499,7 @@ export class WeeklyFlowWorker {
       retryPausedPlaylistIds: this._normalizeRetryPausedPlaylistIds(
         raw.retryPausedPlaylistIds,
       ),
+      existingFileMode: this._normalizeExistingFileMode(raw.existingFileMode),
     };
   }
 
@@ -519,6 +528,10 @@ export class WeeklyFlowWorker {
       retryPausedPlaylistIds: this._normalizeRetryPausedPlaylistIds(
         base.retryPausedPlaylistIds,
       ),
+      existingFileMode:
+        nextSettings.existingFileMode === undefined
+          ? base.existingFileMode
+          : this._normalizeExistingFileMode(nextSettings.existingFileMode),
     };
     dbOps.updateSettings({
       ...current,
@@ -1256,6 +1269,49 @@ export class WeeklyFlowWorker {
       const resolvedTrack = await resolveWeeklyFlowTrackContext(job);
       downloadTracker.updateMetadata(job.id, resolvedTrack);
       Object.assign(job, resolvedTrack);
+      const { existingFileMode } = this.getWorkerSettings();
+      if (existingFileMode !== "download") {
+        const reuse = await reuseTrackForPlaylist(resolvedTrack, job.playlistType, {
+          existingFileMode,
+          weeklyFlowRoot: this.weeklyFlowRoot,
+          existingJobId: job.id,
+          excludeJobIds: [job.id],
+        });
+        if (reuse.reused) {
+          this._resetFailureStreak();
+          this.retryAttempts.delete(job.id);
+          this.retryNotBefore.delete(job.id);
+          this.backupRefillRounds.delete(job.playlistType);
+          this._dropOverflowPendingJobs(job.playlistType);
+          this._recordCompletedTrack(
+            Number(process.hrtime.bigint() - perfStartHr) / 1e6,
+            0,
+          );
+          phaseStart = process.hrtime.bigint();
+          this._assertJobCanContinue(job, runGeneration);
+          await this.checkPlaylistComplete(job.playlistType);
+          timingsMs.completionCheck +=
+            Number(process.hrtime.bigint() - phaseStart) / 1e6;
+          const cpuDelta = process.cpuUsage(perfStartCpu);
+          const elapsedMs = Number(process.hrtime.bigint() - perfStartHr) / 1e6;
+          this.lastJobMetrics = {
+            jobId: job.id,
+            finishedAt: Date.now(),
+            elapsedMs: Math.round(elapsedMs),
+            cpuUserMs: Math.round(cpuDelta.user / 1000),
+            cpuSystemMs: Math.round(cpuDelta.system / 1000),
+            cpuTotalMs: Math.round((cpuDelta.user + cpuDelta.system) / 1000),
+            timingsMs: {
+              search: Math.round(timingsMs.search),
+              download: Math.round(timingsMs.download),
+              finalize: Math.round(timingsMs.finalize),
+              completionCheck: Math.round(timingsMs.completionCheck),
+              cleanupOnError: Math.round(timingsMs.cleanupOnError),
+            },
+          };
+          return;
+        }
+      }
       const searchQueries = buildFlowSearchQueries(resolvedTrack);
       if (searchQueries.length === 0) {
         throw new Error("No search queries could be built");

--- a/flows-and-playlists.md
+++ b/flows-and-playlists.md
@@ -136,6 +136,24 @@ Imported playlists are separate from flows.
 - They do not regenerate on a schedule.
 - They do not use Source Mix, Focus Filters, or Deep Dive.
 - They retry the exact tracklist they were imported with.
+- They can reuse completed Aurral tracks or existing Lidarr files when Worker Settings -> Existing Files is set to Hardlink or Copy.
+
+## Existing file reuse
+
+Aurral keeps every generated playlist entry inside its own playlist folder under `aurral-weekly-flow/<playlist-id>`. When existing file reuse is enabled, that entry can be a hardlink or copy instead of a new Soulseek download.
+
+- `Download` always downloads a new file.
+- `Hardlink` tries to hardlink a matching completed Aurral or Lidarr file, then falls back to copying.
+- `Copy` copies matching completed Aurral or Lidarr files into the generated playlist library.
+
+Aurral-global reuse prevents the same imported track from being downloaded again for another playlist. Lidarr-aware reuse requires Aurral to read the same file path Lidarr reports. If Lidarr reports `/data/Musik/...`, mount the library into Aurral at `/data/Musik`:
+
+```yaml
+aurral:
+  volumes:
+    - /srv/mergerfs/Downloads/Musik/aurral:/app/downloads
+    - /srv/mergerfs/Musik:/data/Musik:ro
+```
 
 ## What the importer accepts
 
@@ -256,6 +274,7 @@ Aurral accepts CSVJSON output directly as one playlist and understands Spotify-s
 - A top-level array of playlist objects is treated as multiple playlists.
 - If an imported playlist name conflicts with an existing playlist, Aurral renames it automatically.
 - Imported playlists queue their own downloads and do not affect any flow configuration.
+- When existing file reuse succeeds, the imported track is marked complete immediately and is not queued for download.
 
 ### Download retries and failure behavior
 

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -557,8 +557,10 @@ const DEFAULT_WORKER_SETTINGS = {
   preferredFormat: "flac",
   preferredFormatStrict: false,
   retryCycleMinutes: 15,
+  existingFileMode: "hardlink",
 };
 const FLOW_WORKER_RETRY_CYCLE_OPTIONS = [15, 30, 60, 360, 720, 1440];
+const FLOW_WORKER_EXISTING_FILE_MODES = ["download", "hardlink", "copy"];
 
 const normalizeRetryCycleMinutes = (value) => {
   const parsed = Number(value);
@@ -568,6 +570,13 @@ const normalizeRetryCycleMinutes = (value) => {
     return normalized;
   }
   return DEFAULT_WORKER_SETTINGS.retryCycleMinutes;
+};
+
+const normalizeExistingFileMode = (value) => {
+  const normalized = String(value || "").trim().toLowerCase();
+  return FLOW_WORKER_EXISTING_FILE_MODES.includes(normalized)
+    ? normalized
+    : DEFAULT_WORKER_SETTINGS.existingFileMode;
 };
 
 const buildFlowStatsFromJobs = (jobs) => {
@@ -1236,11 +1245,13 @@ function FlowPage() {
         : "flac";
     const preferredFormatStrict = raw.preferredFormatStrict === true;
     const retryCycleMinutes = normalizeRetryCycleMinutes(raw.retryCycleMinutes);
+    const existingFileMode = normalizeExistingFileMode(raw.existingFileMode);
     return {
       concurrency,
       preferredFormat,
       preferredFormatStrict,
       retryCycleMinutes,
+      existingFileMode,
     };
   };
 
@@ -1515,12 +1526,16 @@ function FlowPage() {
     const safeRetryCycleMinutes = normalizeRetryCycleMinutes(
       workerSettingsDraft.retryCycleMinutes,
     );
+    const safeExistingFileMode = normalizeExistingFileMode(
+      workerSettingsDraft.existingFileMode,
+    );
     const current = workerSettingsBaseline;
     const hasChanges =
       safeConcurrency !== current.concurrency ||
       safePreferredFormat !== current.preferredFormat ||
       safePreferredFormatStrict !== current.preferredFormatStrict ||
-      safeRetryCycleMinutes !== current.retryCycleMinutes;
+      safeRetryCycleMinutes !== current.retryCycleMinutes ||
+      safeExistingFileMode !== current.existingFileMode;
     if (!hasChanges || savingWorkerSettings) return;
     setSavingWorkerSettings(true);
     try {
@@ -1529,12 +1544,14 @@ function FlowPage() {
         preferredFormat: safePreferredFormat,
         preferredFormatStrict: safePreferredFormatStrict,
         retryCycleMinutes: safeRetryCycleMinutes,
+        existingFileMode: safeExistingFileMode,
       });
       setWorkerSettingsBaseline({
         concurrency: safeConcurrency,
         preferredFormat: safePreferredFormat,
         preferredFormatStrict: safePreferredFormatStrict,
         retryCycleMinutes: safeRetryCycleMinutes,
+        existingFileMode: safeExistingFileMode,
       });
       showSuccess("Flow worker settings updated");
       setIsWorkerSettingsOpen(false);
@@ -1778,7 +1795,9 @@ function FlowPage() {
     (workerSettingsDraft.preferredFormatStrict === true) !==
       currentWorkerSettings.preferredFormatStrict ||
     normalizeRetryCycleMinutes(workerSettingsDraft.retryCycleMinutes) !==
-      currentWorkerSettings.retryCycleMinutes;
+      currentWorkerSettings.retryCycleMinutes ||
+    normalizeExistingFileMode(workerSettingsDraft.existingFileMode) !==
+      currentWorkerSettings.existingFileMode;
 
   return (
     <div className="flow-page max-w-6xl mx-auto pb-10 sm:px-4">

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -65,6 +65,11 @@ const FLOW_WORKER_FORMAT_OPTIONS = [
   { id: "flac", label: "FLAC" },
   { id: "mp3", label: "MP3" },
 ];
+const FLOW_WORKER_EXISTING_FILE_OPTIONS = [
+  { id: "download", label: "Download" },
+  { id: "hardlink", label: "Hardlink" },
+  { id: "copy", label: "Copy" },
+];
 const FLOW_WORKER_RETRY_CYCLE_OPTIONS = [
   { minutes: 15, label: "15 min" },
   { minutes: 30, label: "30 min" },
@@ -3349,6 +3354,35 @@ export function FlowWorkerSettingsModal({
                   }}
                 />
               </div>
+            </div>
+          </div>
+          <div className="grid gap-1.5">
+            <label className="text-xs uppercase tracking-wider text-[#8b8b90] font-medium">
+              Existing Files
+            </label>
+            <div className="relative">
+              <select
+                value={settings.existingFileMode || "hardlink"}
+                onChange={(event) =>
+                  onChange((prev) => ({
+                    ...prev,
+                    existingFileMode: event.target.value,
+                  }))
+                }
+                className="h-[52px] w-full appearance-none rounded-md border border-white/10 bg-black/20 pl-3 pr-12 text-sm text-white outline-none transition focus:border-[#90a07d] focus:ring-1 focus:ring-[#90a07d]"
+                title="How generated playlists reuse existing Aurral or Lidarr files"
+              >
+                {FLOW_WORKER_EXISTING_FILE_OPTIONS.map((option) => (
+                  <option
+                    key={option.id}
+                    value={option.id}
+                    className="bg-[#131419] text-white"
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-5 w-5 -translate-y-1/2 text-white" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add worker-level `Existing Files` modes to weekly flows and imported playlists: `download`, `hardlink`, and `copy`.
- Reuse completed Aurral tracks or matching Lidarr files before queueing new downloads, and mark reused tracks complete immediately.
- Update the weekly flow UI, backend settings normalization, and docs to expose the new reuse behavior.
- Add coverage for mode normalization, hardlink/copy reuse, and the disabled-reuse path.

## Testing
- Not run
- Added node tests in `.tests/weekly-flow/file-reuse.test.js` covering reuse and file-linking behavior.
- Manual validation not run in this workspace.