### PR TITLE
ci: run lint from repository root

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,7 +41,6 @@ jobs:
       - run: npm ci
 
       - run: npm run lint
-        working-directory: frontend
 
       - name: Run test suite
         run: npm test


### PR DESCRIPTION
## Summary

Run the lint command from the repository root so it uses the root project configuration.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change