### PR TITLE
fix: install Node before stable release guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.23.2
+
       - name: Verify main and requested version
         env:
           REQUESTED_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Restores the Stable Release guard by installing the pinned Node runtime before it reads package.json. The failed v2.0.0 release completed all validation; no tag, image, or GitHub Release was published.