### PR TITLE
Resize toggle and power switch controls

### DIFF
--- a/frontend/src/components/PillToggle.css
+++ b/frontend/src/components/PillToggle.css
@@ -4,7 +4,7 @@
   --track-off: #313033;
   --thumb-off: #aeaaae;
   --focus-ring: rgba(132, 218, 137, 0.42);
-  --w: 62.9px;
+  --w: 47.2px;
   --h: calc(var(--w) * 0.4865);
   --thumb-size: calc(var(--w) * 0.3784);
   --thumb-offset: calc(var(--w) * 0.0541);

--- a/frontend/src/components/PowerSwitch.css
+++ b/frontend/src/components/PowerSwitch.css
@@ -1,7 +1,7 @@
 .power-switch {
   --color-invert: #ffffff;
-  --width: 120px;
-  --height: 120px;
+  --width: 90px;
+  --height: 90px;
   position: relative;
   display: flex;
   justify-content: center;
@@ -11,8 +11,8 @@
 }
 
 .flow-page .power-switch {
-  --width: 44px;
-  --height: 44px;
+  --width: 33px;
+  --height: 33px;
 }
 
 .power-switch .button {


### PR DESCRIPTION
## Summary
- Reduced the default size of the pill toggle for a more compact control.
- Scaled down the power switch control in both its standard and `.flow-page` variants.
- Kept the component proportions intact by updating the size variables rather than the layout structure.

## Testing
- Not run (CSS-only change).
- Visually inspect the pill toggle and power switch at standard and `.flow-page` sizes.