### PR TITLE
fix(imageProxy): prevent SSRF by correctly blocking loopback IPs and bracketed IPv6

### DIFF
--- a/.tests/artist-images.test.js
+++ b/.tests/artist-images.test.js
@@ -50,6 +50,7 @@ test("album image selection prefers cover art over disc art", () => {
   assert.equal(selected?.url, "https://example.test/cover.jpg");
 });
 
+
 test("album image selection accepts raw BrainzMash image casing", () => {
   const selected = selectBestAlbumImage([
     { CoverType: "Disc", Url: "https://example.test/disc.png" },
@@ -58,3 +59,18 @@ test("album image selection accepts raw BrainzMash image casing", () => {
 
   assert.equal(selected?.Url, "https://example.test/cover.jpg");
 });
+
+import { isPrivateHostname } from "../backend/services/imageProxyService.js";
+
+test("isPrivateHostname blocks local and loopback addresses", () => {
+  assert.equal(isPrivateHostname("localhost"), true);
+  assert.equal(isPrivateHostname("127.0.0.1"), true);
+  assert.equal(isPrivateHostname("127.255.0.1"), true);
+  assert.equal(isPrivateHostname("10.0.0.1"), true);
+  assert.equal(isPrivateHostname("192.168.1.5"), true);
+  assert.equal(isPrivateHostname("[::1]"), true);
+  assert.equal(isPrivateHostname("example.local"), true);
+  assert.equal(isPrivateHostname("example.com"), false);
+  assert.equal(isPrivateHostname("127a.com"), false);
+});
+

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -122,11 +122,15 @@ export const getImageProxyCacheSizeBytes = () => {
   return total;
 };
 
-const isPrivateHostname = (hostname) => {
-  const normalized = String(hostname || "").trim().toLowerCase();
+export const isPrivateHostname = (hostname) => {
+  let normalized = String(hostname || "").trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
   if (!normalized) return true;
   if (normalized.endsWith(".local")) return true;
   if (PRIVATE_172_RANGE.test(normalized)) return true;
+  if (/^127\./.test(normalized)) return true;
   return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(normalized));
 };
 


### PR DESCRIPTION
Implements more robust SSRF protection in the image proxy service by exporting and improving `isPrivateHostname` to correctly detect all loopback addresses (like 127.x.x.x) and strip enclosing brackets from IPv6 hostnames (like `[::1]`) before performing matching against patterns. Unit tests have been added to verify these behaviors.