### PR TITLE
Lower MoreMenu z-index stacking

### DIFF
--- a/frontend/src/pages/FlowPageComponents.jsx
+++ b/frontend/src/pages/FlowPageComponents.jsx
@@ -853,7 +853,7 @@ export function MoreMenu({ children, activeButtonClass = "btn-primary" }) {
   }, [isOpen]);
 
   return (
-    <div className={`relative ${isOpen ? "z-[300]" : "z-30"}`} ref={menuRef}>
+    <div className={`relative ${isOpen ? "z-20" : "z-10"}`} ref={menuRef}>
       <button 
         type="button" 
         onClick={(e) => { e.stopPropagation(); setIsOpen(!isOpen); }} 
@@ -864,7 +864,7 @@ export function MoreMenu({ children, activeButtonClass = "btn-primary" }) {
         <span className="hidden sm:inline">More</span>
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-48 rounded-md border border-[#3a3a44] bg-[#2d2d36] py-1 z-[320] flex flex-col"
+        <div className="absolute right-0 top-full mt-2 z-30 flex w-48 flex-col rounded-md border border-[#3a3a44] bg-[#2d2d36] py-1"
              onClick={() => setIsOpen(false)}>
           {children}
         </div>


### PR DESCRIPTION
## Summary
- Reduced the `MoreMenu` stacking context values so the menu no longer dominates nearby overlays.
- Kept the open menu above its trigger while lowering the overall z-index footprint.
- Adjusted the menu container and dropdown panel classes in `frontend/src/pages/FlowPageComponents.jsx`.

## Testing
- Not run
- Reviewed the diff to confirm the open menu still uses a higher z-index than the closed state
- Verified the class updates are limited to `MoreMenu`