### PR TITLE
fix(lidarr): prevent duplicate album additions

### DIFF
--- a/.tests/frontend/plex-settings.test.js
+++ b/.tests/frontend/plex-settings.test.js
@@ -18,6 +18,18 @@ test("resolvePlexConnectionUrl prefers direct local HTTP over plex.direct URIs",
   );
 });
 
+test("resolvePlexConnectionUrl handles a local address that already includes its port", () => {
+  assert.equal(
+    resolvePlexConnectionUrl({
+      uri: "https://192-168-1-63.1234567890abcdef.plex.direct:32400",
+      local: true,
+      address: "192.168.1.63:32400",
+      port: "32400",
+    }),
+    "http://192.168.1.63:32400",
+  );
+});
+
 test("pickBestPlexConnection falls back to the first usable remote URI", () => {
   const connection = pickBestPlexConnection({
     connections: [

--- a/.tests/search/search-service.test.js
+++ b/.tests/search/search-service.test.js
@@ -175,6 +175,50 @@ test("requestAlbumFromSearch delegates a new artist album directly to addAlbum",
   }
 });
 
+test("requestAlbumFromSearch preserves an addAlbum conflict status", async () => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalGetArtist = libraryManager.getArtist;
+  const originalEnsureArtistMonitored = libraryManager.ensureArtistMonitored;
+  const originalAddAlbum = libraryManager.addAlbum;
+
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getAlbumByMbid = async () => null;
+  libraryManager.getArtist = async () => ({
+    id: "7",
+    artistName: "Boards of Canada",
+    foreignArtistId: "artist-mbid",
+  });
+  libraryManager.ensureArtistMonitored = async (artist) => artist;
+  libraryManager.addAlbum = async () => ({
+    error: "Album already exists in Lidarr under a different artist",
+    statusCode: 409,
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        libraryManager.requestAlbumFromSearch({
+          albumMbid: "album-mbid",
+          albumName: "Geogaddi",
+          artistMbid: "artist-mbid",
+          artistName: "Boards of Canada",
+        }),
+      (error) => {
+        assert.equal(error.statusCode, 409);
+        assert.equal(error.message, "Album already exists in Lidarr under a different artist");
+        return true;
+      },
+    );
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    libraryManager.getArtist = originalGetArtist;
+    libraryManager.ensureArtistMonitored = originalEnsureArtistMonitored;
+    libraryManager.addAlbum = originalAddAlbum;
+  }
+});
+
 test("requestAlbumFromSearch rejects when artist must be created without addArtist permission", async () => {
   const originalIsConfigured = lidarrClient.isConfigured;
   const originalGetArtist = libraryManager.getArtist;
@@ -262,6 +306,167 @@ test("addAlbum checks artist monitoring while monitoring only the requested albu
     lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
     lidarrClient.addAlbum = originalAddAlbum;
     lidarrClient.updateArtistMonitoring = originalUpdateArtistMonitoring;
+  }
+});
+
+test("addAlbum force-refreshes the album preflight before creating it", async () => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetArtist = lidarrClient.getArtist;
+  const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalGetAlbum = lidarrClient.getAlbum;
+  const originalAddAlbum = lidarrClient.addAlbum;
+
+  const existingAlbum = {
+    id: 42,
+    artistId: 7,
+    foreignAlbumId: "fresh-album-mbid",
+    title: "Geogaddi",
+    monitored: true,
+    statistics: {
+      percentOfTracks: 0,
+      sizeOnDisk: 0,
+    },
+  };
+  let preflightOptions = null;
+  let addCalls = 0;
+
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getArtist = async () => ({
+    id: 7,
+    artistName: "Boards of Canada",
+    foreignArtistId: "artist-mbid",
+    monitored: true,
+    monitor: "none",
+  });
+  lidarrClient.getAlbumByMbid = async (_mbid, options) => {
+    preflightOptions = options;
+    return existingAlbum;
+  };
+  lidarrClient.getAlbum = async () => existingAlbum;
+  lidarrClient.addAlbum = async () => {
+    addCalls += 1;
+    return existingAlbum;
+  };
+
+  try {
+    const album = await libraryManager.addAlbum(7, "fresh-album-mbid", "Geogaddi");
+
+    assert.equal(album.id, "42");
+    assert.equal(preflightOptions?.forceRefresh, true);
+    assert.equal(addCalls, 0);
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getArtist = originalGetArtist;
+    lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    lidarrClient.getAlbum = originalGetAlbum;
+    lidarrClient.addAlbum = originalAddAlbum;
+  }
+});
+
+test("addAlbum coalesces concurrent requests for the same album", async () => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetArtist = lidarrClient.getArtist;
+  const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalAddAlbum = lidarrClient.addAlbum;
+
+  let addCalls = 0;
+  let releaseAdd;
+  const addGate = new Promise((resolve) => {
+    releaseAdd = resolve;
+  });
+
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getArtist = async () => ({
+    id: 7,
+    artistName: "Boards of Canada",
+    foreignArtistId: "artist-mbid",
+    monitored: true,
+    monitor: "none",
+  });
+  lidarrClient.getAlbumByMbid = async () => null;
+  lidarrClient.addAlbum = async () => {
+    addCalls += 1;
+    await addGate;
+    return {
+      id: 42,
+      artistId: 7,
+      foreignAlbumId: "concurrent-album-mbid",
+      title: "Geogaddi",
+      monitored: true,
+      statistics: {
+        percentOfTracks: 0,
+        sizeOnDisk: 0,
+      },
+    };
+  };
+
+  try {
+    const firstRequest = libraryManager.addAlbum(
+      7,
+      "concurrent-album-mbid",
+      "Geogaddi",
+    );
+    const secondRequest = libraryManager.addAlbum(
+      7,
+      "concurrent-album-mbid",
+      "Geogaddi",
+    );
+    releaseAdd();
+
+    const [first, second] = await Promise.all([firstRequest, secondRequest]);
+    assert.equal(addCalls, 1);
+    assert.equal(first.id, "42");
+    assert.equal(second.id, "42");
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getArtist = originalGetArtist;
+    lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    lidarrClient.addAlbum = originalAddAlbum;
+  }
+});
+
+test("addAlbum reports when Lidarr already owns an album under another artist", async () => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetArtist = lidarrClient.getArtist;
+  const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalAddAlbum = lidarrClient.addAlbum;
+
+  let addCalls = 0;
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getArtist = async () => ({
+    id: 7,
+    artistName: "Boards of Canada",
+    foreignArtistId: "artist-mbid",
+    monitored: true,
+    monitor: "none",
+  });
+  lidarrClient.getAlbumByMbid = async () => ({
+    id: 99,
+    artistId: 8,
+    foreignAlbumId: "owned-by-another-artist",
+    title: "Geogaddi",
+    monitored: true,
+  });
+  lidarrClient.addAlbum = async () => {
+    addCalls += 1;
+    throw new Error("AlbumExistsValidator: This album has already been added");
+  };
+
+  try {
+    const result = await libraryManager.addAlbum(
+      7,
+      "owned-by-another-artist",
+      "Geogaddi",
+    );
+
+    assert.equal(result.statusCode, 409);
+    assert.equal(result.error, "Album already exists in Lidarr under a different artist");
+    assert.equal(addCalls, 0);
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getArtist = originalGetArtist;
+    lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    lidarrClient.addAlbum = originalAddAlbum;
   }
 });
 

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -82,7 +82,11 @@ export function registerAlbums(router) {
           logger.error("library", `Failed to add album ${albumName}:`, {
             message: album.error,
           });
-          return res.status(503).json({
+          const statusCode =
+            Number.isInteger(album.statusCode) && album.statusCode >= 400
+              ? album.statusCode
+              : 503;
+          return res.status(statusCode).json({
             error: "Failed to add album",
             message: album.error,
           });

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -35,6 +35,9 @@ let _lastFullArtistFetchAt = 0;
 const _tracksCache = new Map();
 let _playbackQueueCache = null;
 const _artistMonitoringRepairs = new Map();
+const _albumAddInflight = new Map();
+const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
+  "Album already exists in Lidarr under a different artist";
 
 function buildTrackFileIndex(trackFiles) {
   const index = new Map();
@@ -948,6 +951,37 @@ export class LibraryManager {
   }
 
   async addAlbum(artistId, releaseGroupMbid, albumName, options = {}) {
+    const albumKey = String(releaseGroupMbid || "")
+      .trim()
+      .toLowerCase();
+    if (!albumKey) {
+      return this._addAlbum(artistId, releaseGroupMbid, albumName, options);
+    }
+
+    const existingRequest = _albumAddInflight.get(albumKey);
+    if (existingRequest) {
+      const result = await existingRequest;
+      if (result?.artistId != null && String(result.artistId) !== String(artistId)) {
+        return {
+          error: ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR,
+          statusCode: 409,
+        };
+      }
+      return result;
+    }
+
+    const request = this._addAlbum(artistId, releaseGroupMbid, albumName, options).finally(
+      () => {
+        if (_albumAddInflight.get(albumKey) === request) {
+          _albumAddInflight.delete(albumKey);
+        }
+      },
+    );
+    _albumAddInflight.set(albumKey, request);
+    return request;
+  }
+
+  async _addAlbum(artistId, releaseGroupMbid, albumName, options = {}) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
       return { error: "Lidarr is not configured" };
@@ -1011,10 +1045,18 @@ export class LibraryManager {
           lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none",
         );
       }
-      const existing = await lidarr.getAlbumByMbid(releaseGroupMbid);
+      const existing = await lidarr.getAlbumByMbid(releaseGroupMbid, {
+        forceRefresh: true,
+      });
       const artistNumericId = parseInt(artistId, 10);
       const sameArtistExisting =
         existing && String(existing.artistId) === String(artistNumericId) ? existing : null;
+      if (existing?.artistId != null && !sameArtistExisting) {
+        return {
+          error: ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR,
+          statusCode: 409,
+        };
+      }
       if (sameArtistExisting) {
         const mappedExisting = await mapExistingAlbum(sameArtistExisting, lidarrArtist);
         if (mappedExisting) return mappedExisting;
@@ -1037,7 +1079,10 @@ export class LibraryManager {
             const existingAfterConflict =
               (await this.waitForAlbumByMbidForArtist(releaseGroupMbid, artistNumericId, {
                 delaysMs: [500, 1000, 2000, 4000],
-              })) || (await lidarr.getAlbumByMbid(releaseGroupMbid).catch(() => null));
+              })) ||
+              (await lidarr
+                .getAlbumByMbid(releaseGroupMbid, { forceRefresh: true })
+                .catch(() => null));
             const sameArtistAfterConflict =
               existingAfterConflict &&
               String(existingAfterConflict.artistId) === String(artistNumericId)
@@ -1049,6 +1094,12 @@ export class LibraryManager {
                 lidarrArtist,
               );
               if (mappedConflictAlbum) return mappedConflictAlbum;
+            }
+            if (existingAfterConflict?.artistId != null) {
+              return {
+                error: ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR,
+                statusCode: 409,
+              };
             }
           }
           if (attempt < addAlbumAttempts && isArtistNotReadyError(error)) {
@@ -1148,13 +1199,15 @@ export class LibraryManager {
 
     artist = await this.ensureArtistMonitored(artist);
 
-    let existingAlbum = await lidarr.getAlbumByMbid(normalizedAlbumMbid);
+    let existingAlbum = await lidarr.getAlbumByMbid(normalizedAlbumMbid, {
+      forceRefresh: true,
+    });
     if (
       existingAlbum &&
       existingAlbum.artistId != null &&
       String(existingAlbum.artistId) !== String(artist.id)
     ) {
-      const error = new Error("Album already exists in Lidarr under a different artist");
+      const error = new Error(ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR);
       error.statusCode = 409;
       throw error;
     }
@@ -1168,7 +1221,10 @@ export class LibraryManager {
 
     if (album?.error) {
       const error = new Error(album.error);
-      error.statusCode = 503;
+      error.statusCode =
+        Number.isInteger(album.statusCode) && album.statusCode >= 400
+          ? album.statusCode
+          : 503;
       throw error;
     }
 

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -1,4 +1,3 @@
-import createCache from "./apiClients/simpleCache.js";
 import { getDiscoveryCache } from "./discovery/index.js";
 import { getLastfmApiKey, lastfmRequest } from "./apiClients/index.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
@@ -27,8 +26,6 @@ const ALL_RELEASE_TYPES = new Set([
   ...PRIMARY_RELEASE_TYPE_LIST,
   ...SECONDARY_RELEASE_TYPE_LIST,
 ]);
-const albumLibraryLookupCache = createCache(60);
-
 async function getAlbumLibraryLookup(albumMbids) {
   const lookup = new Map();
   if (!lidarrClient.isConfigured() || albumMbids.length === 0) {
@@ -36,13 +33,7 @@ async function getAlbumLibraryLookup(albumMbids) {
   }
 
   try {
-    let lidarrAlbums = albumLibraryLookupCache.get("lidarrAlbums");
-    if (!lidarrAlbums) {
-      lidarrAlbums = await lidarrClient.getAllAlbums();
-      if (lidarrAlbums.length > 0) {
-        albumLibraryLookupCache.set("lidarrAlbums", lidarrAlbums);
-      }
-    }
+    const lidarrAlbums = await lidarrClient.getAllAlbums();
     if (!lidarrAlbums?.length) return lookup;
     const wanted = new Set(albumMbids);
     for (const album of Array.isArray(lidarrAlbums) ? lidarrAlbums : []) {

--- a/frontend/src/pages/Settings/utils/plexConnections.js
+++ b/frontend/src/pages/Settings/utils/plexConnections.js
@@ -9,14 +9,48 @@ function normalizeHost(value) {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }
 
+function parseConnectionAddress(value, fallbackPort) {
+  const address = String(value || "").trim();
+  if (!address) return { host: "", port: "" };
+
+  if (address.startsWith("[")) {
+    const closingBracket = address.indexOf("]");
+    if (closingBracket <= 1) return { host: "", port: "" };
+    const suffix = address.slice(closingBracket + 1);
+    if (!suffix) {
+      return { host: address.slice(1, closingBracket), port: fallbackPort };
+    }
+    if (!suffix.startsWith(":")) return { host: "", port: "" };
+    const port = normalizePort(suffix.slice(1));
+    return port
+      ? { host: address.slice(1, closingBracket), port }
+      : { host: "", port: "" };
+  }
+
+  const colonCount = (address.match(/:/g) || []).length;
+  if (colonCount === 1) {
+    const separator = address.lastIndexOf(":");
+    const port = normalizePort(address.slice(separator + 1));
+    return port
+      ? { host: address.slice(0, separator), port }
+      : { host: "", port: "" };
+  }
+
+  return { host: address, port: fallbackPort };
+}
+
 function isLocalConnection(connection) {
   return connection?.local === true || connection?.local === 1 || connection?.local === "1";
 }
 
 export function resolvePlexConnectionUrl(connection) {
   const uri = String(connection?.uri || "").trim();
-  const host = normalizeHost(connection?.address);
-  const port = normalizePort(connection?.port);
+  const address = parseConnectionAddress(
+    connection?.address,
+    normalizePort(connection?.port),
+  );
+  const host = normalizeHost(address.host);
+  const port = address.port;
 
   if (isLocalConnection(connection) && host && port) {
     return `http://${host}:${port}`;


### PR DESCRIPTION
## Summary

Prevent duplicate and conflicting Lidarr album additions by force-refreshing album lookups, coalescing concurrent requests, and returning conflict status `409` when an album belongs to another artist. Also remove stale search lookup caching and correctly parse Plex addresses that include ports.

## Validation

- [x] CI passes
- [x] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change