### PR TITLE
feat(plex): Plex integration for Aurral 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Aurral is a self-hosted music discovery app for the Lidarr stack. Find new artis
 - **Library** — Browse and search artists already in Lidarr.
 - **Playlists** — Run scheduled flows, adopt discover playlists like Release Radar, import static playlists, and convert flows to fixed tracklists.
 - **History** — One timeline for Lidarr requests, slskd downloads, and Aurral playlist activity.
-- **Integrations** — Lidarr, Last.fm, ListenBrainz, slskd, Navidrome, Ticketmaster, Gotify, and webhooks.
-- **Playback** — Stream through Navidrome with generated libraries and M3U playlists in a dedicated folder.
+- **Integrations** — Lidarr, Last.fm, ListenBrainz, slskd, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
+- **Playback** — Stream through Navidrome (M3U playlists) or Plex/Plexamp (API-synced playlists) from a dedicated download folder.
 - **Multi-user** — Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, and reverse-proxy SSO.
 
 ## Screenshots
@@ -44,7 +44,8 @@ Aurral only needs Lidarr to get started. It works best with the stack self-hoste
 | ------------------------------------------ | ----------------------------------------------------------- |
 | [Lidarr](https://github.com/Lidarr/Lidarr) | Library management, artist and album requests, queue status |
 | [slskd](https://github.com/slskd/slskd)    | Soulseek-backed downloads for flows and playlists           |
-| [Navidrome](https://www.navidrome.org)     | Streaming and playback for generated playlists              |
+| [Navidrome](https://www.navidrome.org)     | Streaming and playback via generated M3U playlists          |
+| [Plex](https://www.plex.tv)                | Flow playlists in Plexamp (optional)                      |
 
 
 ## Quick Start
@@ -66,7 +67,7 @@ services:
       - ${CONFIG:-./config}:/config
 ```
 
-Change `${MEDIA_ROOT:-/srv/media}` to the host path you use for media. For file reuse, slskd downloads, and generated playlists, mount the **same root directory** into Aurral, Lidarr, slskd, and Navidrome at the same container path (for example `/srv/media:/data`). See [shared storage](https://docs.aurral.org/getting-started/storage/).
+Change `${MEDIA_ROOT:-/srv/media}` to the host path you use for media. For file reuse, slskd downloads, and generated playlists, mount the **same root directory** into Aurral, Lidarr, slskd, and your player (Navidrome or Plex) at the same container path (for example `/srv/media:/data`). See [shared storage](https://docs.aurral.org/getting-started/storage/).
 
 ```bash
 docker compose up -d
@@ -74,7 +75,7 @@ docker compose up -d
 
 Open `http://localhost:3001` and complete onboarding.
 
-For a full stack with Lidarr, slskd, and Navidrome, see `[docker-compose.example.yml](docker-compose.example.yml)`.
+For a full stack with Lidarr, slskd, and Navidrome or Plex, see [`docker-compose.example.yml`](docker-compose.example.yml). Plex setup: [docs](https://docs.aurral.org/integrations/plex/).
 
 ## macOS app
 

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -179,6 +179,13 @@ export const defaultData = {
     ],
     integrations: {
       navidrome: { url: "", username: "", password: "", m3uPathMode: "local" },
+      plex: {
+        url: "",
+        token: "",
+        clientId: "",
+        machineIdentifier: "",
+        downloadsPath: "",
+      },
       lastfm: {
         apiKey: "",
         username: "",

--- a/backend/config/encryption.js
+++ b/backend/config/encryption.js
@@ -42,6 +42,7 @@ function decryptWithKey(text, key) {
 
 const SENSITIVE_PATHS = [
   ["navidrome", "password"],
+  ["plex", "token"],
   ["general", "authPassword"],
   ["lidarr", "apiKey"],
   ["slskd", "apiKey"],

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -802,8 +802,6 @@ router.post("/lidarr/apply-community-guide", async (req, res) => {
   }
 });
 
-});
-
 router.get("/browse", async (req, res) => {
   try {
     const fs = await import("fs/promises");

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -202,6 +202,16 @@ router.post("/", async (req, res) => {
           ? {
               ...(mergedIntegrations.plex || {}),
               ...integrations.plex,
+              // Never let a blank token/clientId from the client wipe the
+              // stored credentials (the UI doesn't always carry them).
+              token:
+                integrations.plex.token ||
+                mergedIntegrations.plex?.token ||
+                "",
+              clientId:
+                integrations.plex.clientId ||
+                mergedIntegrations.plex?.clientId ||
+                "",
             }
           : mergedIntegrations.plex,
         slskd: integrations.slskd
@@ -903,18 +913,29 @@ router.post("/plex/auth/check", async (req, res) => {
 router.post("/plex/resources", async (req, res) => {
   try {
     const { PlexClient } = await import("../services/plex.js");
-    const clientId = getPlexConfig().clientId;
-    const token = req.body?.token || getPlexConfig().token;
+    const stored = getPlexConfig();
+    // Use the freshest token the client has (e.g. just-minted during connect),
+    // falling back to the persisted one. The clientId MUST be the stored one
+    // the token was minted under — Plex ties the token to that identifier.
+    const token = req.body?.token || stored.token;
+    const clientId = stored.clientId;
     if (!token || !clientId) {
       return res.status(400).json({ error: "Plex authentication required" });
     }
-    const servers = await PlexClient.getResources(token, clientId);
-    res.json({ servers });
+    const { servers, total } = await PlexClient.getResources(token, clientId);
+    res.json({ servers, total });
   } catch (error) {
-    console.error("[Settings] Plex resources failed:", error.message);
-    res.status(500).json({
+    const status = error.response?.status;
+    console.error(
+      "[Settings] Plex resources failed:",
+      status ? `${status} ${JSON.stringify(error.response?.data)}` : error.message,
+    );
+    res.status(status === 401 ? 401 : 500).json({
       error: "Failed to list Plex servers",
-      message: error.message,
+      message:
+        status === 401
+          ? "Plex rejected the token (401). Reconnect your Plex account."
+          : error.message,
     });
   }
 });

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -802,6 +802,43 @@ router.post("/lidarr/apply-community-guide", async (req, res) => {
   }
 });
 
+});
+
+router.get("/browse", async (req, res) => {
+  try {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const target = path.resolve(req.query.path ? String(req.query.path) : "/");
+    const dirents = await fs.readdir(target, { withFileTypes: true });
+    const directories = (
+      await Promise.all(
+        dirents.map(async (d) => {
+          let isDir = d.isDirectory();
+          if (!isDir && d.isSymbolicLink()) {
+            try {
+              isDir = (await fs.stat(path.join(target, d.name))).isDirectory();
+            } catch {
+              isDir = false;
+            }
+          }
+          return isDir ? { name: d.name, path: path.join(target, d.name) } : null;
+        }),
+      )
+    )
+      .filter(Boolean)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    res.json({
+      path: target,
+      parent: target === "/" ? null : path.dirname(target),
+      directories,
+    });
+  } catch (error) {
+    res
+      .status(400)
+      .json({ error: "Cannot read path", message: error.message });
+  }
+});
+
 function getPlexConfig() {
   return dbOps.getSettings()?.integrations?.plex || {};
 }

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -851,7 +851,6 @@ function getPlexConfig() {
   return dbOps.getSettings()?.integrations?.plex || {};
 }
 
-// Start the PIN OAuth flow: returns the PIN id + the app.plex.tv URL to visit.
 router.post("/plex/auth/pin", async (req, res) => {
   try {
     const { PlexClient } = await import("../services/plex.js");
@@ -885,7 +884,6 @@ router.post("/plex/auth/pin", async (req, res) => {
   }
 });
 
-// Poll a PIN. Returns { token } once the user authorizes, else { pending: true }.
 router.post("/plex/auth/check", async (req, res) => {
   try {
     const { PlexClient } = await import("../services/plex.js");
@@ -909,7 +907,6 @@ router.post("/plex/auth/check", async (req, res) => {
   }
 });
 
-// List Plex servers available to the authenticated account.
 router.post("/plex/resources", async (req, res) => {
   try {
     const { PlexClient } = await import("../services/plex.js");
@@ -940,7 +937,6 @@ router.post("/plex/resources", async (req, res) => {
   }
 });
 
-// Test connectivity to a Plex Media Server and capture its machineIdentifier.
 router.post("/plex/test", async (req, res) => {
   try {
     const { PlexClient } = await import("../services/plex.js");
@@ -972,7 +968,6 @@ router.post("/plex/test", async (req, res) => {
   }
 });
 
-// Build the Aurral library + flow playlists on the configured Plex server now.
 router.post("/plex/sync", async (req, res) => {
   try {
     const plex = getPlexConfig();

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -198,6 +198,12 @@ router.post("/", async (req, res) => {
               ...integrations.navidrome,
             }
           : mergedIntegrations.navidrome,
+        plex: integrations.plex
+          ? {
+              ...(mergedIntegrations.plex || {}),
+              ...integrations.plex,
+            }
+          : mergedIntegrations.plex,
         slskd: integrations.slskd
           ? {
               ...(mergedIntegrations.slskd || {}),
@@ -796,6 +802,144 @@ router.post("/lidarr/apply-community-guide", async (req, res) => {
   }
 });
 
+function getPlexConfig() {
+  return dbOps.getSettings()?.integrations?.plex || {};
+}
+
+// Start the PIN OAuth flow: returns the PIN id + the app.plex.tv URL to visit.
+router.post("/plex/auth/pin", async (req, res) => {
+  try {
+    const { PlexClient } = await import("../services/plex.js");
+    const settings = dbOps.getSettings();
+    const plex = settings.integrations?.plex || {};
+    let clientId = plex.clientId;
+    if (!clientId) {
+      clientId = PlexClient.generateClientId();
+      dbOps.updateSettings({
+        ...settings,
+        integrations: {
+          ...settings.integrations,
+          plex: { ...plex, clientId },
+        },
+      });
+    }
+    const { id, code } = await PlexClient.generatePin(clientId);
+    const forwardUrl = req.body?.forwardUrl;
+    res.json({
+      pinId: id,
+      code,
+      clientId,
+      authUrl: PlexClient.buildAuthUrl(clientId, code, forwardUrl),
+    });
+  } catch (error) {
+    console.error("[Settings] Plex PIN generation failed:", error.message);
+    res.status(500).json({
+      error: "Failed to start Plex authentication",
+      message: error.message,
+    });
+  }
+});
+
+// Poll a PIN. Returns { token } once the user authorizes, else { pending: true }.
+router.post("/plex/auth/check", async (req, res) => {
+  try {
+    const { PlexClient } = await import("../services/plex.js");
+    const { pinId, code } = req.body || {};
+    if (!pinId || !code) {
+      return res.status(400).json({ error: "pinId and code are required" });
+    }
+    const clientId = getPlexConfig().clientId;
+    if (!clientId) {
+      return res.status(400).json({ error: "Plex client not initialized" });
+    }
+    const token = await PlexClient.checkPin(pinId, code, clientId);
+    if (!token) return res.json({ pending: true });
+    res.json({ token });
+  } catch (error) {
+    console.error("[Settings] Plex PIN check failed:", error.message);
+    res.status(500).json({
+      error: "Failed to check Plex authentication",
+      message: error.message,
+    });
+  }
+});
+
+// List Plex servers available to the authenticated account.
+router.post("/plex/resources", async (req, res) => {
+  try {
+    const { PlexClient } = await import("../services/plex.js");
+    const clientId = getPlexConfig().clientId;
+    const token = req.body?.token || getPlexConfig().token;
+    if (!token || !clientId) {
+      return res.status(400).json({ error: "Plex authentication required" });
+    }
+    const servers = await PlexClient.getResources(token, clientId);
+    res.json({ servers });
+  } catch (error) {
+    console.error("[Settings] Plex resources failed:", error.message);
+    res.status(500).json({
+      error: "Failed to list Plex servers",
+      message: error.message,
+    });
+  }
+});
+
+// Test connectivity to a Plex Media Server and capture its machineIdentifier.
+router.post("/plex/test", async (req, res) => {
+  try {
+    const { PlexClient } = await import("../services/plex.js");
+    const stored = getPlexConfig();
+    let url = (req.body?.url || stored.url || "").trim().replace(/\/+$/, "");
+    const token = req.body?.token || stored.token;
+    const clientId = stored.clientId;
+    if (!url || !token) {
+      return res.status(400).json({ error: "Server URL and token are required" });
+    }
+    const urlValidation = validateExternalUrl(url);
+    if (!urlValidation.valid) {
+      return res.status(400).json({ error: urlValidation.error });
+    }
+    url = urlValidation.url;
+    const client = new PlexClient(url, token, clientId);
+    const identity = await client.ping();
+    res.json({
+      success: true,
+      message: "Connection successful",
+      machineIdentifier: identity.machineIdentifier,
+      version: identity.version,
+    });
+  } catch (error) {
+    res.status(400).json({
+      error: "Connection failed",
+      message: error.response?.data || error.message,
+    });
+  }
+});
+
+// Build the Aurral library + flow playlists on the configured Plex server now.
+router.post("/plex/sync", async (req, res) => {
+  try {
+    const plex = getPlexConfig();
+    if (!plex.url || !plex.token) {
+      return res.status(400).json({
+        error: "Plex not configured",
+        message: "Connect Plex and save settings before syncing",
+      });
+    }
+    const { playlistManager } = await import(
+      "../services/weeklyFlowPlaylistManager.js"
+    );
+    playlistManager.updateConfig(false);
+    const result = await playlistManager.syncPlexNow();
+    res.json({ success: true, ...result });
+  } catch (error) {
+    console.error("[Settings] Plex sync failed:", error.message);
+    res.status(500).json({
+      error: "Plex sync failed",
+      message: error.response?.data || error.message,
+    });
+  }
+});
 
 router.post("/logs/level", async (req, res) => {
   try {

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -244,16 +244,38 @@ export class PlexClient {
   }
 
   async getTracks(sectionId) {
-    const data = await this.request(`/library/sections/${sectionId}/all`, {
-      params: { type: TRACK_TYPE },
-    });
-    const items = data?.MediaContainer?.Metadata || [];
-    return items.map((t) => ({
-      ratingKey: t.ratingKey,
-      title: t.title,
-      artist: t.grandparentTitle || t.originalTitle,
-      file: t.Media?.[0]?.Part?.[0]?.file || null,
-    }));
+    const pageSize = 200;
+    const out = [];
+    let start = 0;
+    for (;;) {
+      const data = await this.request(`/library/sections/${sectionId}/all`, {
+        params: {
+          type: TRACK_TYPE,
+          "X-Plex-Container-Start": start,
+          "X-Plex-Container-Size": pageSize,
+        },
+      });
+      const mc = data?.MediaContainer || {};
+      const items = mc.Metadata || [];
+      for (const t of items) {
+        // A track can have several versions (one Media/Part per file), e.g. the
+        // same song downloaded into more than one flow folder. Capture every
+        // path so a track matches all flows it actually lives in.
+        const files = (t.Media || [])
+          .flatMap((m) => (m.Part || []).map((p) => p.file))
+          .filter(Boolean);
+        out.push({
+          ratingKey: t.ratingKey,
+          title: t.title,
+          artist: t.grandparentTitle || t.originalTitle,
+          files,
+        });
+      }
+      const total = Number(mc.totalSize ?? mc.size ?? items.length);
+      start += items.length;
+      if (items.length === 0 || start >= total) break;
+    }
+    return out;
   }
 
   async getPlaylists() {

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -1,0 +1,293 @@
+import axios from "axios";
+import crypto from "crypto";
+
+const PLEX_TV = "https://plex.tv";
+const PLEX_AUTH_APP = "https://app.plex.tv";
+const PLEX_PRODUCT = "Aurral";
+// Plex music libraries use the "artist" section type with these defaults.
+const MUSIC_SECTION_TYPE = "artist";
+const MUSIC_AGENT = "tv.plex.agents.music";
+const MUSIC_SCANNER = "Plex Music";
+const TRACK_TYPE = 10; // Plex metadata type for audio tracks
+
+/**
+ * Client for the Plex Media Server + plex.tv APIs.
+ *
+ * Authentication uses the PIN-based OAuth flow (see the static auth helpers).
+ * Once a token is obtained it is used as `X-Plex-Token` against the user's
+ * local Plex Media Server for library and playlist management.
+ */
+export class PlexClient {
+  constructor(url, token, clientId) {
+    this.url = url ? url.replace(/\/+$/, "") : null;
+    this.token = token || null;
+    this.clientId = clientId || null;
+    this._machineIdentifier = null;
+  }
+
+  isConfigured() {
+    return !!(this.url && this.token);
+  }
+
+  // --- plex.tv OAuth (PIN) flow -------------------------------------------
+
+  static plexHeaders(clientId, { token } = {}) {
+    const headers = {
+      Accept: "application/json",
+      "X-Plex-Product": PLEX_PRODUCT,
+      "X-Plex-Client-Identifier": clientId,
+    };
+    if (token) headers["X-Plex-Token"] = token;
+    return headers;
+  }
+
+  /** Generate a fresh, stable client identifier for this Aurral install. */
+  static generateClientId() {
+    return crypto.randomUUID();
+  }
+
+  /**
+   * Request a strong PIN from plex.tv. Returns { id, code }.
+   * The user authorizes the PIN at the URL from `buildAuthUrl`.
+   */
+  static async generatePin(clientId) {
+    const { data } = await axios.post(
+      `${PLEX_TV}/api/v2/pins`,
+      null,
+      {
+        params: { strong: true },
+        headers: PlexClient.plexHeaders(clientId),
+      },
+    );
+    return { id: data.id, code: data.code };
+  }
+
+  /** Build the app.plex.tv URL the user visits to authorize the PIN. */
+  static buildAuthUrl(clientId, code, forwardUrl) {
+    const params = new URLSearchParams({
+      clientID: clientId,
+      code,
+      "context[device][product]": PLEX_PRODUCT,
+    });
+    if (forwardUrl) params.set("forwardUrl", forwardUrl);
+    return `${PLEX_AUTH_APP}/auth#?${params.toString()}`;
+  }
+
+  /**
+   * Poll a PIN. Returns the authToken once the user authorizes, else null.
+   */
+  static async checkPin(pinId, code, clientId) {
+    const { data } = await axios.get(`${PLEX_TV}/api/v2/pins/${pinId}`, {
+      params: { code },
+      headers: PlexClient.plexHeaders(clientId),
+    });
+    return data.authToken || null;
+  }
+
+  /** Validate a token against plex.tv. Returns the account object or null. */
+  static async validateToken(token, clientId) {
+    try {
+      const { data } = await axios.get(`${PLEX_TV}/api/v2/user`, {
+        headers: PlexClient.plexHeaders(clientId, { token }),
+      });
+      return data || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Discover Plex servers owned by / shared with the account.
+   * Returns [{ name, clientIdentifier, owned, connections: [{ uri, local }] }].
+   */
+  static async getResources(token, clientId) {
+    const { data } = await axios.get(`${PLEX_TV}/api/v2/resources`, {
+      params: { includeHttps: 1, includeRelay: 1 },
+      headers: PlexClient.plexHeaders(clientId, { token }),
+    });
+    const list = Array.isArray(data) ? data : [];
+    return list
+      .filter((r) => r.provides && r.provides.includes("server"))
+      .map((r) => ({
+        name: r.name,
+        clientIdentifier: r.clientIdentifier,
+        owned: !!r.owned,
+        connections: (r.connections || []).map((c) => ({
+          uri: c.uri,
+          local: !!c.local,
+          address: c.address,
+          port: c.port,
+        })),
+      }));
+  }
+
+  // --- Plex Media Server requests -----------------------------------------
+
+  async request(path, { params = {}, method = "GET", data = null } = {}) {
+    if (!this.isConfigured()) throw new Error("Plex not configured");
+    try {
+      const response = await axios({
+        method,
+        url: `${this.url}${path}`,
+        params,
+        data,
+        headers: PlexClient.plexHeaders(this.clientId, { token: this.token }),
+      });
+      return response.data;
+    } catch (error) {
+      const detail = error.response?.data || error.message;
+      console.error(
+        `Plex Error [${method} ${path}]:`,
+        typeof detail === "string" ? detail : error.message,
+      );
+      throw error;
+    }
+  }
+
+  /** Test connectivity + capture the server's machineIdentifier. */
+  async ping() {
+    const data = await this.request("/identity");
+    const mc = data?.MediaContainer || {};
+    if (mc.machineIdentifier) this._machineIdentifier = mc.machineIdentifier;
+    return mc;
+  }
+
+  async getMachineIdentifier() {
+    if (this._machineIdentifier) return this._machineIdentifier;
+    await this.ping();
+    return this._machineIdentifier;
+  }
+
+  async getLibraries() {
+    const data = await this.request("/library/sections");
+    return data?.MediaContainer?.Directory || [];
+  }
+
+  /**
+   * Find (or create) the Aurral music library pointed at `libraryPath`.
+   * Mirrors NavidromeClient.ensureWeeklyFlowLibrary.
+   */
+  async ensureWeeklyFlowLibrary(libraryPath) {
+    if (!this.isConfigured()) return null;
+    const name = "Aurral Flow";
+    try {
+      const libs = await this.getLibraries();
+      const existing = libs.find(
+        (lib) =>
+          lib.title === name ||
+          (lib.Location || []).some((loc) => loc.path === libraryPath),
+      );
+      if (existing) return existing;
+
+      // POST /library/sections creates the library; returns the new section.
+      const data = await this.request("/library/sections", {
+        method: "POST",
+        params: {
+          name,
+          type: MUSIC_SECTION_TYPE,
+          agent: MUSIC_AGENT,
+          scanner: MUSIC_SCANNER,
+          language: "en",
+          location: libraryPath,
+        },
+      });
+      return data?.MediaContainer?.Directory?.[0] || null;
+    } catch (err) {
+      console.warn(
+        "[Plex] ensureWeeklyFlowLibrary failed:",
+        err?.response?.data || err.message,
+      );
+      return null;
+    }
+  }
+
+  async scanLibrary(sectionId) {
+    if (!this.isConfigured() || sectionId == null) return null;
+    try {
+      return await this.request(`/library/sections/${sectionId}/refresh`);
+    } catch (err) {
+      console.warn("[Plex] scanLibrary failed:", err?.message);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch all tracks in a library section with their on-disk file paths.
+   * Returns [{ ratingKey, title, artist, file }].
+   */
+  async getTracks(sectionId) {
+    const data = await this.request(`/library/sections/${sectionId}/all`, {
+      params: { type: TRACK_TYPE },
+    });
+    const items = data?.MediaContainer?.Metadata || [];
+    return items.map((t) => ({
+      ratingKey: t.ratingKey,
+      title: t.title,
+      artist: t.grandparentTitle || t.originalTitle,
+      file: t.Media?.[0]?.Part?.[0]?.file || null,
+    }));
+  }
+
+  async getPlaylists() {
+    const data = await this.request("/playlists", {
+      params: { playlistType: "audio" },
+    });
+    return data?.MediaContainer?.Metadata || [];
+  }
+
+  _metadataUri(machineId, ratingKeys) {
+    const keys = (Array.isArray(ratingKeys) ? ratingKeys : [ratingKeys]).join(
+      ",",
+    );
+    return `server://${machineId}/com.plexapp.plugins.library/library/metadata/${keys}`;
+  }
+
+  /**
+   * Create (or replace) an audio playlist from a list of track ratingKeys.
+   * Mirrors NavidromeClient.createPlaylist.
+   */
+  async createPlaylist(title, ratingKeys, replace = false) {
+    const machineId = await this.getMachineIdentifier();
+    if (!machineId) throw new Error("Could not resolve Plex machineIdentifier");
+
+    const existing = (await this.getPlaylists()).find(
+      (p) => p.title === title,
+    );
+
+    if (existing && replace) {
+      await this.deletePlaylist(existing.ratingKey);
+    } else if (existing && !replace) {
+      if (ratingKeys?.length) {
+        await this.addToPlaylist(existing.ratingKey, ratingKeys);
+      }
+      return existing;
+    }
+
+    if (!ratingKeys?.length) return null;
+
+    const data = await this.request("/playlists", {
+      method: "POST",
+      params: {
+        type: "audio",
+        title,
+        smart: 0,
+        uri: this._metadataUri(machineId, ratingKeys),
+      },
+    });
+    return data?.MediaContainer?.Metadata?.[0] || null;
+  }
+
+  async addToPlaylist(playlistRatingKey, ratingKeys) {
+    const machineId = await this.getMachineIdentifier();
+    return this.request(`/playlists/${playlistRatingKey}/items`, {
+      method: "PUT",
+      params: { uri: this._metadataUri(machineId, ratingKeys) },
+    });
+  }
+
+  async deletePlaylist(playlistRatingKey) {
+    return this.request(`/playlists/${playlistRatingKey}`, {
+      method: "DELETE",
+    });
+  }
+}

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -105,20 +105,34 @@ export class PlexClient {
       params: { includeHttps: 1, includeRelay: 1 },
       headers: PlexClient.plexHeaders(clientId, { token }),
     });
-    const list = Array.isArray(data) ? data : [];
-    return list
-      .filter((r) => r.provides && r.provides.includes("server"))
-      .map((r) => ({
-        name: r.name,
-        clientIdentifier: r.clientIdentifier,
-        owned: !!r.owned,
-        connections: (r.connections || []).map((c) => ({
-          uri: c.uri,
-          local: !!c.local,
-          address: c.address,
-          port: c.port,
-        })),
-      }));
+    // v2 returns a JSON array; tolerate XML-shaped responses too.
+    let list = [];
+    if (Array.isArray(data)) list = data;
+    else if (Array.isArray(data?.MediaContainer?.Device))
+      list = data.MediaContainer.Device;
+    else if (data?.MediaContainer?.Device) list = [data.MediaContainer.Device];
+
+    const servers = list
+      .filter((r) => String(r.provides || "").includes("server"))
+      .map((r) => {
+        const rawConns = r.connections || r.Connection || [];
+        const conns = Array.isArray(rawConns) ? rawConns : [rawConns];
+        return {
+          name: r.name,
+          clientIdentifier: r.clientIdentifier,
+          owned: r.owned === true || r.owned === "1" || r.owned === 1,
+          connections: conns.map((c) => ({
+            uri: c.uri,
+            local: c.local === true || c.local === "1" || c.local === 1,
+            address: c.address,
+            port: c.port,
+          })),
+        };
+      });
+    console.log(
+      `[Plex] getResources: ${list.length} device(s) returned, ${servers.length} provide "server"`,
+    );
+    return { servers, total: list.length };
   }
 
   // --- Plex Media Server requests -----------------------------------------

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -178,7 +178,28 @@ export class PlexClient {
       );
 
     const existing = findExisting(await this.getLibraries());
-    if (existing) return existing;
+    if (existing) {
+      // The library already exists. Reconcile its folder(s) to the desired
+      // path so changing the downloads-path setting actually takes effect
+      // (Plex keeps the original location otherwise).
+      const currentLocations = (existing.Location || [])
+        .map((loc) => loc.path)
+        .filter(Boolean);
+      const alreadyCorrect =
+        currentLocations.length === 1 && currentLocations[0] === libraryPath;
+      if (!alreadyCorrect) {
+        try {
+          await this.setLibraryLocations(existing.key, [libraryPath]);
+          return findExisting(await this.getLibraries()) || existing;
+        } catch (err) {
+          console.warn(
+            "[Plex] Could not update Aurral library location:",
+            err?.response?.data || err.message,
+          );
+        }
+      }
+      return existing;
+    }
 
     // POST /library/sections creates the library. Plex's response shape here
     // is inconsistent across versions, so we create then re-read the section
@@ -225,6 +246,20 @@ export class PlexClient {
   }
 
   /**
+   * Replace a library section's folder locations. Plex expects repeated
+   * `location=` query params (no array brackets), so the query is built by
+   * hand. The Plex server must be able to browse each path.
+   */
+  async setLibraryLocations(sectionId, locations) {
+    const qs = new URLSearchParams();
+    qs.set("agent", MUSIC_AGENT);
+    for (const loc of locations) qs.append("location", loc);
+    return this.request(`/library/sections/${sectionId}?${qs.toString()}`, {
+      method: "PUT",
+    });
+  }
+
+  /**
    * Fetch all tracks in a library section with their on-disk file paths.
    * Returns [{ ratingKey, title, artist, file }].
    */
@@ -248,6 +283,13 @@ export class PlexClient {
     return data?.MediaContainer?.Metadata || [];
   }
 
+  /** Return the track ratingKeys currently in a playlist. */
+  async getPlaylistItems(playlistRatingKey) {
+    const data = await this.request(`/playlists/${playlistRatingKey}/items`);
+    const items = data?.MediaContainer?.Metadata || [];
+    return items.map((i) => i.ratingKey).filter(Boolean);
+  }
+
   _metadataUri(machineId, ratingKeys) {
     const keys = (Array.isArray(ratingKeys) ? ratingKeys : [ratingKeys]).join(
       ",",
@@ -268,6 +310,16 @@ export class PlexClient {
     );
 
     if (existing && replace) {
+      // Skip the delete+recreate churn when the playlist already holds exactly
+      // the desired tracks (order-insensitive) — keeps the playlist's identity
+      // and history intact.
+      const current = await this.getPlaylistItems(existing.ratingKey);
+      const desiredSet = new Set((ratingKeys || []).map(String));
+      const currentSet = new Set(current.map(String));
+      const unchanged =
+        desiredSet.size === currentSet.size &&
+        [...desiredSet].every((k) => currentSet.has(k));
+      if (unchanged) return existing;
       await this.deletePlaylist(existing.ratingKey);
     } else if (existing && !replace) {
       if (ratingKeys?.length) {

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -170,17 +170,21 @@ export class PlexClient {
   async ensureWeeklyFlowLibrary(libraryPath) {
     if (!this.isConfigured()) return null;
     const name = "Aurral Flow";
-    try {
-      const libs = await this.getLibraries();
-      const existing = libs.find(
+    const findExisting = (libs) =>
+      libs.find(
         (lib) =>
           lib.title === name ||
           (lib.Location || []).some((loc) => loc.path === libraryPath),
       );
-      if (existing) return existing;
 
-      // POST /library/sections creates the library; returns the new section.
-      const data = await this.request("/library/sections", {
+    const existing = findExisting(await this.getLibraries());
+    if (existing) return existing;
+
+    // POST /library/sections creates the library. Plex's response shape here
+    // is inconsistent across versions, so we create then re-read the section
+    // list to resolve the new library (and its `key`) reliably.
+    try {
+      await this.request("/library/sections", {
         method: "POST",
         params: {
           name,
@@ -191,14 +195,23 @@ export class PlexClient {
           location: libraryPath,
         },
       });
-      return data?.MediaContainer?.Directory?.[0] || null;
     } catch (err) {
-      console.warn(
-        "[Plex] ensureWeeklyFlowLibrary failed:",
-        err?.response?.data || err.message,
+      const detail = err?.response?.data || err.message;
+      const status = err?.response?.status;
+      throw new Error(
+        `Plex rejected library creation (${status || "no status"}) for path "${libraryPath}": ${
+          typeof detail === "string" ? detail : JSON.stringify(detail)
+        }`,
       );
-      return null;
     }
+
+    const created = findExisting(await this.getLibraries());
+    if (!created) {
+      throw new Error(
+        `Plex accepted the request but no "Aurral Flow" library appeared. Verify the Plex server can access the path "${libraryPath}".`,
+      );
+    }
+    return created;
   }
 
   async scanLibrary(sectionId) {

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -244,11 +244,8 @@ export class PlexClient {
   }
 
   async getTracks(sectionId) {
-    // The section listing only returns each track's PRIMARY version, so a song
-    // duplicated across flow folders looks like it has one path. Fetch full
-    // metadata (which includes every version/part) to get all file paths.
     const pageSize = 200;
-    const keys = [];
+    const out = [];
     let start = 0;
     for (;;) {
       const data = await this.request(`/library/sections/${sectionId}/all`, {
@@ -260,18 +257,6 @@ export class PlexClient {
       });
       const mc = data?.MediaContainer || {};
       const items = mc.Metadata || [];
-      for (const t of items) if (t.ratingKey) keys.push(t.ratingKey);
-      const total = Number(mc.totalSize ?? mc.size ?? items.length);
-      start += items.length;
-      if (items.length === 0 || start >= total) break;
-    }
-
-    const out = [];
-    const chunkSize = 150;
-    for (let i = 0; i < keys.length; i += chunkSize) {
-      const chunk = keys.slice(i, i + chunkSize);
-      const data = await this.request(`/library/metadata/${chunk.join(",")}`);
-      const items = data?.MediaContainer?.Metadata || [];
       for (const t of items) {
         const files = (t.Media || [])
           .flatMap((m) => (m.Part || []).map((p) => p.file))
@@ -283,6 +268,9 @@ export class PlexClient {
           files,
         });
       }
+      const total = Number(mc.totalSize ?? mc.size ?? items.length);
+      start += items.length;
+      if (items.length === 0 || start >= total) break;
     }
     return out;
   }

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -244,8 +244,11 @@ export class PlexClient {
   }
 
   async getTracks(sectionId) {
+    // The section listing only returns each track's PRIMARY version, so a song
+    // duplicated across flow folders looks like it has one path. Fetch full
+    // metadata (which includes every version/part) to get all file paths.
     const pageSize = 200;
-    const out = [];
+    const keys = [];
     let start = 0;
     for (;;) {
       const data = await this.request(`/library/sections/${sectionId}/all`, {
@@ -257,10 +260,19 @@ export class PlexClient {
       });
       const mc = data?.MediaContainer || {};
       const items = mc.Metadata || [];
+      for (const t of items) if (t.ratingKey) keys.push(t.ratingKey);
+      const total = Number(mc.totalSize ?? mc.size ?? items.length);
+      start += items.length;
+      if (items.length === 0 || start >= total) break;
+    }
+
+    const out = [];
+    const chunkSize = 150;
+    for (let i = 0; i < keys.length; i += chunkSize) {
+      const chunk = keys.slice(i, i + chunkSize);
+      const data = await this.request(`/library/metadata/${chunk.join(",")}`);
+      const items = data?.MediaContainer?.Metadata || [];
       for (const t of items) {
-        // A track can have several versions (one Media/Part per file), e.g. the
-        // same song downloaded into more than one flow folder. Capture every
-        // path so a track matches all flows it actually lives in.
         const files = (t.Media || [])
           .flatMap((m) => (m.Part || []).map((p) => p.file))
           .filter(Boolean);
@@ -271,9 +283,6 @@ export class PlexClient {
           files,
         });
       }
-      const total = Number(mc.totalSize ?? mc.size ?? items.length);
-      start += items.length;
-      if (items.length === 0 || start >= total) break;
     }
     return out;
   }

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -153,31 +153,34 @@ export class PlexClient {
 
   async ensureWeeklyFlowLibrary(libraryPath) {
     if (!this.isConfigured()) return null;
-    const name = "Aurral Flow";
+    const name = "Aurral";
+    // Also match the legacy "Aurral Flow" name so existing libraries are reused
+    // and renamed rather than duplicated.
     const findExisting = (libs) =>
       libs.find(
         (lib) =>
           lib.title === name ||
+          lib.title === "Aurral Flow" ||
           (lib.Location || []).some((loc) => loc.path === libraryPath),
       );
 
     const existing = findExisting(await this.getLibraries());
     if (existing) {
-      // The library already exists. Reconcile its folder(s) to the desired
-      // path so changing the downloads-path setting actually takes effect
-      // (Plex keeps the original location otherwise).
+      // Reconcile name + folder so a rename or a changed downloads-path setting
+      // actually takes effect (Plex keeps the originals otherwise).
       const currentLocations = (existing.Location || [])
         .map((loc) => loc.path)
         .filter(Boolean);
-      const alreadyCorrect =
+      const locationOk =
         currentLocations.length === 1 && currentLocations[0] === libraryPath;
-      if (!alreadyCorrect) {
+      const nameOk = existing.title === name;
+      if (!locationOk || !nameOk) {
         try {
-          await this.setLibraryLocations(existing.key, [libraryPath]);
+          await this.editLibrary(existing.key, { name, locations: [libraryPath] });
           return findExisting(await this.getLibraries()) || existing;
         } catch (err) {
           console.warn(
-            "[Plex] Could not update Aurral library location:",
+            "[Plex] Could not update Aurral library:",
             err?.response?.data || err.message,
           );
         }
@@ -213,7 +216,7 @@ export class PlexClient {
     const created = findExisting(await this.getLibraries());
     if (!created) {
       throw new Error(
-        `Plex accepted the request but no "Aurral Flow" library appeared. Verify the Plex server can access the path "${libraryPath}".`,
+        `Plex accepted the request but no "Aurral" library appeared. Verify the Plex server can access the path "${libraryPath}".`,
       );
     }
     return created;
@@ -230,14 +233,15 @@ export class PlexClient {
   }
 
   /**
-   * Replace a library section's folder locations. Plex expects repeated
-   * `location=` query params (no array brackets), so the query is built by
-   * hand. The Plex server must be able to browse each path.
+   * Rename a library section and/or replace its folder locations. Plex expects
+   * repeated `location=` query params (no array brackets), so the query is
+   * built by hand. The Plex server must be able to browse each path.
    */
-  async setLibraryLocations(sectionId, locations) {
+  async editLibrary(sectionId, { name, locations } = {}) {
     const qs = new URLSearchParams();
     qs.set("agent", MUSIC_AGENT);
-    for (const loc of locations) qs.append("location", loc);
+    if (name) qs.set("name", name);
+    for (const loc of locations || []) qs.append("location", loc);
     return this.request(`/library/sections/${sectionId}?${qs.toString()}`, {
       method: "PUT",
     });

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -10,13 +10,6 @@ const MUSIC_AGENT = "tv.plex.agents.music";
 const MUSIC_SCANNER = "Plex Music";
 const TRACK_TYPE = 10; // Plex metadata type for audio tracks
 
-/**
- * Client for the Plex Media Server + plex.tv APIs.
- *
- * Authentication uses the PIN-based OAuth flow (see the static auth helpers).
- * Once a token is obtained it is used as `X-Plex-Token` against the user's
- * local Plex Media Server for library and playlist management.
- */
 export class PlexClient {
   constructor(url, token, clientId) {
     this.url = url ? url.replace(/\/+$/, "") : null;
@@ -29,8 +22,6 @@ export class PlexClient {
     return !!(this.url && this.token);
   }
 
-  // --- plex.tv OAuth (PIN) flow -------------------------------------------
-
   static plexHeaders(clientId, { token } = {}) {
     const headers = {
       Accept: "application/json",
@@ -41,15 +32,10 @@ export class PlexClient {
     return headers;
   }
 
-  /** Generate a fresh, stable client identifier for this Aurral install. */
   static generateClientId() {
     return crypto.randomUUID();
   }
 
-  /**
-   * Request a strong PIN from plex.tv. Returns { id, code }.
-   * The user authorizes the PIN at the URL from `buildAuthUrl`.
-   */
   static async generatePin(clientId) {
     const { data } = await axios.post(
       `${PLEX_TV}/api/v2/pins`,
@@ -62,7 +48,6 @@ export class PlexClient {
     return { id: data.id, code: data.code };
   }
 
-  /** Build the app.plex.tv URL the user visits to authorize the PIN. */
   static buildAuthUrl(clientId, code, forwardUrl) {
     const params = new URLSearchParams({
       clientID: clientId,
@@ -73,9 +58,6 @@ export class PlexClient {
     return `${PLEX_AUTH_APP}/auth#?${params.toString()}`;
   }
 
-  /**
-   * Poll a PIN. Returns the authToken once the user authorizes, else null.
-   */
   static async checkPin(pinId, code, clientId) {
     const { data } = await axios.get(`${PLEX_TV}/api/v2/pins/${pinId}`, {
       params: { code },
@@ -84,7 +66,6 @@ export class PlexClient {
     return data.authToken || null;
   }
 
-  /** Validate a token against plex.tv. Returns the account object or null. */
   static async validateToken(token, clientId) {
     try {
       const { data } = await axios.get(`${PLEX_TV}/api/v2/user`, {
@@ -96,10 +77,6 @@ export class PlexClient {
     }
   }
 
-  /**
-   * Discover Plex servers owned by / shared with the account.
-   * Returns [{ name, clientIdentifier, owned, connections: [{ uri, local }] }].
-   */
   static async getResources(token, clientId) {
     const { data } = await axios.get(`${PLEX_TV}/api/v2/resources`, {
       params: { includeHttps: 1, includeRelay: 1 },
@@ -135,8 +112,6 @@ export class PlexClient {
     return { servers, total: list.length };
   }
 
-  // --- Plex Media Server requests -----------------------------------------
-
   async request(path, { params = {}, method = "GET", data = null } = {}) {
     if (!this.isConfigured()) throw new Error("Plex not configured");
     try {
@@ -158,7 +133,6 @@ export class PlexClient {
     }
   }
 
-  /** Test connectivity + capture the server's machineIdentifier. */
   async ping() {
     const data = await this.request("/identity");
     const mc = data?.MediaContainer || {};
@@ -177,10 +151,6 @@ export class PlexClient {
     return data?.MediaContainer?.Directory || [];
   }
 
-  /**
-   * Find (or create) the Aurral music library pointed at `libraryPath`.
-   * Mirrors NavidromeClient.ensureWeeklyFlowLibrary.
-   */
   async ensureWeeklyFlowLibrary(libraryPath) {
     if (!this.isConfigured()) return null;
     const name = "Aurral Flow";
@@ -273,10 +243,6 @@ export class PlexClient {
     });
   }
 
-  /**
-   * Fetch all tracks in a library section with their on-disk file paths.
-   * Returns [{ ratingKey, title, artist, file }].
-   */
   async getTracks(sectionId) {
     const data = await this.request(`/library/sections/${sectionId}/all`, {
       params: { type: TRACK_TYPE },
@@ -297,7 +263,6 @@ export class PlexClient {
     return data?.MediaContainer?.Metadata || [];
   }
 
-  /** Return the track ratingKeys currently in a playlist. */
   async getPlaylistItems(playlistRatingKey) {
     const data = await this.request(`/playlists/${playlistRatingKey}/items`);
     const items = data?.MediaContainer?.Metadata || [];
@@ -311,10 +276,6 @@ export class PlexClient {
     return `server://${machineId}/com.plexapp.plugins.library/library/metadata/${keys}`;
   }
 
-  /**
-   * Create (or replace) an audio playlist from a list of track ratingKeys.
-   * Mirrors NavidromeClient.createPlaylist.
-   */
   async createPlaylist(title, ratingKeys, replace = false) {
     const machineId = await this.getMachineIdentifier();
     if (!machineId) throw new Error("Could not resolve Plex machineIdentifier");
@@ -324,9 +285,7 @@ export class PlexClient {
     );
 
     if (existing && replace) {
-      // Skip the delete+recreate churn when the playlist already holds exactly
-      // the desired tracks (order-insensitive) — keeps the playlist's identity
-      // and history intact.
+      // Skip delete+recreate when the track set already matches (order-insensitive).
       const current = await this.getPlaylistItems(existing.ratingKey);
       const desiredSet = new Set((ratingKeys || []).map(String));
       const currentSet = new Set(current.map(String));

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -191,7 +191,7 @@ export class PlexClient {
           type: MUSIC_SECTION_TYPE,
           agent: MUSIC_AGENT,
           scanner: MUSIC_SCANNER,
-          language: "en",
+          language: "en-US",
           location: libraryPath,
         },
       });

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -39,8 +39,8 @@ export class WeeklyFlowPlaylistManager {
     this.plexClient = null;
     this._plexConfigKey = "";
     this._plexSectionId = null;
-    // playlist title -> fingerprint of the track set we last pushed to Plex,
-    // so unchanged playlists skip the getPlaylistItems round-trip.
+    // playlist title -> fingerprint last pushed, so unchanged playlists skip
+    // the getPlaylistItems round-trip.
     this._plexSyncHashes = new Map();
     this._ensureInFlight = null;
     this._refreshInFlight = new Map();
@@ -392,10 +392,8 @@ export class WeeklyFlowPlaylistManager {
     }
   }
 
-  // The library location must be the path the Plex server uses to reach the
-  // downloads, which can differ from Aurral's host path when Plex runs in its
-  // own container. Prefer the user-provided override; fall back to the host
-  // path when unset.
+  // The location must be the path the Plex server uses, which differs from
+  // Aurral's host path when Plex runs in its own container.
   _getPlexLibraryPath() {
     const override = String(this._plexDownloadsPath || "").trim();
     if (override) {
@@ -420,13 +418,8 @@ export class WeeklyFlowPlaylistManager {
     return id;
   }
 
-  /**
-   * Plex has no equivalent of Navidrome's .nsp smart playlists, so we build
-   * regular audio playlists from the tracks Plex has indexed: group indexed
-   * tracks by their weekly-flow subfolder and create/replace one playlist per
-   * enabled flow / shared playlist. New downloads are picked up on the next
-   * sync once Plex has scanned them.
-   */
+  // Plex has no equivalent of Navidrome's .nsp smart playlists, so we build
+  // regular playlists from indexed tracks, grouped by their weekly-flow subfolder.
   async _syncPlexPlaylists(flows, sharedPlaylists) {
     const sectionId = await this._ensurePlexSectionId();
     if (sectionId == null) return;
@@ -457,8 +450,6 @@ export class WeeklyFlowPlaylistManager {
       }
     };
 
-    // Build/refresh a playlist only when its desired track set changed since
-    // the last sync — skips the getPlaylistItems round-trip on no-op runs.
     const buildIfChanged = async (desired, ratingKeys) => {
       const hash = this._hashKeys(ratingKeys);
       if (this._plexSyncHashes.get(desired) === hash) return;
@@ -466,9 +457,7 @@ export class WeeklyFlowPlaylistManager {
       this._plexSyncHashes.set(desired, hash);
     };
 
-    // Plex playlists use the flow/playlist name directly (no "[A]"/"[AS]"
-    // prefix). Any previously-created prefixed names are treated as stale and
-    // removed so renames are clean.
+    // Plex uses the bare flow name; remove any old "[A]"/"[AS]" prefixed names.
     for (const flow of flows) {
       const desired = String(flow.name || "").trim();
       const { current, legacy } = this._getFlowPlaylistNames(flow.name);
@@ -503,13 +492,9 @@ export class WeeklyFlowPlaylistManager {
     }
   }
 
-  /**
-   * Manual Plex sync for an existing flow. Returns quickly: ensures the
-   * library, triggers a scan, builds playlists from whatever Plex has already
-   * indexed, and reports status. Because Plex's music scan (with online
-   * metadata matching) can take minutes, we don't block on it here — instead a
-   * background catch-up rebuilds the playlists as tracks get indexed.
-   */
+  // Returns quickly rather than blocking: Plex's music scan (with online
+  // metadata matching) can take minutes, so a background catch-up rebuilds the
+  // playlists as tracks get indexed.
   async syncPlexNow() {
     if (!this.plexClient?.isConfigured()) {
       return { configured: false };
@@ -531,8 +516,6 @@ export class WeeklyFlowPlaylistManager {
     const tracks = await this.plexClient.getTracks(sectionId);
     const playlists = await this.plexClient.getPlaylists();
 
-    // Kick off a non-blocking catch-up so playlists fill in once Plex finishes
-    // indexing, without the user needing to click sync again.
     this._schedulePlexCatchup(sectionId);
 
     const managedNames = new Set(

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -425,18 +425,50 @@ export class WeeklyFlowPlaylistManager {
     if (sectionId == null) return;
 
     const tracks = await this.plexClient.getTracks(sectionId);
-    // A track shared across flows is one Plex track with several version files;
-    // match if any of its paths is under this flow's folder so it lands in
-    // every playlist it belongs to.
-    const ratingKeysFor = (playlistType) => {
-      const needle = `/${playlistType}/`;
-      return tracks
-        .filter((t) =>
-          t.files.some((f) => f.replace(/\\/g, "/").includes(needle)),
-        )
-        .map((t) => t.ratingKey)
-        .filter(Boolean);
+    // Plex de-duplicates the same song across flow folders inconsistently:
+    // sometimes one track with one path, sometimes two separate tracks sharing
+    // a relative path. So resolve membership per relative file (Artist/Album/
+    // Title.ext) from disk, picking ONE representative track per file — the
+    // copy whose own path is in this flow when available. This puts shared
+    // songs in every flow that holds the file without duplicating a track.
+    const relativeOf = (file) => {
+      const parts = (file || "").replace(/\\/g, "/").split("/aurral-weekly-flow/");
+      if (parts.length < 2) return null;
+      const segs = parts[1].split("/");
+      segs.shift(); // drop the flow-id segment
+      return segs.join("/") || null;
     };
+    const byRelative = new Map();
+    for (const t of tracks) {
+      const rel = relativeOf(t.files[0]);
+      if (!rel) continue;
+      if (!byRelative.has(rel)) byRelative.set(rel, []);
+      byRelative.get(rel).push(t);
+    }
+    const playlistIds = [
+      ...new Set([
+        ...flows.map((f) => f.id),
+        ...sharedPlaylists.map((p) => p.id),
+      ]),
+    ];
+    const membership = new Map(playlistIds.map((id) => [id, []]));
+    for (const id of playlistIds) {
+      for (const [rel, group] of byRelative) {
+        const ownsPath = (t) =>
+          t.files.some((f) => f.replace(/\\/g, "/").includes(`/${id}/`));
+        let present = group.some(ownsPath);
+        if (!present) {
+          try {
+            await fs.access(path.join(this.libraryRoot, id, rel));
+            present = true;
+          } catch {}
+        }
+        if (!present) continue;
+        const best = group.find(ownsPath) || group[0];
+        if (best?.ratingKey) membership.get(id).push(best.ratingKey);
+      }
+    }
+    const ratingKeysFor = (playlistType) => membership.get(playlistType) || [];
 
     const deletePlexPlaylistsByNames = async (names) => {
       const playlists = await this.plexClient.getPlaylists();

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs/promises";
 import { dbOps } from "../config/db-helpers.js";
 import { NavidromeClient } from "./navidrome.js";
+import { PlexClient } from "./plex.js";
 import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 import { downloadTracker } from "./weeklyFlowDownloadTracker.js";
 import { writePlaylistArtworkWebpFromBuffer } from "./playlistArtwork.js";
@@ -34,6 +35,9 @@ export class WeeklyFlowPlaylistManager {
     this.libraryRoot = path.join(this.playlistLibraryRoot, "_playlists");
     this.navidromeClient = null;
     this._navidromeConfigKey = "";
+    this.plexClient = null;
+    this._plexConfigKey = "";
+    this._plexSectionId = null;
     this._ensureInFlight = null;
     this._refreshInFlight = new Map();
     this.updateConfig(triggerEnsureOnInit);
@@ -64,6 +68,28 @@ export class WeeklyFlowPlaylistManager {
       }
     } else {
       this.navidromeClient = null;
+    }
+
+    const plexConfig = settings.integrations?.plex || {};
+    const nextPlexKey = JSON.stringify({
+      url: plexConfig.url || "",
+      token: plexConfig.token || "",
+      clientId: plexConfig.clientId || "",
+    });
+    const plexChanged = this._plexConfigKey !== nextPlexKey;
+    this._plexConfigKey = nextPlexKey;
+    if (plexConfig.url && plexConfig.token) {
+      if (!this.plexClient || plexChanged) {
+        this.plexClient = new PlexClient(
+          plexConfig.url,
+          plexConfig.token,
+          plexConfig.clientId,
+        );
+        this._plexSectionId = null;
+      }
+    } else {
+      this.plexClient = null;
+      this._plexSectionId = null;
     }
 
     if (triggerEnsurePlaylists) {
@@ -345,6 +371,131 @@ export class WeeklyFlowPlaylistManager {
         err?.message,
       );
     }
+
+    if (this.plexClient?.isConfigured()) {
+      try {
+        await this._syncPlexPlaylists(flows, sharedPlaylists);
+      } catch (err) {
+        console.warn(
+          "[WeeklyFlowPlaylistManager] Plex playlist sync failed:",
+          err?.message,
+        );
+      }
+    }
+  }
+
+  async _ensurePlexSectionId() {
+    if (this._plexSectionId != null) return this._plexSectionId;
+    const hostPath = this._getWeeklyFlowLibraryHostPath();
+    const library = await this.plexClient.ensureWeeklyFlowLibrary(hostPath);
+    // Plex section objects expose the section id as `key`.
+    const id = library?.key ?? null;
+    this._plexSectionId = id;
+    return id;
+  }
+
+  /**
+   * Plex has no equivalent of Navidrome's .nsp smart playlists, so we build
+   * regular audio playlists from the tracks Plex has indexed: group indexed
+   * tracks by their weekly-flow subfolder and create/replace one playlist per
+   * enabled flow / shared playlist. New downloads are picked up on the next
+   * sync once Plex has scanned them.
+   */
+  async _syncPlexPlaylists(flows, sharedPlaylists) {
+    const sectionId = await this._ensurePlexSectionId();
+    if (sectionId == null) return;
+
+    const tracks = await this.plexClient.getTracks(sectionId);
+    const ratingKeysFor = (playlistType) => {
+      const needle = `/${playlistType}/`;
+      return tracks
+        .filter((t) => t.file && t.file.replace(/\\/g, "/").includes(needle))
+        .map((t) => t.ratingKey)
+        .filter(Boolean);
+    };
+
+    const deletePlexPlaylistsByNames = async (names) => {
+      const playlists = await this.plexClient.getPlaylists();
+      for (const name of [...new Set((names || []).filter(Boolean))]) {
+        const existing = playlists.find((p) => p.title === name);
+        if (existing) {
+          try {
+            await this.plexClient.deletePlaylist(existing.ratingKey);
+          } catch (err) {
+            console.warn(
+              `[WeeklyFlowPlaylistManager] Failed to delete Plex playlist "${name}":`,
+              err?.message,
+            );
+          }
+        }
+      }
+    };
+
+    for (const flow of flows) {
+      const { current, legacy } = this._getFlowPlaylistNames(flow.name);
+      if (flow.enabled) {
+        const ratingKeys = ratingKeysFor(flow.id);
+        if (ratingKeys.length) {
+          await this.plexClient.createPlaylist(current, ratingKeys, true);
+        } else {
+          await deletePlexPlaylistsByNames([current]);
+        }
+        await deletePlexPlaylistsByNames(legacy);
+      } else {
+        await deletePlexPlaylistsByNames([current, ...legacy]);
+      }
+    }
+
+    for (const playlist of sharedPlaylists) {
+      const { current, legacy } = this._getSharedPlaylistNames(playlist.name);
+      const ratingKeys = ratingKeysFor(playlist.id);
+      if (ratingKeys.length) {
+        await this.plexClient.createPlaylist(current, ratingKeys, true);
+      } else {
+        await deletePlexPlaylistsByNames([current]);
+      }
+      await deletePlexPlaylistsByNames(legacy);
+    }
+  }
+
+  /**
+   * One-shot Plex sync for an existing flow: ensure the library exists,
+   * trigger a scan, wait (bounded) for Plex to index the files, then build
+   * the playlists. Returns a summary for the UI.
+   */
+  async syncPlexNow({ waitMs = 30000, intervalMs = 3000 } = {}) {
+    if (!this.plexClient?.isConfigured()) {
+      return { configured: false };
+    }
+    const sectionId = await this._ensurePlexSectionId();
+    if (sectionId == null) {
+      throw new Error("Could not create or find the Aurral Plex library");
+    }
+    await this.plexClient.scanLibrary(sectionId);
+
+    // Poll until Plex has indexed at least one track, or we time out.
+    const deadline = Date.now() + waitMs;
+    let tracks = await this.plexClient.getTracks(sectionId);
+    while (tracks.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, intervalMs));
+      tracks = await this.plexClient.getTracks(sectionId);
+    }
+
+    const flows = flowPlaylistConfig.getFlows();
+    const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
+    await this._syncPlexPlaylists(flows, sharedPlaylists);
+
+    const playlists = await this.plexClient.getPlaylists();
+    return {
+      configured: true,
+      sectionId,
+      indexedTracks: tracks.length,
+      playlists: playlists
+        .filter(
+          (p) => p.title?.startsWith("[A] ") || p.title?.startsWith("[AS] "),
+        )
+        .map((p) => ({ title: p.title, count: p.leafCount ?? null })),
+    };
   }
 
   async _playlistArtworkExists(baseName) {
@@ -360,8 +511,21 @@ export class WeeklyFlowPlaylistManager {
   }
 
   async scanLibrary() {
-    if (!this.navidromeClient?.isConfigured()) return null;
-    return this.navidromeClient.scanLibrary();
+    const results = [];
+    if (this.navidromeClient?.isConfigured()) {
+      results.push(await this.navidromeClient.scanLibrary());
+    }
+    if (this.plexClient?.isConfigured()) {
+      try {
+        const sectionId = await this._ensurePlexSectionId();
+        if (sectionId != null) {
+          results.push(await this.plexClient.scanLibrary(sectionId));
+        }
+      } catch (err) {
+        console.warn("[WeeklyFlowPlaylistManager] Plex scan failed:", err?.message);
+      }
+    }
+    return results.length ? results : null;
   }
 
   async weeklyReset(playlistTypes = null) {

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -75,9 +75,11 @@ export class WeeklyFlowPlaylistManager {
       url: plexConfig.url || "",
       token: plexConfig.token || "",
       clientId: plexConfig.clientId || "",
+      downloadsPath: plexConfig.downloadsPath || "",
     });
     const plexChanged = this._plexConfigKey !== nextPlexKey;
     this._plexConfigKey = nextPlexKey;
+    this._plexDownloadsPath = plexConfig.downloadsPath || "";
     if (plexConfig.url && plexConfig.token) {
       if (!this.plexClient || plexChanged) {
         this.plexClient = new PlexClient(
@@ -384,10 +386,23 @@ export class WeeklyFlowPlaylistManager {
     }
   }
 
+  // The library location must be the path the *Plex server* uses to reach the
+  // downloads, which can differ from Aurral's host path when Plex runs in its
+  // own container. Prefer the user-provided override; fall back to the host
+  // path when unset.
+  _getPlexLibraryPath() {
+    const override = String(this._plexDownloadsPath || "").trim();
+    if (override) {
+      const base = override.replace(/\\/g, "/").replace(/\/+$/, "");
+      return `${base}/aurral-weekly-flow`;
+    }
+    return this._getWeeklyFlowLibraryHostPath();
+  }
+
   async _ensurePlexSectionId() {
     if (this._plexSectionId != null) return this._plexSectionId;
-    const hostPath = this._getWeeklyFlowLibraryHostPath();
-    const library = await this.plexClient.ensureWeeklyFlowLibrary(hostPath);
+    const libraryPath = this._getPlexLibraryPath();
+    const library = await this.plexClient.ensureWeeklyFlowLibrary(libraryPath);
     // Plex section objects expose the section id as `key`.
     const id = library?.key ?? null;
     this._plexSectionId = id;

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -425,10 +425,15 @@ export class WeeklyFlowPlaylistManager {
     if (sectionId == null) return;
 
     const tracks = await this.plexClient.getTracks(sectionId);
+    // A track shared across flows is one Plex track with several version files;
+    // match if any of its paths is under this flow's folder so it lands in
+    // every playlist it belongs to.
     const ratingKeysFor = (playlistType) => {
       const needle = `/${playlistType}/`;
       return tracks
-        .filter((t) => t.file && t.file.replace(/\\/g, "/").includes(needle))
+        .filter((t) =>
+          t.files.some((f) => f.replace(/\\/g, "/").includes(needle)),
+        )
         .map((t) => t.ratingKey)
         .filter(Boolean);
     };

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -39,9 +39,8 @@ export class WeeklyFlowPlaylistManager {
     this.plexClient = null;
     this._plexConfigKey = "";
     this._plexSectionId = null;
-    // playlist title -> fingerprint last pushed, so unchanged playlists skip
-    // the getPlaylistItems round-trip.
     this._plexSyncHashes = new Map();
+    this._plexCatchupRunning = false;
     this._ensureInFlight = null;
     this._refreshInFlight = new Map();
     this.updateConfig(triggerEnsureOnInit);
@@ -398,9 +397,9 @@ export class WeeklyFlowPlaylistManager {
     const override = String(this._plexDownloadsPath || "").trim();
     if (override) {
       const base = override.replace(/\\/g, "/").replace(/\/+$/, "");
-      return `${base}/aurral-weekly-flow`;
+      return `${base}/${PLAYLIST_LIBRARY_DIR}`;
     }
-    return this._getWeeklyFlowLibraryHostPath();
+    return this._getPlaylistLibraryHostPath();
   }
 
   _hashKeys(ratingKeys) {
@@ -459,7 +458,7 @@ export class WeeklyFlowPlaylistManager {
         let present = group.some(ownsPath);
         if (!present) {
           try {
-            await fs.access(path.join(this.libraryRoot, id, rel));
+            await fs.access(path.join(this.playlistLibraryRoot, id, rel));
             present = true;
           } catch {}
         }

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -459,11 +459,13 @@ export class WeeklyFlowPlaylistManager {
   }
 
   /**
-   * One-shot Plex sync for an existing flow: ensure the library exists,
-   * trigger a scan, wait (bounded) for Plex to index the files, then build
-   * the playlists. Returns a summary for the UI.
+   * Manual Plex sync for an existing flow. Returns quickly: ensures the
+   * library, triggers a scan, builds playlists from whatever Plex has already
+   * indexed, and reports status. Because Plex's music scan (with online
+   * metadata matching) can take minutes, we don't block on it here — instead a
+   * background catch-up rebuilds the playlists as tracks get indexed.
    */
-  async syncPlexNow({ waitMs = 30000, intervalMs = 3000 } = {}) {
+  async syncPlexNow() {
     if (!this.plexClient?.isConfigured()) {
       return { configured: false };
     }
@@ -473,29 +475,52 @@ export class WeeklyFlowPlaylistManager {
     }
     await this.plexClient.scanLibrary(sectionId);
 
-    // Poll until Plex has indexed at least one track, or we time out.
-    const deadline = Date.now() + waitMs;
-    let tracks = await this.plexClient.getTracks(sectionId);
-    while (tracks.length === 0 && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, intervalMs));
-      tracks = await this.plexClient.getTracks(sectionId);
-    }
-
     const flows = flowPlaylistConfig.getFlows();
     const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
     await this._syncPlexPlaylists(flows, sharedPlaylists);
 
+    const tracks = await this.plexClient.getTracks(sectionId);
     const playlists = await this.plexClient.getPlaylists();
+
+    // Kick off a non-blocking catch-up so playlists fill in once Plex finishes
+    // indexing, without the user needing to click sync again.
+    this._schedulePlexCatchup(sectionId);
+
     return {
       configured: true,
       sectionId,
       indexedTracks: tracks.length,
+      scanInProgress: tracks.length === 0,
       playlists: playlists
         .filter(
           (p) => p.title?.startsWith("[A] ") || p.title?.startsWith("[AS] "),
         )
         .map((p) => ({ title: p.title, count: p.leafCount ?? null })),
     };
+  }
+
+  _schedulePlexCatchup(sectionId, delaysMs = [30000, 90000, 180000]) {
+    if (this._plexCatchupRunning) return;
+    this._plexCatchupRunning = true;
+    const run = async () => {
+      try {
+        for (const delay of delaysMs) {
+          await new Promise((r) => setTimeout(r, delay));
+          if (!this.plexClient?.isConfigured()) break;
+          const flows = flowPlaylistConfig.getFlows();
+          const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
+          await this._syncPlexPlaylists(flows, sharedPlaylists);
+        }
+      } catch (err) {
+        console.warn(
+          "[WeeklyFlowPlaylistManager] Plex catch-up failed:",
+          err?.message,
+        );
+      } finally {
+        this._plexCatchupRunning = false;
+      }
+    };
+    run();
   }
 
   async _playlistArtworkExists(baseName) {

--- a/backend/services/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlowPlaylistManager.js
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs/promises";
+import crypto from "crypto";
 import { dbOps } from "../config/db-helpers.js";
 import { NavidromeClient } from "./navidrome.js";
 import { PlexClient } from "./plex.js";
@@ -38,6 +39,9 @@ export class WeeklyFlowPlaylistManager {
     this.plexClient = null;
     this._plexConfigKey = "";
     this._plexSectionId = null;
+    // playlist title -> fingerprint of the track set we last pushed to Plex,
+    // so unchanged playlists skip the getPlaylistItems round-trip.
+    this._plexSyncHashes = new Map();
     this._ensureInFlight = null;
     this._refreshInFlight = new Map();
     this.updateConfig(triggerEnsureOnInit);
@@ -88,10 +92,12 @@ export class WeeklyFlowPlaylistManager {
           plexConfig.clientId,
         );
         this._plexSectionId = null;
+        this._plexSyncHashes.clear();
       }
     } else {
       this.plexClient = null;
       this._plexSectionId = null;
+      this._plexSyncHashes.clear();
     }
 
     if (triggerEnsurePlaylists) {
@@ -386,7 +392,7 @@ export class WeeklyFlowPlaylistManager {
     }
   }
 
-  // The library location must be the path the *Plex server* uses to reach the
+  // The library location must be the path the Plex server uses to reach the
   // downloads, which can differ from Aurral's host path when Plex runs in its
   // own container. Prefer the user-provided override; fall back to the host
   // path when unset.
@@ -397,6 +403,11 @@ export class WeeklyFlowPlaylistManager {
       return `${base}/aurral-weekly-flow`;
     }
     return this._getWeeklyFlowLibraryHostPath();
+  }
+
+  _hashKeys(ratingKeys) {
+    const sorted = (ratingKeys || []).map(String).sort();
+    return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
   }
 
   async _ensurePlexSectionId() {
@@ -446,30 +457,49 @@ export class WeeklyFlowPlaylistManager {
       }
     };
 
+    // Build/refresh a playlist only when its desired track set changed since
+    // the last sync — skips the getPlaylistItems round-trip on no-op runs.
+    const buildIfChanged = async (desired, ratingKeys) => {
+      const hash = this._hashKeys(ratingKeys);
+      if (this._plexSyncHashes.get(desired) === hash) return;
+      await this.plexClient.createPlaylist(desired, ratingKeys, true);
+      this._plexSyncHashes.set(desired, hash);
+    };
+
+    // Plex playlists use the flow/playlist name directly (no "[A]"/"[AS]"
+    // prefix). Any previously-created prefixed names are treated as stale and
+    // removed so renames are clean.
     for (const flow of flows) {
+      const desired = String(flow.name || "").trim();
       const { current, legacy } = this._getFlowPlaylistNames(flow.name);
+      const stale = [current, ...legacy].filter((name) => name !== desired);
       if (flow.enabled) {
         const ratingKeys = ratingKeysFor(flow.id);
         if (ratingKeys.length) {
-          await this.plexClient.createPlaylist(current, ratingKeys, true);
+          await buildIfChanged(desired, ratingKeys);
         } else {
-          await deletePlexPlaylistsByNames([current]);
+          await deletePlexPlaylistsByNames([desired]);
+          this._plexSyncHashes.delete(desired);
         }
-        await deletePlexPlaylistsByNames(legacy);
+        await deletePlexPlaylistsByNames(stale);
       } else {
-        await deletePlexPlaylistsByNames([current, ...legacy]);
+        await deletePlexPlaylistsByNames([desired, ...stale]);
+        this._plexSyncHashes.delete(desired);
       }
     }
 
     for (const playlist of sharedPlaylists) {
+      const desired = String(playlist.name || "").trim();
       const { current, legacy } = this._getSharedPlaylistNames(playlist.name);
+      const stale = [current, ...legacy].filter((name) => name !== desired);
       const ratingKeys = ratingKeysFor(playlist.id);
       if (ratingKeys.length) {
-        await this.plexClient.createPlaylist(current, ratingKeys, true);
+        await buildIfChanged(desired, ratingKeys);
       } else {
-        await deletePlexPlaylistsByNames([current]);
+        await deletePlexPlaylistsByNames([desired]);
+        this._plexSyncHashes.delete(desired);
       }
-      await deletePlexPlaylistsByNames(legacy);
+      await deletePlexPlaylistsByNames(stale);
     }
   }
 
@@ -490,6 +520,10 @@ export class WeeklyFlowPlaylistManager {
     }
     await this.plexClient.scanLibrary(sectionId);
 
+    // Manual sync is authoritative: drop cached fingerprints so we reconcile
+    // against Plex's real state (catches manual edits made in Plex).
+    this._plexSyncHashes.clear();
+
     const flows = flowPlaylistConfig.getFlows();
     const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
     await this._syncPlexPlaylists(flows, sharedPlaylists);
@@ -501,15 +535,20 @@ export class WeeklyFlowPlaylistManager {
     // indexing, without the user needing to click sync again.
     this._schedulePlexCatchup(sectionId);
 
+    const managedNames = new Set(
+      [
+        ...flows.map((f) => String(f.name || "").trim()),
+        ...sharedPlaylists.map((p) => String(p.name || "").trim()),
+      ].filter(Boolean),
+    );
+
     return {
       configured: true,
       sectionId,
       indexedTracks: tracks.length,
       scanInProgress: tracks.length === 0,
       playlists: playlists
-        .filter(
-          (p) => p.title?.startsWith("[A] ") || p.title?.startsWith("[AS] "),
-        )
+        .filter((p) => managedNames.has(p.title))
         .map((p) => ({ title: p.title, count: p.leafCount ?? null })),
     };
   }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
             { slug: "integrations/koito" },
             { slug: "integrations/slskd" },
             { slug: "integrations/navidrome" },
+            { slug: "integrations/plex" },
             { slug: "integrations/ticketmaster" },
             { slug: "integrations/metadata" },
           ],

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -57,6 +57,18 @@ Leave **Use host paths in playlist files** off when Navidrome is in Docker with 
 
 See [Navidrome — Mixed Windows and Docker](/integrations/navidrome/#mixed-windows-and-docker-navidrome).
 
+## Plex playlists are empty or tracks are missing
+
+Symptoms: **Sync to Plex now** succeeds but playlists have no tracks, or the **Aurral** library in Plex stays empty after a scan.
+
+- Confirm Plex can read the flow download tree. From inside the Plex container or host, the path should exist: `<downloads>/aurral-weekly-flow/<flow-id>/...`.
+- If Plex and Aurral use different mounts, set **Settings → Integrations → Plex → Plex downloads path** to the folder Plex sees (without `/aurral-weekly-flow`). Leave it blank when both services share the same path prefix.
+- Save settings, then run **Sync to Plex now** again. Initial music scans can take several minutes; Aurral runs background catch-up syncs while Plex indexes files.
+- Confirm flows have finished downloading tracks under `aurral-weekly-flow` before expecting Plex playlists to populate.
+- **Use host paths in playlist files** under Navidrome does not apply to Plex.
+
+See [Plex integration](/integrations/plex/).
+
 ## Permission errors
 
 - Make sure mounted folders are writable by the container user.

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -13,13 +13,14 @@ Onboarding gets Aurral usable quickly. You can skip optional services and finish
 2. Set your download folder inside the shared `/data` mount.
 3. Connect Lidarr, test library access, and choose default profiles.
 4. Optionally apply the community Lidarr guide for discovery-friendly defaults.
-5. Optionally connect Navidrome, Plex, Last.fm, slskd, Ticketmaster, and metadata services.
+5. Optionally connect Navidrome, Last.fm, slskd, Ticketmaster, and metadata services.
 
 ## Good first settings
 
 After onboarding, check these areas:
 
 - **Integrations → Lidarr** — quality profile, tag, monitoring option, and search-on-add behavior.
+- **Integrations → Plex** — optional; connect in Settings after onboarding ([Plex setup](/integrations/plex/)).
 - **Integrations → Last.fm** — API key for stronger discovery.
 - **Profile** — your listening-history provider (Last.fm or ListenBrainz username, or Koito instance URL).
 - **Settings → Discover** — refresh cadence and discovery mode (Safer, Balanced, or Deeper).

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -13,7 +13,7 @@ Onboarding gets Aurral usable quickly. You can skip optional services and finish
 2. Set your download folder inside the shared `/data` mount.
 3. Connect Lidarr, test library access, and choose default profiles.
 4. Optionally apply the community Lidarr guide for discovery-friendly defaults.
-5. Optionally connect Navidrome, Last.fm, slskd, Ticketmaster, and metadata services.
+5. Optionally connect Navidrome, Plex, Last.fm, slskd, Ticketmaster, and metadata services.
 
 ## Good first settings
 

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -1,9 +1,9 @@
 ---
 title: Shared storage
-description: Mount the same media root in Aurral, Lidarr, slskd, and Navidrome.
+description: Mount the same media root in Aurral, Lidarr, slskd, Navidrome, and Plex.
 ---
 
-Flows, slskd handoff, Lidarr file reuse, and Navidrome playback all depend on **the same host folder mounted at the same container path** across services. This guide uses `/data`.
+Flows, slskd handoff, Lidarr file reuse, Navidrome playback, and Plex library scanning all depend on **the same host folder mounted at the same container path** across services. This guide uses `/data`.
 
 Docker only exposes mounted paths. Aurral uses the literal filesystem paths Lidarr and slskd report over their APIs. If Lidarr stores a file at `/data/music/...` but Aurral does not have `/data/music` mounted, library checks and reuse will fail even when the API connection works.
 
@@ -27,6 +27,7 @@ Docker only exposes mounted paths. Aurral uses the literal filesystem paths Lida
 | slskd | `/srv/media:/data` | Downloads `/data/downloads/slskd/complete` |
 | Aurral | `/srv/media:/data` | `DOWNLOAD_FOLDER=/data/downloads/aurral` |
 | Navidrome | `/srv/media:/data:ro` | Scan `/data/music` and `/data/downloads/aurral` |
+| Plex | `/srv/media:/data` | Read `/data/downloads/aurral/aurral-weekly-flow` (Aurral creates the library via API) |
 
 Aurral app state stays in `/config` and does not need to be shared with the other apps.
 
@@ -109,8 +110,9 @@ These solve two different problems in mixed Windows/Docker setups:
 | --- | --- | --- |
 | **Path mappings** (`PATH_MAPPINGS` or **Settings → Playlists**) | Host → container (`N:\...` → `/music/...`) | Aurral reading Lidarr/slskd files, library reuse, **Test library access** |
 | **Playlist file paths** (`M3U_PATH_MODE=remote` or Navidrome setting) | Container → host (`/music/...` → `N:\...`) | M3U playlists Navidrome reads when it is **not** in Docker |
+| **Plex downloads path** (Plex integration setting) | Aurral → Plex library root | Plex music library location when Plex sees a different mount than Aurral |
 
-Path mappings let Aurral open files inside the container. They do not change what Navidrome sees in generated `.m3u` files unless you also enable host paths for playlists.
+Path mappings let Aurral open files inside the container. They do not change what Navidrome sees in generated `.m3u` files unless you also enable host paths for playlists. Plex uses its own downloads-path override instead of M3U path mode. See [Plex](/integrations/plex/#plex-downloads-path-optional).
 
 When reusing tracks from Lidarr, Aurral stores the original Lidarr path and prefers that in remote M3U output. Downloaded tracks fall back to inverting your path mappings.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -39,17 +39,13 @@ Use this page as a starting point for setup, day-to-day use, integrations, and a
   </Card>
   <Card title="Playlists" icon="list-format">
     Scheduled flows, static imports, Release Radar-style discover playlists, and Navidrome or Plex playback.
+    [Read Playlists](/using/playlists/)
   </Card>
   <Card title="History" icon="document">
     One timeline for Lidarr requests, slskd downloads, and Aurral playlist jobs.
   </Card>
   <Card title="Integrations" icon="setting">
     Lidarr, Last.fm, ListenBrainz, Koito, slskd, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
-    Scheduled flows, imported playlists, Release Radar-style discover playlists, and Navidrome playback.
-    [Read Playlists](/using/playlists/)
-  </Card>
-  <Card title="Integrations" icon="setting">
-    Lidarr, Last.fm, ListenBrainz, Koito, slskd, Navidrome, Ticketmaster, Gotify, and webhooks.
     [Read integrations](/integrations/lidarr/)
   </Card>
   <Card title="Administration" icon="document">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -32,13 +32,13 @@ Aurral connects recommendation, requests, downloads, and playback for Lidarr-bas
     Recommendations, trends, tags, discover playlists, recent releases, and nearby shows.
   </Card>
   <Card title="Playlists" icon="list-format">
-    Scheduled flows, static imports, Release Radar-style discover playlists, and Navidrome playback.
+    Scheduled flows, static imports, Release Radar-style discover playlists, and Navidrome or Plex playback.
   </Card>
   <Card title="History" icon="document">
     One timeline for Lidarr requests, slskd downloads, and Aurral playlist jobs.
   </Card>
   <Card title="Integrations" icon="setting">
-    Lidarr, Last.fm, ListenBrainz, Koito, slskd, Navidrome, Ticketmaster, Gotify, and webhooks.
+    Lidarr, Last.fm, ListenBrainz, Koito, slskd, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
   </Card>
 </CardGrid>
 
@@ -51,7 +51,8 @@ Aurral connects recommendation, requests, downloads, and playback for Lidarr-bas
 | ListenBrainz | Optional per-user listening history | No |
 | Koito | Self-hosted per-user listening history | No |
 | slskd | Soulseek-backed downloads for flows and playlists | For downloads |
-| Navidrome | Streaming generated playlists | No |
+| Navidrome | Streaming generated playlists (M3U) | No |
+| Plex | Flow playlists in Plexamp | No |
 | Ticketmaster | Local concert recommendations | No |
 
 ## Where to start

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -60,3 +60,5 @@ ND_SCANNER_PURGEMISSING=always
 ```
 
 Purging missing tracks helps Navidrome clean up old flow entries after a flow rotates.
+
+For Plex and Plexamp instead, see [Plex](/integrations/plex/).

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -1,0 +1,89 @@
+---
+title: Plex
+description: Flow and playlist playback in Plex and Plexamp.
+---
+
+Plex is optional. When configured, Aurral creates an **Aurral** music library in Plex Media Server, scans your flow downloads, and builds a **regular Plex playlist** for each enabled flow and shared playlist. Playlists appear in Plex and Plexamp alongside your other libraries.
+
+Plex does not read Aurral's `.m3u` files. Playlist sync uses the Plex API after Plex indexes the audio files on disk.
+
+## Setup
+
+1. Follow [Shared storage](/getting-started/storage/) so Plex can read the same `DOWNLOAD_FOLDER` tree Aurral writes.
+2. Open **Settings → Integrations → Plex**.
+3. Click **Connect Plex account** and approve the PIN in the Plex popup.
+4. Select your Plex server and confirm the server URL.
+5. Save settings, then click **Test connection**.
+6. After flows have downloaded tracks, click **Sync to Plex now** (or wait for the next playlist ensure cycle).
+
+Aurral registers the library at:
+
+```text
+<plex-visible-downloads>/aurral-weekly-flow
+```
+
+Track files live in flow subfolders under that path, for example `aurral-weekly-flow/<flow-id>/Artist/Album/track.flac`. M3U playlists for Navidrome stay in `aurral-weekly-flow/_playlists/` and are not used by Plex.
+
+## Plex vs Navidrome
+
+You can run both at the same time. They use the same download tree but different playback mechanisms.
+
+| | Navidrome | Plex |
+| --- | --- | --- |
+| Playlist format | `.m3u` files on disk | Regular Plex playlists via API |
+| Library setup | Scan folders + read M3U | Aurral creates an **Aurral** music library via API |
+| Path mismatch fix | **Use host paths in playlist files** / `M3U_PATH_MODE` | **Plex downloads path** (optional) |
+| Playlist names | `[A] Flow name`, `[AS] Shared name` | Bare flow or playlist name |
+
+Navidrome's **Use host paths in playlist files** setting does not affect Plex. It only changes paths written inside `.m3u` files.
+
+## Plex downloads path (optional)
+
+Leave this blank when Aurral and Plex share the same filesystem view (same host, or the same Docker volume mounted at the same path in both containers).
+
+Set it when Plex runs in a **different container or host** and sees a different mount prefix than Aurral. Enter the downloads folder **as the Plex server sees it** — Aurral appends `/aurral-weekly-flow` when creating the library.
+
+| Aurral writes to | Plex sees | Plex downloads path |
+| --- | --- | --- |
+| `/data/downloads/aurral` | `/data/downloads/aurral` | Leave blank |
+| `/music/Aurral` (in Docker) | `/data/media` (Plex container) | `/data/media` |
+
+**Browse** shows folders as Aurral sees them. If Plex's mount differs, type Plex's path manually.
+
+This is the Plex equivalent of aligning library roots in shared storage — not the same as Navidrome's M3U host-path toggle.
+
+## Sync behavior
+
+**Sync to Plex now**:
+
+1. Ensures the **Aurral** music library exists at the configured path
+2. Triggers a Plex library scan
+3. Builds or updates playlists from tracks Plex has already indexed
+4. Schedules background catch-up syncs while scanning continues
+
+Plex music scans can take minutes. If sync returns immediately with zero indexed tracks, wait for the scan to finish — catch-up runs automatically, or click **Sync to Plex now** again.
+
+Aurral skips no-op playlist rebuilds when the track set has not changed. Disabling a flow removes its Plex playlist on the next sync.
+
+## Mixed Docker setups
+
+When Aurral and Plex both run in Docker with the same `/data` mount, leave **Plex downloads path** empty and mount the shared root into both services:
+
+```yaml
+services:
+  aurral:
+    environment:
+      - DOWNLOAD_FOLDER=/data/downloads/aurral
+    volumes:
+      - /srv/media:/data
+
+  plex:
+    volumes:
+      - /srv/media:/data
+```
+
+In Plex, you do not need to add the folder manually — Aurral creates the **Aurral** library via API. Confirm Plex can read `/data/downloads/aurral/aurral-weekly-flow` from inside the Plex container.
+
+If Aurral uses `PATH_MAPPINGS` for Lidarr reuse on Windows, that affects how Aurral reads files internally. It does not replace **Plex downloads path** when Plex's library mount differs from Aurral's.
+
+See [Shared storage](/getting-started/storage/) and [Troubleshooting — Plex](/admin/troubleshooting/#plex-playlists-are-empty-or-tracks-are-missing).

--- a/docs/src/content/docs/using/flows.mdx
+++ b/docs/src/content/docs/using/flows.mdx
@@ -3,7 +3,7 @@ title: Flows
 description: Schedule, source mix, focus, and flow generation behavior.
 ---
 
-Flows are dynamic playlists. They regenerate on their schedule, download into Aurral's own folder, and can be exposed to Navidrome.
+Flows are dynamic playlists. They regenerate on their schedule, download into Aurral's own folder, and can be exposed to Navidrome or Plex.
 
 ![Aurral flow editor](../../../assets/screenshots/flow-editor.webp)
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -26,7 +26,7 @@ Generated playlists are written inside your `DOWNLOAD_FOLDER`, typically:
 /data/downloads/aurral/aurral-weekly-flow/<playlist-id>/
 ```
 
-Navidrome can scan the same tree for playback. See [Navidrome](/integrations/navidrome/) and [Shared storage](/getting-started/storage/).
+Navidrome can scan the same tree and play `.m3u` playlists. Plex can index the track folders and receive API-synced playlists for Plexamp. See [Navidrome](/integrations/navidrome/), [Plex](/integrations/plex/), and [Shared storage](/getting-started/storage/).
 
 ## Next steps
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7619,6 +7619,13 @@ textarea {
   border-radius: var(--aurral-radius);
 }
 
+/* Space out stacked fields/hints/buttons inside a section's fieldset, which is
+   otherwise a plain block with no gap. */
+.settings-page__section fieldset {
+  display: grid;
+  gap: 1rem;
+}
+
 .settings-page__section--narrow {
   max-width: 28rem;
 }

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
-import {
-  CheckCircle,
-  ChevronDown,
-  RefreshCw,
-  Folder,
-  CornerLeftUp,
-} from "lucide-react";
+import { CheckCircle, ChevronDown, RefreshCw } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { LidarrLibraryAccessCheck } from "./LidarrLibraryAccessCheck";
@@ -21,7 +15,6 @@ import {
   getPlexResources,
   testPlexConnection,
   syncPlexNow,
-  browsePaths,
 } from "../../../utils/api";
 
 export function SettingsIntegrationsTab({
@@ -70,13 +63,6 @@ export function SettingsIntegrationsTab({
   const [testingPlex, setTestingPlex] = useState(false);
   const [syncingPlex, setSyncingPlex] = useState(false);
   const [plexServers, setPlexServers] = useState([]);
-  const [browseOpen, setBrowseOpen] = useState(false);
-  const [browseLoading, setBrowseLoading] = useState(false);
-  const [browseState, setBrowseState] = useState({
-    path: "/",
-    parent: null,
-    directories: [],
-  });
   const safeLidarrProfiles = Array.isArray(lidarrProfiles)
     ? lidarrProfiles
     : [];
@@ -157,6 +143,13 @@ export function SettingsIntegrationsTab({
     } catch {
       setPlexServers([]);
       return [];
+    }
+  };
+
+  const handleChoosePlexServer = async () => {
+    const servers = await loadPlexServers(settings.integrations?.plex?.token);
+    if (!servers || servers.length === 0) {
+      showError("No Plex servers found for this account.");
     }
   };
 
@@ -279,34 +272,6 @@ export function SettingsIntegrationsTab({
     } finally {
       setSyncingPlex(false);
     }
-  };
-
-  const loadBrowse = async (path) => {
-    setBrowseLoading(true);
-    try {
-      const result = await browsePaths(path);
-      setBrowseState(result);
-    } catch (err) {
-      const errorMsg =
-        err.response?.data?.message || err.response?.data?.error || err.message;
-      showError(`Cannot read path: ${errorMsg}`);
-    } finally {
-      setBrowseLoading(false);
-    }
-  };
-
-  const handleToggleBrowse = () => {
-    if (browseOpen) {
-      setBrowseOpen(false);
-      return;
-    }
-    setBrowseOpen(true);
-    loadBrowse(settings.integrations?.plex?.downloadsPath || "/");
-  };
-
-  const handleUseBrowsedFolder = () => {
-    updatePlex({ downloadsPath: browseState.path });
-    setBrowseOpen(false);
   };
 
   const handleTestLidarr = async () => {
@@ -1533,10 +1498,19 @@ export function SettingsIntegrationsTab({
                       : "Connect Plex account"}
                 </button>
                 {settings.integrations?.plex?.token && (
-                  <span className="settings-page__status">
-                    <CheckCircle className="settings-page__status-icon" />
-                    Signed in
-                  </span>
+                  <>
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={handleChoosePlexServer}
+                    >
+                      Choose server
+                    </button>
+                    <span className="settings-page__status">
+                      <CheckCircle className="settings-page__status-icon" />
+                      Signed in
+                    </span>
+                  </>
                 )}
               </div>
 

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -10,6 +10,11 @@ import {
   testLidarrConnection,
   testLidarrLibraryAccess,
   testSlskdConnection,
+  startPlexAuth,
+  checkPlexAuth,
+  getPlexResources,
+  testPlexConnection,
+  syncPlexNow,
 } from "../../../utils/api";
 
 export function SettingsIntegrationsTab({
@@ -46,6 +51,7 @@ export function SettingsIntegrationsTab({
     ticketmaster: true,
     navidrome: true,
     slskd: false,
+    plex: true,
   });
   const [testingSlskd, setTestingSlskd] = useState(false);
   const [lidarrTestLatencyMs, setLidarrTestLatencyMs] = useState(null);
@@ -53,6 +59,10 @@ export function SettingsIntegrationsTab({
     useState(false);
   const [lidarrLibraryAccessResult, setLidarrLibraryAccessResult] =
     useState(null);
+  const [plexConnecting, setPlexConnecting] = useState(false);
+  const [testingPlex, setTestingPlex] = useState(false);
+  const [syncingPlex, setSyncingPlex] = useState(false);
+  const [plexServers, setPlexServers] = useState([]);
   const safeLidarrProfiles = Array.isArray(lidarrProfiles)
     ? lidarrProfiles
     : [];
@@ -113,6 +123,147 @@ export function SettingsIntegrationsTab({
       showError(message);
     } finally {
       setTestingLidarrLibraryAccess(false);
+    }
+  };
+
+  const updatePlex = (patch) =>
+    updateSettings({
+      ...settings,
+      integrations: {
+        ...settings.integrations,
+        plex: { ...(settings.integrations?.plex || {}), ...patch },
+      },
+    });
+
+  const loadPlexServers = async (token) => {
+    try {
+      const { servers } = await getPlexResources(token);
+      setPlexServers(Array.isArray(servers) ? servers : []);
+      return servers;
+    } catch {
+      setPlexServers([]);
+      return [];
+    }
+  };
+
+  const handleConnectPlex = async () => {
+    setPlexConnecting(true);
+    try {
+      const { pinId, code, authUrl } = await startPlexAuth();
+      const popup = window.open(
+        authUrl,
+        "plex-auth",
+        "width=600,height=700",
+      );
+      const deadline = Date.now() + 3 * 60 * 1000;
+      let token = null;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 2000));
+        try {
+          const res = await checkPlexAuth(pinId, code);
+          if (res.token) {
+            token = res.token;
+            break;
+          }
+        } catch {}
+      }
+      if (popup && !popup.closed) popup.close();
+      if (!token) {
+        showError("Plex authentication timed out. Please try again.");
+        return;
+      }
+      updatePlex({ token });
+      showSuccess("Signed in to Plex. Select your server below.");
+      const servers = await loadPlexServers(token);
+      const owned = (servers || []).filter((s) => s.owned);
+      if (owned.length === 1) {
+        handleSelectPlexServer(owned[0], token);
+      }
+    } catch (err) {
+      const errorMsg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Plex sign-in failed: ${errorMsg}`);
+    } finally {
+      setPlexConnecting(false);
+    }
+  };
+
+  const handleSelectPlexServer = (server, tokenOverride) => {
+    const conns = server.connections || [];
+    const best =
+      conns.find((c) => c.local) || conns.find((c) => c.uri) || conns[0];
+    if (!best?.uri) {
+      showError("Selected Plex server has no usable connection.");
+      return;
+    }
+    updateSettings({
+      ...settings,
+      integrations: {
+        ...settings.integrations,
+        plex: {
+          ...(settings.integrations?.plex || {}),
+          ...(tokenOverride ? { token: tokenOverride } : {}),
+          url: best.uri,
+          machineIdentifier: server.clientIdentifier,
+        },
+      },
+    });
+    showInfo(`Selected "${server.name}". Remember to Save settings.`);
+  };
+
+  const handleTestPlex = async () => {
+    const url = settings.integrations?.plex?.url;
+    const token = settings.integrations?.plex?.token;
+    if (!url || !token) {
+      showError("Connect to Plex and select a server first");
+      return;
+    }
+    setTestingPlex(true);
+    try {
+      const result = await testPlexConnection(url, token);
+      if (result.success) {
+        showSuccess(
+          `Plex connection successful!${result.version ? ` (v${result.version})` : ""}`,
+        );
+        if (result.machineIdentifier) {
+          updatePlex({ machineIdentifier: result.machineIdentifier });
+        }
+      } else {
+        showError(`Connection failed: ${result.message || result.error}`);
+      }
+    } catch (err) {
+      const errorMsg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Connection failed: ${errorMsg}`);
+    } finally {
+      setTestingPlex(false);
+    }
+  };
+
+  const handleSyncPlex = async () => {
+    if (hasUnsavedChanges) {
+      showError("Save settings first, then sync to Plex.");
+      return;
+    }
+    setSyncingPlex(true);
+    try {
+      const result = await syncPlexNow();
+      const built = (result.playlists || []).length;
+      if (result.indexedTracks === 0) {
+        showInfo(
+          "Library created and a Plex scan was triggered, but no tracks are indexed yet. Give Plex a minute to scan, then sync again.",
+        );
+      } else {
+        showSuccess(
+          `Synced to Plex: ${built} playlist(s) from ${result.indexedTracks} indexed track(s).`,
+        );
+      }
+    } catch (err) {
+      const errorMsg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Plex sync failed: ${errorMsg}`);
+    } finally {
+      setSyncingPlex(false);
     }
   };
 
@@ -1296,7 +1447,156 @@ export function SettingsIntegrationsTab({
             </fieldset>
           )}
         </div>
+        <div className="settings-page__section">
+          <div className="settings-page__section-header">
+            <button
+              type="button"
+              onClick={() => toggleSection("plex")}
+              className="settings-page__section-toggle"
+              aria-expanded={!collapsedSections.plex}
+            >
+              <ChevronDown
+                className={`settings-page__section-toggle-icon${collapsedSections.plex ? " is-collapsed" : ""}`}
+              />
+              <span>Plex</span>
+            </button>
+            <div className="settings-page__inline-row">
+              {settings.integrations?.plex?.token &&
+                settings.integrations?.plex?.url && (
+                  <span className="settings-page__status">
+                    <CheckCircle className="settings-page__status-icon" />
+                    Configured
+                  </span>
+                )}
+            </div>
+          </div>
+          {!collapsedSections.plex && (
+            <fieldset className="settings-page__fields">
+              <p className="settings-page__hint">
+                Sign in with your Plex account to let Aurral create a dedicated
+                music library pointed at your flow downloads and build a
+                playlist for each flow. Playlists appear in Plex and Plexamp.
+              </p>
+              <div className="settings-page__inline-row">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={handleConnectPlex}
+                  disabled={plexConnecting}
+                >
+                  {plexConnecting
+                    ? "Waiting for Plex…"
+                    : settings.integrations?.plex?.token
+                      ? "Reconnect Plex account"
+                      : "Connect Plex account"}
+                </button>
+                {settings.integrations?.plex?.token && (
+                  <span className="settings-page__status">
+                    <CheckCircle className="settings-page__status-icon" />
+                    Signed in
+                  </span>
+                )}
+              </div>
 
+              {settings.integrations?.plex?.token && (
+                <div>
+                  <label className="artist-field-label">Plex server</label>
+                  <SettingsSelect
+                    value={settings.integrations?.plex?.machineIdentifier || ""}
+                    onChange={(e) => {
+                      const server = plexServers.find(
+                        (s) => s.clientIdentifier === e.target.value,
+                      );
+                      if (server) handleSelectPlexServer(server);
+                    }}
+                  >
+                    <option value="" disabled>
+                      {plexServers.length
+                        ? "Select a server…"
+                        : "Loading servers…"}
+                    </option>
+                    {plexServers.map((s) => (
+                      <option
+                        key={s.clientIdentifier}
+                        value={s.clientIdentifier}
+                      >
+                        {s.name}
+                        {s.owned ? "" : " (shared)"}
+                      </option>
+                    ))}
+                  </SettingsSelect>
+                </div>
+              )}
+
+              <div>
+                <label className="artist-field-label">Server URL</label>
+                <SettingsInput
+                  type="url"
+                  placeholder="http://localhost:32400"
+                  autoComplete="off"
+                  value={settings.integrations?.plex?.url || ""}
+                  onChange={(e) => updatePlex({ url: e.target.value })}
+                />
+                <p className="settings-page__hint">
+                  Auto-filled when you select a server, or enter it manually.
+                </p>
+              </div>
+
+              <div>
+                <label className="artist-field-label">
+                  Plex downloads path (optional)
+                </label>
+                <SettingsInput
+                  type="text"
+                  placeholder="/data/aurral_downloads"
+                  autoComplete="off"
+                  value={settings.integrations?.plex?.downloadsPath || ""}
+                  onChange={(e) => updatePlex({ downloadsPath: e.target.value })}
+                />
+                <p className="settings-page__hint">
+                  Only needed if Plex runs in a different container/host than
+                  Aurral. Enter the downloads folder path as the{" "}
+                  <strong>Plex server</strong> sees it — Aurral appends{" "}
+                  <code>/aurral-weekly-flow</code>. Leave blank to use
+                  Aurral&apos;s own download path.
+                </p>
+              </div>
+
+              <div className="settings-page__inline-row">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={handleTestPlex}
+                  disabled={
+                    testingPlex ||
+                    !settings.integrations?.plex?.url ||
+                    !settings.integrations?.plex?.token
+                  }
+                >
+                  {testingPlex ? "Testing…" : "Test connection"}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleSyncPlex}
+                  disabled={
+                    syncingPlex ||
+                    !settings.integrations?.plex?.url ||
+                    !settings.integrations?.plex?.token
+                  }
+                >
+                  {syncingPlex ? "Syncing…" : "Sync to Plex now"}
+                </button>
+              </div>
+              <p className="settings-page__hint">
+                Creates an &quot;Aurral&quot; music library pointed at your
+                downloads, scans it, and builds a playlist per flow. The Plex
+                server must be able to read the same downloads path Aurral
+                writes to. Save settings before syncing.
+              </p>
+            </fieldset>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -150,8 +150,7 @@ export function SettingsIntegrationsTab({
     return list;
   };
 
-  // Auto-load the account's servers whenever we have a token, so the dropdown
-  // is always populated (e.g. on page load) without a manual "choose" step.
+  // Auto-load servers when we have a token so the dropdown is always populated.
   const plexToken = settings.integrations?.plex?.token;
   useEffect(() => {
     if (!plexToken) {

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
-import { CheckCircle, ChevronDown, RefreshCw } from "lucide-react";
+import {
+  CheckCircle,
+  ChevronDown,
+  RefreshCw,
+  Folder,
+  CornerLeftUp,
+} from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { LidarrLibraryAccessCheck } from "./LidarrLibraryAccessCheck";
@@ -15,6 +21,7 @@ import {
   getPlexResources,
   testPlexConnection,
   syncPlexNow,
+  browsePaths,
 } from "../../../utils/api";
 
 export function SettingsIntegrationsTab({
@@ -63,6 +70,13 @@ export function SettingsIntegrationsTab({
   const [testingPlex, setTestingPlex] = useState(false);
   const [syncingPlex, setSyncingPlex] = useState(false);
   const [plexServers, setPlexServers] = useState([]);
+  const [browseOpen, setBrowseOpen] = useState(false);
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseState, setBrowseState] = useState({
+    path: "/",
+    parent: null,
+    directories: [],
+  });
   const safeLidarrProfiles = Array.isArray(lidarrProfiles)
     ? lidarrProfiles
     : [];
@@ -265,6 +279,34 @@ export function SettingsIntegrationsTab({
     } finally {
       setSyncingPlex(false);
     }
+  };
+
+  const loadBrowse = async (path) => {
+    setBrowseLoading(true);
+    try {
+      const result = await browsePaths(path);
+      setBrowseState(result);
+    } catch (err) {
+      const errorMsg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Cannot read path: ${errorMsg}`);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
+
+  const handleToggleBrowse = () => {
+    if (browseOpen) {
+      setBrowseOpen(false);
+      return;
+    }
+    setBrowseOpen(true);
+    loadBrowse(settings.integrations?.plex?.downloadsPath || "/");
+  };
+
+  const handleUseBrowsedFolder = () => {
+    updatePlex({ downloadsPath: browseState.path });
+    setBrowseOpen(false);
   };
 
   const handleTestLidarr = async () => {
@@ -1546,20 +1588,97 @@ export function SettingsIntegrationsTab({
                 <label className="artist-field-label">
                   Plex downloads path (optional)
                 </label>
-                <SettingsInput
-                  type="text"
-                  placeholder="/data/aurral_downloads"
-                  autoComplete="off"
-                  value={settings.integrations?.plex?.downloadsPath || ""}
-                  onChange={(e) => updatePlex({ downloadsPath: e.target.value })}
-                />
+                <div className="settings-page__field-row">
+                  <SettingsInput
+                    wrapperClassName="settings-page__field-grow"
+                    type="text"
+                    placeholder="/data/aurral_downloads"
+                    autoComplete="off"
+                    value={settings.integrations?.plex?.downloadsPath || ""}
+                    onChange={(e) =>
+                      updatePlex({ downloadsPath: e.target.value })
+                    }
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={handleToggleBrowse}
+                  >
+                    <span className="settings-page__inline-row">
+                      <Folder className="settings-page__status-icon" />
+                      {browseOpen ? "Close" : "Browse"}
+                    </span>
+                  </button>
+                </div>
                 <p className="settings-page__hint">
                   Only needed if Plex runs in a different container/host than
                   Aurral. Enter the downloads folder path as the{" "}
                   <strong>Plex server</strong> sees it — Aurral appends{" "}
                   <code>/aurral-weekly-flow</code>. Leave blank to use
-                  Aurral&apos;s own download path.
+                  Aurral&apos;s own download path. Browse shows the filesystem
+                  as Aurral sees it; type manually if Plex&apos;s mount path
+                  differs.
                 </p>
+
+                {browseOpen && (
+                  <div className="settings-page__browse-panel">
+                    <div className="settings-page__inline-row settings-page__browse-header">
+                      <code
+                        className="settings-page__browse-path"
+                        title={browseState.path}
+                      >
+                        {browseState.path}
+                      </code>
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        onClick={handleUseBrowsedFolder}
+                      >
+                        Use this folder
+                      </button>
+                    </div>
+                    <div className="settings-page__browse-list">
+                      {browseLoading ? (
+                        <div className="settings-page__browse-loading">
+                          <RefreshCw className="settings-page__status-icon animate-spin" />
+                          Loading…
+                        </div>
+                      ) : (
+                        <ul className="settings-page__browse-items">
+                          {browseState.parent && (
+                            <li>
+                              <button
+                                type="button"
+                                className="settings-page__browse-item"
+                                onClick={() => loadBrowse(browseState.parent)}
+                              >
+                                <CornerLeftUp className="settings-page__status-icon" />
+                                <span>..</span>
+                              </button>
+                            </li>
+                          )}
+                          {browseState.directories.length === 0 && (
+                            <li className="settings-page__browse-empty">
+                              No subfolders here.
+                            </li>
+                          )}
+                          {browseState.directories.map((dir) => (
+                            <li key={dir.path}>
+                              <button
+                                type="button"
+                                className="settings-page__browse-item"
+                                onClick={() => loadBrowse(dir.path)}
+                              >
+                                <Folder className="settings-page__status-icon" />
+                                <span className="truncate">{dir.name}</span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div className="settings-page__inline-row">

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CheckCircle, ChevronDown, RefreshCw } from "lucide-react";
 import FlipSaveButton from "../../../components/FlipSaveButton";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
@@ -15,6 +15,7 @@ import {
   getPlexResources,
   testPlexConnection,
   syncPlexNow,
+  browsePaths,
 } from "../../../utils/api";
 
 export function SettingsIntegrationsTab({
@@ -63,6 +64,13 @@ export function SettingsIntegrationsTab({
   const [testingPlex, setTestingPlex] = useState(false);
   const [syncingPlex, setSyncingPlex] = useState(false);
   const [plexServers, setPlexServers] = useState([]);
+  const [browseOpen, setBrowseOpen] = useState(false);
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseState, setBrowseState] = useState({
+    path: "/",
+    parent: null,
+    directories: [],
+  });
   const safeLidarrProfiles = Array.isArray(lidarrProfiles)
     ? lidarrProfiles
     : [];
@@ -142,21 +150,51 @@ export function SettingsIntegrationsTab({
     return list;
   };
 
-  const handleChoosePlexServer = async () => {
-    try {
-      const servers = await loadPlexServers(settings.integrations?.plex?.token);
-      if (servers.length === 0) {
-        showError(
-          "Plex returned no servers for this account. Make sure your server is signed in to the same Plex account."
-        );
-      } else {
-        showInfo(`Found ${servers.length} Plex server(s).`);
-      }
-    } catch (err) {
-      const msg =
-        err.response?.data?.message || err.response?.data?.error || err.message;
-      showError(`Failed to load Plex servers: ${msg}`);
+  // Auto-load the account's servers whenever we have a token, so the dropdown
+  // is always populated (e.g. on page load) without a manual "choose" step.
+  const plexToken = settings.integrations?.plex?.token;
+  useEffect(() => {
+    if (!plexToken) {
+      setPlexServers([]);
+      return;
     }
+    let cancelled = false;
+    getPlexResources(plexToken)
+      .then(({ servers }) => {
+        if (!cancelled) setPlexServers(Array.isArray(servers) ? servers : []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [plexToken]);
+
+  const loadBrowse = async (path) => {
+    setBrowseLoading(true);
+    try {
+      const result = await browsePaths(path);
+      setBrowseState(result);
+    } catch (err) {
+      const errorMsg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Cannot read path: ${errorMsg}`);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
+
+  const handleToggleBrowse = () => {
+    if (browseOpen) {
+      setBrowseOpen(false);
+      return;
+    }
+    setBrowseOpen(true);
+    loadBrowse(settings.integrations?.plex?.downloadsPath || "/");
+  };
+
+  const handleUseBrowsedFolder = () => {
+    updatePlex({ downloadsPath: browseState.path });
+    setBrowseOpen(false);
   };
 
   const handleConnectPlex = async () => {
@@ -1505,19 +1543,10 @@ export function SettingsIntegrationsTab({
                       : "Connect Plex account"}
                 </button>
                 {settings.integrations?.plex?.token && (
-                  <>
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      onClick={handleChoosePlexServer}
-                    >
-                      Choose server
-                    </button>
-                    <span className="settings-page__status">
-                      <CheckCircle className="settings-page__status-icon" />
-                      Signed in
-                    </span>
-                  </>
+                  <span className="settings-page__status">
+                    <CheckCircle className="settings-page__status-icon" />
+                    Signed in
+                  </span>
                 )}
               </div>
 
@@ -1585,10 +1614,7 @@ export function SettingsIntegrationsTab({
                     className="btn btn-secondary"
                     onClick={handleToggleBrowse}
                   >
-                    <span className="settings-page__inline-row">
-                      <Folder className="settings-page__status-icon" />
-                      {browseOpen ? "Close" : "Browse"}
-                    </span>
+                    {browseOpen ? "Close" : "Browse"}
                   </button>
                 </div>
                 <p className="settings-page__hint">
@@ -1602,14 +1628,12 @@ export function SettingsIntegrationsTab({
                 </p>
 
                 {browseOpen && (
-                  <div className="settings-page__browse-panel">
-                    <div className="settings-page__inline-row settings-page__browse-header">
-                      <code
-                        className="settings-page__browse-path"
-                        title={browseState.path}
-                      >
-                        {browseState.path}
-                      </code>
+                  <div
+                    className="settings-page__section"
+                    style={{ marginTop: "0.75rem" }}
+                  >
+                    <div className="settings-page__inline-row">
+                      <code className="settings-page__hint">{browseState.path}</code>
                       <button
                         type="button"
                         className="btn btn-primary btn-sm"
@@ -1618,28 +1642,30 @@ export function SettingsIntegrationsTab({
                         Use this folder
                       </button>
                     </div>
-                    <div className="settings-page__browse-list">
+                    <div
+                      style={{
+                        maxHeight: "14rem",
+                        overflowY: "auto",
+                        marginTop: "0.5rem",
+                      }}
+                    >
                       {browseLoading ? (
-                        <div className="settings-page__browse-loading">
-                          <RefreshCw className="settings-page__status-icon animate-spin" />
-                          Loading…
-                        </div>
+                        <p className="settings-page__hint">Loading…</p>
                       ) : (
-                        <ul className="settings-page__browse-items">
+                        <ul className="settings-page__fields">
                           {browseState.parent && (
                             <li>
                               <button
                                 type="button"
-                                className="settings-page__browse-item"
+                                className="btn btn-secondary btn-sm"
                                 onClick={() => loadBrowse(browseState.parent)}
                               >
-                                <CornerLeftUp className="settings-page__status-icon" />
-                                <span>..</span>
+                                ..
                               </button>
                             </li>
                           )}
                           {browseState.directories.length === 0 && (
-                            <li className="settings-page__browse-empty">
+                            <li className="settings-page__hint">
                               No subfolders here.
                             </li>
                           )}
@@ -1647,11 +1673,10 @@ export function SettingsIntegrationsTab({
                             <li key={dir.path}>
                               <button
                                 type="button"
-                                className="settings-page__browse-item"
+                                className="btn btn-secondary btn-sm"
                                 onClick={() => loadBrowse(dir.path)}
                               >
-                                <Folder className="settings-page__status-icon" />
-                                <span className="truncate">{dir.name}</span>
+                                {dir.name}
                               </button>
                             </li>
                           ))}

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -136,27 +136,33 @@ export function SettingsIntegrationsTab({
     });
 
   const loadPlexServers = async (token) => {
-    try {
-      const { servers } = await getPlexResources(token);
-      setPlexServers(Array.isArray(servers) ? servers : []);
-      return servers;
-    } catch {
-      setPlexServers([]);
-      return [];
-    }
+    const { servers } = await getPlexResources(token);
+    const list = Array.isArray(servers) ? servers : [];
+    setPlexServers(list);
+    return list;
   };
 
   const handleChoosePlexServer = async () => {
-    const servers = await loadPlexServers(settings.integrations?.plex?.token);
-    if (!servers || servers.length === 0) {
-      showError("No Plex servers found for this account.");
+    try {
+      const servers = await loadPlexServers(settings.integrations?.plex?.token);
+      if (servers.length === 0) {
+        showError(
+          "Plex returned no servers for this account. Make sure your server is signed in to the same Plex account."
+        );
+      } else {
+        showInfo(`Found ${servers.length} Plex server(s).`);
+      }
+    } catch (err) {
+      const msg =
+        err.response?.data?.message || err.response?.data?.error || err.message;
+      showError(`Failed to load Plex servers: ${msg}`);
     }
   };
 
   const handleConnectPlex = async () => {
     setPlexConnecting(true);
     try {
-      const { pinId, code, authUrl } = await startPlexAuth();
+      const { pinId, code, authUrl, clientId } = await startPlexAuth();
       const popup = window.open(
         authUrl,
         "plex-auth",
@@ -179,13 +185,22 @@ export function SettingsIntegrationsTab({
         showError("Plex authentication timed out. Please try again.");
         return;
       }
-      updatePlex({ token });
-      showSuccess("Signed in to Plex. Select your server below.");
       const servers = await loadPlexServers(token);
       const owned = (servers || []).filter((s) => s.owned);
+      const patch = { token, ...(clientId ? { clientId } : {}) };
       if (owned.length === 1) {
-        handleSelectPlexServer(owned[0], token);
+        const best = pickBestConnection(owned[0]);
+        if (best?.uri) {
+          patch.url = best.uri;
+          patch.machineIdentifier = owned[0].clientIdentifier;
+        }
       }
+      updatePlex(patch);
+      showSuccess(
+        owned.length === 1 && patch.url
+          ? `Signed in and selected "${owned[0].name}". Remember to Save settings.`
+          : "Signed in to Plex. Select your server below.",
+      );
     } catch (err) {
       const errorMsg =
         err.response?.data?.message || err.response?.data?.error || err.message;
@@ -195,26 +210,18 @@ export function SettingsIntegrationsTab({
     }
   };
 
-  const handleSelectPlexServer = (server, tokenOverride) => {
+  const pickBestConnection = (server) => {
     const conns = server.connections || [];
-    const best =
-      conns.find((c) => c.local) || conns.find((c) => c.uri) || conns[0];
+    return conns.find((c) => c.local) || conns.find((c) => c.uri) || conns[0];
+  };
+
+  const handleSelectPlexServer = (server) => {
+    const best = pickBestConnection(server);
     if (!best?.uri) {
       showError("Selected Plex server has no usable connection.");
       return;
     }
-    updateSettings({
-      ...settings,
-      integrations: {
-        ...settings.integrations,
-        plex: {
-          ...(settings.integrations?.plex || {}),
-          ...(tokenOverride ? { token: tokenOverride } : {}),
-          url: best.uri,
-          machineIdentifier: server.clientIdentifier,
-        },
-      },
-    });
+    updatePlex({ url: best.uri, machineIdentifier: server.clientIdentifier });
     showInfo(`Selected "${server.name}". Remember to Save settings.`);
   };
 

--- a/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIntegrationsTab.jsx
@@ -249,9 +249,9 @@ export function SettingsIntegrationsTab({
     try {
       const result = await syncPlexNow();
       const built = (result.playlists || []).length;
-      if (result.indexedTracks === 0) {
+      if (result.scanInProgress) {
         showInfo(
-          "Library created and a Plex scan was triggered, but no tracks are indexed yet. Give Plex a minute to scan, then sync again.",
+          "Library ready and a Plex scan is running. Playlists will fill in automatically over the next few minutes as Plex indexes the tracks — no need to click again.",
         );
       } else {
         showSuccess(

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -29,6 +29,13 @@ const defaultSettings = {
   releaseTypes: allReleaseTypes,
   integrations: {
     navidrome: { url: "", username: "", password: "", m3uPathMode: "local" },
+    plex: {
+      url: "",
+      token: "",
+      clientId: "",
+      machineIdentifier: "",
+      downloadsPath: "",
+    },
     lastfm: {
       apiKey: "",
       username: "",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -86,6 +86,13 @@ export const normalizeSettings = (savedSettings) => {
             ? "remote"
             : "local",
       },
+      plex: {
+        url: "",
+        token: "",
+        clientId: "",
+        machineIdentifier: "",
+        ...(savedSettings.integrations?.plex || {}),
+      },
       lastfm: {
         apiKey: "",
         username: "",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -91,6 +91,7 @@ export const normalizeSettings = (savedSettings) => {
         token: "",
         clientId: "",
         machineIdentifier: "",
+        downloadsPath: "",
         ...(savedSettings.integrations?.plex || {}),
       },
       lastfm: {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -283,6 +283,13 @@ export const syncPlexNow = async () => {
   return response.data;
 };
 
+export const browsePaths = async (path) => {
+  const response = await api.get("/settings/browse", {
+    params: path ? { path } : {},
+  });
+  return response.data;
+};
+
 export const searchUnified = async (
   query,
   { mode = "suggest", limit } = {},

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -255,6 +255,34 @@ export const testNavidromeOnboarding = async (url, username, password) => {
   return response.data;
 };
 
+export const startPlexAuth = async (forwardUrl) => {
+  const response = await api.post("/settings/plex/auth/pin", { forwardUrl });
+  return response.data;
+};
+
+export const checkPlexAuth = async (pinId, code) => {
+  const response = await api.post("/settings/plex/auth/check", { pinId, code });
+  return response.data;
+};
+
+export const getPlexResources = async (token) => {
+  const response = await api.post("/settings/plex/resources", { token });
+  return response.data;
+};
+
+export const testPlexConnection = async (url, token) => {
+  const response = await api.post("/settings/plex/test", {
+    url: url?.replace(/\/+$/, ""),
+    token,
+  });
+  return response.data;
+};
+
+export const syncPlexNow = async () => {
+  const response = await api.post("/settings/plex/sync");
+  return response.data;
+};
+
 export const searchUnified = async (
   query,
   { mode = "suggest", limit } = {},


### PR DESCRIPTION
## Summary

Ports [@dylfrancis](https://github.com/dylfrancis)' Plex integration ([#399](https://github.com/lklynet/aurral/pull/399)) onto Aurral 2.0 (`release/v2`), adapted for the M3U-based playlist library layout instead of 1.x NSP smart playlists.

- OAuth PIN auth, server selection, optional Plex-visible downloads path, and API-synced weekly flow playlists in Plexamp
- Settings → Integrations UI with manual sync, library scan, and path browsing
- v2 path alignment: Plex library root uses `PLAYLIST_LIBRARY_DIR` / `{downloads}/aurral-weekly-flow` (not legacy `_playlists`)
- Docs and README updates; Plex is configured post-onboarding in Settings (not in the first-run wizard)

**Credit:** 14 feature commits cherry-picked from @dylfrancis with `-x` trailers; v2 path fix and docs by @lklynet.

Closes #63. Supersedes #399.

## Test plan

- [x] User testing on `test` / `dev` (already merged) before marking ready for review
- [ ] Connect Plex via Settings → Integrations (OAuth PIN, pick server, set downloads path if needed)
- [ ] Generate or refresh a weekly flow; confirm playlist appears in Plexamp
- [ ] Manual sync and library scan from Settings
- [ ] Verify Navidrome-only setups are unaffected when Plex is disabled
- [ ] Confirm shared `/data` mount paths work with hardlinks / duplicate tracks across flows