### PR TITLE
Fix websocket authentication when using proxy auth

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -391,7 +391,7 @@ export function reconcileLocalNetworkBypassSetting() {
   };
 }
 
-function resolveProxyUser(req) {
+export function resolveProxyUser(req) {
   if (!isProxyAuthEnabled()) return null;
   if (!isTrustedProxy(req)) return null;
   const headerName = getProxyHeaderName();

--- a/backend/services/websocketService.js
+++ b/backend/services/websocketService.js
@@ -5,6 +5,7 @@ import {
   isProxyAuthEnabled,
   resolveLocalNetworkBypassUser,
   resolveSessionUserFromToken,
+  resolveProxyUser,
 } from "../middleware/auth.js";
 
 const isAuthRequired = () => {
@@ -45,6 +46,9 @@ class WebSocketService {
       const requestUrl = new URL(req.url || "", "http://localhost");
       const token = requestUrl.searchParams.get("token");
       sessionUser = resolveSessionUserFromToken(token);
+      if (!sessionUser) {
+        sessionUser = resolveProxyUser(req);
+      }
       if (sessionUser) {
         authSource = "session";
       } else {


### PR DESCRIPTION
## Summary
Currently websocket authentication fails if you're using proxy authentication (a `401` is returned to the client). This PR adds the same `resolveProxyUser` to the websocket endpoint to allow connections that are authorized with a proxy.

## Testing
- Image built & tested on a local instance behind a nginx reverse proxy with Authelia