### PR TITLE
Simplify tag search and surface flow run metadata

### DIFF
--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -45,6 +45,7 @@ test("creates flows with normalized scheduling and enforces unique names", () =>
   assert.deepEqual(flow.scheduleDays, [1, 5]);
   assert.equal(flow.scheduleTime, "06:00");
   assert.equal(flow.enabled, false);
+  assert.equal(flow.lastRunAt, null);
 
   assert.throws(
     () =>
@@ -53,6 +54,20 @@ test("creates flows with normalized scheduling and enforces unique names", () =>
       }),
     /already exists/,
   );
+});
+
+test("records flow last run time", () => {
+  const flow = flowPlaylistConfig.createFlow({
+    name: "Morning",
+    size: 20,
+  });
+  const lastRunAt = 1710000000000;
+
+  const updated = flowPlaylistConfig.markLastRunAt(flow.id, lastRunAt);
+  const stored = flowPlaylistConfig.getFlow(flow.id);
+
+  assert.equal(updated?.lastRunAt, lastRunAt);
+  assert.equal(stored?.lastRunAt, lastRunAt);
 });
 
 test("stores full shared playlists but exposes trackless summaries for hot paths", () => {

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -15,7 +15,6 @@ router.get("/", noCache, async (req, res) => {
       scope = "artist",
       limit = 24,
       offset = 0,
-      tagScope = "merged",
       releaseTypes = "",
     } = req.query;
 
@@ -28,7 +27,7 @@ router.get("/", noCache, async (req, res) => {
     }
 
     if (scope === "tag") {
-      return res.json(await searchTags(q, limit, offset, tagScope));
+      return res.json(await searchTags(q, limit, offset));
     }
 
     return res.json(await searchArtists(q, limit, offset));

--- a/backend/services/playlistArtwork.js
+++ b/backend/services/playlistArtwork.js
@@ -18,6 +18,13 @@ const TAG_COLORS = [
 ];
 
 const ARTWORK_SIZE = 1000;
+const TITLE_SAFE_WIDTH = 760;
+const TITLE_SAFE_TOP = 240;
+const TITLE_SAFE_BOTTOM = 890;
+const TITLE_SAFE_HEIGHT = TITLE_SAFE_BOTTOM - TITLE_SAFE_TOP;
+const TITLE_MAX_LINES = 6;
+const AURRAL_LOGO_PATH =
+  "m471 0.68c-1.38 0.23-7.23 1.33-13 2.46-5.77 1.13-14.77 3.64-20 5.58-5.23 1.94-13.55 5.56-18.5 8.04-4.95 2.48-11.48 6.18-14.5 8.23-3.02 2.04-8.2 6.05-11.5 8.91-3.3 2.86-9.33 8.89-13.4 13.4-4.07 4.51-9.61 11.57-12.31 15.7-2.71 4.13-6.64 11.1-8.74 15.5-2.1 4.4-5.26 12.05-7.01 17-1.75 4.95-4.53 14.4-6.18 21-2.56 10.26-3.07 14.54-3.52 29.5-0.4 13.19-0.2 18.48 0.82 21.46 0.86 2.56 2.58 4.79 4.84 6.28 2.19 1.45 4.99 2.32 7.5 2.32 2.81 0 5.19-0.86 8-2.87 2.2-1.58 8.14-6.43 13.21-10.78 5.06-4.35 11.59-9.36 14.5-11.13 2.91-1.78 10.46-5.49 16.79-8.26 6.33-2.77 12.63-5.86 14-6.87 1.51-1.11 4.09-5.58 6.5-11.25 2.2-5.17 5.07-11.43 6.39-13.9 1.31-2.48 6.04-8.13 10.5-12.56 4.48-4.46 10.12-9 12.61-10.14 2.48-1.15 7.42-3.07 11-4.28 4.38-1.48 10.08-2.38 17.5-2.76 6.75-0.35 14.09-0.08 19 0.68 4.4 0.69 11.15 2.56 15 4.15 4.38 1.82 9.78 5.25 14.43 9.16 4.09 3.44 9.82 9.4 12.75 13.25 2.93 3.85 6.85 10.15 8.72 14 1.87 3.85 4.57 10.6 6 15 1.43 4.4 3.37 11.6 4.31 16 1.28 5.97 1.72 12.96 1.75 27.5 0.02 15.16-0.37 21.39-1.78 28-1 4.68-2.95 11.88-4.33 16-1.38 4.13-4.74 12-7.46 17.5-2.73 5.5-7.85 14.05-11.37 19-3.53 4.95-13.68 17.77-22.56 28.5-8.87 10.73-18.53 22.88-21.46 27-2.93 4.13-7.37 11.33-9.88 16-2.5 4.67-5.86 12.1-7.47 16.5-1.61 4.4-3.65 11.38-4.54 15.5-0.9 4.13-2.25 12.45-3 18.5-0.76 6.05-2.05 12.35-2.86 14-0.82 1.65-2.67 3.79-4.12 4.75-1.45 0.96-3.75 1.75-5.13 1.75-1.37 0-5.2-1.12-8.5-2.5-3.73-1.55-7.98-2.51-11.25-2.53-3.64-0.03-6.02 0.54-7.75 1.85-1.37 1.04-5.75 6.57-9.72 12.29-3.96 5.71-11.28 15-16.25 20.64-4.96 5.64-9.32 11.49-9.67 13-0.35 1.51-0.41 5.45-0.14 8.75 0.45 5.58 0.79 6.27 4.88 9.9 2.42 2.15 9.35 6.3 15.4 9.22 6.05 2.93 14.6 6.26 19 7.39 4.4 1.14 12.95 2.33 19 2.65 7.93 0.41 13.58 0.13 20.25-1.04 5.09-0.89 13.2-3.08 18.03-4.87 4.83-1.79 12.52-5.5 17.1-8.25 5.46-3.28 10.94-7.76 15.97-13.04 4.21-4.42 9.49-11.17 11.74-15 2.24-3.83 5.55-10.79 7.34-15.46 1.79-4.67 3.88-11.65 4.65-15.5 0.78-3.85 2.05-11.73 2.84-17.5 0.79-5.77 2.05-12.3 2.79-14.5 0.74-2.2 3.43-7.15 5.98-11 2.55-3.85 8.58-11.73 13.41-17.5 4.84-5.77 13.33-16.13 18.88-23 5.55-6.88 13.06-17 16.69-22.5 3.62-5.5 8.87-14.27 11.66-19.5 2.8-5.23 7.07-14.23 9.5-20 2.43-5.77 6.02-16.35 7.98-23.5 1.96-7.15 4.38-17.27 5.37-22.5 1.49-7.8 1.81-14.69 1.82-38.5 0-23.9-0.32-30.67-1.82-38.5-1-5.23-2.71-13.1-3.79-17.5-1.09-4.4-3.15-11.6-4.58-16-1.43-4.4-4.48-12.27-6.78-17.5-2.3-5.23-6.71-13.77-9.79-19-3.09-5.22-8.51-13.1-12.04-17.5-3.53-4.4-10.42-11.79-15.31-16.41-4.89-4.63-11.14-10.08-13.89-12.12-2.75-2.03-8.83-5.72-13.5-8.2-4.67-2.48-12.55-6.13-17.5-8.1-4.95-1.98-13.5-4.74-19-6.13-5.5-1.4-14.73-3-20.5-3.54-5.77-0.55-16.58-0.94-24-0.86-7.42 0.07-14.63 0.32-16 0.54zm-268.5 78.76c-3.85 0.7-11.05 2.93-16 4.96-4.95 2.03-11.7 5.64-15 8.01-3.3 2.38-8.7 7.19-12.01 10.71-3.31 3.51-8.34 10.2-11.17 14.88-2.84 4.68-6.81 12.32-8.82 17-2 4.68-4.97 13.23-6.6 19-1.62 5.77-3.82 15.68-4.88 22-1.07 6.32-2.43 16-3.03 21.5-0.6 5.5-2.01 13.37-3.11 17.5-1.11 4.12-3.68 10.64-5.7 14.48-2.02 3.84-6.38 9.88-9.68 13.42-3.3 3.54-9.15 8.51-13 11.05-3.85 2.53-10.49 6.06-14.75 7.83-4.26 1.77-9.66 3.49-12 3.83-3.28 0.46-5.73 0-10.75-2.05-3.57-1.46-8.75-4.36-11.5-6.44-2.75-2.09-6.35-5.14-8-6.78-1.65-1.64-5.14-4.64-7.75-6.66-3.05-2.37-5.82-3.68-7.75-3.68-1.65 0-5.01 1.24-7.46 2.75-2.81 1.73-5.2 4.23-6.43 6.75-1.08 2.2-2.91 9.18-4.07 15.5-1.16 6.32-2.37 16.45-2.7 22.5-0.36 6.49-0.11 14.69 0.59 20 0.65 4.95 1.92 11.48 2.81 14.5 1.1 3.72 2.86 6.71 5.44 9.25 2.1 2.06 7.08 5.31 11.07 7.21 3.99 1.9 11.3 4.63 16.25 6.07 4.95 1.43 12.37 2.96 16.5 3.4 4.82 0.51 10.9 0.36 17-0.44 5.22-0.68 12.43-1.99 16-2.91 3.57-0.92 10.1-2.82 14.5-4.21 4.4-1.4 11.82-4.32 16.5-6.51 4.68-2.18 12.1-6.03 16.5-8.56 4.4-2.52 11.6-7.39 16-10.82 4.4-3.42 11.94-10.33 16.75-15.35 4.81-5.02 11.17-12.84 14.13-17.38 2.96-4.54 7.3-12.07 9.64-16.75 2.34-4.68 5.32-11.31 6.62-14.75 1.3-3.44 3.23-9.96 4.3-14.5 1.06-4.54 3.32-17.93 5-29.75 1.69-11.82 3.9-24.43 4.91-28 1.02-3.57 2.82-8.64 4-11.25 1.18-2.61 2.87-5.09 3.76-5.5 1.12-0.52 2.17 0.02 3.43 1.75 0.99 1.37 2.98 5.87 4.4 10 1.43 4.12 3.45 12 4.5 17.5 1.05 5.5 2.18 16.52 2.51 24.5 0.33 7.98 1.05 32.73 1.6 55 0.56 23.02 1.66 46.33 2.54 54 0.85 7.42 2.45 18 3.54 23.5 1.09 5.5 2.67 12.7 3.51 16 0.84 3.3 3.11 10.27 5.05 15.5 1.93 5.23 6.28 14.43 9.66 20.46 4.77 8.51 8.16 13.02 15.15 20.14 7.48 7.64 10.52 9.94 18 13.69 4.95 2.47 11.93 5.48 15.5 6.68 4.8 1.61 9.91 2.32 19.5 2.71 9.45 0.39 14.91 0.12 20-0.96 3.85-0.81 10.15-2.74 14-4.27 3.85-1.54 9.7-4.38 13-6.31 3.3-1.94 9.15-6.7 13-10.58 3.86-3.88 9.39-10.66 12.31-15.06 2.91-4.4 6.59-10.7 8.19-14 1.59-3.3 4.52-10.95 6.5-17 1.99-6.05 4.91-17.52 6.5-25.5 1.59-7.98 3.59-23.05 4.44-33.5 0.86-10.45 2.06-24.63 2.67-31.5 0.61-6.88 2.13-16.55 3.39-21.5 1.25-4.95 3.38-11.48 4.71-14.5 1.34-3.02 3.98-7.25 5.86-9.39 1.89-2.13 4.44-4.27 5.68-4.75 1.46-0.56 3.39-0.39 5.5 0.48 1.79 0.74 4.42 2.87 5.86 4.75 1.44 1.88 3.96 6.11 5.61 9.41 1.66 3.3 4.42 10.61 6.14 16.25 2.46 8.03 3.79 10.79 6.14 12.75 2.32 1.93 4.13 2.5 8 2.5 2.75 0 6.24-0.62 7.75-1.38 1.51-0.77 5.68-4.48 9.27-8.25 3.58-3.78 9.04-10.25 12.13-14.37 3.08-4.13 7.67-11.1 10.19-15.5 2.52-4.4 5.95-11.71 7.62-16.25 1.67-4.54 3.04-10.05 3.04-12.25 0-2.2-0.75-5.91-1.67-8.25-0.91-2.34-3.27-6.73-5.24-9.75-1.97-3.02-6.96-9.05-11.09-13.38-4.12-4.33-10.2-9.71-13.5-11.94-3.3-2.24-9.6-5.72-14-7.75-4.4-2.03-10.48-4.45-13.5-5.38-3.46-1.06-10.7-1.89-19.5-2.24-8.17-0.32-17.75-0.08-23 0.59-6.69 0.85-11.44 2.22-18.5 5.34-5.23 2.31-12.65 6.32-16.5 8.91-3.85 2.59-9.55 7.33-12.66 10.53-3.11 3.2-8.07 9.19-11.02 13.32-2.95 4.12-7.67 12.23-10.49 18-2.81 5.77-6.32 14.32-7.79 19-1.47 4.68-3.74 13.45-5.04 19.5-1.3 6.05-2.85 14.6-3.43 19-0.59 4.4-1.75 17.68-2.59 29.5-0.83 11.82-2.23 25.77-3.1 31-0.87 5.23-2.89 13.55-4.48 18.5-1.6 4.95-3.69 10.04-4.65 11.31-1.68 2.21-1.82 2.23-3.46 0.5-0.95-1-3.06-5.64-4.7-10.31-1.64-4.67-3.87-13.45-4.95-19.5-1.09-6.05-2.24-16.63-2.57-23.5-0.34-6.88-1.07-32.3-1.62-56.5-0.64-27.37-1.6-48.54-2.55-56-0.84-6.6-2.66-17.4-4.06-24-1.39-6.6-4-16.5-5.81-22-1.8-5.5-5.52-14.5-8.27-20-2.75-5.5-7.68-13.38-10.95-17.5-3.27-4.13-8.39-9.68-11.38-12.34-2.99-2.67-7.68-6.13-10.43-7.7-2.75-1.56-8.15-4.04-12-5.51-3.85-1.46-10.38-3.28-14.5-4.02-4.13-0.75-11.77-1.34-17-1.3-5.23 0.03-12.65 0.62-16.5 1.31z";
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
@@ -98,43 +105,107 @@ const chunkWord = (word, limit) => {
   return chunks;
 };
 
-const buildTitleLines = (value) => {
+const SMALL_TITLE_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "by",
+  "for",
+  "in",
+  "of",
+  "on",
+  "or",
+  "the",
+  "to",
+  "vs",
+  "with",
+]);
+
+const isSmallTitleWord = (word) => {
+  const normalized = String(word || "")
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase();
+  return normalized.length <= 3 || SMALL_TITLE_WORDS.has(normalized);
+};
+
+const buildTitlePhrases = (words, limit) => {
+  const phrases = [];
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index];
+    if (!isSmallTitleWord(word)) {
+      phrases.push(word);
+      continue;
+    }
+
+    const smallWords = [word];
+    let nextIndex = index + 1;
+    while (nextIndex < words.length && isSmallTitleWord(words[nextIndex])) {
+      const nextPhrase = `${smallWords.join(" ")} ${words[nextIndex]}`;
+      if (nextPhrase.length > limit) break;
+      smallWords.push(words[nextIndex]);
+      nextIndex += 1;
+    }
+
+    if (smallWords.length > 1) {
+      phrases.push(smallWords.join(" "));
+      index = nextIndex - 1;
+      continue;
+    }
+
+    const nextWord = words[index + 1];
+    if (
+      nextWord &&
+      !isSmallTitleWord(nextWord) &&
+      `${word} ${nextWord}`.length <= limit
+    ) {
+      phrases.push(`${word} ${nextWord}`);
+      index += 1;
+      continue;
+    }
+
+    phrases.push(word);
+  }
+  return phrases;
+};
+
+const buildTitleLayout = (value) => {
   const input = String(value || "").trim() || "Untitled";
-  const target = input.length > 24 ? 13 : input.length > 16 ? 16 : 20;
+  const chunkLimit = input.length > 36 ? 12 : 14;
   const words = input
     .split(/\s+/)
     .flatMap((word) =>
-      word.length > target ? chunkWord(word, target) : [word],
+      word.length > chunkLimit ? chunkWord(word, chunkLimit) : [word],
     )
     .filter(Boolean);
-  const lines = [];
-  let current = "";
-  for (const word of words) {
-    const next = current ? `${current} ${word}` : word;
-    if (next.length <= target || !current) {
-      current = next;
-      continue;
-    }
-    lines.push(current);
-    current = word;
-    if (lines.length === 2) break;
-  }
-  if (lines.length < 2 && current) {
-    lines.push(current);
-  }
-  if (lines.length > 2) {
-    lines.length = 2;
-  }
-  const consumed = lines.join(" ").length;
-  if (consumed < input.length) {
+  const phrases = buildTitlePhrases(words, chunkLimit + 6);
+  const lines = phrases.slice(0, TITLE_MAX_LINES);
+  if (phrases.length > TITLE_MAX_LINES) {
     const lastIndex = Math.max(lines.length - 1, 0);
-    const base = lines[lastIndex] || input.slice(0, target);
-    lines[lastIndex] =
-      base.length >= target
-        ? `${base.slice(0, Math.max(target - 1, 1)).trimEnd()}…`
-        : `${base}…`;
+    const base = lines[lastIndex] || "";
+    lines[lastIndex] = base.length >= chunkLimit
+      ? `${base.slice(0, Math.max(chunkLimit - 1, 1)).trimEnd()}…`
+      : `${base}…`;
   }
-  return lines.slice(0, 2);
+
+  const maxLineLength = Math.max(...lines.map((line) => line.length), 1);
+  const widthLimitedSize = Math.floor(TITLE_SAFE_WIDTH / (maxLineLength * 0.58));
+  const heightLimitedSize = Math.floor(TITLE_SAFE_HEIGHT / (lines.length * 1.12));
+  const fontSize = clamp(
+    Math.min(132, widthLimitedSize, heightLimitedSize),
+    64,
+    132,
+  );
+  const lineHeight = Math.round(fontSize * 1.1);
+  const totalHeight = fontSize + lineHeight * (lines.length - 1);
+  const y = Math.round(
+    TITLE_SAFE_TOP +
+      (TITLE_SAFE_HEIGHT - totalHeight) / 2 +
+      fontSize * 0.78,
+  );
+
+  return { lines, fontSize, lineHeight, y };
 };
 
 const getPalette = (playlistName) => {
@@ -150,12 +221,9 @@ const getPalette = (playlistName) => {
     blob2: hexToRgba(base2, 0.35),
     blob3: hexToRgba(base3, 0.4),
     blob4: hexToRgba(base4, 0.3),
-    chip: mixHex(base1, "#ffffff", 0.22),
-    chipStroke: hexToRgba("#ffffff", 0.16),
     line1: hexToRgba(base3, 0.15),
     line2: hexToRgba(base4, 0.15),
     title: "#f5f2ea",
-    subtitle: "rgba(245, 242, 234, 0.76)",
   };
 };
 
@@ -195,18 +263,14 @@ const buildArtworkSvg = ({ playlistName, kind }) => {
   const displayName = normalizeDisplayName(playlistName) || "Untitled";
   const normalizedKind = normalizeKind(kind);
   const palette = getPalette(displayName);
-  const titleLines = buildTitleLines(displayName);
-  const titleY = titleLines.length === 1 ? 500 : 450;
-  const titleSize = titleLines.some((line) => line.length > 16) ? 104 : 116;
+  const titleLayout = buildTitleLayout(displayName);
   const seed = hashString(`${normalizedKind}:${displayName}`);
   const angle = seed % 360;
 
-  const chipWidth = normalizedKind === "Flow" ? 188 : 220;
-  const chipX = (ARTWORK_SIZE - chipWidth) / 2;
-  const titleMarkup = titleLines
+  const titleMarkup = titleLayout.lines
     .map(
       (line, index) =>
-        `<tspan x="500" dy="${index === 0 ? 0 : 128}">${escapeXml(line)}</tspan>`,
+        `<tspan x="500" dy="${index === 0 ? 0 : titleLayout.lineHeight}">${escapeXml(line)}</tspan>`,
     )
     .join("");
 
@@ -265,10 +329,10 @@ const buildArtworkSvg = ({ playlistName, kind }) => {
     <path d="${lb1}" fill="none" stroke="${palette.line1}" stroke-width="2" />
     <path d="${lb2}" fill="none" stroke="${palette.line2}" stroke-width="1.5" />
   </g>
-  <rect x="${chipX}" y="136" width="${chipWidth}" height="58" rx="29" fill="${palette.chip}" stroke="${palette.chipStroke}" />
-  <text x="500" y="174" text-anchor="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="700" fill="${palette.subtitle}">${normalizedKind.toUpperCase().split("").join(" ")}</text>
-  <text x="500" y="${titleY}" text-anchor="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${titleSize}" font-weight="800" fill="${palette.title}">${titleMarkup}</text>
-  <text x="500" y="878" text-anchor="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="600" fill="${palette.subtitle}">A U R R A L</text>
+  <svg x="425" y="74" width="150" height="112" viewBox="0 0 650 485" opacity="0.72">
+    <path d="${AURRAL_LOGO_PATH}" fill="${palette.title}" />
+  </svg>
+  <text x="500" y="${titleLayout.y}" text-anchor="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${titleLayout.fontSize}" font-weight="800" fill="${palette.title}">${titleMarkup}</text>
 </svg>`.trim();
 };
 

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -427,7 +427,6 @@ export async function searchTags(
   query,
   limit = 24,
   offset = 0,
-  tagScope = "merged",
 ) {
   const tag = String(query || "").trim().replace(/^#/, "");
   const limitInt = parsePositiveInt(limit, 24);
@@ -459,131 +458,6 @@ export async function searchTags(
       ),
   );
 
-  if (tagScope === "recommended") {
-    return {
-      scope: "tag",
-      query: tag,
-      count: recommendedMatches.length,
-      offset: offsetInt,
-      hasMore: offsetInt + limitInt < recommendedMatches.length,
-      items: recommendedMatches.slice(offsetInt, offsetInt + limitInt),
-    };
-  }
-
-  if (tagScope === "all") {
-    if (getLastfmApiKey()) {
-      const page = Math.floor(offsetInt / limitInt) + 1;
-      const data = await lastfmRequest("tag.getTopArtists", {
-        tag,
-        limit: limitInt,
-        page,
-      });
-      const artists = Array.isArray(data?.topartists?.artist)
-        ? data.topartists.artist
-        : data?.topartists?.artist
-          ? [data.topartists.artist]
-          : [];
-      const items = artists
-        .map((artist) => normalizeLastfmTagArtist(artist, tag))
-        .filter((artist) => artist.id);
-
-      return {
-        scope: "tag",
-        query: tag,
-        count:
-          Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length,
-        offset: offsetInt,
-        hasMore:
-          offsetInt + items.length <
-          (Number.parseInt(data?.topartists?.["@attr"]?.total, 10) || items.length),
-        items,
-      };
-    }
-
-    const discoveryCacheData = getDiscoveryCache();
-    const fallbackResult = await searchFallbackGenreArtists({
-      tag,
-      limit: limitInt,
-      offset: offsetInt,
-      precomputedGenrePools:
-        discoveryCacheData?.fallbackGenrePools &&
-        Object.keys(discoveryCacheData.fallbackGenrePools).length > 0
-          ? discoveryCacheData.fallbackGenrePools
-          : null,
-    });
-    if (fallbackResult) {
-      return {
-        scope: "tag",
-        query: tag,
-        count: fallbackResult.total,
-        offset: offsetInt,
-        provider: DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK,
-        fallbackLimited: true,
-        hasMore: offsetInt + fallbackResult.artists.length < fallbackResult.total,
-        items: fallbackResult.artists.map((artist) =>
-          normalizeTagArtistItem(
-            {
-              type: "artist",
-              id: artist.id || artist.mbid || null,
-              name: artist.name || "Unknown Artist",
-              sortName: artist.sortName || artist.name || "Unknown Artist",
-              image: artist.image || artist.imageUrl || null,
-              imageUrl: artist.image || artist.imageUrl || null,
-              artistType: null,
-              country: null,
-              area: null,
-              begin: null,
-              end: null,
-              disambiguation: null,
-              tags: artist.tags || [tag],
-              genres: artist.genres || [tag],
-              inLibrary: false,
-              score: 0,
-            },
-            tag,
-          ),
-        ),
-      };
-    }
-
-    const discoveryCache = discoveryCacheData;
-    const sourceMap = getTagSourceMap(recommendedMatches);
-    const poolItems = dedupeTagArtists([
-      ...(Array.isArray(discoveryCache.recommendations)
-        ? discoveryCache.recommendations
-        : []),
-      ...(Array.isArray(discoveryCache.globalTop) ? discoveryCache.globalTop : []),
-      ...(Array.isArray(discoveryCache.basedOn) ? discoveryCache.basedOn : []),
-      ...(Array.isArray(discoveryCache.fallbackGenres)
-        ? discoveryCache.fallbackGenres.flatMap((section) =>
-            Array.isArray(section?.artists) ? section.artists : [],
-          )
-        : []),
-    ])
-      .filter((artist) => matchesTagSearch(artist, tagLower))
-      .map((artist) =>
-        normalizeTagArtistItem(
-          {
-            ...artist,
-            tagResultSource: sourceMap.get(getTagArtistKey(artist)) || "all",
-          },
-          tag,
-        ),
-      );
-
-    return {
-      scope: "tag",
-      query: tag,
-      count: poolItems.length,
-      offset: offsetInt,
-      provider: DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK,
-      fallbackLimited: true,
-      message: "Tag search is limited without Last.fm",
-      hasMore: offsetInt + limitInt < poolItems.length,
-      items: poolItems.slice(offsetInt, offsetInt + limitInt),
-    };
-  }
-
   if (getLastfmApiKey()) {
     const merged = await fetchMergedLastfmTagArtists(
       tag,
@@ -600,6 +474,58 @@ export async function searchTags(
         : offsetInt + items.length + (merged.items.length > offsetInt + items.length ? 1 : 0),
       offset: offsetInt,
       hasMore: !merged.exhausted || offsetInt + items.length < merged.items.length,
+      items,
+    };
+  }
+
+  const fallbackResult = await searchFallbackGenreArtists({
+    tag,
+    limit: offsetInt + limitInt,
+    offset: 0,
+    precomputedGenrePools:
+      discoveryCache?.fallbackGenrePools &&
+      Object.keys(discoveryCache.fallbackGenrePools).length > 0
+        ? discoveryCache.fallbackGenrePools
+        : null,
+  });
+  if (fallbackResult) {
+    const sourceMap = getTagSourceMap(recommendedMatches);
+    const fallbackItems = fallbackResult.artists.map((artist) =>
+      normalizeTagArtistItem(
+        {
+          type: "artist",
+          id: artist.id || artist.mbid || null,
+          name: artist.name || "Unknown Artist",
+          sortName: artist.sortName || artist.name || "Unknown Artist",
+          image: artist.image || artist.imageUrl || null,
+          imageUrl: artist.image || artist.imageUrl || null,
+          artistType: null,
+          country: null,
+          area: null,
+          begin: null,
+          end: null,
+          disambiguation: null,
+          tags: artist.tags || [tag],
+          genres: artist.genres || [tag],
+          inLibrary: false,
+          score: 0,
+          tagResultSource: sourceMap.get(getTagArtistKey(artist)) || "all",
+        },
+        tag,
+      ),
+    );
+    const mergedItems = dedupeTagArtists([...recommendedMatches, ...fallbackItems]);
+    const items = mergedItems.slice(offsetInt, offsetInt + limitInt);
+    return {
+      scope: "tag",
+      query: tag,
+      count: Math.max(mergedItems.length, fallbackResult.total),
+      offset: offsetInt,
+      provider: DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK,
+      fallbackLimited: true,
+      hasMore:
+        offsetInt + items.length < mergedItems.length ||
+        offsetInt + limitInt < fallbackResult.total,
       items,
     };
   }

--- a/backend/services/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlowPlaylistConfig.js
@@ -355,6 +355,10 @@ const normalizeFlow = (flow) => {
       flow?.nextRunAt != null && Number.isFinite(Number(flow.nextRunAt))
         ? Number(flow.nextRunAt)
         : null,
+    lastRunAt:
+      flow?.lastRunAt != null && Number.isFinite(Number(flow.lastRunAt))
+        ? Number(flow.lastRunAt)
+        : null,
     size: baseSize > 0 ? baseSize : size,
     mix,
     tags,
@@ -722,6 +726,7 @@ export const flowPlaylistConfig = {
       ownerUserId,
       enabled: false,
       nextRunAt: null,
+      lastRunAt: null,
     });
     flows.push(flow);
     setFlows(flows);
@@ -753,6 +758,7 @@ export const flowPlaylistConfig = {
           : current.deepDive,
       enabled: current.enabled,
       nextRunAt: current.nextRunAt,
+      lastRunAt: current.lastRunAt,
       createdAt: current.createdAt,
     });
     const nextSchedule = normalizeScheduleDays(next.scheduleDays);
@@ -807,6 +813,20 @@ export const flowPlaylistConfig = {
       nextRunAt != null && Number.isFinite(Number(nextRunAt))
         ? Number(nextRunAt)
         : null;
+    flows[index] = flow;
+    setFlows(flows);
+    return flow;
+  },
+
+  markLastRunAt(flowId, lastRunAt = Date.now()) {
+    const flows = getStoredFlows();
+    const index = flows.findIndex((flow) => flow.id === flowId);
+    if (index === -1) return null;
+    const flow = { ...flows[index] };
+    flow.lastRunAt =
+      lastRunAt != null && Number.isFinite(Number(lastRunAt))
+        ? Number(lastRunAt)
+        : Date.now();
     flows[index] = flow;
     setFlows(flows);
     return flow;

--- a/backend/services/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlowWorker.js
@@ -673,6 +673,7 @@ export class WeeklyFlowWorker {
     const primaryTracks = Array.isArray(plan?.primaryTracks)
       ? plan.primaryTracks
       : [];
+    flowPlaylistConfig.markLastRunAt(key);
     const jobIds = downloadTracker.addJobs(primaryTracks, key);
     return {
       tracksQueued: primaryTracks.length,

--- a/frontend/src/components/PillToggle.css
+++ b/frontend/src/components/PillToggle.css
@@ -1,86 +1,100 @@
 .pill-toggle {
-  --pill-bg: #9a9a9a;
-  --pill-coal: #333;
-  --pill-white: #fff;
-  --pill-focus: #002a2a;
-  --w: 44px;
-  --h: calc(var(--w) / 2);
-  --br: calc(var(--w) / 1);
-  --size: calc(var(--w) / 3);
-  --offset: calc(var(--w) / 12);
+  --secondary-container: #3a4b39;
+  --primary: #84da89;
+  --track-off: #313033;
+  --thumb-off: #aeaaae;
+  --focus-ring: rgba(132, 218, 137, 0.42);
+  --w: 62.9px;
+  --h: calc(var(--w) * 0.4865);
+  --thumb-size: calc(var(--w) * 0.3784);
+  --thumb-offset: calc(var(--w) * 0.0541);
+  --thumb-travel: calc(var(--w) - var(--thumb-size) - (var(--thumb-offset) * 2));
   position: relative;
   display: inline-block;
+  width: var(--w);
+  height: var(--h);
   flex-shrink: 0;
+  font-size: 17px;
 }
 
 .pill-toggle input {
   position: absolute;
+  width: 1px;
+  height: 1px;
   opacity: 0;
+  pointer-events: none;
 }
 
 .pill-toggle input + label {
-  outline: 2px solid transparent;
-  transform: scale(1, 1);
-  transition: outline 0.25s ease, transform 0.15s ease, background 0.35s ease;
-}
-
-.pill-toggle input:focus + label {
-  outline: 2px solid var(--pill-focus);
-}
-
-.pill-toggle input:active + label {
-  transform: scale(1.05);
-}
-
-.pill-toggle label {
-  position: relative;
-  background: var(--pill-white);
+  position: absolute;
+  inset: 0;
   display: block;
-  width: var(--w);
-  height: var(--h);
-  border-radius: var(--br);
-  box-shadow: 0px calc(var(--w) / 7.5) calc(var(--w) / 3.75) 0px
-    rgba(51, 51, 51, 0.1);
-  cursor: pointer;
-  text-indent: 200vw;
   overflow: hidden;
+  cursor: pointer;
+  border-radius: 999px;
+  background-color: var(--track-off);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  text-indent: 200vw;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.pill-toggle input + label::before {
+  position: absolute;
+  content: "";
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  left: var(--thumb-offset);
+  bottom: var(--thumb-offset);
+  border-radius: 999px;
+  background-color: var(--thumb-off);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition:
+    transform 0.28s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .pill-toggle input:checked + label {
-  background: var(--pill-coal);
+  background-color: var(--secondary-container);
+  box-shadow:
+    inset 0 0 0 1px rgba(132, 218, 137, 0.18),
+    0 0 0 1px rgba(132, 218, 137, 0.08);
 }
 
-.pill-toggle label::before,
-.pill-toggle label::after {
-  content: "";
-  position: absolute;
+.pill-toggle input:checked + label::before {
+  transform: translateX(var(--thumb-travel));
+  background-color: var(--primary);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.42),
+    0 0 0 1px rgba(132, 218, 137, 0.28);
 }
 
-.pill-toggle label::before {
-  width: var(--size);
-  height: var(--size);
-  border-radius: 50%;
-  background: var(--pill-coal);
-  left: 0;
-  top: 50%;
-  transform: translate(var(--offset), -50%);
-  box-shadow: calc(var(--w) - calc(var(--offset) * 2) - var(--size)) 0px 0px
-    var(--pill-white);
-  z-index: 1;
+.pill-toggle input:focus-visible + label {
+  box-shadow:
+    0 0 0 3px var(--focus-ring),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
-.pill-toggle label::after {
-  width: var(--size);
-  height: var(--size);
-  left: 0;
-  top: 50%;
-  background: var(--pill-coal);
-  transform: translate(-100%, -50%) scale(1);
-  transform-origin: left;
-  border-radius: 50%;
-  transition: transform 0.35s ease;
+.pill-toggle input:checked:focus-visible + label {
+  box-shadow:
+    0 0 0 3px var(--focus-ring),
+    inset 0 0 0 1px rgba(132, 218, 137, 0.28);
 }
 
-.pill-toggle input:checked + label::after {
-  transform: translate(-100%, -50%) scale(5);
+.pill-toggle input:active + label::before {
+  transform: scale(0.94);
+}
+
+.pill-toggle input:checked:active + label::before {
+  transform: translateX(var(--thumb-travel)) scale(0.94);
+}
+
+.pill-toggle input:disabled + label {
+  cursor: not-allowed;
+  opacity: 0.5;
 }

--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -622,9 +622,10 @@ export function FlowFormFields({
                 disabled={Object.keys(disabledSources || {}).length > 0}
                 title={
                   Object.keys(disabledSources || {}).length > 0
-                    ? "Last.fm API key required"
-                    : undefined
+                    ? "Last.fm API key required. Deep Dive skips the most obvious tracks and pulls tracks ranked 10-25."
+                    : "Deep Dive skips the most obvious tracks and pulls tracks ranked 10-25."
                 }
+                aria-label={`Deep Dive ${draft.deepDive === true ? "on" : "off"}. Deep Dive pulls tracks ranked 10 through 25 instead of the top 10.`}
               >
                 <span>Deep Dive</span>
                 <span className={draft.deepDive === true ? "text-black/65" : "text-[#76767d]"}>
@@ -1429,6 +1430,20 @@ const shouldHandleMobileCardTap = (event) => {
   return !interactiveTarget;
 };
 
+const formatFlowLastRun = (lastRunAt) => {
+  const timestamp =
+    typeof lastRunAt === "number" ? lastRunAt : Number.parseInt(lastRunAt, 10);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return null;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
 export function FlowCard({
   flow,
   isAdminView = false,
@@ -1562,6 +1577,10 @@ export function FlowCard({
     flowWorkerMessage = hintMessage;
   }
   const metaItems = [];
+  const lastRun = formatFlowLastRun(flow?.lastRunAt);
+  if (lastRun) {
+    metaItems.push(`Last run ${lastRun}`);
+  }
   if (enabled && nextRun && state !== "running" && !isGeneratingThisFlow) {
     metaItems.push(
       nextRun === "soon" ? "Next update soon" : `Next update in ${nextRun}`,

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -26,7 +26,6 @@ import {
   searchCatalog,
   updateBlocklist,
 } from "../utils/api";
-import PillToggle from "../components/PillToggle";
 import SearchAlbumResults from "../components/SearchAlbumResults";
 import SearchArtistResults from "../components/SearchArtistResults";
 import { useAuth } from "../contexts/AuthContext";
@@ -159,11 +158,7 @@ function SearchResultsPage() {
   }, [type, trimmedQuery]);
   const isTagSearch = normalizedType === "tag";
   const isAlbumSearch = normalizedType === "album";
-  const tagScope = searchParams.get("scope") || "all";
-  const effectiveTagScope =
-    isTagSearch && lastfmConfigured === false ? "all" : tagScope;
   const albumSort = searchParams.get("sort") || DEFAULT_ALBUM_SORT;
-  const showAllTagResults = isTagSearch && effectiveTagScope === "all";
   const showTagBanner = isTagSearch && lastfmConfigured === false && !dismissedTagBanner;
   const supportsDiscoveryFeedback =
     normalizedType === "recommended" || isTagSearch;
@@ -181,15 +176,6 @@ function SearchResultsPage() {
         (typeName) => !selectedReleaseTypes.includes(typeName),
       ).length,
     [allReleaseTypes, selectedReleaseTypes],
-  );
-
-  const updateTagScope = useCallback(
-    (nextScope) => {
-      const params = new URLSearchParams(searchParams);
-      params.set("scope", nextScope === "all" ? "all" : "recommended");
-      setSearchParams(params);
-    },
-    [searchParams, setSearchParams],
   );
 
   const updateAlbumSort = useCallback(
@@ -302,7 +288,6 @@ function SearchResultsPage() {
         const data = await searchCatalog(searchQuery, normalizedType, {
           limit: PAGE_SIZE,
           offset: 0,
-          tagScope: effectiveTagScope,
           releaseTypes: isAlbumSearch ? selectedReleaseTypes : [],
         });
         const nextResults = isAlbumSearch
@@ -344,7 +329,6 @@ function SearchResultsPage() {
   }, [
     trimmedQuery,
     normalizedType,
-    effectiveTagScope,
     isAlbumSearch,
     isTagSearch,
     selectedReleaseTypes,
@@ -589,7 +573,6 @@ function SearchResultsPage() {
       const data = await searchCatalog(searchQuery, normalizedType, {
         limit: PAGE_SIZE,
         offset: results.length,
-        tagScope: effectiveTagScope,
         releaseTypes: isAlbumSearch ? selectedReleaseTypes : [],
       });
       const newItems = data.items || [];
@@ -626,7 +609,6 @@ function SearchResultsPage() {
     results,
     searchTotalCount,
     selectedReleaseTypes,
-    effectiveTagScope,
     trimmedQuery,
     visibleCount,
   ]);
@@ -894,28 +876,6 @@ function SearchResultsPage() {
                       : "Search Results"}
           </h1>
 
-          {isTagSearch && lastfmConfigured !== false && (
-            <div className="ml-auto inline-flex items-center gap-3">
-              <span
-                className="text-sm"
-                style={{ color: showAllTagResults ? "#8a8a8f" : "#fff" }}
-              >
-                Recommended
-              </span>
-              <PillToggle
-                checked={showAllTagResults}
-                onChange={(event) =>
-                  updateTagScope(event.target.checked ? "all" : "recommended")
-                }
-              />
-              <span
-                className="text-sm"
-                style={{ color: showAllTagResults ? "#fff" : "#8a8a8f" }}
-              >
-                All
-              </span>
-            </div>
-          )}
         </div>
 
         {normalizedType === "recommended" && (
@@ -932,10 +892,8 @@ function SearchResultsPage() {
             className="flex flex-wrap items-center gap-x-3 gap-y-2"
             style={{ color: "#c1c1c3" }}
           >
-            <p>
-              {`${lastfmConfigured === false || showAllTagResults ? "Top artists" : "Recommended artists"} for tag "${trimmedQuery.replace(/^#/, "")}"`}
-            </p>
-            {lastfmConfigured !== false && showAllTagResults && (
+            <p>{`Artists for tag "${trimmedQuery.replace(/^#/, "")}"`}</p>
+            {lastfmConfigured !== false && (
               <div className="ml-auto flex items-center gap-1.5 text-sm">
                 <Star
                   className="h-3.5 w-3.5"

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import { Pencil } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 
 export function SettingsAccountTab({
@@ -19,8 +17,6 @@ export function SettingsAccountTab({
   saving,
   handleSave,
 }) {
-  const [editing, setEditing] = useState(false);
-
   if (loading) {
     return (
       <div className="card animate-fade-in">
@@ -67,33 +63,16 @@ export function SettingsAccountTab({
               Listening History
             </h3>
             <div className="flex items-center gap-2">
-              {listenHistoryUsername && !editing && (
+              {listenHistoryUsername && (
                 <span className="text-sm" style={{ color: "#c1c1c3" }}>
                   {listenHistoryProvider === "listenbrainz"
                     ? `ListenBrainz: ${listenHistoryUsername}`
                     : `Last.fm: ${listenHistoryUsername}`}
                 </span>
               )}
-              <button
-                type="button"
-                className={`btn ${
-                  editing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setEditing((v) => !v)}
-                aria-label={
-                  editing
-                    ? "Lock listening history settings"
-                    : "Edit listening history settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
-          <fieldset
-            disabled={!editing}
-            className={`space-y-4 ${editing ? "" : "opacity-60"}`}
-          >
+          <fieldset className="space-y-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"

--- a/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
@@ -3,7 +3,6 @@ import {
   RefreshCw,
   Trash2,
   Compass,
-  Pencil,
   ChevronDown,
   X,
 } from "lucide-react";
@@ -58,7 +57,6 @@ export function SettingsDiscoverTab({
   handleRefreshDiscovery,
   handleClearCache,
 }) {
-  const [discoverEditing, setDiscoverEditing] = useState(false);
   const [lastfmBannerDismissed, setLastfmBannerDismissed] = useState(
     readLastfmDiscoverBannerDismissed,
   );
@@ -146,25 +144,8 @@ export function SettingsDiscoverTab({
             <h3 className="text-lg font-medium" style={{ color: "#fff" }}>
               Discovery behavior
             </h3>
-            <button
-              type="button"
-              className={`btn ${
-                discoverEditing ? "btn-primary" : "btn-secondary"
-              } px-2 py-1`}
-              onClick={() => setDiscoverEditing((value) => !value)}
-              aria-label={
-                discoverEditing
-                  ? "Lock discovery settings"
-                  : "Edit discovery settings"
-              }
-            >
-              <Pencil className="w-4 h-4" />
-            </button>
           </div>
-          <fieldset
-            disabled={!discoverEditing}
-            className={`space-y-4 ${discoverEditing ? "" : "opacity-60"}`}
-          >
+          <fieldset className="space-y-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CheckCircle, ChevronDown, Pencil, RefreshCw } from "lucide-react";
+import { CheckCircle, ChevronDown, RefreshCw } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 import {
   getLidarrMetadataProfiles,
@@ -35,10 +35,6 @@ export function SettingsIntegrationsTab({
   showError,
   showInfo,
 }) {
-  const [lidarrEditing, setLidarrEditing] = useState(false);
-  const [ticketmasterEditing, setTicketmasterEditing] = useState(false);
-  const [navidromeEditing, setNavidromeEditing] = useState(false);
-  const [lastfmEditing, setLastfmEditing] = useState(false);
   const [collapsedSections, setCollapsedSections] = useState({
     lidarr: false,
     lastfm: true,
@@ -271,27 +267,10 @@ export function SettingsIntegrationsTab({
                   Connected
                 </span>
               )}
-              <button
-                type="button"
-                className={`btn ${
-                  lidarrEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setLidarrEditing((value) => !value)}
-                aria-label={
-                  lidarrEditing ? "Lock Lidarr settings" : "Edit Lidarr settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
           {!collapsedSections.lidarr && (
-          <fieldset
-            disabled={!lidarrEditing}
-            className={`grid grid-cols-1 gap-4 ${
-              lidarrEditing ? "" : "opacity-60"
-            }`}
-          >
+          <fieldset className="grid grid-cols-1 gap-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"
@@ -745,27 +724,10 @@ export function SettingsIntegrationsTab({
                   Configured
                 </span>
               )}
-              <button
-                type="button"
-                className={`btn ${
-                  lastfmEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setLastfmEditing((value) => !value)}
-                aria-label={
-                  lastfmEditing
-                    ? "Lock Last.fm settings"
-                    : "Edit Last.fm settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
           {!collapsedSections.lastfm && (
-          <fieldset
-            disabled={!lastfmEditing}
-            className={`space-y-4 ${lastfmEditing ? "" : "opacity-60"}`}
-          >
+          <fieldset className="space-y-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"
@@ -861,27 +823,10 @@ export function SettingsIntegrationsTab({
                   Configured
                 </span>
               )}
-              <button
-                type="button"
-                className={`btn ${
-                  ticketmasterEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setTicketmasterEditing((value) => !value)}
-                aria-label={
-                  ticketmasterEditing
-                    ? "Lock Ticketmaster settings"
-                    : "Edit Ticketmaster settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
           {!collapsedSections.ticketmaster && (
-          <fieldset
-            disabled={!ticketmasterEditing}
-            className={`space-y-4 ${ticketmasterEditing ? "" : "opacity-60"}`}
-          >
+          <fieldset className="space-y-4">
             <div
               className="rounded-lg p-4 space-y-2"
               style={{ backgroundColor: "#141418", border: "1px solid #2a2a2e" }}
@@ -1048,27 +993,10 @@ export function SettingsIntegrationsTab({
                   Configured
                 </span>
               )}
-              <button
-                type="button"
-                className={`btn ${
-                  navidromeEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setNavidromeEditing((value) => !value)}
-                aria-label={
-                  navidromeEditing
-                    ? "Lock Subsonic / Navidrome settings"
-                    : "Edit Subsonic / Navidrome settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
           {!collapsedSections.navidrome && (
-          <fieldset
-            disabled={!navidromeEditing}
-            className={`${navidromeEditing ? "" : "opacity-60"}`}
-          >
+          <fieldset>
             <div>
             <label
               className="block text-sm font-medium mb-1"

--- a/frontend/src/pages/Settings/components/SettingsNotificationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsNotificationsTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { CheckCircle, Pencil, Plus, Trash2, GripVertical } from "lucide-react";
+import { CheckCircle, Plus, Trash2, GripVertical } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 import PillToggle from "../../../components/PillToggle";
 import { testGotifyConnection } from "../../../utils/api";
@@ -15,8 +15,6 @@ export function SettingsNotificationsTab({
   showSuccess,
   showError,
 }) {
-  const [gotifyEditing, setGotifyEditing] = useState(false);
-
   const handleTestGotify = async () => {
     const url = settings.integrations?.gotify?.url;
     const token = settings.integrations?.gotify?.token;
@@ -167,26 +165,9 @@ export function SettingsNotificationsTab({
                     Configured
                   </span>
                 )}
-              <button
-                type="button"
-                className={`btn ${
-                  gotifyEditing ? "btn-primary" : "btn-secondary"
-                } px-2 py-1`}
-                onClick={() => setGotifyEditing((value) => !value)}
-                aria-label={
-                  gotifyEditing ? "Lock Gotify settings" : "Edit Gotify settings"
-                }
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
             </div>
           </div>
-          <fieldset
-            disabled={!gotifyEditing}
-            className={`grid grid-cols-1 gap-4 ${
-              gotifyEditing ? "" : "opacity-60"
-            }`}
-          >
+          <fieldset className="grid grid-cols-1 gap-4">
             <div>
               <label
                 className="block text-sm font-medium mb-1"
@@ -533,4 +514,3 @@ export function SettingsNotificationsTab({
     </div>
   );
 }
-

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -1,4 +1,4 @@
-import { UserPlus, Lock, Pencil, Trash2, X } from "lucide-react";
+import { UserPlus, Lock, Trash2, X } from "lucide-react";
 import { GRANULAR_PERMISSIONS, granularPerms } from "../constants";
 import { loginApi, setStoredAuth } from "../../../utils/api";
 
@@ -372,8 +372,8 @@ export function SettingsUsersTab({
                           );
                         }}
                       >
-                        <Pencil className="w-4 h-4" />
-                        Edit
+                        <Lock className="w-4 h-4" />
+                        Manage
                       </button>
                       <button
                         type="button"
@@ -649,7 +649,7 @@ export function SettingsUsersTab({
               >
                 <div className="flex items-center justify-between mb-6">
                   <h3 className="text-xl font-bold text-main">
-                    Edit {editUser.username}
+                    Manage {editUser.username}
                   </h3>
                   <button
                     type="button"

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -259,14 +259,10 @@ export const searchCatalog = async (
   {
     limit = 24,
     offset = 0,
-    tagScope = "merged",
     releaseTypes = [],
   } = {},
 ) => {
   const params = { q: query, scope, limit, offset };
-  if (scope === "tag") {
-    params.tagScope = tagScope;
-  }
   if (scope === "album" && Array.isArray(releaseTypes) && releaseTypes.length) {
     params.releaseTypes = releaseTypes.join(",");
   }


### PR DESCRIPTION
## Summary
- Simplified tag search by removing the scope toggle from the UI and consolidating backend tag result handling into a single merged flow.
- Updated tag search to return a more consistent fallback result set when Last.fm is unavailable, while preserving recommended artist matching.
- Added flow `lastRunAt` persistence and display so flow cards can show the most recent run time.
- Refined playlist artwork generation with larger, more flexible title layouts and updated visual treatment.
- Cleaned up several settings tabs by removing edit-lock toggles and unnecessary controls.

## Testing
- Added `.tests/weekly-flow/playlist-config.test.js` coverage for initializing `lastRunAt` and recording the last run timestamp.
- Not run: frontend unit tests.
- Not run: backend integration tests.
- Not run: full app smoke test in browser.