### PR TITLE
feat: restyle aurral.org landing as a Winamp-inspired player

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,16 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <style>
       :root {
+        --bg: #0a0c0c;
+        --face: #1a1f1a;
+        --face-hi: #2a3228;
+        --face-lo: #0f120f;
+        --edge: #3d4638;
+        --lcd: #0c1408;
+        --lcd-text: #84cc16;
+        --lcd-dim: #3f6212;
+        --text: #a3a99c;
+        --bright: #c9cec4;
         color-scheme: dark;
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       }
@@ -21,69 +31,101 @@
       }
 
       body {
-        background: #0a0c0c;
-        color: #8e9489;
+        background:
+          radial-gradient(ellipse at 50% 30%, #121612 0%, var(--bg) 70%),
+          var(--bg);
+        color: var(--text);
         margin: 0;
+        min-height: 100svh;
       }
 
       main {
         align-items: center;
         display: flex;
-        flex-direction: column;
         justify-content: center;
         min-height: 100svh;
         padding: clamp(1rem, 4vw, 3rem);
       }
 
-      .terminal {
-        border: 1px solid #394036;
-        border-radius: 0.55rem;
-        overflow: hidden;
-        width: min(60rem, 100%);
-      }
-
-      .terminal-bar {
-        align-items: center;
+      .player {
+        background: linear-gradient(160deg, var(--face-hi), var(--face) 40%, var(--face-lo));
+        border: 1px solid var(--edge);
+        box-shadow:
+          inset 1px 1px 0 #4a5544,
+          inset -1px -1px 0 #0a0d0a,
+          0 18px 40px rgba(0, 0, 0, 0.45);
         display: grid;
-        font-size: clamp(0.55rem, 1vw, 0.72rem);
-        letter-spacing: 0.06em;
-        min-height: 2.7rem;
-        padding: 0 1rem;
-      }
-
-      .terminal-bar {
-        border-bottom: 1px dashed #30372d;
-        grid-template-columns: 1fr auto 1fr;
-      }
-
-      .terminal-controls {
-        display: flex;
         gap: 0.55rem;
+        padding: 0.45rem;
+        width: min(42rem, 100%);
       }
 
-      .terminal-controls b {
+      .titlebar {
+        align-items: center;
+        color: var(--bright);
+        display: flex;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        padding: 0.15rem 0.35rem 0.35rem;
+        text-transform: uppercase;
+      }
+
+      .titlebar span {
+        flex: 1;
+      }
+
+      .titlebar b {
+        color: var(--lcd-dim);
         font-weight: 500;
+        letter-spacing: 0.08em;
       }
 
-      .terminal-controls b:first-child {
-        color: #ff6b64;
+      .lcd {
+        background: var(--lcd);
+        border: 1px solid #000;
+        box-shadow: inset 0 0 0 1px #24301c, inset 0 2px 8px rgba(0, 0, 0, 0.65);
+        color: var(--lcd-text);
+        display: grid;
+        gap: 0.35rem;
+        grid-template-columns: auto 1fr auto;
+        padding: 0.55rem 0.7rem;
       }
 
-      .terminal-controls b:nth-child(2) {
-        color: #f2bd4b;
+      .lcd-time {
+        font-size: 0.95rem;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.08em;
       }
 
-      .terminal-controls b:last-child {
-        color: #48ca65;
+      .lcd-track {
+        min-width: 0;
+        overflow: hidden;
+        white-space: nowrap;
       }
 
-      .terminal-title {
-        color: #c9cec4;
+      .lcd-track p {
+        animation: marquee 14s linear infinite;
+        display: inline-block;
+        font-size: 0.78rem;
+        letter-spacing: 0.04em;
+        margin: 0;
+        padding-right: 2rem;
+        text-transform: uppercase;
+      }
+
+      .lcd-kbps {
+        color: var(--lcd-dim);
+        font-size: 0.65rem;
+        letter-spacing: 0.06em;
       }
 
       .stage {
         align-items: center;
         aspect-ratio: 16 / 9;
+        background: #050705;
+        border: 1px solid #000;
+        box-shadow: inset 0 0 0 1px #1c2618, inset 0 0 24px rgba(0, 0, 0, 0.7);
         display: flex;
         justify-content: center;
         overflow: hidden;
@@ -96,7 +138,7 @@
       pre {
         flex: 0 0 auto;
         font:
-          600 clamp(3.5px, 0.9vw, 12px) / 0.88 ui-monospace,
+          600 clamp(3px, 0.72vw, 9px) / 0.88 ui-monospace,
           SFMono-Regular,
           Menlo,
           Monaco,
@@ -115,74 +157,181 @@
         color: #a3e635;
       }
 
-      nav {
+      .deck {
+        align-items: stretch;
+        display: grid;
+        gap: 0.55rem;
+        grid-template-columns: 1fr auto;
+      }
+
+      .transport {
         display: flex;
-        gap: clamp(0.8rem, 2vw, 1.5rem);
+        flex-wrap: wrap;
+        gap: 0.35rem;
       }
 
-      a {
-        color: #84cc16;
-        text-decoration-color: transparent;
-        text-underline-offset: 0.3em;
-      }
-
-      a:hover,
-      a:focus-visible {
-        color: #b5ec5a;
-        text-decoration-color: currentColor;
-      }
-
-      .tagline {
-        font-family: system-ui, sans-serif;
-        font-size: clamp(0.8rem, 1.2vw, 1rem);
-        margin: clamp(1.25rem, 3vw, 2rem) 0 0;
-        text-align: center;
-      }
-
-      .actions {
+      .transport a,
+      .transport span {
+        align-items: center;
+        background: linear-gradient(180deg, #2c3428, #171c16);
+        border: 1px solid #000;
+        box-shadow: inset 1px 1px 0 #46503f, inset -1px -1px 0 #0a0d0a;
+        color: var(--bright);
+        display: inline-flex;
+        font-size: 0.72rem;
         justify-content: center;
-        margin-top: 1rem;
-      }
-
-      .button {
-        border: 1px solid #46503f;
-        border-radius: 0.25rem;
-        padding: 0.55rem 0.9rem;
+        letter-spacing: 0.04em;
+        min-height: 2.2rem;
+        min-width: 2.4rem;
+        padding: 0.35rem 0.55rem;
         text-decoration: none;
+        text-transform: uppercase;
       }
 
-      .button:hover,
-      .button:focus-visible {
-        border-color: #84cc16;
+      .transport a:hover,
+      .transport a:focus-visible {
+        background: linear-gradient(180deg, #384232, #1d241b);
+        color: #b5ec5a;
+        outline: 1px solid var(--lcd-text);
+      }
+
+      .transport .play {
+        color: var(--lcd-text);
+        min-width: 4.5rem;
+      }
+
+      .transport span {
+        color: var(--lcd-dim);
+        cursor: default;
+      }
+
+      .eq {
+        align-items: end;
+        background: var(--lcd);
+        border: 1px solid #000;
+        box-shadow: inset 0 0 0 1px #24301c;
+        display: flex;
+        gap: 0.18rem;
+        height: 2.2rem;
+        padding: 0.3rem 0.4rem;
+      }
+
+      .eq i {
+        animation: eq 1.1s ease-in-out infinite;
+        background: var(--lcd-text);
+        display: block;
+        flex: 1;
+        min-width: 0.25rem;
+        opacity: 0.85;
+        transform-origin: bottom;
+      }
+
+      .eq i:nth-child(2) {
+        animation-delay: -0.15s;
+      }
+      .eq i:nth-child(3) {
+        animation-delay: -0.4s;
+      }
+      .eq i:nth-child(4) {
+        animation-delay: -0.05s;
+      }
+      .eq i:nth-child(5) {
+        animation-delay: -0.55s;
+      }
+      .eq i:nth-child(6) {
+        animation-delay: -0.25s;
+      }
+      .eq i:nth-child(7) {
+        animation-delay: -0.7s;
+      }
+      .eq i:nth-child(8) {
+        animation-delay: -0.35s;
+      }
+
+      .status {
+        border-top: 1px solid #2a3228;
+        color: var(--text);
+        display: flex;
+        font-size: 0.65rem;
+        gap: 0.75rem;
+        justify-content: space-between;
+        letter-spacing: 0.05em;
+        padding: 0.35rem 0.4rem 0.15rem;
+        text-transform: uppercase;
+      }
+
+      .status strong {
+        color: var(--lcd-text);
+        font-weight: 600;
+      }
+
+      @keyframes marquee {
+        from {
+          transform: translateX(0);
+        }
+        to {
+          transform: translateX(-50%);
+        }
+      }
+
+      @keyframes eq {
+        0%,
+        100% {
+          transform: scaleY(0.25);
+        }
+        50% {
+          transform: scaleY(1);
+        }
       }
 
       @media (max-width: 520px) {
         main {
-          justify-content: flex-start;
+          align-items: flex-start;
         }
 
-        .terminal {
-          border-radius: 0.4rem;
+        .lcd {
+          grid-template-columns: 1fr;
         }
 
-        .terminal-bar {
-          min-height: 2.3rem;
-          padding-inline: 0.65rem;
+        .deck {
+          grid-template-columns: 1fr;
         }
 
-        .terminal-bar {
-          grid-template-columns: 1fr auto;
+        .eq {
+          height: 1.8rem;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .lcd-track p,
+        .eq i {
+          animation: none;
+        }
+
+        .eq i {
+          transform: scaleY(0.55);
         }
       }
     </style>
   </head>
   <body>
     <main>
-      <section class="terminal" aria-label="Aurral terminal">
-        <header class="terminal-bar">
-          <span class="terminal-controls" aria-hidden="true"> <b>[x]</b><b>[-]</b><b>[+]</b> </span>
-          <span class="terminal-title">♫ aurral</span>
+      <section class="player" aria-label="Aurral player">
+        <header class="titlebar">
+          <span>Aurral</span>
+          <b aria-hidden="true">□□ ×</b>
         </header>
+
+        <div class="lcd" aria-hidden="true">
+          <div class="lcd-time">0:01</div>
+          <div class="lcd-track">
+            <p>
+              Aurral — the Lidarr companion for music discovery. · Aurral — the Lidarr companion for
+              music discovery.
+            </p>
+          </div>
+          <div class="lcd-kbps">320kbps</div>
+        </div>
 
         <div class="stage" role="img" aria-label="A rotating Aurral logo rendered as ASCII art">
           <div class="ascii-stack" aria-hidden="true">
@@ -191,13 +340,25 @@
           </div>
           <noscript>Aurral</noscript>
         </div>
-      </section>
 
-      <p class="tagline">The Lidarr companion for music discovery.</p>
-      <nav class="actions" aria-label="Aurral links">
-        <a class="button" href="https://github.com/lklynet/aurral">GitHub</a>
-        <a class="button" href="https://docs.aurral.org/">Docs</a>
-      </nav>
+        <div class="deck">
+          <nav class="transport" aria-label="Aurral links">
+            <span aria-hidden="true">◀◀</span>
+            <a class="play" href="https://docs.aurral.org/">▶ Docs</a>
+            <span aria-hidden="true">■</span>
+            <span aria-hidden="true">▶▶</span>
+            <a href="https://github.com/lklynet/aurral">⏏ GitHub</a>
+          </nav>
+          <div class="eq" aria-hidden="true">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+          </div>
+        </div>
+
+        <p class="status">
+          <span>stereo · playlist ready</span>
+          <strong>self-hosted</strong>
+        </p>
+      </section>
     </main>
 
     <script type="module">


### PR DESCRIPTION
## Summary
- Replace the generic terminal chrome on `aurral.org` with a Winamp-inspired mini-player shell
- Keep the existing ASCII logo animation as the visualization stage
- Wire transport controls to Docs (play) and GitHub (eject), with LCD marquee and EQ chrome