### PR TITLE
fix(lidarr): diagnose tracks outside root folders

### DIFF
--- a/.tests/library/lidarr-library-access.test.js
+++ b/.tests/library/lidarr-library-access.test.js
@@ -119,6 +119,84 @@ test("runLidarrLibraryAccessTest shows translated root path when manual Lidarr m
   assert.match(mountStep?.detail || "", / -> /);
 });
 
+function createMultiArtistClient(rootPath, artists) {
+  return createMockLidarrClient({
+    rootPath,
+    request: async (endpoint) => {
+      if (endpoint === "/artist") {
+        return artists.map(({ id, path: artistPath }) => ({
+          id,
+          artistName: `Artist ${id}`,
+          path: artistPath,
+        }));
+      }
+      const match = endpoint.match(/^\/album\?artistId=(\d+)$/);
+      if (match) {
+        return [{ id: Number(match[1]), title: "Album", statistics: { sizeOnDisk: 100 } }];
+      }
+      return [];
+    },
+    getTracksByAlbumId: async (albumId) => [
+      { id: albumId, title: "Track", hasFile: true, trackFileId: albumId },
+    ],
+    getTrackFilesByAlbumId: async (albumId) => [
+      {
+        id: albumId,
+        path: artists.find((artist) => artist.id === albumId).trackPath,
+        size: 5,
+      },
+    ],
+  });
+}
+
+test("runLidarrLibraryAccessTest samples an artist inside the root folder over a stale one", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-lidarr-stale-"));
+  const rootDir = path.join(tempDir, "Music, Vol 1");
+  const trackPath = path.join(rootDir, "Artist 2", "Album", "01 - Track.mp3");
+  await fs.mkdir(path.dirname(trackPath), { recursive: true });
+  await fs.writeFile(trackPath, "audio");
+
+  const result = await runLidarrLibraryAccessTest(
+    createMultiArtistClient(rootDir, [
+      {
+        id: 1,
+        path: "/legacy-root/Artist 1",
+        trackPath: "/legacy-root/Artist 1/Album/01 - Track.mp3",
+      },
+      { id: 2, path: path.dirname(path.dirname(trackPath)), trackPath },
+    ]),
+  );
+
+  await fs.rm(tempDir, { recursive: true, force: true });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.partial, false);
+  assert.equal(result.sample?.path, trackPath);
+  assert.deepEqual(result.rootPaths, [rootDir]);
+});
+
+test("runLidarrLibraryAccessTest blames the root folder, not mounts, for a track outside every root", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-lidarr-outside-"));
+
+  const result = await runLidarrLibraryAccessTest(
+    createMultiArtistClient(rootDir, [
+      {
+        id: 1,
+        path: "/legacy-root/Artist 1",
+        trackPath: "/legacy-root/Artist 1/Album/01 - Track.mp3",
+      },
+    ]),
+  );
+
+  await fs.rm(rootDir, { recursive: true, force: true });
+
+  const fileStep = result.steps.find((step) => step.id === "file");
+  assert.equal(result.ok, false);
+  assert.equal(fileStep?.status, "fail");
+  assert.match(fileStep?.fix || "", /outside its root folders/);
+  assert.doesNotMatch(fileStep?.fix || "", /PUID/);
+});
+
 test("runLidarrLibraryAccessTest omits unrelated filesystem placement checks", async () => {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-lidarr-test-"));
   const albumDir = path.join(rootDir, "Artist", "Album");

--- a/backend/services/lidarrLibraryAccessTest.js
+++ b/backend/services/lidarrLibraryAccessTest.js
@@ -54,7 +54,22 @@ function pathHasPrefix(candidate, prefix) {
   );
 }
 
-export async function findSampleTrackFile(lidarrClient) {
+function artistIsOutsideRoots(artist, rootPaths) {
+  const artistPath = String(artist?.path || "").trim();
+  if (!artistPath || rootPaths.length === 0) return false;
+  return !rootPaths.some((rootPath) => pathHasPrefix(artistPath, rootPath));
+}
+
+function unreadableSampleFix(samplePath, rootPaths) {
+  if (rootPaths.length > 0 && !rootPaths.some((rootPath) => pathHasPrefix(samplePath, rootPath))) {
+    return `Lidarr reports this track outside its root folders (${rootPaths.join(", ")}), which usually means the artist folder was left behind by a root folder change. In Lidarr, open the artist, choose Edit, and move the files into the current root folder, or add the old location as a Lidarr root folder and mount it into Aurral.`;
+  }
+  return looksLikeExternalOnlyPath(samplePath)
+    ? "Lidarr reports a host path Aurral cannot read inside Docker. Mount the parent folder into Aurral, then add a manual Lidarr path mapping under Settings → System → Storage."
+    : "Lidarr reports this file path, but Aurral cannot read it. Check Docker mounts and folder permissions (PUID/PGID). If Lidarr and Aurral intentionally use different container paths, add a manual Lidarr path mapping.";
+}
+
+export async function findSampleTrackFile(lidarrClient, rootPaths = []) {
   let artists = [];
   try {
     artists = await lidarrClient.request("/artist");
@@ -63,7 +78,12 @@ export async function findSampleTrackFile(lidarrClient) {
   }
   if (!Array.isArray(artists)) return null;
 
-  for (const artist of artists) {
+  const orderedArtists = [
+    ...artists.filter((artist) => !artistIsOutsideRoots(artist, rootPaths)),
+    ...artists.filter((artist) => artistIsOutsideRoots(artist, rootPaths)),
+  ];
+
+  for (const artist of orderedArtists) {
     if (!artist?.id) continue;
     let albums = [];
     try {
@@ -162,7 +182,7 @@ export async function runLidarrLibraryAccessTest(lidarrClient) {
     }
   }
 
-  const sample = await findSampleTrackFile(lidarrClient);
+  const sample = await findSampleTrackFile(lidarrClient, rootPaths);
 
   if (unreadableRoots.length > 0) {
     const missingPath = unreadableRoots[0];
@@ -175,7 +195,7 @@ export async function runLidarrLibraryAccessTest(lidarrClient) {
           : `Lidarr stores files at ${missingPath}, but Aurral cannot read that path. Recommended fix: mount the same host root into Aurral and Lidarr at the same container path, such as /data.`,
       }),
     );
-    return { ok: false, steps, sample };
+    return { ok: false, steps, sample, rootPaths };
   }
 
   steps.push(
@@ -204,6 +224,7 @@ export async function runLidarrLibraryAccessTest(lidarrClient) {
       ok: true,
       steps,
       sample: null,
+      rootPaths,
       partial: true,
     };
   }
@@ -213,12 +234,10 @@ export async function runLidarrLibraryAccessTest(lidarrClient) {
     steps.push(
       step("file", "fail", "Sample Lidarr track file is readable from Aurral", {
         detail: sample.path,
-        fix: looksLikeExternalOnlyPath(sample.path)
-          ? "Lidarr reports a host path Aurral cannot read inside Docker. Mount the parent folder into Aurral, then add a manual Lidarr path mapping under Settings → System → Storage."
-          : "Lidarr reports this file path, but Aurral cannot read it. Check Docker mounts and folder permissions (PUID/PGID). If Lidarr and Aurral intentionally use different container paths, add a manual Lidarr path mapping.",
+        fix: unreadableSampleFix(sample.path, rootPaths),
       }),
     );
-    return { ok: false, steps, sample };
+    return { ok: false, steps, sample, rootPaths };
   }
 
   const resolvedSamplePath = readableSamplePath || (await pathIsReadable(sample.path));
@@ -250,6 +269,7 @@ export async function runLidarrLibraryAccessTest(lidarrClient) {
       ...sample,
       path: resolvedSamplePath || sample.path,
     },
+    rootPaths,
     partial: steps.some((entry) => entry.status === "warn"),
   };
 }

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -549,18 +549,11 @@ async function checkLidarrSection() {
   }
 
   const result = await runLidarrLibraryAccessTest(lidarrClient);
-  const rootStep = (result.steps || []).find((entry) => entry.id === "root");
-  const rootPaths = rootStep?.detail
-    ? String(rootStep.detail)
-        .split(",")
-        .map((entry) => entry.trim())
-        .filter(Boolean)
-    : [];
 
   return {
     section: buildSection("lidarr", "Lidarr library", result.steps || []),
     sample: result.sample || null,
-    rootPaths,
+    rootPaths: result.rootPaths || [],
   };
 }
 

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -55,6 +55,16 @@ Completed slskd or Usenet files can also remain in their source folders. **Test 
 
 See [Match Lidarr: Windows and mixed Docker setups](/getting-started/storage/#windows-and-mixed-docker-setups).
 
+## Library access fails on a folder that is not your root folder
+
+**Test library access** and **Storage health** can fail on a sample track whose path sits outside every Lidarr root folder, even though the root folder itself passes.
+
+Lidarr keeps each artist's own folder when you change or rename a root folder, so artists stay at the old location.
+
+- Compare the failing path with **Root folder in Lidarr** in the same check.
+- If the failing path is outside it, open that artist in Lidarr, select **Edit**, and move the files into the current root folder.
+- Otherwise, add the old location as a Lidarr root folder and mount it into Aurral.
+
 ## Navidrome playlists show but tracks will not play
 
 Flows or shared playlists can appear in Navidrome, but the tracks do not play.

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -22,6 +22,10 @@ Aurral tests file access at each path that Lidarr reports. If the test fails, mo
 
 See [Match Lidarr](/getting-started/storage/).
 
+The check samples a track from an artist inside a root folder. It falls back to an artist outside them and then reports that the artist was left behind by a root folder change.
+
+See [Library access fails on a folder that is not your root folder](/admin/troubleshooting/#library-access-fails-on-a-folder-that-is-not-your-root-folder).
+
 In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports.
 
 If Aurral mounts that folder at a different path, add a mapping under **Settings > Download Clients > Remote Path Mappings**.


### PR DESCRIPTION
## Summary

Improve Lidarr library access diagnostics by preferring tracks inside configured root folders and identifying tracks left behind after a root folder change. Preserve root folder data in health results and document the remediation steps.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-482` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change