### PR TITLE
feat: add yt-dlp as a built-in download source for flows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     make \
     g++ \
+    ffmpeg \
+    ca-certificates \
+    curl \
+    && curl -fsSL -o /usr/local/bin/yt-dlp \
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp" \
+    && chmod a+rx /usr/local/bin/yt-dlp \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 1001 nodejs \
     && useradd --uid 1001 --gid nodejs --shell /usr/sbin/nologin --create-home nodejs \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Aurral is a self-hosted music discovery app for the Lidarr stack. Find new artists, request albums, custom automatic rotating playlists, and import existing spotify playlists. Built by a developer with over a decade of experience.
 
 > [!NOTE]
-> **[Aurral v2 is here.](V2.md)** Spotify import, Usenet downloads, Plex sync, Gotify/webhook notifications, reverse-proxy auth, per-user discovery, and more.
+> **[Aurral v2 is here.](V2.md)** Spotify import, yt-dlp and Usenet downloads, Plex sync, Gotify/webhook notifications, reverse-proxy auth, per-user discovery, and more.
 
 > [!NOTE]
 > **AI disclosure** - Aurral is built with a hybrid approach to development. The foundation is hand-written code. For feature work, specifications are written by a developer, and any AI-generated code is thoroughly reviewed before being merged.
@@ -32,8 +32,8 @@ Aurral is a self-hosted music discovery app for the Lidarr stack. Find new artis
 - **Search** — Find artists and albums, preview tracks, and add to Lidarr with your defaults.
 - **Library** — Browse and search artists already in Lidarr.
 - **Playlists** — Run scheduled flows, adopt discover playlists like Release Radar, import static playlists, and convert flows to fixed tracklists.
-- **Activity** — Queue, review, and history for Lidarr requests, slskd and Usenet downloads, and Aurral playlist jobs.
-- **Integrations** — Lidarr, Last.fm, ListenBrainz, Koito, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
+- **Activity** — Queue, review, and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, and Aurral playlist jobs.
+- **Integrations** — Lidarr, Last.fm, ListenBrainz, Koito, yt-dlp, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
 - **Playback** — Stream through Navidrome (M3U playlists) or Plex/Plexamp (API-synced playlists) from a dedicated download folder.
 - **Multi-user** — Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, and reverse-proxy SSO.
 
@@ -57,7 +57,8 @@ Aurral only needs Lidarr to get started. It works best with the stack self-hoste
 | App or service                             | Role                                                        |
 | ------------------------------------------ | ----------------------------------------------------------- |
 | [Lidarr](https://github.com/Lidarr/Lidarr) | Library management, artist and album requests, queue status |
-| [slskd](https://github.com/slskd/slskd)    | Soulseek-backed downloads for flows and playlists           |
+| [yt-dlp](https://github.com/yt-dlp/yt-dlp) | Built-in YouTube/web fallback for flows and playlists       |
+| [slskd](https://github.com/slskd/slskd)    | Optional Soulseek-backed downloads for flows and playlists  |
 | [Navidrome](https://www.navidrome.org)     | Streaming and playback via generated M3U playlists          |
 
 ## Quick Start

--- a/V2.md
+++ b/V2.md
@@ -11,7 +11,7 @@ v2 is a major rewrite. Hundreds of improvements, but here is what you will actua
 | "Weekly Flow" everywhere                          | "Playlists" - flows still exist as the dynamic kind             |
 | Requests + Downloads + History pages              | One Activity page with Queue, Review, and History tabs          |
 | Settings as one long page                         | Tabbed settings with test-before-save on every integration      |
-| Custom Soulseek client built into Aurral          | You run slskd alongside Aurral, Aurral orchestrates it          |
+| Custom Soulseek client built into Aurral          | slskd, Usenet, and/or built-in yt-dlp — Aurral orchestrates them |
 | Spotify import = export CSV, convert, import JSON | In-app OAuth on the Playlists page, connect and pick a playlist |
 | Blocklist page                                    | Discovery feedback (thumbs-up/thumbs-down)                      |
 
@@ -27,8 +27,9 @@ v2 is a major rewrite. Hundreds of improvements, but here is what you will actua
 
 ### Downloads
 
+- **yt-dlp** - built-in YouTube/web fallback (no separate daemon; included in the Docker image). Works alone or after slskd/Usenet
 - **Usenet support** - Prowlarr + SABnzbd/NZBGet as an alternate or fallback download source
-- **Source priority** - Aurral tries sources in order (slskd first by default, or Usenet first if you swap)
+- **Source priority** - Aurral tries sources in order (slskd `10`, Usenet `20`, yt-dlp `50` by default; swap as you like)
 - **Track review** - optional approval step before downloaded tracks are finalized
 
 ### Discovery

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -78,6 +78,10 @@ export const defaultData = {
         priority: 20,
         addPaused: false,
       },
+      ytdlp: {
+        enabled: true,
+        priority: 50,
+      },
       ticketmaster: {
         apiKey: "",
         searchRadiusMiles: 250,

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -263,6 +263,7 @@ function buildBootstrapPayload(req) {
     nzbgetConfigured: downloadSources.usenet.nzbgetConfigured,
     sabnzbdConfigured: downloadSources.usenet.sabnzbdConfigured,
     usenetConfigured: downloadSources.usenet.configured,
+    ytdlpConfigured: downloadSources.ytdlp.configured,
     downloadSources,
     metadataProviders: getMetadataProviderHealthSnapshot(),
     localNetworkBypass,

--- a/backend/routes/settings/handlers/downloadClients.js
+++ b/backend/routes/settings/handlers/downloadClients.js
@@ -103,6 +103,28 @@ export function registerDownloadClients(router) {
     }
   });
 
+  router.post("/ytdlp/test", async (req, res) => {
+    try {
+      const { ytdlpClient } = await import("../../../services/ytdlpClient.js");
+      const result = await ytdlpClient.testConnection({ force: true });
+      if (!result.configured) {
+        return res.status(400).json(result);
+      }
+      if (!result.ok) {
+        return res.status(502).json(result);
+      }
+      return res.json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      return res.status(500).json({
+        error: "yt-dlp test failed",
+        message: error.message,
+      });
+    }
+  });
+
   router.post("/gotify/test", async (req, res) => {
     try {
       const { sendGotifyTest } =

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -233,6 +233,20 @@ export function registerGeneral(router) {
           ? Math.min(1000, Math.max(1, priority))
           : 10;
       }
+      if (integrations?.ytdlp) {
+        const nextYtdlp = {
+          ...(currentSettings.integrations?.ytdlp || {}),
+          ...integrations.ytdlp,
+        };
+        nextYtdlp.enabled = nextYtdlp.enabled !== false;
+        const priority = Number.parseInt(nextYtdlp.priority, 10);
+        nextYtdlp.priority = Number.isFinite(priority)
+          ? Math.min(1000, Math.max(1, priority))
+          : 50;
+        delete nextYtdlp.binaryPath;
+        delete nextYtdlp.audioFormat;
+        integrations.ytdlp = nextYtdlp;
+      }
       if (integrations?.navidrome) {
         integrations.navidrome.m3uPathMode = normalizeM3uPathMode(
           integrations.navidrome.m3uPathMode,
@@ -242,7 +256,7 @@ export function registerGeneral(router) {
         );
       }
 
-      const INTEGRATION_KEYS = ["lidarr", "navidrome", "slskd", "prowlarr", "nzbget", "lastfm", "ticketmaster", "metadata", "general", "gotify", "webhookEvents"];
+      const INTEGRATION_KEYS = ["lidarr", "navidrome", "slskd", "prowlarr", "nzbget", "ytdlp", "lastfm", "ticketmaster", "metadata", "general", "gotify", "webhookEvents"];
       let mergedIntegrations =
         currentSettings.integrations || defaultData.settings.integrations || {};
       if (integrations) {

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -225,7 +225,9 @@ export function registerJobs(router) {
     const deniedSourceKey =
       job.downloadSource === "usenet"
         ? String(job.releaseGuid || "").trim()
-        : `${String(job.remoteUsername || "").trim()}\0${String(job.remoteFilename || "").trim()}`;
+        : job.downloadSource === "ytdlp"
+          ? String(job.releaseGuid || "").trim()
+          : `${String(job.remoteUsername || "").trim()}\0${String(job.remoteFilename || "").trim()}`;
     if (job.downloadSource && deniedSourceKey) {
       downloadTracker.recordDeniedSource(job.id, job.downloadSource, deniedSourceKey);
     }

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -62,10 +62,16 @@ const resolveTrackDownloadHistorySource = (downloadSource, downloadClient) => {
     if (client === "sabnzbd") return "sabnzbd";
     return "nzbget";
   }
+  if (normalized === "ytdlp") return "ytdlp";
   return "slskd";
 };
 
-const CLIENT_LABELS = { sabnzbd: "SABnzbd", nzbget: "NZBGet", slskd: "slskd" };
+const CLIENT_LABELS = {
+  sabnzbd: "SABnzbd",
+  nzbget: "NZBGet",
+  slskd: "slskd",
+  ytdlp: "yt-dlp",
+};
 const resolveDownloadClientLabel = (downloadSource, downloadClient) =>
   CLIENT_LABELS[resolveTrackDownloadHistorySource(downloadSource, downloadClient)] || "slskd";
 

--- a/backend/services/downloadSourceService.js
+++ b/backend/services/downloadSourceService.js
@@ -3,10 +3,12 @@ import { slskdClient } from "./slskdClient.js";
 import { prowlarrClient } from "./prowlarrClient.js";
 import { nzbgetClient } from "./nzbgetClient.js";
 import { sabnzbdClient } from "./sabnzbdClient.js";
+import { ytdlpClient } from "./ytdlpClient.js";
 
 const SOURCE_LABELS = {
   slskd: "Soulseek",
   usenet: "Usenet",
+  ytdlp: "yt-dlp",
 };
 
 function normalizePriority(value, fallback) {
@@ -37,12 +39,18 @@ function getUsenetPriority() {
   return normalizePriority(integrations.nzbget?.priority, 20);
 }
 
+function getYtdlpPriority() {
+  const ytdlp = getIntegrations().ytdlp || {};
+  return normalizePriority(ytdlp.priority, 50);
+}
+
 export function getDownloadSourceStatus() {
   const slskdConfigured = isSlskdEnabled() && slskdClient.isConfigured();
   const prowlarrConfigured = prowlarrClient.isConfigured();
   const nzbgetConfigured = nzbgetClient.isConfigured();
   const sabnzbdConfigured = sabnzbdClient.isConfigured();
   const usenetConfigured = prowlarrConfigured && (nzbgetConfigured || sabnzbdConfigured);
+  const ytdlpConfigured = ytdlpClient.isConfigured();
   return {
     slskd: {
       id: "slskd",
@@ -61,6 +69,13 @@ export function getDownloadSourceStatus() {
       nzbgetConfigured,
       sabnzbdConfigured,
     },
+    ytdlp: {
+      id: "ytdlp",
+      label: SOURCE_LABELS.ytdlp,
+      enabled: ytdlpClient.isEnabled(),
+      configured: ytdlpConfigured,
+      priority: getYtdlpPriority(),
+    },
   };
 }
 
@@ -69,6 +84,7 @@ export function getEnabledDownloadSources() {
   const sources = [];
   if (status.slskd.configured) sources.push(status.slskd);
   if (status.usenet.configured) sources.push(status.usenet);
+  if (status.ytdlp.configured) sources.push(status.ytdlp);
   return sources.sort((left, right) => {
     if (left.priority !== right.priority) return left.priority - right.priority;
     return left.id.localeCompare(right.id);
@@ -84,6 +100,7 @@ export function getDownloadSourceNotConfiguredMessage() {
   const pieces = [];
   if (!status.slskd.configured) pieces.push("slskd");
   if (!status.usenet.configured) pieces.push("Prowlarr + NZBGet or SABnzbd");
+  if (!status.ytdlp.configured) pieces.push("yt-dlp");
   return `No download source is configured. Configure ${pieces.join(" or ")} in Settings > Integrations to enable downloads for flows and playlists.`;
 }
 

--- a/backend/services/slskdOrchestrator.js
+++ b/backend/services/slskdOrchestrator.js
@@ -18,6 +18,7 @@ import {
   recordSlskdTransferOutcome,
 } from "./slskdTransferHistory.js";
 import { processUsenetPipelinePayload } from "./usenetOrchestrator.js";
+import { processYtdlpPipelinePayload } from "./ytdlpOrchestrator.js";
 import {
   getDownloadSourceNotConfiguredMessage,
   getEnabledDownloadSources,
@@ -319,6 +320,7 @@ function buildNextSourcePayload(payload, failedSource = null, reason = null) {
     legacyTransfer: null,
     nzbId: null,
     history: null,
+    downloadedPath: null,
     triedSources: [...tried],
     sourceErrors,
   };
@@ -1101,6 +1103,13 @@ export async function processPipelinePayload(payload) {
       return job ? failOrTryNextSource(payload, job, "Usenet is not configured") : null;
     }
     return processUsenetPipelinePayload(payload, { failOrTryNextSource });
+  }
+  if (payload.source === "ytdlp") {
+    if (!isSourceConfigured("ytdlp")) {
+      const job = downloadTracker.getJob(payload.jobId);
+      return job ? failOrTryNextSource(payload, job, "yt-dlp is not configured") : null;
+    }
+    return processYtdlpPipelinePayload(payload, { failOrTryNextSource });
   }
   if (payload.source !== "slskd") {
     const job = downloadTracker.getJob(payload.jobId);

--- a/backend/services/weeklyFlow/weeklyFlowOperationQueue.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperationQueue.js
@@ -1,6 +1,5 @@
 import { enqueueWeeklyFlowOperationJob, getHonkerQueueDepth } from "../honkerDb.js";
 
-let workerRunning = false;
 let workerCurrentLabel = null;
 
 class WeeklyFlowOperationQueue {
@@ -15,7 +14,7 @@ class WeeklyFlowOperationQueue {
       pending = getHonkerQueueDepth("weekly-flow-operation");
     } catch {}
     return {
-      processing: workerRunning,
+      processing: Boolean(workerCurrentLabel) || pending > 0,
       pending,
       durablePending: 0,
       currentLabel: workerCurrentLabel,
@@ -24,10 +23,8 @@ class WeeklyFlowOperationQueue {
 }
 
 export function setWeeklyFlowOperationWorkerState({
-  running = false,
   currentLabel = null,
 } = {}) {
-  workerRunning = running === true;
   workerCurrentLabel =
     currentLabel == null ? null : String(currentLabel).trim() || null;
 }

--- a/backend/services/weeklyFlow/weeklyFlowOperationWorker.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperationWorker.js
@@ -3,13 +3,16 @@ import { getWeeklyFlowOperationQueue } from "../honkerDb.js";
 import { processWeeklyFlowOperation } from "./weeklyFlowOperations.js";
 import { setWeeklyFlowOperationWorkerState } from "./weeklyFlowOperationQueue.js";
 
-const PERMANENT_ERROR_CODES = new Set(["SHARED_PLAYLIST_NAME_CONFLICT", "FLOW_NAME_CONFLICT"]);
+const PERMANENT_ERROR_CODES = new Set([
+  "SHARED_PLAYLIST_NAME_CONFLICT",
+  "FLOW_NAME_CONFLICT",
+  "NO_DOWNLOAD_SOURCE",
+]);
 
 let currentLabel = null;
 
-function syncWorkerState(running) {
+function syncWorkerState() {
   setWeeklyFlowOperationWorkerState({
-    running,
     currentLabel,
   });
 }
@@ -23,15 +26,15 @@ const worker = createHonkerWorker({
   maxAttempts: 3,
   onJobDequeue(payload) {
     currentLabel = payload?.label || payload?.kind || null;
-    syncWorkerState(true);
+    syncWorkerState();
   },
   onJobSuccess() {
     currentLabel = null;
-    syncWorkerState(worker.isRunning());
+    syncWorkerState();
   },
   onJobError() {
     currentLabel = null;
-    syncWorkerState(worker.isRunning());
+    syncWorkerState();
   },
   resolveRetry(error, job) {
     const message = error?.message || String(error);

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -20,7 +20,10 @@ import {
 } from "./weeklyFlowFileReuse.js";
 import { downloadTracker } from "./weeklyFlowDownloadTracker.js";
 import { playlistManager } from "./weeklyFlowPlaylistManager.js";
-import { slskdClient } from "../slskdClient.js";
+import {
+  getDownloadSourceNotConfiguredMessage,
+  isAnyDownloadSourceConfigured,
+} from "../downloadSourceService.js";
 import { weeklyFlowWorker } from "./weeklyFlowWorker.js";
 import {
   restartWorkerIfPending,
@@ -33,8 +36,6 @@ import { schedulePlaylistMbidEnrichment } from "../playlistMbidEnrichmentService
 
 const DEFAULT_LIMIT = 30;
 const OPERATION_TOKENS_KEY = "weeklyFlowOperationTokens";
-const SLSKD_NOT_CONFIGURED_MESSAGE =
-  "slskd is not configured. Add your slskd URL and API key in Settings > Integrations to enable Soulseek downloads for flows and playlists.";
 
 export function createWeeklyFlowOperationToken() {
   return `${Date.now()}-${randomUUID()}`;
@@ -268,8 +269,10 @@ async function runFlowSeed({
   if (!isLatestWeeklyFlowOperationToken(tokenScope, token)) {
     return { cancelled: true };
   }
-  if (!slskdClient.isConfigured()) {
-    throw new Error(SLSKD_NOT_CONFIGURED_MESSAGE);
+  if (!isAnyDownloadSourceConfigured()) {
+    const error = new Error(getDownloadSourceNotConfiguredMessage());
+    error.code = "NO_DOWNLOAD_SOURCE";
+    throw error;
   }
   const flow = flowPlaylistConfig.getFlow(safeFlowId);
   if (!flow) return { missing: true };

--- a/backend/services/weeklyFlow/weeklyFlowScheduler.js
+++ b/backend/services/weeklyFlow/weeklyFlowScheduler.js
@@ -1,7 +1,7 @@
 import { downloadTracker } from "./weeklyFlowDownloadTracker.js";
 import { weeklyFlowWorker } from "./weeklyFlowWorker.js";
 import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
-import { slskdClient } from "../slskdClient.js";
+import { isAnyDownloadSourceConfigured } from "../downloadSourceService.js";
 import { weeklyFlowOperationQueue } from "./weeklyFlowOperationQueue.js";
 import {
   createWeeklyFlowOperationToken,
@@ -9,7 +9,7 @@ import {
 } from "./weeklyFlowOperations.js";
 
 export async function runScheduledRefresh() {
-  if (!slskdClient.isConfigured()) return;
+  if (!isAnyDownloadSourceConfigured()) return;
 
   const due = flowPlaylistConfig.getDueForRefresh();
   if (due.length === 0) return;

--- a/backend/services/weeklyFlow/weeklyFlowYtdlpMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowYtdlpMatcher.js
@@ -1,0 +1,147 @@
+import {
+  normalizeReleaseText as normalizeText,
+  scoreTextMatch,
+} from "../providers/brainzmashRanking.js";
+
+const MAX_CANDIDATES = 5;
+const REJECT_PATTERNS =
+  /\b(karaoke|instrumental|cover|nightcore|sped up|slowed|8d audio|10 hour|10hr|hours? long|full album|discography|reaction|tutorial|lesson|remix|mashup|live performance|concert|fan.?made)\b/i;
+const PREFER_PATTERNS =
+  /\b(official audio|official video|official lyric|topic|audio)\b/i;
+
+function readContext(context) {
+  return {
+    trackName: String(context?.trackName || context?.title || "").trim(),
+    artistName: String(context?.artistName || context?.artist || "").trim(),
+    albumName: String(context?.albumName || context?.album || "").trim(),
+    durationMs: Number(context?.durationMs || 0),
+  };
+}
+
+function scoreDuration(durationSec, expectedMs) {
+  if (!Number.isFinite(expectedMs) || expectedMs <= 0) return { ok: true, score: 0 };
+  if (!Number.isFinite(durationSec) || durationSec <= 0) return { ok: true, score: -8 };
+  const diff = Math.abs(durationSec * 1000 - expectedMs);
+  const ok =
+    diff <= 25000 || diff <= Math.max(12000, expectedMs * 0.18);
+  if (!ok) return { ok: false, score: -40 };
+  if (diff <= 5000) return { ok: true, score: 25 };
+  if (diff <= 12000) return { ok: true, score: 18 };
+  if (diff <= 25000) return { ok: true, score: 10 };
+  return { ok: true, score: 0 };
+}
+
+function scoreNoise(title, channel) {
+  let score = 0;
+  if (PREFER_PATTERNS.test(`${title} ${channel}`)) score += 12;
+  if (/\btopic\b/i.test(channel)) score += 18;
+  if (/\bofficial\b/i.test(channel)) score += 8;
+  return score;
+}
+
+export function buildYtdlpSearchQueries(context) {
+  const ctx = readContext(context);
+  if (!ctx.trackName) return [];
+  const queries = [];
+  if (ctx.artistName) {
+    queries.push(`${ctx.artistName} ${ctx.trackName}`);
+    queries.push(`${ctx.artistName} ${ctx.trackName} official audio`);
+  } else {
+    queries.push(ctx.trackName);
+  }
+  const seen = new Set();
+  return queries.filter((query) => {
+    const key = normalizeText(query);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function rankYtdlpResults(results, context) {
+  const ctx = readContext(context);
+  const ranked = [];
+  for (const result of Array.isArray(results) ? results : []) {
+    const title = String(result?.title || "").trim();
+    const channel = String(result?.channel || "").trim();
+    const id = String(result?.id || "").trim();
+    if (!id || !title) continue;
+    if (String(result?.liveStatus || "").includes("live")) continue;
+    if (REJECT_PATTERNS.test(`${title} ${channel}`)) continue;
+    const duration = scoreDuration(result.durationSec, ctx.durationMs);
+    if (!duration.ok) continue;
+
+    const titleScore = Math.max(
+      scoreTextMatch(title, ctx.trackName),
+      scoreTextMatch(title, `${ctx.artistName} ${ctx.trackName}`),
+    );
+    const artistScore = Math.max(
+      scoreTextMatch(title, ctx.artistName),
+      scoreTextMatch(channel, ctx.artistName),
+    );
+    const noiseScore = scoreNoise(title, channel);
+    if (titleScore < 40 || artistScore < 25) continue;
+    ranked.push({
+      raw: {
+        id,
+        title,
+        url: result.url,
+        channel,
+        durationSec: result.durationSec,
+        file: title,
+      },
+      score: titleScore + artistScore + duration.score + noiseScore,
+      scores: {
+        title: titleScore,
+        artist: artistScore,
+        duration: duration.score,
+        noise: noiseScore,
+      },
+      resolvedAlbumName: ctx.albumName || null,
+      preDownloadValid:
+        titleScore >= 55 &&
+        artistScore >= 40 &&
+        duration.score >= -8 &&
+        noiseScore >= -20,
+    });
+  }
+  ranked.sort((left, right) => right.score - left.score);
+  return ranked.slice(0, MAX_CANDIDATES);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("weeklyFlowYtdlpMatcher.js")) {
+  const ranked = rankYtdlpResults(
+    [
+      {
+        id: "good",
+        title: "Daft Punk - Get Lucky (Official Audio)",
+        channel: "Daft Punk",
+        durationSec: 248,
+        url: "https://www.youtube.com/watch?v=good",
+      },
+      {
+        id: "bad",
+        title: "Get Lucky karaoke version",
+        channel: "Random",
+        durationSec: 248,
+        url: "https://www.youtube.com/watch?v=bad",
+      },
+      {
+        id: "long",
+        title: "Daft Punk Get Lucky 10 hour",
+        channel: "Loops",
+        durationSec: 36000,
+        url: "https://www.youtube.com/watch?v=long",
+      },
+    ],
+    {
+      artistName: "Daft Punk",
+      trackName: "Get Lucky",
+      durationMs: 248000,
+    },
+  );
+  console.assert(ranked[0]?.raw?.id === "good", "preferred official audio");
+  console.assert(!ranked.some((entry) => entry.raw.id === "long"), "reject long junk");
+  console.assert(!ranked.some((entry) => entry.raw.id === "bad"), "reject karaoke");
+  console.log("weeklyFlowYtdlpMatcher self-check ok");
+}

--- a/backend/services/ytdlpClient.js
+++ b/backend/services/ytdlpClient.js
@@ -1,0 +1,206 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import fsPromises from "fs/promises";
+import path from "path";
+import { dbOps } from "../db/helpers/index.js";
+import { resolvePlaylistRoot } from "./playlistPaths.js";
+
+const DEFAULT_BINARY = "yt-dlp";
+const SEARCH_LIMIT = 5;
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+const AUDIO_FORMAT = "m4a";
+
+function getSettings() {
+  return dbOps.getSettings()?.integrations?.ytdlp || {};
+}
+
+function getBinaryPath() {
+  return DEFAULT_BINARY;
+}
+
+export function isYtdlpEnabled() {
+  return getSettings().enabled !== false;
+}
+
+function resolveBinaryExists(binary) {
+  const candidates = path.isAbsolute(binary)
+    ? [binary]
+    : String(process.env.PATH || "")
+        .split(path.delimiter)
+        .filter(Boolean)
+        .map((dir) => path.join(dir, binary));
+  return candidates.some((candidate) => {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function isConfigured() {
+  return isYtdlpEnabled() && resolveBinaryExists(getBinaryPath());
+}
+
+function runYtdlp(args, { timeoutMs = 120000, cwd } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(getBinaryPath(), args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`yt-dlp timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        const detail = String(stderr || stdout || "").trim().slice(-500);
+        reject(new Error(detail || `yt-dlp exited with code ${code}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+export async function testConnection({ force: _force = false } = {}) {
+  if (!isYtdlpEnabled()) {
+    return { configured: false, ok: false, message: "yt-dlp is disabled" };
+  }
+  const binary = getBinaryPath();
+  if (!resolveBinaryExists(binary)) {
+    return {
+      configured: false,
+      ok: false,
+      message: `yt-dlp binary not found (${binary}). Install yt-dlp and ffmpeg.`,
+    };
+  }
+  try {
+    const { stdout } = await runYtdlp(["--version"], { timeoutMs: 15000 });
+    const version = String(stdout || "").trim().split(/\s+/)[0] || "ok";
+    return { configured: true, ok: true, version, message: `yt-dlp ${version}` };
+  } catch (error) {
+    return { configured: true, ok: false, message: error?.message || String(error) };
+  }
+}
+
+export async function search(query, { limit = SEARCH_LIMIT } = {}) {
+  const trimmed = String(query || "").trim();
+  if (!trimmed) return [];
+  const capped = Math.min(Math.max(Number(limit) || SEARCH_LIMIT, 1), 10);
+  const { stdout } = await runYtdlp(
+    [
+      "--flat-playlist",
+      "--dump-json",
+      "--no-download",
+      "--no-warnings",
+      `ytsearch${capped}:${trimmed}`,
+    ],
+    { timeoutMs: 60000 },
+  );
+  const results = [];
+  for (const line of String(stdout || "").split("\n")) {
+    const raw = line.trim();
+    if (!raw) continue;
+    try {
+      const entry = JSON.parse(raw);
+      const id = String(entry.id || entry.url || "").trim();
+      if (!id) continue;
+      results.push({
+        id,
+        title: String(entry.title || "").trim(),
+        url:
+          String(entry.webpage_url || entry.url || "").trim() ||
+          `https://www.youtube.com/watch?v=${id}`,
+        channel: String(entry.channel || entry.uploader || "").trim(),
+        durationSec:
+          Number.isFinite(Number(entry.duration)) && Number(entry.duration) > 0
+            ? Number(entry.duration)
+            : null,
+        liveStatus: String(entry.live_status || "").trim().toLowerCase(),
+      });
+    } catch {
+    }
+  }
+  return results;
+}
+
+function resolveStagingDir(jobId) {
+  return path.join(resolvePlaylistRoot(), ".ytdlp-staging", String(jobId || "unknown"));
+}
+
+async function findDownloadedAudio(dir) {
+  const entries = await fsPromises.readdir(dir).catch(() => []);
+  const audioExt = new Set([".m4a", ".mp3", ".opus", ".flac", ".ogg", ".webm", ".wav"]);
+  for (const name of entries) {
+    const full = path.join(dir, name);
+    if (!audioExt.has(path.extname(name).toLowerCase())) continue;
+    const stat = await fsPromises.stat(full).catch(() => null);
+    if (stat?.isFile() && stat.size > 0) return full;
+  }
+  return null;
+}
+
+export async function downloadAudio(videoUrl, { jobId } = {}) {
+  const url = String(videoUrl || "").trim();
+  if (!url) throw new Error("Missing yt-dlp download URL");
+  const stagingDir = resolveStagingDir(jobId);
+  await fsPromises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+  await fsPromises.mkdir(stagingDir, { recursive: true });
+  const outTemplate = path.join(stagingDir, "%(id)s.%(ext)s");
+  try {
+    await runYtdlp(
+      [
+        "--no-playlist",
+        "--no-warnings",
+        "-x",
+        "--audio-format",
+        AUDIO_FORMAT,
+        "--audio-quality",
+        "0",
+        "-o",
+        outTemplate,
+        "--",
+        url,
+      ],
+      { timeoutMs: DOWNLOAD_TIMEOUT_MS, cwd: stagingDir },
+    );
+  } catch (error) {
+    await fsPromises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+  const filePath = await findDownloadedAudio(stagingDir);
+  if (!filePath) {
+    await fsPromises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+    throw new Error("yt-dlp finished without an audio file");
+  }
+  return { filePath, stagingDir };
+}
+
+export async function cleanupStaging(jobId) {
+  await fsPromises.rm(resolveStagingDir(jobId), { recursive: true, force: true }).catch(() => {});
+}
+
+export const ytdlpClient = {
+  isConfigured,
+  isEnabled: isYtdlpEnabled,
+  testConnection,
+  search,
+  downloadAudio,
+  cleanupStaging,
+};

--- a/backend/services/ytdlpOrchestrator.js
+++ b/backend/services/ytdlpOrchestrator.js
@@ -1,0 +1,222 @@
+import path from "path";
+import fs from "fs/promises";
+import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
+import { ytdlpClient } from "./ytdlpClient.js";
+import { logger } from "./logger.js";
+import { validateDownloadedTrack } from "./weeklyFlow/weeklyFlowSoulseekMatcher.js";
+import {
+  buildYtdlpSearchQueries,
+  rankYtdlpResults,
+} from "./weeklyFlow/weeklyFlowYtdlpMatcher.js";
+import { resolvePlaylistRoot } from "./playlistPaths.js";
+import {
+  buildResolvedPlaylistTrack as buildResolvedTrack,
+  commitImportToPlaylistLibrary,
+  joinUnderRoot,
+  sanitizePathPart,
+} from "./playlistDownloadUtils.js";
+import {
+  getPayloadCandidate,
+  hasNextCandidate,
+  buildNextCandidatePayload,
+  mergeSearchResults,
+  finalizePipelineJobSuccess,
+} from "./pipelineHelpers.js";
+
+function hasEnoughCandidates(aggregated, resolvedTrack) {
+  return rankYtdlpResults(aggregated, resolvedTrack).some((entry) => entry.preDownloadValid);
+}
+
+async function handleYtdlpSearch(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  downloadTracker.setDownloading(job.id);
+  downloadTracker.updateDownloadMetadata(job.id, {
+    downloadSource: "ytdlp",
+    downloadClient: "ytdlp",
+  });
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobSearching }) => recordTrackJobSearching(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+
+  const resolvedTrack = buildResolvedTrack(job, payload.track);
+  const queries = buildYtdlpSearchQueries(resolvedTrack);
+  const aggregated = [];
+  const seen = new Set();
+  let lastError = "";
+  for (const query of queries) {
+    if (hasEnoughCandidates(aggregated, resolvedTrack)) break;
+    try {
+      const results = await ytdlpClient.search(query, { limit: 5 });
+      mergeSearchResults(aggregated, seen, results, (entry) =>
+        String(entry.id || entry.url || "").trim().toLowerCase(),
+      );
+    } catch (error) {
+      lastError = error?.message || String(error);
+      logger.warn("ytdlp", "yt-dlp search failed", {
+        jobId: job.id,
+        query,
+        error: lastError,
+      });
+    }
+  }
+
+  const ranked = rankYtdlpResults(aggregated, resolvedTrack);
+  const deniedIds = new Set(
+    (Array.isArray(job.deniedRemoteSources) ? job.deniedRemoteSources : [])
+      .filter((entry) => Array.isArray(entry) && entry[0] === "ytdlp")
+      .map((entry) => String(entry[1] || "").trim()),
+  );
+  const candidates =
+    deniedIds.size > 0
+      ? ranked.filter((entry) => !deniedIds.has(String(entry?.raw?.id || "").trim()))
+      : ranked;
+  if (candidates.length === 0) {
+    const message =
+      lastError && aggregated.length === 0
+        ? `yt-dlp search failed: ${lastError}`
+        : "No suitable yt-dlp search results";
+    return helpers.failOrTryNextSource(payload, job, message, {
+      queryCount: queries.length,
+      rawResultCount: aggregated.length,
+      rankedCount: ranked.length,
+    });
+  }
+  return {
+    ...payload,
+    phase: "download",
+    source: "ytdlp",
+    candidates,
+    candidateIndex: 0,
+    resolvedTrack,
+  };
+}
+
+async function handleYtdlpDownload(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+  const index = Number(payload.candidateIndex || 0);
+  const candidate = candidates[index];
+  const url = candidate?.raw?.url;
+  if (!url) {
+    return helpers.failOrTryNextSource(payload, job, "No yt-dlp video URL available");
+  }
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobDownloading }) => recordTrackJobDownloading(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+
+  let downloaded;
+  try {
+    downloaded = await ytdlpClient.downloadAudio(url, { jobId: job.id });
+  } catch (error) {
+    const message = error?.message || String(error);
+    logger.warn("ytdlp", "yt-dlp download failed", {
+      jobId: job.id,
+      url,
+      error: message,
+    });
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { downloadedPath: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, message);
+  }
+
+  downloadTracker.updateDownloadMetadata(job.id, {
+    downloadSource: "ytdlp",
+    downloadClient: "ytdlp",
+    releaseGuid: candidate.raw.id,
+    releaseTitle: candidate.raw.title,
+    remoteUsername: candidate.raw.channel,
+    remoteFilename: candidate.raw.title,
+  });
+
+  return {
+    ...payload,
+    phase: "finalize",
+    source: "ytdlp",
+    candidate,
+    candidateIndex: index,
+    downloadedPath: downloaded.filePath,
+  };
+}
+
+async function handleYtdlpFinalize(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  const candidate = getPayloadCandidate(payload);
+  const resolvedTrack = buildResolvedTrack(job, payload.track);
+  const filePath = String(payload.downloadedPath || "").trim();
+  if (!filePath) {
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { downloadedPath: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, "yt-dlp download missing output file");
+  }
+
+  const validation = await validateDownloadedTrack(
+    filePath,
+    {
+      ...candidate,
+      raw: {
+        ...(candidate?.raw || {}),
+        file: candidate?.raw?.title || filePath,
+      },
+    },
+    resolvedTrack,
+  );
+  if (!validation.valid) {
+    await fs.rm(filePath, { force: true }).catch(() => {});
+    await ytdlpClient.cleanupStaging(job.id);
+    const reason = validation.reason || "yt-dlp download failed track validation";
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { downloadedPath: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, reason);
+  }
+
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobMoving }) => recordTrackJobMoving(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+  const playlistRoot = resolvePlaylistRoot();
+  const destination = String(payload.destination || "").trim();
+  const ext = path.extname(filePath).toLowerCase();
+  const finalDir = joinUnderRoot(playlistRoot, destination);
+  const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".m4a"}`;
+  const finalPath = path.join(finalDir, finalName);
+  const committedFinalPath = await commitImportToPlaylistLibrary(filePath, finalPath);
+  await ytdlpClient.cleanupStaging(job.id);
+  return finalizePipelineJobSuccess({
+    downloadTracker,
+    job,
+    committedFinalPath,
+    album: candidate?.resolvedAlbumName || job.albumName,
+  });
+}
+
+export async function processYtdlpPipelinePayload(payload, helpers = {}) {
+  logger.debug("ytdlp", "ytdlp pipeline phase", {
+    phase: payload.phase,
+    jobId: payload.jobId,
+    source: payload.source,
+  });
+  switch (payload.phase) {
+    case "search":
+      return handleYtdlpSearch(payload, helpers);
+    case "download":
+      return handleYtdlpDownload(payload, helpers);
+    case "finalize":
+      return handleYtdlpFinalize(payload, helpers);
+    default:
+      throw new Error(`Unknown yt-dlp pipeline phase: ${payload.phase}`);
+  }
+}

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -94,6 +94,7 @@ export default defineConfig({
             { slug: "integrations/lastfm" },
             { slug: "integrations/koito" },
             { slug: "integrations/slskd" },
+            { slug: "integrations/ytdlp" },
             { slug: "integrations/usenet" },
             { slug: "integrations/navidrome" },
             { slug: "integrations/plex" },

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -17,7 +17,8 @@ description: Common setup and runtime issues.
 
 ## Playlists are not downloading
 
-- Confirm at least one download client is configured in **Settings → Download Clients** and/or an indexer in **Settings → Indexers** (slskd and/or Prowlarr + SABnzbd/NZBGet).
+- Confirm at least one download client is configured in **Settings → Download Clients** and/or an indexer in **Settings → Indexers** (yt-dlp, slskd, and/or Prowlarr + SABnzbd/NZBGet).
+- For yt-dlp: **Test connection** and confirm `yt-dlp` plus ffmpeg are installed (included in the Docker image).
 - For slskd: check connection and Soulseek login status.
 - For Usenet: confirm Prowlarr indexers are enabled and the download client can reach completed files.
 - Try disabling **Strict format only** on the slskd card, or switch preferred format to MP3 if FLAC matches are scarce.

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -22,7 +22,7 @@ After onboarding, check these areas:
 - **Settings → Lidarr** — quality profile, tag, monitoring option, and search-on-add behavior.
 - **Settings → Playback → Plex** — optional; connect after onboarding ([Plex setup](/integrations/plex/)).
 - **Settings → Discover** — Last.fm API key, refresh cadence, and discovery mode (Safer, Balanced, or Deeper).
-- **Settings → Download Clients** and **Settings → Indexers** — slskd and/or Prowlarr + SABnzbd/NZBGet for flow and playlist downloads.
+- **Settings → Download Clients** and **Settings → Indexers** — yt-dlp (default), slskd, and/or Prowlarr + SABnzbd/NZBGet for flow and playlist downloads.
 - **Profile** — your listening-history provider (Last.fm or ListenBrainz username, or Koito instance URL).
 
 ## Per-user setup

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -28,7 +28,7 @@ Every service mounts the same media root at `/data` inside the container.
 | slskd     | `/data:/data`    | Downloads `/data/downloads/slskd/complete`      |
 | NZBGet    | `/data:/data`    | Completed `/data/downloads/nzbget/completed`    |
 | SABnzbd   | `/data:/data`    | Completed per SABnzbd config                    |
-| Aurral    | `/data:/data`    | `DOWNLOAD_FOLDER=/data/downloads/aurral`        |
+| Aurral    | `/data:/data`    | `DOWNLOAD_FOLDER=/data/downloads/aurral` (yt-dlp needs no extra mount) |
 | Navidrome | `/data:/data:ro` | Scan `/data/music` and `/data/downloads/aurral` |
 | Plex      | `/data:/data`    | Read `/data/downloads/aurral/aurral-weekly-flow`|
 

--- a/docs/src/content/docs/guides/self-hosting.mdx
+++ b/docs/src/content/docs/guides/self-hosting.mdx
@@ -22,7 +22,8 @@ Self-hosting music works best when each tool has a narrow job.
 | [Lidarr](https://github.com/Lidarr/Lidarr)        | Artists, albums, metadata, imports, and long-term library state         |
 | [Aurral](https://aurral.org)                      | Discovery, flows, imported playlists, and Lidarr adds                   |
 | [Navidrome](https://www.navidrome.org)            | Main library and Aurral-generated playback over Subsonic                |
-| [slskd](https://github.com/slskd/slskd)           | Soulseek client used by Aurral for flow and playlist downloads          |
+| [yt-dlp](https://github.com/yt-dlp/yt-dlp)         | Built-in YouTube/web fallback for Aurral flow and playlist downloads    |
+| [slskd](https://github.com/slskd/slskd)           | Optional Soulseek client for Aurral flow and playlist downloads         |
 | [Tubifarry](https://github.com/TypNull/Tubifarry) | Optional Lidarr plugin for Soulseek-backed **album** searches in Lidarr |
 | [Amperfy](https://github.com/BLeeEZ/amperfy)      | Native-feeling iOS playback against Navidrome                           |
 | [Tailscale](https://tailscale.com)                | Private remote access without exposing admin tools publicly             |
@@ -32,9 +33,9 @@ Self-hosting music works best when each tool has a narrow job.
 Keep these separate in your head:
 
 1. **Library albums** — Lidarr (optionally with Tubifarry + slskd as indexer and download client) pulls full albums into `/data/music`.
-2. **Flows and playlists** — Aurral talks to slskd directly, picks candidates, and moves completed files into `DOWNLOAD_FOLDER` under `aurral-weekly-flow/`.
+2. **Flows and playlists** — Aurral downloads via yt-dlp, slskd, and/or Usenet, then writes completed files into `DOWNLOAD_FOLDER` under `aurral-weekly-flow/`.
 
-Aurral does not route flow downloads through Lidarr. Lidarr and Aurral can both use the same slskd instance, but they serve different jobs.
+Aurral does not route flow downloads through Lidarr. Lidarr and Aurral can share the same slskd instance when you use Soulseek, but they serve different jobs.
 
 :::note
 Tubifarry requires [Lidarr nightly](https://github.com/Lidarr/Lidarr) for plugin support. Aurral itself works with stable Lidarr — nightly is only needed if you want the Tubifarry plugin path for album acquisition.
@@ -82,10 +83,11 @@ If you want Soulseek-backed **album** downloads inside Lidarr:
 
 For **Aurral flows and playlists**, connect download clients in **Settings → Download Clients**:
 
+- **yt-dlp** for YouTube/web fallback — enabled by default when `yt-dlp` and ffmpeg are available. No separate daemon. See [yt-dlp](/integrations/ytdlp/).
 - **slskd** for Soulseek — Aurral sends searches, selects the best candidate, and moves completed files from slskd's download directory into your `DOWNLOAD_FOLDER`.
 - **Prowlarr + SABnzbd/NZBGet** for Usenet — Aurral searches indexers via Prowlarr, queues NZBs in the download client, and imports completed files the same way. See [Usenet](/integrations/usenet/).
 
-You can run both and set **source priority** so Aurral falls back when one source fails.
+You can run any combination and set **source priority** so Aurral falls back when one source fails.
 
 ### Aurral and slskd are separate from Lidarr album downloads
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,12 +42,12 @@ Use this page as a starting point for setup, day-to-day use, integrations, and a
     playback. [Read Playlists](/using/playlists/)
   </Card>
   <Card title="Activity" icon="document">
-    Queue and history for Lidarr requests, slskd and Usenet downloads, and Aurral playlist jobs.
-    [Read Activity](/using/activity/)
+    Queue and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, and Aurral playlist
+    jobs. [Read Activity](/using/activity/)
   </Card>
   <Card title="Integrations" icon="setting">
-    Lidarr, Last.fm, ListenBrainz, Koito, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster,
-    Gotify, and webhooks. [Read integrations](/integrations/lidarr/)
+    Lidarr, Last.fm, ListenBrainz, Koito, yt-dlp, slskd, SABnzbd/NZBGet, Navidrome, Plex,
+    Ticketmaster, Gotify, and webhooks. [Read integrations](/integrations/lidarr/)
   </Card>
   <Card title="Administration" icon="document">
     Storage, users, environment variables, troubleshooting, and operational details. [Read
@@ -64,6 +64,7 @@ Use this page as a starting point for setup, day-to-day use, integrations, and a
 | ListenBrainz          | Optional per-user listening history                         | No                     |
 | Koito                 | Self-hosted per-user listening history                      | No                     |
 | slskd                 | Soulseek-backed downloads for flows and playlists           | For Soulseek downloads |
+| yt-dlp                | YouTube/web fallback downloads for flows and playlists      | Default when installed |
 | Prowlarr + SABnzbd/NZBGet | Usenet-backed downloads for flows and playlists          | For Usenet downloads   |
 | Navidrome             | Streaming generated playlists (M3U)                         | No                     |
 | Plex                  | Flow playlists in Plexamp                                   | No                     |

--- a/docs/src/content/docs/integrations/slskd.mdx
+++ b/docs/src/content/docs/integrations/slskd.mdx
@@ -27,4 +27,4 @@ Open the **slskd** card in **Settings → Download Clients** to configure:
 
 ## Download fallback
 
-When Usenet is also configured, Aurral tries sources in priority order. If slskd fails, Aurral can fall back to Usenet automatically. See [Usenet](/integrations/usenet/#download-source-priority-and-fallback).
+When Usenet or yt-dlp is also configured, Aurral tries sources in priority order. If slskd fails, Aurral can fall back automatically. See [Usenet](/integrations/usenet/#download-source-priority-and-fallback) and [yt-dlp](/integrations/ytdlp/).

--- a/docs/src/content/docs/integrations/usenet.mdx
+++ b/docs/src/content/docs/integrations/usenet.mdx
@@ -57,9 +57,9 @@ If NZBGet runs on Windows and reports host paths, mount the parent folder into A
 
 ## Download source priority and fallback
 
-Aurral can run slskd and Usenet at the same time. Each client has a **source priority** — lower numbers are tried first.
+Aurral can run slskd, Usenet, and yt-dlp at the same time. Each source has a **source priority** — lower numbers are tried first.
 
-When a source fails or exhausts its candidates, Aurral automatically tries the next configured source for the same track. Swap priorities if you want Usenet first.
+When a source fails or exhausts its candidates, Aurral automatically tries the next configured source for the same track. Swap priorities if you want Usenet or yt-dlp first.
 
 ## History
 

--- a/docs/src/content/docs/integrations/ytdlp.mdx
+++ b/docs/src/content/docs/integrations/ytdlp.mdx
@@ -1,0 +1,27 @@
+---
+title: yt-dlp
+description: YouTube and web-backed downloads for flows and playlists.
+---
+
+yt-dlp is Aurral's built-in fallback download source. It searches YouTube for artist and title matches, extracts audio with ffmpeg, then imports into your `DOWNLOAD_FOLDER`.
+
+No separate daemon is required. The Docker image includes `yt-dlp` and `ffmpeg`. On bare metal, install both on the host and keep `yt-dlp` on `PATH`.
+
+## Setup
+
+1. Open **Settings → Download Clients → yt-dlp**.
+2. Leave **Enable yt-dlp** on (default).
+3. Optionally set **Source priority** (default `50`; slskd is `10`, Usenet is `20`).
+4. **Test connection**, then save.
+
+## Behavior
+
+Aurral tries download sources in priority order. With defaults, slskd and Usenet run first when configured; yt-dlp fills gaps or works alone when nothing else is set up.
+
+Results are ranked by title, artist, duration, and noise filters (karaoke, live loops, and similar junk are skipped). Downloaded audio still passes the same track validation used by other sources.
+
+Audio from YouTube is typically lossy. Prefer slskd or Usenet when you want higher quality.
+
+## Download source priority
+
+See [Usenet](/integrations/usenet/#download-source-priority-and-fallback) for how priority and fallback work across sources.

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -15,4 +15,4 @@ Use **Queue** to see what is downloading or processing right now. Use **Review**
 
 When an album request fails in Lidarr, you can retry the search from History when the entry supports it.
 
-See [slskd](/integrations/slskd/) and [Usenet](/integrations/usenet/) for download client setup.
+See [yt-dlp](/integrations/ytdlp/), [slskd](/integrations/slskd/), and [Usenet](/integrations/usenet/) for download client setup.

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -33,7 +33,7 @@ Scheduled flows, Spotify imports, discover playlists, in-app playback, and downl
 
 ![Aurral activity timeline](../../../assets/screenshots/history.webp)
 
-Queue for active Lidarr requests, download client activity (slskd and Usenet), and Aurral playlist jobs. History for the completed and failed timeline.
+Queue for active Lidarr requests, download client activity (slskd, yt-dlp, and Usenet), and Aurral playlist jobs. History for the completed and failed timeline.
 
 ### Shows
 
@@ -59,7 +59,7 @@ Admin-only configuration, organized into tabs:
 | **Tasks**            | Active and stale worker task management                               |
 | **Lidarr**           | Lidarr connection, profiles, tags, library access check               |
 | **Indexers**         | Prowlarr connection, indexer management, search priorities            |
-| **Download Clients** | slskd, SABnzbd, NZBGet, source priority, format preferences           |
+| **Download Clients** | yt-dlp, slskd, SABnzbd, NZBGet, source priority, format preferences   |
 | **Playback**         | Navidrome and Plex                                                    |
 | **Discover**         | Last.fm, Ticketmaster, discovery refresh and mode                     |
 | **Connect**          | Gotify and webhooks                                                   |

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -32,7 +32,7 @@ Generated playlists are written inside your `DOWNLOAD_FOLDER`, typically:
 /data/downloads/aurral/aurral-weekly-flow/<playlist-id>/
 ```
 
-Navidrome can scan the same tree and play `.m3u` playlists. Plex can index the track folders and receive API-synced playlists for Plexamp. See [Navidrome](/integrations/navidrome/), [Plex](/integrations/plex/), [slskd](/integrations/slskd/), [Usenet](/integrations/usenet/), and [Shared storage](/getting-started/storage/).
+Navidrome can scan the same tree and play `.m3u` playlists. Plex can index the track folders and receive API-synced playlists for Plexamp. See [Navidrome](/integrations/navidrome/), [Plex](/integrations/plex/), [yt-dlp](/integrations/ytdlp/), [slskd](/integrations/slskd/), [Usenet](/integrations/usenet/), and [Shared storage](/getting-started/storage/).
 
 ## Next steps
 

--- a/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
@@ -12,7 +12,7 @@ import {
 import { SettingsArrFieldSet, SettingsArrFormGroup } from "./arr/SettingsArrLayout";
 import { getProviderStatus } from "../utils/integrationStatus";
 import { PATH_MAPPING_SOURCE_OPTIONS, PathMappingModal } from "./PathMappingModal";
-import { testNzbgetConnection, testSabnzbdConnection, testSlskdConnection } from "../../../utils/api";
+import { testNzbgetConnection, testSabnzbdConnection, testSlskdConnection, testYtdlpConnection } from "../../../utils/api";
 
 const PATH_MAPPING_SOURCE_VALUES = new Set(
   PATH_MAPPING_SOURCE_OPTIONS.map((option) => option.value),
@@ -45,6 +45,7 @@ function sourceLabel(source) {
 
 const CLIENT_MODALS = {
   slskd: "slskd",
+  ytdlp: "ytdlp",
   nzbget: "nzbget",
   sabnzbd: "sabnzbd",
 };
@@ -60,6 +61,7 @@ export function SettingsDownloadClientsSection({
 }) {
   const [activeModal, setActiveModal] = useState(null);
   const [testingSlskd, setTestingSlskd] = useState(false);
+  const [testingYtdlp, setTestingYtdlp] = useState(false);
   const [testingNzbget, setTestingNzbget] = useState(false);
   const [testingSabnzbd, setTestingSabnzbd] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -67,6 +69,7 @@ export function SettingsDownloadClientsSection({
 
   const integrations = settings.integrations || {};
   const slskd = integrations.slskd || {};
+  const ytdlp = integrations.ytdlp || {};
   const nzbget = integrations.nzbget || {};
   const sabnzbd = integrations.sabnzbd || {};
   const pathMappings = coercePathMappings(settings.pathMappings).filter(
@@ -74,9 +77,11 @@ export function SettingsDownloadClientsSection({
   );
 
   const slskdConfigured = Boolean(slskd.url && slskd.apiKey);
+  const ytdlpConfigured = health?.ytdlpConfigured === true;
   const nzbgetConfigured = Boolean(nzbget.url);
   const sabnzbdConfigured = Boolean(sabnzbd.url && sabnzbd.apiKey);
   const slskdEnabled = slskd.enabled !== false;
+  const ytdlpEnabled = ytdlp.enabled !== false;
   const nzbgetEnabled = nzbget.enabled === true;
   const sabnzbdEnabled = sabnzbd.enabled === true;
 
@@ -200,6 +205,24 @@ export function SettingsDownloadClientsSection({
     }
   };
 
+  const handleTestYtdlp = async () => {
+    setTestingYtdlp(true);
+    try {
+      await handleSaveSettings();
+      const result = await testYtdlpConnection();
+      showSuccess(result.message || "yt-dlp OK");
+    } catch (error) {
+      showError(
+        error.response?.data?.message ||
+          error.response?.data?.error ||
+          error.message ||
+          "yt-dlp test failed",
+      );
+    } finally {
+      setTestingYtdlp(false);
+    }
+  };
+
   return (
     <>
       <div className="settings-page__section">
@@ -218,6 +241,13 @@ export function SettingsDownloadClientsSection({
             status={getProviderStatus(slskdEnabled, slskdConfigured)}
             meta={`Priority ${slskd.priority ?? 10}`}
             onClick={() => setActiveModal(CLIENT_MODALS.slskd)}
+          />
+          <IntegrationCard
+            title="yt-dlp"
+            subtitle="YouTube / web"
+            status={getProviderStatus(ytdlpEnabled, ytdlpConfigured)}
+            meta={`Priority ${ytdlp.priority ?? 50}`}
+            onClick={() => setActiveModal(CLIENT_MODALS.ytdlp)}
           />
           <IntegrationCard
             title="NZBGet"
@@ -434,6 +464,48 @@ export function SettingsDownloadClientsSection({
                 }
               />
             </SettingsModalToggleGroup>
+          </SettingsModalSection>
+        </SettingsIntegrationModal>
+      )}
+
+      {activeModal === CLIENT_MODALS.ytdlp && (
+        <SettingsIntegrationModal
+          title="yt-dlp"
+          onClose={() => setActiveModal(null)}
+          footerActions={
+            <button
+              type="button"
+              className="btn btn-secondary"
+              disabled={testingYtdlp}
+              onClick={handleTestYtdlp}
+            >
+              <RefreshCw className={`artist-icon-sm${testingYtdlp ? " animate-spin" : ""}`} />
+              {testingYtdlp ? "Testing..." : "Test connection"}
+            </button>
+          }
+        >
+          <SettingsModalSection title="General">
+            <SettingsModalToggle
+              label="Enable yt-dlp"
+              checked={ytdlpEnabled}
+              onChange={(event) => updateIntegration("ytdlp", { enabled: event.target.checked })}
+            />
+          </SettingsModalSection>
+
+          <SettingsModalSection title="Behavior">
+            <SettingsModalField label="Source priority">
+              <SettingsInput
+                type="number"
+                min="1"
+                max="1000"
+                value={ytdlp.priority ?? 50}
+                onChange={(event) =>
+                  updateIntegration("ytdlp", {
+                    priority: toNumber(event.target.value, 50),
+                  })
+                }
+              />
+            </SettingsModalField>
           </SettingsModalSection>
         </SettingsIntegrationModal>
       )}

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -86,6 +86,10 @@ const defaultSettings = {
       priority: 20,
       addPaused: false,
     },
+    ytdlp: {
+      enabled: true,
+      priority: 50,
+    },
     ticketmaster: {
       apiKey: "",
       searchRadiusMiles: 250,

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -134,6 +134,11 @@ export const normalizeSettings = (savedSettings) => {
         addPaused: false,
         ...(savedSettings.integrations?.sabnzbd || {}),
       },
+      ytdlp: {
+        enabled: true,
+        priority: 50,
+        ...(savedSettings.integrations?.ytdlp || {}),
+      },
       ticketmaster: {
         apiKey: "",
         searchRadiusMiles: 250,

--- a/frontend/src/pages/activity/ActivityRequestRow.jsx
+++ b/frontend/src/pages/activity/ActivityRequestRow.jsx
@@ -73,7 +73,9 @@ export default function ActivityRequestRow({
 }) {
   const isSlskd = request.source === "slskd";
   const isUsenet = request.source === "nzbget" || request.source === "sabnzbd";
-  const isTrackDownload = isSlskd || isUsenet || request.kind === "track_download";
+  const isYtdlp = request.source === "ytdlp";
+  const isTrackDownload =
+    isSlskd || isUsenet || isYtdlp || request.kind === "track_download";
   const isAurral = request.source === "aurral" && !isTrackDownload;
   const isActivity = request.type === "activity";
   const isAlbum = request.type === "album";
@@ -93,7 +95,7 @@ export default function ActivityRequestRow({
       : metaLine;
   const artistMbid = isAlbum ? request.artistMbid : request.mbid;
   const canNavigate =
-    ((isSlskd || isUsenet) && request.playlistId) ||
+    ((isSlskd || isUsenet || isYtdlp) && request.playlistId) ||
     ((isAurral || isActivity) && request.href) ||
     (artistMbid && artistMbid !== "null" && artistMbid !== "undefined");
   const timelineTime = formatTimelineTime(request.requestedAt);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -139,6 +139,7 @@ export {
   getProwlarrIndexers,
   testNzbgetConnection,
   testSabnzbdConnection,
+  testYtdlpConnection,
   testLidarrConnection,
   testLidarrLibraryAccess,
   getStorageHealth,

--- a/frontend/src/utils/api/endpoints/settings.js
+++ b/frontend/src/utils/api/endpoints/settings.js
@@ -56,6 +56,8 @@ export const testNzbgetConnection = () => postData("/settings/nzbget/test");
 
 export const testSabnzbdConnection = () => postData("/settings/sabnzbd/test");
 
+export const testYtdlpConnection = () => postData("/settings/ytdlp/test");
+
 export const testLidarrConnection = (url, apiKey) =>
   getData("/settings/lidarr/test", {
     params: lidarrCredentialParams(url, apiKey),


### PR DESCRIPTION
## Summary
- Add yt-dlp as a first-class download source (search → extract audio → import) with Settings UI, health, Docker image install, and docs
- Allow flow seeding/scheduling when any download source is configured (no longer hard-requires slskd)
- Document yt-dlp in V2.md, README, and integration/self-hosting docs; fix stuck "Generating playlist" op-queue status

## Test plan
- [ ] Rebuild Docker image and confirm `yt-dlp` + `ffmpeg` are present
- [ ] Settings → Download Clients → yt-dlp → Test connection succeeds
- [ ] Enable a flow with only yt-dlp configured; Run Now seeds a tracklist and downloads
- [ ] With slskd also configured, confirm priority order (slskd 10 → Usenet 20 → yt-dlp 50)
- [ ] Activity/history labels show yt-dlp for completed tracks