### PR TITLE
fix: fall back to CAA and Deezer when cover hosts fail

### DIFF
--- a/.tests/cover-fallbacks.test.js
+++ b/.tests/cover-fallbacks.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+test("warmPublicImageUrl rejects empty values and failed upstream fetches", async () => {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-warm-public-"));
+  const previousDataDir = process.env.AURRAL_DATA_DIR;
+  const originalFetch = global.fetch;
+  process.env.AURRAL_DATA_DIR = dataDir;
+  try {
+    const { warmPublicImageUrl } = await import(
+      `../backend/services/imageProxyService.js?warm-public=${Date.now()}`
+    );
+    assert.equal(await warmPublicImageUrl(""), null);
+    assert.equal(await warmPublicImageUrl("NOT_FOUND"), null);
+    assert.equal(await warmPublicImageUrl(null), null);
+
+    global.fetch = async () => {
+      throw new Error("upstream down");
+    };
+    assert.equal(
+      await warmPublicImageUrl("https://assets.fanart.tv/fanart/missing.jpg"),
+      null,
+    );
+  } finally {
+    global.fetch = originalFetch;
+    if (previousDataDir === undefined) delete process.env.AURRAL_DATA_DIR;
+    else process.env.AURRAL_DATA_DIR = previousDataDir;
+    await fs.rm(dataDir, { recursive: true, force: true });
+  }
+});

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -662,6 +662,25 @@ export const warmImageProxy = async (sourceUrl) => {
   return request;
 };
 
+export const warmPublicImageUrl = async (sourceUrl) => {
+  const normalized = String(sourceUrl || "").trim();
+  if (!normalized || normalized === "NOT_FOUND") return null;
+  if (isImageProxyLocalUrl(normalized)) {
+    return resolveImageProxyLocalUrl(normalized) || null;
+  }
+  const srcMatch = normalized.match(/\/api\/image-proxy\?src=([^&]+)/i);
+  const remote = srcMatch ? decodeURIComponent(srcMatch[1]) : normalized;
+  if (!remote || remote.startsWith("/") || remote.startsWith("data:") || remote.startsWith("blob:")) {
+    return remote || null;
+  }
+  try {
+    const entry = await warmImageProxy(remote);
+    return entry?.localUrl || null;
+  } catch {
+    return null;
+  }
+};
+
 export const buildImageProxyUrl = (sourceUrl) => {
   const normalized = normalizeKnownImageUrl(sourceUrl);
   if (!normalized) return null;

--- a/backend/services/imageService.js
+++ b/backend/services/imageService.js
@@ -1,11 +1,15 @@
 import { dbOps } from "../db/helpers/index.js";
 import {
-  buildImageProxyUrl,
   isImageProxyLocalUrl,
   resolveImageProxyLocalUrl,
+  warmPublicImageUrl,
 } from "./imageProxyService.js";
 import { getArtistByMbid, listArtistAlbums, searchArtists } from "./providers/brainzmashProvider.js";
-import { fetchReleaseGroupCoverUrl, LEGACY_COVER_HOST_PATTERN } from "./releaseGroupCoverService.js";
+import {
+  fetchDeezerArtistImageUrl,
+  fetchReleaseGroupCoverUrl,
+  LEGACY_COVER_HOST_PATTERN,
+} from "./releaseGroupCoverService.js";
 
 const MAX_NEGATIVE_CACHE = 1000;
 const MAX_PENDING_REQUESTS = 100;
@@ -54,13 +58,7 @@ const getAlbumImageKindRank = (image) => {
 
 const getImageUrl = (image) => image?.url || image?.Url || null;
 
-const toPublicImageUrl = (imageUrl) => {
-  if (!imageUrl || imageUrl === "NOT_FOUND") return null;
-  if (isImageProxyLocalUrl(imageUrl)) {
-    return resolveImageProxyLocalUrl(imageUrl) || buildImageProxyUrl(imageUrl);
-  }
-  return buildImageProxyUrl(imageUrl) || imageUrl;
-};
+const toPublicImageUrl = async (imageUrl) => warmPublicImageUrl(imageUrl);
 
 const selectBestImageByKind = (images = [], getKindRank) => {
   if (!Array.isArray(images)) return null;
@@ -97,7 +95,7 @@ const sortArtistImages = (images = []) => {
     .map((entry) => entry.image);
 };
 
-const buildCachedArtistImagePayload = (cachedImageUrl, metadataArtist = null) => {
+const buildCachedArtistImagePayload = async (cachedImageUrl, metadataArtist = null) => {
   const images = [
     {
       image: cachedImageUrl,
@@ -109,7 +107,7 @@ const buildCachedArtistImagePayload = (cachedImageUrl, metadataArtist = null) =>
   const directImages = sortArtistImages(metadataArtist?.images);
 
   for (const image of directImages) {
-    const publicUrl = toPublicImageUrl(getImageUrl(image));
+    const publicUrl = await toPublicImageUrl(getImageUrl(image));
     if (!publicUrl || seen.has(publicUrl)) continue;
     seen.add(publicUrl);
     images.push({
@@ -122,19 +120,18 @@ const buildCachedArtistImagePayload = (cachedImageUrl, metadataArtist = null) =>
   return images;
 };
 
-const buildDirectArtistImagePayload = (directImages = []) => {
+const buildDirectArtistImagePayload = async (directImages = []) => {
   const sorted = sortArtistImages(directImages);
-  const best = sorted[0] || null;
   const images = [];
   const seen = new Set();
 
   for (const image of sorted) {
-    const publicUrl = toPublicImageUrl(getImageUrl(image));
+    const publicUrl = await toPublicImageUrl(getImageUrl(image));
     if (!publicUrl || seen.has(publicUrl)) continue;
     seen.add(publicUrl);
     images.push({
       image: publicUrl,
-      front: image === best,
+      front: images.length === 0,
       types: [image.kind || image.CoverType || "Artist"],
     });
   }
@@ -168,7 +165,7 @@ const addToPendingRequests = (mbid, promise) => {
   pendingImageRequests.set(mbid, promise);
 };
 
-const getCachedUrl = (cacheKey) => {
+const getCachedUrl = async (cacheKey) => {
   const cached = dbOps.getImage(cacheKey);
   if (
     cached?.imageUrl &&
@@ -183,7 +180,13 @@ const getCachedUrl = (cacheKey) => {
       dbOps.deleteImage(cacheKey);
       return undefined;
     }
-    return cached.imageUrl;
+    const warmed = await warmPublicImageUrl(cached.imageUrl);
+    if (warmed) {
+      if (warmed !== cached.imageUrl) dbOps.setImage(cacheKey, warmed);
+      return warmed;
+    }
+    dbOps.deleteImage(cacheKey);
+    return undefined;
   }
   if (cached?.imageUrl === "NOT_FOUND") {
     return null;
@@ -213,7 +216,7 @@ const recoverArtistCoverFromCachedReleaseGroups = async (resolvedMbid) => {
   const rgCacheKey = `artist_rg:${resolvedMbid}`;
   const cachedRgId = dbOps.getDeezerMbidCache(rgCacheKey);
   if (cachedRgId && cachedRgId !== "NOT_FOUND") {
-    const cachedUrl = getCachedUrl(`rg:${cachedRgId}`);
+    const cachedUrl = await getCachedUrl(`rg:${cachedRgId}`);
     if (cachedUrl) {
       return buildArtistCoverFromUrl(cachedUrl);
     }
@@ -234,7 +237,7 @@ const recoverArtistCoverFromCachedReleaseGroups = async (resolvedMbid) => {
     });
 
   for (const rg of ordered) {
-    const cachedUrl = getCachedUrl(`rg:${rg.id}`);
+    const cachedUrl = await getCachedUrl(`rg:${rg.id}`);
     if (cachedUrl) {
       dbOps.setDeezerMbidCache(rgCacheKey, rg.id);
       return buildArtistCoverFromUrl(cachedUrl);
@@ -284,17 +287,20 @@ export const getArtistImage = async (
     cachedImage &&
     cachedImage.imageUrl &&
     cachedImage.imageUrl !== "NOT_FOUND" &&
-    !LEGACY_COVER_HOST_PATTERN.test(cachedImage.imageUrl) &&
-    (!isImageProxyLocalUrl(cachedImage.imageUrl) ||
-      resolveImageProxyLocalUrl(cachedImage.imageUrl))
+    !LEGACY_COVER_HOST_PATTERN.test(cachedImage.imageUrl)
   ) {
-    const override = dbOps.getArtistOverride(mbid);
-    const resolvedMbid = override?.musicbrainzId || mbid;
-    const metadataArtist = await getArtistByMbid(resolvedMbid).catch(() => null);
-    return {
-      url: cachedImage.imageUrl,
-      images: buildCachedArtistImagePayload(cachedImage.imageUrl, metadataArtist),
-    };
+    const warmedCached = await warmPublicImageUrl(cachedImage.imageUrl);
+    if (warmedCached) {
+      if (warmedCached !== cachedImage.imageUrl) dbOps.setImage(mbid, warmedCached);
+      const override = dbOps.getArtistOverride(mbid);
+      const resolvedMbid = override?.musicbrainzId || mbid;
+      const metadataArtist = await getArtistByMbid(resolvedMbid).catch(() => null);
+      return {
+        url: warmedCached,
+        images: await buildCachedArtistImagePayload(warmedCached, metadataArtist),
+      };
+    }
+    dbOps.deleteImage(mbid);
   }
 
   if (
@@ -319,27 +325,34 @@ export const getArtistImage = async (
   const fetchPromise = (async () => {
     let metadataArtist = null;
     let resolvedMbid = mbid;
+    let override = null;
     try {
-      const override = dbOps.getArtistOverride(mbid);
+      override = dbOps.getArtistOverride(mbid);
       resolvedMbid = override?.musicbrainzId || mbid;
       metadataArtist = await getArtistByMbid(resolvedMbid).catch(() => null);
       const directArtistImages = sortArtistImages(metadataArtist?.images);
-      const directArtistImage = directArtistImages[0] || null;
-
-      if (directArtistImage?.url) {
-        const images = buildDirectArtistImagePayload(directArtistImages);
-        const primaryImage = images.find((image) => image.front) || images[0];
-        if (primaryImage?.image) {
-          negativeImageCache.delete(mbid);
-          dbOps.setImage(mbid, primaryImage.image);
-          return {
-            url: primaryImage.image,
-            images,
-          };
-        }
+      const images = await buildDirectArtistImagePayload(directArtistImages);
+      const primaryImage = images.find((image) => image.front) || images[0];
+      if (primaryImage?.image) {
+        negativeImageCache.delete(mbid);
+        dbOps.setImage(mbid, primaryImage.image);
+        return {
+          url: primaryImage.image,
+          images,
+        };
       }
 
       const resolvedArtistName = metadataArtist?.name || artistName || null;
+      const deezerImage = await fetchDeezerArtistImageUrl({
+        artistName: resolvedArtistName || "",
+        deezerArtistId: override?.deezerArtistId || null,
+      });
+      if (deezerImage) {
+        negativeImageCache.delete(mbid);
+        dbOps.setImage(mbid, deezerImage);
+        return buildArtistCoverFromUrl(deezerImage, ["Artist"]);
+      }
+
       const rgCacheKey = `artist_rg:${resolvedMbid}`;
       const cachedRg = forceRefresh ? null : dbOps.getDeezerMbidCache(rgCacheKey);
       const albums = cachedRg
@@ -431,7 +444,10 @@ export const getArtistImage = async (
         if (siblings.length > 0) {
           siblings.sort((a, b) => b.images.length - a.images.length);
           const sibling = siblings[0];
-          dbOps.setArtistOverride(mbid, { musicbrainzId: sibling.id });
+          dbOps.setArtistOverride(mbid, {
+            musicbrainzId: sibling.id,
+            deezerArtistId: override?.deezerArtistId || null,
+          });
           const siblingResult = await getArtistImage(sibling.id, {
             forceRefresh: false,
             artistName: null,

--- a/backend/services/releaseGroupCoverService.js
+++ b/backend/services/releaseGroupCoverService.js
@@ -1,9 +1,14 @@
 import { dbOps } from "../db/helpers/index.js";
 import {
-  buildImageProxyUrl,
   isImageProxyLocalUrl,
   resolveImageProxyLocalUrl,
+  warmPublicImageUrl,
 } from "./imageProxyService.js";
+import {
+  getDeezerArtist,
+  getDeezerArtistById,
+  resolveDeezerAlbumForPreview,
+} from "./apiClients/deezer.js";
 import { getAlbumByMbid, resolveAlbumByArtistAndTitle } from "./providers/brainzmashProvider.js";
 
 export const LEGACY_COVER_HOST_PATTERN =
@@ -27,15 +32,20 @@ const pickAlbumCoverUrl = (images = []) => {
   return (preferred || ranked[0])?.url || null;
 };
 
+const coverArtArchiveFrontUrl = (releaseGroupMbid) =>
+  `https://coverartarchive.org/release-group/${releaseGroupMbid}/front`;
+
+export { warmPublicImageUrl };
+
 const toPublicCoverUrl = (imageUrl) => {
   if (!imageUrl || imageUrl === "NOT_FOUND") return null;
   if (isImageProxyLocalUrl(imageUrl)) {
-    return resolveImageProxyLocalUrl(imageUrl) || buildImageProxyUrl(imageUrl);
+    return resolveImageProxyLocalUrl(imageUrl) || null;
   }
-  return buildImageProxyUrl(imageUrl) || imageUrl;
+  return null;
 };
 
-const getCachedUrl = (cacheKey) => {
+const getCachedUrl = async (cacheKey) => {
   const cached = dbOps.getImage(cacheKey);
   if (
     cached?.imageUrl &&
@@ -50,7 +60,13 @@ const getCachedUrl = (cacheKey) => {
       dbOps.deleteImage(cacheKey);
       return undefined;
     }
-    return cached.imageUrl;
+    const warmed = await warmPublicImageUrl(cached.imageUrl);
+    if (warmed) {
+      if (warmed !== cached.imageUrl) dbOps.setImage(cacheKey, warmed);
+      return warmed;
+    }
+    dbOps.deleteImage(cacheKey);
+    return undefined;
   }
   if (cached?.imageUrl === "NOT_FOUND") {
     return null;
@@ -62,15 +78,9 @@ const persistCover = (cacheKey, proxiedUrl) => {
   dbOps.setImage(cacheKey, proxiedUrl);
 };
 
-const buildReleaseGroupCoverResult = (cacheKey, album) => {
-  const imageUrl = pickAlbumCoverUrl(album?.images);
-  if (!imageUrl) {
-    return { imageUrl: null, types: [], notFound: true, transientError: false };
-  }
-  const proxiedUrl = toPublicCoverUrl(imageUrl);
-  if (!proxiedUrl) {
-    return { imageUrl: null, types: [], notFound: true, transientError: false };
-  }
+const acceptCoverUrl = async (cacheKey, imageUrl) => {
+  const proxiedUrl = await warmPublicImageUrl(imageUrl);
+  if (!proxiedUrl) return null;
   persistCover(cacheKey, proxiedUrl);
   return {
     imageUrl: proxiedUrl,
@@ -80,16 +90,63 @@ const buildReleaseGroupCoverResult = (cacheKey, album) => {
   };
 };
 
+const buildReleaseGroupCoverResult = async (cacheKey, album) => {
+  const imageUrl = pickAlbumCoverUrl(album?.images);
+  if (!imageUrl) {
+    return { imageUrl: null, types: [], notFound: true, transientError: false };
+  }
+  return (
+    (await acceptCoverUrl(cacheKey, imageUrl)) || {
+      imageUrl: null,
+      types: [],
+      notFound: true,
+      transientError: false,
+    }
+  );
+};
+
+const fetchCoverArtArchiveCover = async (cacheKey, releaseGroupMbid) => {
+  if (!releaseGroupMbid) return null;
+  return acceptCoverUrl(cacheKey, coverArtArchiveFrontUrl(releaseGroupMbid));
+};
+
+const fetchDeezerAlbumCover = async (cacheKey, { artistName = "", albumTitle = "" } = {}) => {
+  if (!albumTitle) return null;
+  try {
+    const album = await resolveDeezerAlbumForPreview({ artistName, albumTitle });
+    if (!album?._coverUrl) return null;
+    return acceptCoverUrl(cacheKey, album._coverUrl);
+  } catch {
+    return null;
+  }
+};
+
+export const fetchDeezerArtistImageUrl = async ({
+  artistName = "",
+  deezerArtistId = null,
+} = {}) => {
+  try {
+    const artist = deezerArtistId
+      ? await getDeezerArtistById(deezerArtistId)
+      : artistName
+        ? await getDeezerArtist(artistName)
+        : null;
+    if (!artist?.imageUrl) return null;
+    return warmPublicImageUrl(artist.imageUrl);
+  } catch {
+    return null;
+  }
+};
+
 export const fetchReleaseGroupCoverUrl = async (
   releaseGroupMbid,
   { artistName = "", albumTitle = "" } = {},
 ) => {
   const cacheKey = `${RG_CACHE_PREFIX}${releaseGroupMbid}`;
-  const cached = getCachedUrl(cacheKey);
+  const cached = await getCachedUrl(cacheKey);
   if (cached !== undefined) {
-    const imageUrl = cached === null ? null : toPublicCoverUrl(cached);
     return {
-      imageUrl,
+      imageUrl: cached,
       notFound: cached === null,
       transientError: false,
     };
@@ -99,7 +156,7 @@ export const fetchReleaseGroupCoverUrl = async (
   let sawTransientError = false;
   try {
     const album = await getAlbumByMbid(releaseGroupMbid);
-    const result = buildReleaseGroupCoverResult(cacheKey, album);
+    const result = await buildReleaseGroupCoverResult(cacheKey, album);
     if (result.imageUrl) {
       return result;
     }
@@ -114,7 +171,7 @@ export const fetchReleaseGroupCoverUrl = async (
       });
       if (resolvedAlbumMbid && resolvedAlbumMbid !== releaseGroupMbid) {
         const resolvedAlbum = await getAlbumByMbid(resolvedAlbumMbid);
-        const result = buildReleaseGroupCoverResult(cacheKey, resolvedAlbum);
+        const result = await buildReleaseGroupCoverResult(cacheKey, resolvedAlbum);
         if (result.imageUrl) {
           return result;
         }
@@ -123,6 +180,13 @@ export const fetchReleaseGroupCoverUrl = async (
       sawTransientError = true;
     }
   }
+  const caaCover = await fetchCoverArtArchiveCover(cacheKey, releaseGroupMbid);
+  if (caaCover?.imageUrl) return caaCover;
+  const deezerCover = await fetchDeezerAlbumCover(cacheKey, {
+    artistName: normalizedArtistName,
+    albumTitle: normalizedAlbumTitle,
+  });
+  if (deezerCover?.imageUrl) return deezerCover;
   if (sawTransientError) {
     return { imageUrl: null, types: [], notFound: false, transientError: true };
   }
@@ -197,6 +261,8 @@ export const resolveReleaseGroupCoversBatch = async (
         covers[item.mbid] = { image: imageUrl, notFound: false };
         continue;
       }
+      missing.push(item);
+      continue;
     }
     if (cached?.imageUrl === "NOT_FOUND") {
       covers[item.mbid] = { image: null, notFound: true };


### PR DESCRIPTION
## Summary
- Warm cover/artist image URLs before caching so unreachable fanart.tv links stop poisoning the proxy cache
- Fall back to Cover Art Archive for release groups and Deezer for artist/album art when BrainzMash-sourced hosts fail
- Add a small regression check for failed upstream warm requests