### PR TITLE
Add Deezer previews and track playlist menus

### DIFF
--- a/backend/routes/artists/handlers/releaseGroup.js
+++ b/backend/routes/artists/handlers/releaseGroup.js
@@ -3,13 +3,27 @@ import { dbOps } from "../../../config/db-helpers.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { warmImageProxy } from "../../../services/imageProxyService.js";
 import { selectBestAlbumImage } from "../../../services/imageService.js";
+import { enrichTracksWithDeezerPreviews } from "../../../services/apiClients.js";
 import {
   getAlbumByMbid,
+  getArtistByMbid,
   getAlbumTracksByAlbumMbid,
 } from "../../../services/metadataProvider.js";
 
 const LEGACY_COVER_HOST_PATTERN =
   /https?:\/\/(?:caa\.lkly\.net|coverartarchive\.org|archive\.org|[\w-]+\.ca\.archive\.org)\//i;
+
+function extractDeezerArtistIdFromLinks(links = []) {
+  if (!Array.isArray(links)) return null;
+  for (const link of links) {
+    const type = String(link?.type || "").toLowerCase();
+    const target = String(link?.target || link?.url?.resource || "").trim();
+    if (type !== "deezer" && !/deezer\.com\/artist\//i.test(target)) continue;
+    const match = target.match(/deezer\.com\/artist\/(\d+)/i);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
 
 export default function registerReleaseGroup(router) {
   router.get("/release-group/:mbid/cover", cacheMiddleware(86400), async (req, res) => {
@@ -107,9 +121,60 @@ export default function registerReleaseGroup(router) {
         return res.status(400).json({ error: "Invalid MBID format" });
       }
 
+      const artistMbid =
+        typeof req.query.artistMbid === "string" &&
+        UUID_REGEX.test(req.query.artistMbid)
+          ? req.query.artistMbid
+          : "";
+      const artistName =
+        typeof req.query.artistName === "string"
+          ? req.query.artistName.trim()
+          : "";
+      const albumTitle =
+        typeof req.query.albumTitle === "string"
+          ? req.query.albumTitle.trim()
+          : "";
+      const releaseType =
+        typeof req.query.releaseType === "string"
+          ? req.query.releaseType.trim()
+          : "";
+      const releaseDate =
+        typeof req.query.releaseDate === "string"
+          ? req.query.releaseDate.trim()
+          : "";
+      const deezerAlbumId =
+        typeof req.query.deezerAlbumId === "string"
+          ? req.query.deezerAlbumId.trim()
+          : "";
+
       const tracks = await getAlbumTracksByAlbumMbid(mbid);
+      let deezerArtistId = "";
+      if (artistMbid) {
+        const override = dbOps.getArtistOverride(artistMbid);
+        deezerArtistId = override?.deezerArtistId || "";
+        if (!deezerArtistId) {
+          const resolvedArtistMbid = override?.musicbrainzId || artistMbid;
+          const metadataArtist = await getArtistByMbid(resolvedArtistMbid).catch(
+            () => null,
+          );
+          deezerArtistId =
+            extractDeezerArtistIdFromLinks(metadataArtist?.links) || "";
+        }
+      }
+      const enrichedTracks = await enrichTracksWithDeezerPreviews(tracks, {
+        artistName,
+        deezerArtistId,
+        deezerAlbumId,
+        albumTitle,
+        releaseType,
+        releaseDate,
+        cacheKey: `release-group:${mbid}:${
+          deezerAlbumId || deezerArtistId || artistName
+        }`,
+      });
+
       res.json(
-        tracks.map((track) => ({
+        enrichedTracks.map((track) => ({
           id: track.recordingId || track.id,
           mbid: track.recordingId || track.id,
           title: track.title,
@@ -117,6 +182,9 @@ export default function registerReleaseGroup(router) {
           trackNumber: track.trackPosition || track.trackNumber || 0,
           position: track.trackPosition || track.trackNumber || 0,
           length: track.durationMs || null,
+          preview_url: track.preview_url || null,
+          previewProvider: track.previewProvider || null,
+          previewTrackId: track.previewTrackId || null,
         })),
       );
     } catch (error) {

--- a/backend/services/apiClients.js
+++ b/backend/services/apiClients.js
@@ -1103,6 +1103,16 @@ const deezerAlbumCache = new NodeCache({
   checkperiod: 120,
   maxKeys: 500,
 });
+const deezerAlbumTrackCache = new NodeCache({
+  stdTTL: 3600,
+  checkperiod: 120,
+  maxKeys: 1000,
+});
+const deezerPreviewMatchCache = new NodeCache({
+  stdTTL: 6 * 3600,
+  checkperiod: 600,
+  maxKeys: 2000,
+});
 
 function normalizeTitle(title) {
   return String(title || "")
@@ -1111,7 +1121,239 @@ function normalizeTitle(title) {
       /\s*[\(\[](deluxe|remaster|anniversary|expanded|bonus|edition|live|mono|stereo|\d{4}).*[\)\]]/gi,
       "",
     )
+    .replace(
+      /\s+-\s+(deluxe|remaster|anniversary|expanded|bonus|edition|live|mono|stereo|\d{4}).*$/gi,
+      "",
+    )
+    .replace(/[’']/g, "")
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\b(the|a|an)\b/g, " ")
+    .replace(/\s+/g, " ")
     .trim();
+}
+
+function getReleaseYear(value) {
+  const match = String(value || "").match(/\d{4}/);
+  return match ? Number.parseInt(match[0], 10) : null;
+}
+
+function normalizeDeezerPrimaryType(value) {
+  const normalized = String(value || "album").toLowerCase();
+  if (normalized === "ep") return "EP";
+  if (normalized === "single") return "Single";
+  return "Album";
+}
+
+function normalizeMbidTrackNumber(value) {
+  const raw = String(value || "").trim();
+  const numeric = Number.parseInt(raw, 10);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function getTrackPosition(track) {
+  const raw =
+    track?.trackPosition ??
+    track?.track_position ??
+    track?.trackNumber ??
+    track?.tracknumber ??
+    track?.position;
+  const numeric = Number.parseInt(raw, 10);
+  if (Number.isFinite(numeric) && numeric > 0) return numeric;
+  return normalizeMbidTrackNumber(raw);
+}
+
+function getTrackMedium(track) {
+  const numeric = Number.parseInt(
+    track?.mediumNumber ??
+      track?.mediumnumber ??
+      track?.disk_number ??
+      track?.diskNumber,
+    10,
+  );
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function getTrackDurationMs(track) {
+  const raw =
+    track?.durationMs ??
+    track?.duration_ms ??
+    track?.durationms ??
+    track?.length ??
+    null;
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function getTrackTitle(track) {
+  return track?.title || track?.trackName || track?.trackname || "";
+}
+
+async function getDeezerAlbumsForArtist(artist) {
+  if (!artist?.id) return [];
+  const cacheKey = `dz-albums:${artist.id}`;
+  const cached = deezerAlbumCache.get(cacheKey);
+  if (cached) return cached;
+
+  const res = await axios.get(
+    `https://api.deezer.com/artist/${artist.id}/albums`,
+    { params: { limit: 100 }, timeout: 3000 },
+  );
+  const raw = res.data?.data || [];
+  const allowed = ["album", "ep", "single"];
+  const albums = raw
+    .filter((a) =>
+      allowed.includes((a.record_type || a.type || "").toLowerCase()),
+    )
+    .map((a) => {
+      const primaryType = normalizeDeezerPrimaryType(a.record_type || a.type);
+      const title = a.title || "";
+      const releaseDate = a.release_date || "";
+      return {
+        id: a.id,
+        title,
+        "first-release-date": releaseDate ? releaseDate.slice(0, 4) : null,
+        "primary-type": primaryType,
+        "secondary-types": [],
+        _coverUrl: a.cover_big || a.cover_medium || a.cover || null,
+        fans: typeof a.fans === "number" ? a.fans : 0,
+        _normalizedTitle: normalizeTitle(title),
+        _releaseDate: releaseDate,
+      };
+    });
+
+  deezerAlbumCache.set(cacheKey, albums);
+  return albums;
+}
+
+function selectBestDeezerAlbumMatch(
+  deezerAlbums,
+  { albumTitle = "", releaseType = "", releaseDate = "" } = {},
+) {
+  if (!Array.isArray(deezerAlbums) || deezerAlbums.length === 0 || !albumTitle) {
+    return null;
+  }
+  const targetTitle = normalizeTitle(albumTitle);
+  const targetType = String(releaseType || "").trim();
+  const targetYear = getReleaseYear(releaseDate);
+
+  const ranked = deezerAlbums
+    .map((album) => {
+      const albumTitle = album._normalizedTitle || normalizeTitle(album.title);
+      let score = 0;
+      if (albumTitle === targetTitle) {
+        score += 100;
+      } else if (
+        albumTitle.includes(targetTitle) ||
+        targetTitle.includes(albumTitle)
+      ) {
+        score += 45;
+      }
+
+      if (targetType && album["primary-type"] === targetType) {
+        score += 20;
+      }
+
+      const albumYear = getReleaseYear(
+        album._releaseDate || album["first-release-date"],
+      );
+      if (targetYear && albumYear) {
+        const distance = Math.abs(targetYear - albumYear);
+        if (distance === 0) score += 20;
+        else if (distance <= 1) score += 10;
+        else if (distance <= 3) score += 3;
+      }
+
+      score += Math.min(10, Math.log10(Math.max(1, album.fans || 0) + 1) * 2);
+      return { album, score };
+    })
+    .filter((entry) => entry.score >= 80)
+    .sort((left, right) => right.score - left.score);
+
+  return ranked[0]?.album || null;
+}
+
+async function resolveDeezerAlbumForPreview({
+  artistName = "",
+  deezerArtistId = null,
+  albumTitle = "",
+  releaseType = "",
+  releaseDate = "",
+} = {}) {
+  const artist = deezerArtistId
+    ? await getDeezerArtistById(deezerArtistId)
+    : await getDeezerArtist(artistName);
+  if (!artist) return null;
+
+  const albums = await getDeezerAlbumsForArtist(artist);
+  return selectBestDeezerAlbumMatch(albums, {
+    albumTitle,
+    releaseType,
+    releaseDate,
+  });
+}
+
+function scoreDeezerTrackMatch(track, deezerTrack) {
+  const targetTitle = normalizeTitle(getTrackTitle(track));
+  const candidateTitle = normalizeTitle(getTrackTitle(deezerTrack));
+  const trackPosition = getTrackPosition(track);
+  const deezerPosition = getTrackPosition(deezerTrack);
+  const trackMedium = getTrackMedium(track);
+  const deezerMedium = getTrackMedium(deezerTrack);
+  const trackDuration = getTrackDurationMs(track);
+  const deezerDuration = getTrackDurationMs(deezerTrack);
+
+  let score = 0;
+  if (targetTitle && candidateTitle) {
+    if (targetTitle === candidateTitle) {
+      score += 70;
+    } else if (
+      targetTitle.includes(candidateTitle) ||
+      candidateTitle.includes(targetTitle)
+    ) {
+      score += 35;
+    }
+  }
+
+  if (trackPosition && deezerPosition && trackPosition === deezerPosition) {
+    score += 25;
+  }
+  if (trackMedium && deezerMedium && trackMedium === deezerMedium) {
+    score += 10;
+  }
+  if (trackDuration && deezerDuration) {
+    const diff = Math.abs(trackDuration - deezerDuration);
+    if (diff <= 3000) score += 15;
+    else if (diff <= 10000) score += 8;
+    else if (diff <= 20000) score += 3;
+  }
+
+  return score;
+}
+
+function attachDeezerTrackPreviews(tracks, deezerTracks) {
+  if (!Array.isArray(tracks) || tracks.length === 0) return tracks || [];
+  if (!Array.isArray(deezerTracks) || deezerTracks.length === 0) return tracks;
+
+  const used = new Set();
+  return tracks.map((track) => {
+    let best = null;
+    for (const candidate of deezerTracks) {
+      if (!candidate?.preview_url || used.has(candidate.id)) continue;
+      const score = scoreDeezerTrackMatch(track, candidate);
+      if (!best || score > best.score) {
+        best = { track: candidate, score };
+      }
+    }
+    if (!best || best.score < 80) return track;
+    used.add(best.track.id);
+    return {
+      ...track,
+      preview_url: best.track.preview_url,
+      previewProvider: "deezer",
+      previewTrackId: best.track.id,
+    };
+  });
 }
 
 const ALLOWED_PRIMARY_TYPES = new Set(["album", "ep", "single"]);
@@ -1221,34 +1463,26 @@ export async function enrichReleaseGroupsWithDeezer(
       : await getDeezerArtist(artistName);
     if (!artist) return mbReleaseGroups;
 
-    const res = await axios.get(
-      `https://api.deezer.com/artist/${artist.id}/albums`,
-      { params: { limit: 100 }, timeout: 3000 },
-    );
-    const raw = res.data?.data || [];
-    const allowed = ["album", "ep", "single"];
+    const albums = await getDeezerAlbumsForArtist(artist);
     const byKey = new Map();
-    for (const a of raw) {
-      const rt = (a.record_type || a.type || "album").toLowerCase();
-      if (!allowed.includes(rt)) continue;
-      const primaryType =
-        rt === "ep" ? "EP" : rt === "single" ? "Single" : "Album";
+    for (const a of albums) {
+      const primaryType = a["primary-type"] || "Album";
       const title = a.title || "";
       const key = `${primaryType}:${normalizeTitle(title)}`;
       const fans = typeof a.fans === "number" ? a.fans : 0;
-      const coverUrl = a.cover_big || a.cover_medium || a.cover || null;
+      const coverUrl = a._coverUrl || null;
       const existing = byKey.get(key);
       if (
         !existing ||
         fans > existing.fans ||
         (fans === existing.fans &&
-          (a.release_date || "") < (existing.release_date || ""))
+          (a._releaseDate || "") < (existing.release_date || ""))
       ) {
         byKey.set(key, {
           id: a.id,
           fans,
           coverUrl,
-          release_date: a.release_date || "",
+          release_date: a._releaseDate || "",
         });
       }
     }
@@ -1313,39 +1547,17 @@ export async function deezerGetArtistAlbums(artistName) {
   try {
     const artist = await getDeezerArtist(artistName);
     if (!artist) return [];
-
-    const cacheKey = `dz-albums:${artist.id}`;
-    const cached = deezerAlbumCache.get(cacheKey);
-    if (cached) return cached;
-
-    const res = await axios.get(
-      `https://api.deezer.com/artist/${artist.id}/albums`,
-      { params: { limit: 100 }, timeout: 3000 },
-    );
-    const raw = res.data?.data || [];
-    const allowed = ["album", "ep", "single"];
-    const filtered = raw.filter((a) =>
-      allowed.includes((a.record_type || a.type || "").toLowerCase()),
-    );
-    const mapped = filtered.map((a) => {
-      const rt = (a.record_type || a.type || "album").toLowerCase();
-      const primaryType =
-        rt === "ep" ? "EP" : rt === "single" ? "Single" : "Album";
-      const title = a.title || "";
-      const releaseDate = a.release_date ? a.release_date.slice(0, 4) : null;
-      const fans = typeof a.fans === "number" ? a.fans : 0;
-      return {
-        id: `dz-${a.id}`,
-        title,
-        "first-release-date": releaseDate,
-        "primary-type": primaryType,
-        "secondary-types": [],
-        _coverUrl: a.cover_big || a.cover_medium || a.cover || null,
-        _fans: fans,
-        _normalizedTitle: normalizeTitle(title),
-        _releaseDate: a.release_date || "",
-      };
-    });
+    const mapped = (await getDeezerAlbumsForArtist(artist)).map((a) => ({
+      id: `dz-${a.id}`,
+      title: a.title,
+      "first-release-date": a["first-release-date"],
+      "primary-type": a["primary-type"],
+      "secondary-types": [],
+      _coverUrl: a._coverUrl,
+      _fans: a.fans || 0,
+      _normalizedTitle: a._normalizedTitle,
+      _releaseDate: a._releaseDate || "",
+    }));
     const byKey = new Map();
     for (const item of mapped) {
       const key = `${item["primary-type"]}:${item._normalizedTitle}`;
@@ -1365,7 +1577,6 @@ export async function deezerGetArtistAlbums(artistName) {
         fans: _fans,
       }),
     );
-    deezerAlbumCache.set(cacheKey, albums);
     return albums;
   } catch (e) {
     return [];
@@ -1375,24 +1586,72 @@ export async function deezerGetArtistAlbums(artistName) {
 export async function deezerGetAlbumTracks(deezerAlbumId) {
   const id = String(deezerAlbumId).replace(/^dz-/, "");
   if (!id || id === "dz") return [];
+  const cacheKey = `dz-tracks:${id}`;
+  const cached = deezerAlbumTrackCache.get(cacheKey);
+  if (cached) return cached;
   try {
     const res = await axios.get(`https://api.deezer.com/album/${id}/tracks`, {
       timeout: 3000,
     });
     const raw = res.data?.data || [];
-    return raw.map((t, i) => ({
+    const tracks = raw.map((t, i) => ({
       id: String(t.id),
       mbid: String(t.id),
       title: t.title || "",
       trackName: t.title || "",
       trackNumber: t.track_position || i + 1,
       position: t.track_position || i + 1,
+      mediumNumber: t.disk_number || null,
       length: t.duration ? t.duration * 1000 : null,
       duration_ms: t.duration ? t.duration * 1000 : null,
       preview_url: t.preview || null,
     }));
+    deezerAlbumTrackCache.set(cacheKey, tracks);
+    return tracks;
   } catch (e) {
     return [];
+  }
+}
+
+export async function enrichTracksWithDeezerPreviews(
+  tracks,
+  {
+    artistName = "",
+    deezerArtistId = null,
+    deezerAlbumId = null,
+    albumTitle = "",
+    releaseType = "",
+    releaseDate = "",
+    cacheKey = "",
+  } = {},
+) {
+  if (!Array.isArray(tracks) || tracks.length === 0) return tracks || [];
+  const normalizedCacheKey =
+    cacheKey ||
+    `preview:${deezerAlbumId || deezerArtistId || artistName}:${albumTitle}:${releaseType}:${releaseDate}`;
+  const cached = deezerPreviewMatchCache.get(normalizedCacheKey);
+  if (cached) return cached;
+
+  try {
+    let resolvedAlbumId = String(deezerAlbumId || "").replace(/^dz-/, "").trim();
+    if (!resolvedAlbumId) {
+      const album = await resolveDeezerAlbumForPreview({
+        artistName,
+        deezerArtistId,
+        albumTitle,
+        releaseType,
+        releaseDate,
+      });
+      resolvedAlbumId = album?.id ? String(album.id) : "";
+    }
+    if (!resolvedAlbumId) return tracks;
+
+    const deezerTracks = await deezerGetAlbumTracks(resolvedAlbumId);
+    const enriched = attachDeezerTrackPreviews(tracks, deezerTracks);
+    deezerPreviewMatchCache.set(normalizedCacheKey, enriched);
+    return enriched;
+  } catch {
+    return tracks;
   }
 }
 

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -14,7 +14,6 @@ import { ArtistDetailsSimilar } from "./components/ArtistDetailsSimilar";
 import { DeleteArtistModal } from "./components/DeleteArtistModal";
 import { DeleteAlbumModal } from "./components/DeleteAlbumModal";
 import { AddArtistCustomizeModal } from "./components/AddArtistCustomizeModal";
-import { PlaylistTrackModal } from "../../components/PlaylistModals";
 import {
   addSharedPlaylistTracks,
   getArtistCover,
@@ -86,10 +85,9 @@ function ArtistDetailsPage() {
     deezerArtistId: "",
   });
   const [sharedPlaylists, setSharedPlaylists] = useState([]);
-  const [playlistTrackModal, setPlaylistTrackModal] = useState(null);
   const [playlistModalLoading, setPlaylistModalLoading] = useState(false);
-  const [playlistModalSubmitting, setPlaylistModalSubmitting] = useState(false);
   const [playlistModalError, setPlaylistModalError] = useState("");
+  const [playlistMenuSavingKey, setPlaylistMenuSavingKey] = useState("");
   const [blockingArtist, setBlockingArtist] = useState(false);
   const [artistBlocked, setArtistBlocked] = useState(false);
   const [visibleReleaseGroupCoverIds, setVisibleReleaseGroupCoverIds] = useState(
@@ -396,28 +394,17 @@ function ArtistDetailsPage() {
     }
   };
 
-  const openPlaylistTrackModal = async (trackPayload) => {
-    if (!trackPayload?.artistName || !trackPayload?.trackName) {
-      showError("Track details are incomplete");
-      return;
-    }
-    setPlaylistModalError("");
-    const playlists = await loadSharedPlaylists();
-    if (!playlists) return;
-    setPlaylistTrackModal({
-      tracks: [trackPayload],
-      defaultNewPlaylistName: reserveUniquePlaylistName(
-        playlists,
-        `${trackPayload.artistName} Picks`,
-      ),
-    });
-  };
+  const getDefaultTrackPlaylistName = (track) =>
+    reserveUniquePlaylistName(
+      sharedPlaylists,
+      `${artist?.name || artistNameFromNav || track?.artistName || "Artist"} Picks`,
+    );
 
-  const handleReleaseTrackAdd = (track, releaseGroup) => {
+  const buildReleaseTrackPayload = (track, releaseGroup) => {
     const year = String(
       releaseGroup?.["first-release-date"] || "",
     ).slice(0, 4);
-    void openPlaylistTrackModal({
+    return {
       artistName: artist?.name || artistNameFromNav || "",
       trackName: track?.trackName || track?.title || "",
       albumName: releaseGroup?.title || "",
@@ -431,12 +418,12 @@ function ArtistDetailsPage() {
           : null,
       reason: null,
       artistAliases: [],
-    });
+    };
   };
 
-  const handleLibraryTrackAdd = (track, libraryAlbum, releaseGroupId) => {
+  const buildLibraryTrackPayload = (track, libraryAlbum, releaseGroupId) => {
     const year = String(libraryAlbum?.releaseDate || "").slice(0, 4);
-    void openPlaylistTrackModal({
+    return {
       artistName: artist?.name || artistNameFromNav || "",
       trackName: track?.trackName || track?.title || "",
       albumName: libraryAlbum?.albumName || "",
@@ -450,33 +437,42 @@ function ArtistDetailsPage() {
           : null,
       reason: null,
       artistAliases: [],
-    });
+    };
   };
 
-  const handleSubmitPlaylistTrackModal = async (payload) => {
-    setPlaylistModalSubmitting(true);
+  const saveTrackToPlaylist = async (trackPayload, target, savingKey) => {
+    if (!trackPayload?.artistName || !trackPayload?.trackName) {
+      showError("Track details are incomplete");
+      return;
+    }
     setPlaylistModalError("");
+    setPlaylistMenuSavingKey(String(savingKey || ""));
     try {
-      if (payload?.mode === "new") {
+      if (target?.mode === "new") {
+        const name =
+          String(target?.name || "").trim() ||
+          reserveUniquePlaylistName(
+            sharedPlaylists,
+            `${trackPayload.artistName} Picks`,
+          );
         const response = await createSharedPlaylist({
-          name: payload.name,
-          tracks: payload.tracks,
+          name,
+          tracks: [trackPayload],
         });
         showSuccess(
-          `Track saved to ${response?.playlist?.name || payload.name}`,
+          `Track saved to ${response?.playlist?.name || name}`,
         );
       } else {
         const targetPlaylist = sharedPlaylists.find(
-          (playlist) => playlist.id === payload?.playlistId,
+          (playlist) => playlist.id === target?.playlistId,
         );
-        await addSharedPlaylistTracks(payload.playlistId, {
-          tracks: payload.tracks,
+        await addSharedPlaylistTracks(target.playlistId, {
+          tracks: [trackPayload],
         });
         showSuccess(
           `Track added to ${targetPlaylist?.name || "playlist"}`,
         );
       }
-      setPlaylistTrackModal(null);
       const nextPlaylists = await loadSharedPlaylists();
       if (nextPlaylists) {
         setSharedPlaylists(nextPlaylists);
@@ -490,8 +486,20 @@ function ArtistDetailsPage() {
       setPlaylistModalError(message);
       showError(message);
     } finally {
-      setPlaylistModalSubmitting(false);
+      setPlaylistMenuSavingKey("");
     }
+  };
+
+  const handleReleaseTrackAdd = (track, releaseGroup, target) => {
+    const payload = buildReleaseTrackPayload(track, releaseGroup);
+    const savingKey = String(track?.id ?? track?.mbid ?? "");
+    return saveTrackToPlaylist(payload, target, savingKey);
+  };
+
+  const handleLibraryTrackAdd = (track, libraryAlbum, releaseGroupId, target) => {
+    const payload = buildLibraryTrackPayload(track, libraryAlbum, releaseGroupId);
+    const savingKey = String(track?.id ?? track?.mbid ?? track?.title ?? "");
+    return saveTrackToPlaylist(payload, target, savingKey);
   };
 
   if (loading) {
@@ -599,6 +607,12 @@ function ArtistDetailsPage() {
           handleReSearchAlbum={library.handleReSearchAlbum}
           handleReSearchMissingDownloads={library.handleReSearchMissingDownloads}
           onAddTrackToPlaylist={handleLibraryTrackAdd}
+          playlists={sharedPlaylists}
+          playlistsLoading={playlistModalLoading}
+          playlistSavingKey={playlistMenuSavingKey}
+          playlistError={playlistModalError}
+          getDefaultPlaylistName={getDefaultTrackPlaylistName}
+          onLoadPlaylists={loadSharedPlaylists}
           onVisibleCoverIdsChange={setVisibleLibraryCoverIds}
         />
       )}
@@ -639,6 +653,12 @@ function ArtistDetailsPage() {
             library.isReleaseGroupDownloadedInLibrary
           }
           onAddTrackToPlaylist={handleReleaseTrackAdd}
+          playlists={sharedPlaylists}
+          playlistsLoading={playlistModalLoading}
+          playlistSavingKey={playlistMenuSavingKey}
+          playlistError={playlistModalError}
+          getDefaultPlaylistName={getDefaultTrackPlaylistName}
+          onLoadPlaylists={loadSharedPlaylists}
           onVisibleCoverIdsChange={setVisibleReleaseGroupCoverIds}
         />
       )}
@@ -708,28 +728,6 @@ function ArtistDetailsPage() {
         onSave={handleSaveIds}
       />
 
-      <PlaylistTrackModal
-        open={!!playlistTrackModal}
-        title="Add Track To Playlist"
-        description={
-          playlistModalLoading
-            ? "Loading your playlists..."
-            : "Save this song into an existing playlist or start a new one."
-        }
-        playlists={sharedPlaylists}
-        initialTracks={playlistTrackModal?.tracks || []}
-        defaultNewPlaylistName={
-          playlistTrackModal?.defaultNewPlaylistName || "Playlist"
-        }
-        saving={playlistModalSubmitting || playlistModalLoading}
-        error={playlistModalError}
-        onClose={() => {
-          if (playlistModalSubmitting || playlistModalLoading) return;
-          setPlaylistModalError("");
-          setPlaylistTrackModal(null);
-        }}
-        onSubmit={handleSubmitPlaylistTrackModal}
-      />
     </div>
   );
 }

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import {
   Loader,
   Music,
-  CheckCircle,
   ChevronLeft,
   ChevronRight,
   ChevronDown,
@@ -12,9 +11,9 @@ import {
   ExternalLink,
   Trash2,
   RefreshCw,
-  Plus,
 } from "lucide-react";
 import { getPopularityScale } from "../utils";
+import { TrackPlaylistMenu } from "./TrackPlaylistMenu";
 
 export function ArtistDetailsLibraryAlbums({
   artist,
@@ -36,6 +35,12 @@ export function ArtistDetailsLibraryAlbums({
   handleReSearchAlbum,
   handleReSearchMissingDownloads,
   onAddTrackToPlaylist,
+  playlists,
+  playlistsLoading,
+  playlistSavingKey,
+  playlistError,
+  getDefaultPlaylistName,
+  onLoadPlaylists,
   onVisibleCoverIdsChange,
 }) {
   const railRef = useRef(null);
@@ -43,6 +48,7 @@ export function ArtistDetailsLibraryAlbums({
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const [completionFilter, setCompletionFilter] = useState("all");
+  const [activePlaylistTrackKey, setActivePlaylistTrackKey] = useState(null);
   const downloadedAlbums = libraryAlbums.filter((album) => {
     if (String(album.id ?? "").startsWith("pending-")) return false;
     return (
@@ -586,69 +592,87 @@ export function ArtistDetailsLibraryAlbums({
                 </div>
               ) : tracks && tracks.length > 0 ? (
                 <div className="space-y-1">
-                  {tracks.map((track, idx) => (
-                    <div
-                      key={track.id || track.title || idx}
-                      className="group flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-white/5"
-                    >
-                      <div className="flex min-w-0 flex-1 items-center gap-3">
-                        <span
-                          className="w-6 flex-shrink-0 text-xs"
-                          style={{ color: "#c1c1c3" }}
-                        >
-                          {track.trackNumber || track.position || idx + 1}
-                        </span>
-                        <span className="truncate text-sm" style={{ color: "#fff" }}>
-                          {track.title || track.trackName || "Unknown Track"}
-                        </span>
-                      </div>
-                      <div className="flex flex-shrink-0 items-center gap-2">
-                        {track.length && (
-                          <span className="text-xs" style={{ color: "#c1c1c3" }}>
-                            {Math.floor(track.length / 60000)}:
-                            {Math.floor((track.length % 60000) / 1000)
+                  {tracks.map((track, idx) => {
+                    const trackMenuKey = String(
+                      track.id || track.mbid || track.title || idx,
+                    );
+                    const isPlaylistMenuOpen =
+                      activePlaylistTrackKey === trackMenuKey;
+                    return (
+                      <div
+                        key={trackMenuKey}
+                        className="flex items-center gap-3 rounded-lg px-2 py-2.5 text-sm transition-colors"
+                        style={{
+                          backgroundColor: isPlaylistMenuOpen
+                            ? "rgba(255, 255, 255, 0.06)"
+                            : "transparent",
+                        }}
+                        onMouseEnter={(event) => {
+                          event.currentTarget.style.backgroundColor =
+                            "rgba(255, 255, 255, 0.06)";
+                        }}
+                        onMouseLeave={(event) => {
+                          event.currentTarget.style.backgroundColor =
+                            isPlaylistMenuOpen
+                              ? "rgba(255, 255, 255, 0.06)"
+                              : "transparent";
+                        }}
+                      >
+                      <span
+                        className="w-7 flex-shrink-0 text-xs tabular-nums"
+                        style={{ color: "#c1c1c3" }}
+                      >
+                        {track.trackNumber || track.position || idx + 1}
+                      </span>
+                      <span
+                        className="min-w-0 flex-1 truncate text-sm"
+                        style={{ color: "#fff" }}
+                      >
+                        {track.title || track.trackName || "Unknown Track"}
+                      </span>
+                      {onAddTrackToPlaylist ? (
+                        <TrackPlaylistMenu
+                          playlists={playlists}
+                          loading={playlistsLoading}
+                          saving={
+                            playlistSavingKey === trackMenuKey
+                          }
+                          error={playlistError}
+                          defaultNewPlaylistName={getDefaultPlaylistName?.(
+                            track,
+                            libraryAlbum,
+                          )}
+                          onLoadPlaylists={onLoadPlaylists}
+                          onSelect={(target) =>
+                            onAddTrackToPlaylist(
+                              track,
+                              libraryAlbum,
+                              rgId,
+                              target,
+                            )
+                          }
+                          onOpenChange={(open) =>
+                            setActivePlaylistTrackKey(
+                              open ? trackMenuKey : null,
+                            )
+                          }
+                        />
+                      ) : null}
+                      <span
+                        className="w-11 flex-shrink-0 text-right text-xs tabular-nums"
+                        style={{ color: "#c1c1c3" }}
+                      >
+                        {track.length
+                          ? `${Math.floor(track.length / 60000)}:${Math.floor(
+                              (track.length % 60000) / 1000
+                            )
                               .toString()
-                              .padStart(2, "0")}
-                          </span>
-                        )}
-                        {onAddTrackToPlaylist ? (
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              onAddTrackToPlaylist(track, libraryAlbum, rgId);
-                            }}
-                            className="group inline-flex h-7 w-7 items-center overflow-hidden rounded-full transition-all duration-200 ease-out hover:w-[118px]"
-                            style={{
-                              backgroundColor: "rgba(255,255,255,0.06)",
-                              color: "#fff",
-                            }}
-                            title="Add to playlist"
-                            aria-label="Add to playlist"
-                          >
-                            <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center">
-                              <Plus className="w-3.5 h-3.5" />
-                            </span>
-                            <span className="pr-3 text-xs font-medium whitespace-nowrap opacity-0 transition-all duration-150 ease-out -translate-x-2 group-hover:translate-x-0 group-hover:opacity-100">
-                              Add to playlist
-                            </span>
-                          </button>
-                        ) : null}
-                        {track.hasFile ||
-                        libraryAlbum?.statistics?.percentOfTracks >= 100 ||
-                        libraryAlbum?.statistics?.sizeOnDisk > 0 ? (
-                          <span
-                            className="flex w-12 items-center justify-end"
-                            style={{ color: "#c1c1c3" }}
-                          >
-                            <CheckCircle className="w-4 h-4 text-green-500" />
-                          </span>
-                        ) : (
-                          <span className="w-12" />
-                        )}
+                              .padStart(2, "0")}`
+                          : ""}
+                      </span>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               ) : (
                 <p className="py-4 text-sm italic" style={{ color: "#c1c1c3" }}>
@@ -683,5 +707,11 @@ ArtistDetailsLibraryAlbums.propTypes = {
   handleReSearchAlbum: PropTypes.func,
   handleReSearchMissingDownloads: PropTypes.func,
   onAddTrackToPlaylist: PropTypes.func,
+  playlists: PropTypes.array,
+  playlistsLoading: PropTypes.bool,
+  playlistSavingKey: PropTypes.string,
+  playlistError: PropTypes.string,
+  getDefaultPlaylistName: PropTypes.func,
+  onLoadPlaylists: PropTypes.func,
   onVisibleCoverIdsChange: PropTypes.func,
 };

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -14,7 +14,6 @@ import {
   Filter,
   ExternalLink,
   Trash2,
-  Plus,
   Disc,
   Disc3,
   FileMusic,
@@ -24,6 +23,7 @@ import {
 } from "lucide-react";
 import AddAlbumButton from "../../../components/AddAlbumButton";
 import { matchesReleaseTypeFilter } from "../utils";
+import { TrackPlaylistMenu } from "./TrackPlaylistMenu";
 
 export function ArtistDetailsReleaseGroups({
   artist,
@@ -53,11 +53,18 @@ export function ArtistDetailsReleaseGroups({
   previewVolume,
   isReleaseGroupDownloadedInLibrary,
   onAddTrackToPlaylist,
+  playlists,
+  playlistsLoading,
+  playlistSavingKey,
+  playlistError,
+  getDefaultPlaylistName,
+  onLoadPlaylists,
   onVisibleCoverIdsChange,
 }) {
   const [sortMode, setSortMode] = useState("date");
   const [playingTrackId, setPlayingTrackId] = useState(null);
   const [loadingTrackId, setLoadingTrackId] = useState(null);
+  const [activePlaylistTrackId, setActivePlaylistTrackId] = useState(null);
   const [showMobileFilterMenu, setShowMobileFilterMenu] = useState(false);
   const previewAudioRef = useRef(null);
   const listRef = useRef(null);
@@ -573,7 +580,7 @@ export function ArtistDetailsReleaseGroups({
                   className="flex min-w-0 cursor-pointer items-start justify-between gap-3 px-3 py-3 sm:items-center"
                   onClick={() =>
                     handleReleaseGroupAlbumClick(
-                      releaseGroup.id,
+                      releaseGroup,
                       status?.libraryId
                     )
                   }
@@ -584,7 +591,7 @@ export function ArtistDetailsReleaseGroups({
                       onClick={(e) => {
                         e.stopPropagation();
                         handleReleaseGroupAlbumClick(
-                          releaseGroup.id,
+                          releaseGroup,
                           status?.libraryId
                         );
                       }}
@@ -914,108 +921,106 @@ export function ArtistDetailsReleaseGroups({
                                   .toString()
                                   .padStart(2, "0")}`
                               : "";
+                            const trackRowBg =
+                              idx % 2 === 0
+                                ? "transparent"
+                                : "rgba(255, 255, 255, 0.02)";
+                            const trackRowActiveBg = "rgba(255, 255, 255, 0.06)";
+                            const isPlaylistMenuOpen =
+                              activePlaylistTrackId === trackId;
 
                             return (
                               <div
                                 key={trackId}
-                                className="flex items-center justify-between py-1.5 px-2 transition-colors text-sm"
+                                className="flex items-center gap-3 rounded-lg px-2 py-2.5 text-sm transition-colors"
                                 style={{
-                                  backgroundColor:
-                                    idx % 2 === 0
-                                      ? "transparent"
-                                      : "rgba(255, 255, 255, 0.02)",
+                                  backgroundColor: isPlaylistMenuOpen
+                                    ? trackRowActiveBg
+                                    : trackRowBg,
+                                }}
+                                onMouseEnter={(e) => {
+                                  e.currentTarget.style.backgroundColor =
+                                    trackRowActiveBg;
+                                }}
+                                onMouseLeave={(e) => {
+                                  e.currentTarget.style.backgroundColor =
+                                    isPlaylistMenuOpen
+                                      ? trackRowActiveBg
+                                      : trackRowBg;
                                 }}
                               >
-                                <div className="flex items-center gap-3 flex-1 min-w-0">
-                                  <span
-                                    className="text-xs  w-6 flex-shrink-0"
-                                    style={{ color: "#c1c1c3" }}
+                                <span
+                                  className="w-7 flex-shrink-0 text-xs tabular-nums"
+                                  style={{ color: "#c1c1c3" }}
+                                >
+                                  {track.trackNumber || track.position || idx + 1}
+                                </span>
+                                {hasPreview ? (
+                                  <button
+                                    type="button"
+                                    className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-white/10"
+                                    style={{
+                                      backgroundColor: "rgba(255,255,255,0.06)",
+                                      color: "#fff",
+                                    }}
+                                    onClick={(e) =>
+                                      handleTrackPreviewPlay(track, e)
+                                    }
+                                    title={
+                                      isPlaying ? "Pause preview" : "Play preview"
+                                    }
+                                    aria-label={
+                                      isPlaying ? "Pause preview" : "Play preview"
+                                    }
                                   >
-                                    {track.trackNumber ||
-                                      track.position ||
-                                      idx + 1}
-                                  </span>
-                                  <span
-                                    className="text-sm  truncate"
-                                    style={{ color: "#fff" }}
-                                  >
-                                    {track.title ||
-                                      track.trackName ||
-                                      "Unknown Track"}
-                                  </span>
-                                </div>
-                                <div className="flex items-center gap-2 flex-shrink-0">
-                                  <span
-                                    className="text-xs w-10 text-right tabular-nums"
-                                    style={{ color: "#c1c1c3" }}
-                                  >
-                                    {durationLabel}
-                                  </span>
-                                  {onAddTrackToPlaylist ? (
-                                    <button
-                                      type="button"
-                                      className="group inline-flex h-7 w-7 items-center overflow-hidden rounded-full transition-all duration-200 ease-out hover:w-[118px]"
-                                      style={{
-                                        backgroundColor: "rgba(255,255,255,0.06)",
-                                        color: "#fff",
-                                      }}
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        onAddTrackToPlaylist(track, releaseGroup);
-                                      }}
-                                      title="Add to playlist"
-                                      aria-label="Add to playlist"
-                                    >
-                                      <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center">
-                                        <Plus className="w-3.5 h-3.5" />
-                                      </span>
-                                      <span className="pr-3 text-xs font-medium whitespace-nowrap opacity-0 transition-all duration-150 ease-out -translate-x-2 group-hover:translate-x-0 group-hover:opacity-100">
-                                        Add to playlist
-                                      </span>
-                                    </button>
-                                  ) : null}
-                                  {hasPreview && (
-                                    <button
-                                      type="button"
-                                      className="w-7 h-7 rounded-full flex items-center justify-center transition-colors"
-                                      style={{
-                                        backgroundColor: "rgba(255,255,255,0.06)",
-                                        color: "#fff",
-                                      }}
-                                      onClick={(e) =>
-                                        handleTrackPreviewPlay(track, e)
-                                      }
-                                      title={
-                                        isPlaying ? "Pause preview" : "Play preview"
-                                      }
-                                      aria-label={
-                                        isPlaying ? "Pause preview" : "Play preview"
-                                      }
-                                    >
-                                      {isLoadingPreview ? (
-                                        <Loader className="w-3.5 h-3.5 animate-spin" />
-                                      ) : isPlaying ? (
-                                        <Pause className="w-3.5 h-3.5" />
-                                      ) : (
-                                        <Play className="w-3.5 h-3.5 ml-0.5" />
-                                      )}
-                                    </button>
-                                  )}
-                                  {track.hasFile ||
-                                  status?.albumInfo?.statistics
-                                    ?.percentOfTracks >= 100 ||
-                                  status?.albumInfo?.statistics?.sizeOnDisk >
-                                    0 ? (
-                                    <span
-                                      className="w-12 flex items-center justify-end"
-                                      style={{ color: "#c1c1c3" }}
-                                    >
-                                      <CheckCircle className="w-4 h-4 text-green-500" />
-                                    </span>
-                                  ) : (
-                                    <span className="w-12" />
-                                  )}
-                                </div>
+                                    {isLoadingPreview ? (
+                                      <Loader className="h-3.5 w-3.5 animate-spin" />
+                                    ) : isPlaying ? (
+                                      <Pause className="h-3.5 w-3.5" />
+                                    ) : (
+                                      <Play className="ml-0.5 h-3.5 w-3.5" />
+                                    )}
+                                  </button>
+                                ) : null}
+                                <span
+                                  className="min-w-0 flex-1 truncate text-sm"
+                                  style={{ color: "#fff" }}
+                                >
+                                  {track.title ||
+                                    track.trackName ||
+                                    "Unknown Track"}
+                                </span>
+                                {onAddTrackToPlaylist ? (
+                                  <TrackPlaylistMenu
+                                    playlists={playlists}
+                                    loading={playlistsLoading}
+                                    saving={playlistSavingKey === trackId}
+                                    error={playlistError}
+                                    defaultNewPlaylistName={getDefaultPlaylistName?.(
+                                      track,
+                                      releaseGroup,
+                                    )}
+                                    onLoadPlaylists={onLoadPlaylists}
+                                    onSelect={(target) =>
+                                      onAddTrackToPlaylist(
+                                        track,
+                                        releaseGroup,
+                                        target,
+                                      )
+                                    }
+                                    onOpenChange={(open) =>
+                                      setActivePlaylistTrackId(
+                                        open ? trackId : null,
+                                      )
+                                    }
+                                  />
+                                ) : null}
+                                <span
+                                  className="w-11 flex-shrink-0 text-right text-xs tabular-nums"
+                                  style={{ color: "#c1c1c3" }}
+                                >
+                                  {durationLabel}
+                                </span>
                               </div>
                             );
                           })}
@@ -1067,5 +1072,11 @@ ArtistDetailsReleaseGroups.propTypes = {
   previewVolume: PropTypes.number,
   isReleaseGroupDownloadedInLibrary: PropTypes.func,
   onAddTrackToPlaylist: PropTypes.func,
+  playlists: PropTypes.array,
+  playlistsLoading: PropTypes.bool,
+  playlistSavingKey: PropTypes.string,
+  playlistError: PropTypes.string,
+  getDefaultPlaylistName: PropTypes.func,
+  onLoadPlaylists: PropTypes.func,
   onVisibleCoverIdsChange: PropTypes.func,
 };

--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Check, ListMusic, Loader, Plus } from "lucide-react";
+
+export function TrackPlaylistMenu({
+  playlists = [],
+  loading = false,
+  saving = false,
+  error = "",
+  defaultNewPlaylistName = "Playlist",
+  onLoadPlaylists,
+  onSelect,
+  onOpenChange,
+}) {
+  const [open, setOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+  const menuRef = useRef(null);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handlePointerDown = (event) => {
+      if (menuRef.current?.contains(event.target)) return;
+      setOpen(false);
+      onOpenChange?.(false);
+    };
+    const handleViewportChange = () => {
+      setOpen(false);
+      onOpenChange?.(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [onOpenChange, open]);
+
+  const handleOpen = async (event) => {
+    event.stopPropagation();
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (rect) {
+      const menuWidth = 256;
+      setMenuPosition({
+        top: rect.bottom + 8,
+        left: Math.max(
+          12,
+          Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 12),
+        ),
+      });
+    }
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+    if (!open) {
+      await onLoadPlaylists?.();
+    }
+  };
+
+  const handleSelect = async (target) => {
+    await onSelect?.(target);
+    setOpen(false);
+    onOpenChange?.(false);
+  };
+
+  return (
+    <div className="relative flex-shrink-0" ref={menuRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`group inline-flex h-7 flex-shrink-0 items-center overflow-hidden rounded-full transition-all duration-200 ease-out hover:w-[118px] ${
+          open ? "w-[118px]" : "w-7"
+        }`}
+        style={{
+          backgroundColor: "rgba(255,255,255,0.06)",
+          color: "#fff",
+        }}
+        onClick={handleOpen}
+        title="Add to playlist"
+        aria-label="Add to playlist"
+        aria-expanded={open}
+        disabled={saving}
+      >
+        <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center">
+          {saving ? (
+            <Loader className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Plus className="h-3.5 w-3.5" />
+          )}
+        </span>
+        <span
+          className={`pr-3 text-xs font-medium whitespace-nowrap transition-all duration-150 ease-out ${
+            open
+              ? "translate-x-0 opacity-100"
+              : "-translate-x-2 opacity-0 group-hover:translate-x-0 group-hover:opacity-100"
+          }`}
+        >
+          Add to playlist
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          className="fixed z-50 w-64 overflow-hidden rounded-xl border border-white/10 bg-[#15151a] py-1 shadow-xl"
+          style={{
+            top: menuPosition.top,
+            left: menuPosition.left,
+          }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2 text-xs font-medium uppercase tracking-[0.14em] text-[#9ea0a8]">
+            <ListMusic className="h-3.5 w-3.5" />
+            Playlists
+          </div>
+          {loading ? (
+            <div className="flex items-center gap-2 px-3 py-3 text-sm text-[#c1c1c3]">
+              <Loader className="h-4 w-4 animate-spin" />
+              Loading playlists
+            </div>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-white transition-colors hover:bg-white/5"
+                onClick={() =>
+                  handleSelect({
+                    mode: "new",
+                    name: defaultNewPlaylistName,
+                  })
+                }
+                disabled={saving}
+              >
+                <Plus className="h-4 w-4 flex-shrink-0 text-[#dfe8d2]" />
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">New playlist</span>
+                  <span className="block truncate text-xs text-[#aeb0b7]">
+                    {defaultNewPlaylistName}
+                  </span>
+                </span>
+              </button>
+              {Array.isArray(playlists) && playlists.length > 0 ? (
+                <div className="max-h-64 overflow-y-auto border-t border-white/10 py-1">
+                  {playlists.map((playlist) => (
+                    <button
+                      key={playlist.id}
+                      type="button"
+                      className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left text-sm text-white transition-colors hover:bg-white/5"
+                      onClick={() =>
+                        handleSelect({
+                          mode: "existing",
+                          playlistId: playlist.id,
+                        })
+                      }
+                      disabled={saving}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium">
+                          {playlist.name}
+                        </span>
+                        <span className="block text-xs text-[#aeb0b7]">
+                          {playlist.trackCount || 0} tracks
+                        </span>
+                      </span>
+                      <Check className="h-4 w-4 flex-shrink-0 opacity-0" />
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              {error ? (
+                <div className="border-t border-white/10 px-3 py-2 text-xs text-red-400">
+                  {error}
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+TrackPlaylistMenu.propTypes = {
+  playlists: PropTypes.array,
+  loading: PropTypes.bool,
+  saving: PropTypes.bool,
+  error: PropTypes.string,
+  defaultNewPlaylistName: PropTypes.string,
+  onLoadPlaylists: PropTypes.func,
+  onSelect: PropTypes.func,
+  onOpenChange: PropTypes.func,
+};

--- a/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useArtistDetailsLibrary.js
@@ -860,10 +860,15 @@ export function useArtistDetailsLibrary({
     }
   };
 
-  const handleReleaseGroupAlbumClick = async (
-    releaseGroupId,
-    libraryAlbumId,
-  ) => {
+  const handleReleaseGroupAlbumClick = async (releaseGroupOrId, libraryAlbumId) => {
+    const releaseGroup =
+      releaseGroupOrId && typeof releaseGroupOrId === "object"
+        ? releaseGroupOrId
+        : artist?.["release-groups"]?.find((rg) => rg.id === releaseGroupOrId);
+    const releaseGroupId =
+      typeof releaseGroupOrId === "string" ? releaseGroupOrId : releaseGroup?.id;
+    if (!releaseGroupId) return;
+
     if (expandedReleaseGroup === releaseGroupId) {
       setExpandedReleaseGroup(null);
       return;
@@ -878,7 +883,14 @@ export function useArtistDetailsLibrary({
           const tracks = await getLibraryTracks(libraryAlbumId, releaseGroupId);
           setAlbumTracks((prev) => ({ ...prev, [trackKey]: tracks }));
         } else {
-          const tracks = await getReleaseGroupTracks(releaseGroupId);
+          const tracks = await getReleaseGroupTracks(releaseGroupId, {
+            artistMbid: artist?.id || "",
+            artistName: artist?.name || "",
+            albumTitle: releaseGroup?.title || "",
+            releaseType: releaseGroup?.["primary-type"] || "",
+            releaseDate: releaseGroup?.["first-release-date"] || "",
+            deezerAlbumId: releaseGroup?._deezerAlbumId || "",
+          });
           setAlbumTracks((prev) => ({ ...prev, [trackKey]: tracks }));
         }
       } catch (err) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -294,8 +294,17 @@ export const getArtistDetails = async (
   return response.data;
 };
 
-export const getReleaseGroupTracks = async (mbid) => {
-  const response = await api.get(`/artists/release-group/${mbid}/tracks`);
+export const getReleaseGroupTracks = async (mbid, context = {}) => {
+  const params = {};
+  if (context.artistMbid) params.artistMbid = context.artistMbid;
+  if (context.artistName) params.artistName = context.artistName;
+  if (context.albumTitle) params.albumTitle = context.albumTitle;
+  if (context.releaseType) params.releaseType = context.releaseType;
+  if (context.releaseDate) params.releaseDate = context.releaseDate;
+  if (context.deezerAlbumId) params.deezerAlbumId = context.deezerAlbumId;
+  const response = await api.get(`/artists/release-group/${mbid}/tracks`, {
+    params,
+  });
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- Add Deezer-backed preview matching for release-group tracks, including album resolution and track-level preview URLs.
- Extend artist detail track rows with inline playlist menus so tracks can be added to existing playlists or saved into a new one without opening a modal.
- Update backend and frontend plumbing to pass playlist state, loading, and error context through the artist details views.
- Refactor Deezer album and track caching to reduce repeated lookups while improving preview matching accuracy.

## Testing
- Not run
- Verified the diff stat and code paths for release-group track enrichment, Deezer album/track lookup, and playlist menu wiring.
- No automated frontend or backend test suite was executed for this change.