### PR TITLE
Warn 1.x users about upcoming v2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Aurral is a self-hosted music discovery app for Lidarr users. It helps you find 
 
 It is built for people who love discovering music and want that discovery loop to feel intentional, visual, and connected to the library they already maintain.
 
+> [!WARNING]
+> **Aurral v2 is coming.** The next major release is a big upgrade. Aurral's built-in Soulseek client is being removed in favor of external [slskd](https://github.com/slskd/slskd) for more reliable flow and playlist downloads. If you want to stay on the current 1.x line, pin your Docker image to a `1.x.x` tag instead of `latest` before updating. See [Pinning to Aurral 1.x](#pinning-to-aurral-1x).
+
 ## Quick Links
 
 - [Docker image](https://ghcr.io/lklynet/aurral)
@@ -105,6 +108,20 @@ STORAGE=./data
 ```
 
 `STORAGE` keeps Aurral's database and settings. `DL_FOLDER` keeps generated flow and playlist files.
+
+## Pinning to Aurral 1.x
+
+Aurral v2 is in development. It removes the built-in Soulseek client and requires [slskd](https://github.com/slskd/slskd) for Soulseek-backed downloads.
+
+If you are not ready for that change yet, pin your image to a specific 1.x release instead of `latest`:
+
+```yaml
+services:
+  aurral:
+    image: ghcr.io/lklynet/aurral:1.76.0
+```
+
+Browse [GitHub releases](https://github.com/lklynet/aurral/releases) for the current 1.x tag. Watchtower, Renovate, and similar auto-updaters will pull v2 if you leave the image on `latest`.
 
 ## First Run
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import { ToastProvider, useToast } from "./contexts/ToastContext";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import ReloadPrompt from "./components/ReloadPrompt";
 import UpdateBanner from "./components/UpdateBanner";
+import V2UpgradeBanner from "./components/V2UpgradeBanner";
 import { useWebSocketChannel } from "./hooks/useWebSocket";
 
 const SearchResultsPage = lazy(() => import("./pages/SearchResultsPage"));
@@ -176,6 +177,7 @@ function AppContent() {
           rootFolderConfigured={rootFolderConfigured}
           appVersion={appVersion}
         >
+          <V2UpgradeBanner />
           <UpdateBanner
             currentVersion={appVersion}
             visible={!user || user.role === "admin"}

--- a/frontend/src/components/V2UpgradeBanner.jsx
+++ b/frontend/src/components/V2UpgradeBanner.jsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+
+const DISMISS_KEY = "aurral:v2-upgrade-warning-dismissed";
+
+const V2UpgradeBanner = () => {
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6 border border-amber-400/40 bg-amber-500/15 px-5 py-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold uppercase tracking-wide text-amber-200">
+            Aurral v2 is coming
+          </p>
+          <p className="text-sm text-[#e8e4dc]">
+            The next major release is a big upgrade. Aurral&apos;s built-in Soulseek client is
+            being removed in favor of external{" "}
+            <a
+              href="https://github.com/slskd/slskd"
+              target="_blank"
+              rel="noreferrer"
+              className="text-amber-200 underline underline-offset-2 hover:text-amber-100"
+            >
+              slskd
+            </a>{" "}
+            for more reliable flow and playlist downloads.
+          </p>
+          <p className="text-xs text-[#c1c1c3]">
+            Want to stay on Aurral 1.x for now? Pin your Docker image to a{" "}
+            <code className="rounded bg-black/20 px-1 py-0.5 text-[11px]">1.x.x</code> tag instead
+            of <code className="rounded bg-black/20 px-1 py-0.5 text-[11px]">latest</code> before
+            you update.
+          </p>
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <a
+            href="https://github.com/lklynet/aurral#pinning-to-aurral-1x"
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-secondary bg-gray-700/50 hover:bg-gray-700/70 btn-sm w-full sm:w-auto"
+          >
+            Pinning guide
+          </a>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm hover:bg-gray-700/50 w-full sm:w-auto"
+            onClick={() => {
+              setDismissed(true);
+              try {
+                localStorage.setItem(DISMISS_KEY, "1");
+              } catch {}
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default V2UpgradeBanner;


### PR DESCRIPTION
## Summary
- Add a prominent README warning and pinning guide for users who want to stay on Aurral 1.x
- Add an in-app upgrade banner (visible to all logged-in users) explaining that v2 removes the built-in Soulseek client in favor of external slskd

## Test plan
- [ ] Open the app and confirm the amber v2 banner appears above the update banner
- [ ] Dismiss the banner and confirm it stays hidden after reload
- [ ] Confirm README warning renders on GitHub and the pinning anchor link works
- [ ] Confirm "Pinning guide" opens the README section