### PR TITLE
fix: prevent JSON.stringify on Blob/File payloads in API client

### DIFF
--- a/frontend/src/utils/api/core.js
+++ b/frontend/src/utils/api/core.js
@@ -67,14 +67,19 @@ async function request(config) {
   }
   const timeoutMs = Number(config.timeout ?? 30000);
   const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
-  const headers = { "Content-Type": "application/json", ...config.headers };
+  const isBinaryData = config.data instanceof Blob || config.data instanceof FormData;
+  const headers = { ...(isBinaryData ? {} : { "Content-Type": "application/json" }), ...config.headers };
   const token = getRequestToken();
   if (token) headers.Authorization = `Bearer ${token}`;
 
   try {
     const init = { method, headers, signal: controller.signal, redirect: "manual" };
     if (config.data != null && method !== "GET" && method !== "HEAD") {
-      init.body = typeof config.data === "string" ? config.data : JSON.stringify(config.data);
+      if (typeof config.data === "string" || isBinaryData) {
+        init.body = config.data;
+      } else {
+        init.body = JSON.stringify(config.data);
+      }
     }
     const res = await fetch(url, init);
 


### PR DESCRIPTION
## Summary

Addresses issue: #471 

- Skips `JSON.stringify` for Blob, File, and FormData payloads, passing them directly as the request body
- Omits the default `Content-Type: application/json` header for binary data so the browser (or caller) can set it correctly

All existing JSON-based API calls are unaffected.

## Validation

- [ ] CI passes
- [x] Tested using the dev container, or not required
- [ ] Tested using the test container, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change