### PR TITLE
Preserve preview volume when audio ref updates

### DIFF
--- a/frontend/src/pages/ArtistDetails/hooks/usePreviewPlayer.js
+++ b/frontend/src/pages/ArtistDetails/hooks/usePreviewPlayer.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { getArtistPreview } from "../../../utils/api";
 
 const SNAP_BACK_MS = 320;
@@ -22,6 +22,13 @@ export function usePreviewPlayer(mbid, artistNameFromNav, artist) {
   const previewAudioRef = useRef(null);
   const previewTickRef = useRef(null);
   const snapBackTimeoutRef = useRef(null);
+  const setPreviewAudioElement = useCallback(
+    (node) => {
+      previewAudioRef.current = node;
+      if (node) node.volume = previewVolume;
+    },
+    [previewVolume],
+  );
 
   useEffect(() => {
     const name = artistNameFromNav || artist?.name;
@@ -47,6 +54,7 @@ export function usePreviewPlayer(mbid, artistNameFromNav, artist) {
   const handlePreviewPlay = (track) => {
     const audio = previewAudioRef.current;
     if (!audio || !track.preview_url) return;
+    audio.volume = previewVolume;
     if (playingPreviewId === track.id) {
       if (audio.paused) {
         if (snapBackTimeoutRef.current)
@@ -158,7 +166,7 @@ export function usePreviewPlayer(mbid, artistNameFromNav, artist) {
     previewSnappingBack,
     previewVolume,
     setPreviewVolume,
-    previewAudioRef,
+    previewAudioRef: setPreviewAudioElement,
     handlePreviewPlay,
   };
 }


### PR DESCRIPTION
## Summary
- Keep the preview audio element volume in sync when the ref callback receives a new node.
- Reapply the current preview volume before playing a track so ref updates do not reset user volume changes.
- Replace the raw audio ref return value with a callback ref to centralize volume synchronization.

## Testing
- Not run (not requested).
- Verified the hook now assigns `volume` when the audio node mounts or changes.
- Verified `handlePreviewPlay` reapplies the current `previewVolume` before playback.