### PR TITLE
ci: add release readiness and build status automation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: >-
+  Report only high-confidence, actionable correctness, security, data-loss,
+  release, or test failures. Do not report style, naming, refactoring,
+  documentation, or speculative improvements. Keep each comment concise.
+
+reviews:
+  profile: quiet
+  request_changes_workflow: false
+
+  high_level_summary: false
+  high_level_summary_in_walkthrough: false
+  collapse_walkthrough: true
+  review_status: false
+  review_progress: true
+  review_details: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: false
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    autofix:
+      enabled: false
+    fix_ci:
+      enabled: false
+    resolve_merge_conflict:
+      enabled: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: off
+    title:
+      mode: off
+    description:
+      mode: off
+    issue_assessment:
+      mode: off
+
+  tools:
+    eslint:
+      enabled: false
+    e18e:
+      enabled: false
+    biome:
+      enabled: false
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+    hadolint:
+      enabled: false
+    actionlint:
+      enabled: true
+    zizmor:
+      enabled: true
+    shellcheck:
+      enabled: true
+
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Report only high-confidence correctness, security, permissions,
+        workflow, release, or data-integrity bugs. Do not report style,
+        refactoring, naming, or documentation nits.
+    - path: "scripts/**"
+      instructions: >-
+        Report only functional correctness, failure handling, security, and
+        release or CI behavior. Do not report style or maintainability nits.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,12 @@
 - [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
 - [ ] Upgrade, migration, and rollback notes are updated where applicable
 
+## Test plan
+
+- Affected area(s): <!-- e.g. authentication, Docker/upgrade, flows, integrations, UI, docs -->
+- Automated coverage: <!-- tests added or existing tests that cover this change -->
+- Manual steps and expected result: <!-- what should a reviewer or nightly tester exercise? -->
+
 ## Release impact
 
 - [ ] Major: incompatible change

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   push:
     branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,9 +22,19 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
       packages: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Verify manual run uses main
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Manual nightly reconciliation must run from main, not ${GITHUB_REF_NAME}."
+            exit 1
+          fi
 
       - name: Resolve build version
         id: version
@@ -54,3 +65,15 @@ jobs:
             RELEASE_CHANNEL=nightly
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update release readiness record
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
+        run: bash scripts/update-release-readiness.sh nightly
+
+      - name: Notify merged pull requests and linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
+        run: bash scripts/notify-github-status.sh nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Verify manual run uses main
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -82,17 +82,17 @@ jobs:
 
           This image was rebuilt from the latest push to this pull request. It will be replaced when you push another change.
 
-          ```bash
+          \`\`\`bash
           docker pull ghcr.io/${REPOSITORY}:${IMAGE_TAG}
-          ```
+          \`\`\`
 
           To test it with your existing Docker Compose setup:
 
           1. Back up your Aurral config.
-          2. Temporarily change the Aurral service image to `ghcr.io/${REPOSITORY}:${IMAGE_TAG}`.
+          2. Temporarily change the Aurral service image to \`ghcr.io/${REPOSITORY}:${IMAGE_TAG}\`.
           3. Run `docker compose pull aurral && docker compose up -d aurral`.
           4. Exercise the behavior changed by this pull request.
-          5. Change the image back to `latest` when finished.
+          5. Restore the image reference that was configured before testing.
 
           [View the preview workflow run](https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}) · [Report a problem](https://github.com/${REPOSITORY}/issues)
           EOF

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -90,7 +90,7 @@ jobs:
 
           1. Back up your Aurral config.
           2. Temporarily change the Aurral service image to \`ghcr.io/${REPOSITORY}:${IMAGE_TAG}\`.
-          3. Run `docker compose pull aurral && docker compose up -d aurral`.
+          3. Run \`docker compose pull aurral && docker compose up -d aurral\`.
           4. Exercise the behavior changed by this pull request.
           5. Restore the image reference that was configured before testing.
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      pull-requests: write
       packages: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -66,6 +67,51 @@ jobs:
             echo "docker pull ghcr.io/${GITHUB_REPOSITORY}:pr-${{ github.event.number }}"
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Comment preview image on pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: pr-${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.number }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          COMMENT_BODY="$(cat <<EOF
+          <!-- aurral-preview-image -->
+          ## Aurral preview image ready
+
+          This image was rebuilt from the latest push to this pull request. It will be replaced when you push another change.
+
+          ```bash
+          docker pull ghcr.io/${REPOSITORY}:${IMAGE_TAG}
+          ```
+
+          To test it with your existing Docker Compose setup:
+
+          1. Back up your Aurral config.
+          2. Temporarily change the Aurral service image to `ghcr.io/${REPOSITORY}:${IMAGE_TAG}`.
+          3. Run `docker compose pull aurral && docker compose up -d aurral`.
+          4. Exercise the behavior changed by this pull request.
+          5. Change the image back to `latest` when finished.
+
+          [View the preview workflow run](https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}) · [Report a problem](https://github.com/${REPOSITORY}/issues)
+          EOF
+          )"
+
+          COMMENT_ID="$(gh api --paginate \
+            "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- aurral-preview-image -->"))) | .id' | head -n1)"
+
+          if [ -n "${COMMENT_ID}" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              -f "body=${COMMENT_BODY}" >/dev/null
+          else
+            gh pr comment "${PR_NUMBER}" \
+              --repo "${REPOSITORY}" \
+              --body "${COMMENT_BODY}" >/dev/null
+          fi
 
   delete-image:
     if: >-

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -1,0 +1,67 @@
+name: Reconcile release notifications
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published stable version to reconcile (for example 2.1.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Resolve published release commit
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          gh release view "${RELEASE_TAG}" >/dev/null
+
+          TAG_OBJECT="$(gh api \
+            "repos/${REPOSITORY}/git/ref/tags/${RELEASE_TAG}" \
+            --jq '.object | "\(.type)\t\(.sha)"')"
+          IFS=$'\t' read -r TAG_TYPE TAG_SHA <<< "${TAG_OBJECT}"
+          if [ "${TAG_TYPE}" = "tag" ]; then
+            TAG_SHA="$(gh api "repos/${REPOSITORY}/git/tags/${TAG_SHA}" --jq '.object.sha')"
+          fi
+
+          {
+            echo "version=${RELEASE_VERSION}"
+            echo "tag=${RELEASE_TAG}"
+            echo "sha=${TAG_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Reconcile release-readiness record
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: bash scripts/update-release-readiness.sh stable
+
+      - name: Reconcile merged pull requests and linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: bash scripts/notify-github-status.sh stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,24 @@ jobs:
           git fetch --force --tags
           node scripts/resolve-next-release.js
 
-  publish-image:
+  check-release-readiness:
     needs: compute-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Require approved release-readiness record
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
+        run: bash scripts/update-release-readiness.sh check
+
+  publish-image:
+    needs: [compute-release, check-release-readiness]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -186,3 +202,28 @@ jobs:
               --generate-notes \
               --latest
           fi
+
+  notify-github-release:
+    needs: [compute-release, publish-github-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Close release-readiness record
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
+        run: bash scripts/update-release-readiness.sh stable
+
+      - name: Notify merged pull requests and linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
+        run: bash scripts/notify-github-status.sh stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,18 @@ jobs:
     needs: compute-release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      existing_release: ${{ steps.readiness.outputs.existing_release }}
     permissions:
       contents: read
       issues: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Require approved release-readiness record
+        id: readiness
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
@@ -90,6 +95,7 @@ jobs:
 
   publish-image:
     needs: [compute-release, check-release-readiness]
+    if: needs.check-release-readiness.outputs.existing_release != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -99,6 +105,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -139,7 +146,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   create-tag:
-    needs: [compute-release, publish-image]
+    needs: [compute-release, check-release-readiness, publish-image]
+    if: ${{ always() && (needs.publish-image.result == 'success' || needs.check-release-readiness.outputs.existing_release == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -176,6 +184,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Publish GitHub release
         env:
@@ -213,6 +223,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Close release-readiness record
         env:

--- a/docs/maintainers/RELEASING.md
+++ b/docs/maintainers/RELEASING.md
@@ -18,7 +18,7 @@ There are no long-lived deployment branches. Channels are container tags produce
 | Channel | Image | Trigger | Version | Git tag |
 | --- | --- | --- | --- | --- |
 | Preview | `ghcr.io/lklynet/aurral:pr-<number>` | Every push to an open PR | `pr.<number>+<short-sha>` | No |
-| Nightly | `ghcr.io/lklynet/aurral:nightly` | Every push to `main` | `nightly.<run>+<short-sha>` | No |
+| Nightly | `ghcr.io/lklynet/aurral:nightly` | Every push to `main`, or manual reconciliation | `nightly.<run>+<short-sha>` | No |
 | Stable | `ghcr.io/lklynet/aurral:latest`, `:2.1.0`, `:2.1`, `:2` | Manual dispatch of a stable version | `2.1.0` | Yes |
 
 Preview and nightly builds create no Git tags. Their identity is the commit they were built from, which is what the update check compares.
@@ -58,9 +58,9 @@ Contributors do not change product versions. `package.json` is package metadata,
    docker pull ghcr.io/lklynet/aurral:pr-464
    ```
 
-5. Test that image. Push fixes to the branch, and each push replaces the preview image.
+5. Test that image. The Preview workflow comments on the PR with the exact pull command and Compose test steps, and updates that comment when a new image is built. Push fixes to the branch, and each push replaces the preview image.
 6. Give the PR a Conventional Commit title such as `feat: add playlist sharing` or `fix: prevent duplicate imports`.
-7. Complete the PR checklist and use **Squash and merge**.
+7. Complete the PR checklist and test plan, including affected areas and manual steps, then use **Squash and merge**.
 8. Delete the working branch. GitHub normally does this automatically.
 
 Preview images are public, so testers can pull `:pr-<number>` without credentials. Keep a PR open when you want user feedback before the change reaches `main`. The image is deleted when the PR closes.
@@ -74,6 +74,18 @@ Every merge to `main` publishes `ghcr.io/lklynet/aurral:nightly` automatically. 
 Nightly is the channel for anyone who wants merged work immediately, including you. It accumulates everything merged since the last release, so integration problems surface between releases rather than during one.
 
 Nightly is also where user testing happens, and it is the last gate before a stable release.
+
+After a successful nightly build, the workflow updates one status comment on each merged PR and each issue linked with a closing reference. The comment includes the nightly build identity, pull command, and links to the workflow and changes. It also applies the `nightly` label and removes `released`. A stable release updates the same comment with the released version, applies `released`, and removes `nightly` instead of adding another status comment.
+
+## Release readiness
+
+The first successful nightly after changes accumulate creates or updates the open **Release readiness: next stable** issue. It contains the current nightly build, source commit, change range, merged PRs, and linked closing issues. Keep test evidence in that issue, including the tester, date, exact nightly build, affected area, and result.
+
+Complete the checklist in the issue and apply the `release-ready` label only when the current nightly candidate is ready to ship. The Release workflow requires both that label and a candidate built from the current `main` commit. Any newer source commit removes `release-ready`, so new changes must be tested before approval is restored.
+
+After a successful stable release, the workflow records the release on the readiness issue and closes it. A later merge creates the next readiness issue. If a nightly notification fails, manually run **Actions → Nightly** on `main`; it rebuilds the current nightly and reconciles every change since the last stable release.
+
+If stable-release comments fail after the release is published, run **Release** again with the already-published version, such as `2.1.0`. Existing releases are treated as an idempotent reconciliation run, so the readiness and PR/issue notifications can finish without publishing a second version.
 
 ## Fix a problem found on nightly
 

--- a/docs/maintainers/RELEASING.md
+++ b/docs/maintainers/RELEASING.md
@@ -85,7 +85,7 @@ Complete the checklist in the issue and apply the `release-ready` label only whe
 
 After a successful stable release, the workflow records the release on the readiness issue and closes it. A later merge creates the next readiness issue. If a nightly notification fails, manually run **Actions → Nightly** on `main`; it rebuilds the current nightly and reconciles every change since the last stable release.
 
-If stable-release comments fail after the release is published, run **Release** again with the already-published version, such as `2.1.0`. Existing releases are treated as an idempotent reconciliation run, so the readiness and PR/issue notifications can finish without publishing a second version.
+If stable-release comments fail after the release is published, run **Release** again with the already-published version, such as `2.1.0`, while `main` is still at the release commit. The existing-release path skips the image build and only finishes the release lifecycle. If `main` has advanced, run **Actions → Reconcile release notifications** with the published version instead; it pins reconciliation to the immutable release tag and never rebuilds or republishes the stable image.
 
 ## Fix a problem found on nightly
 

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -33,12 +33,25 @@ Point `/data:/data` at the host path that Lidarr mounts. `./config` holds Aurral
 | `latest` | The newest stable release | You want a tested release. This is the default. |
 | `2.1.0`, `2.1`, `2` | An exact version, or the newest release in that line | You pin versions or need to roll back to a known build |
 | `nightly` | Every change merged since the last release | You want fixes and features early and can report bugs |
+| `pr-<number>` | The current preview image for an open pull request | You were asked to test a proposed change |
 
 Aurral checks for a newer build in your channel and shows a banner when one exists.
 
 :::caution
 `nightly` is untested by users until you run it. Back up `./config` before switching to it, and report anything broken.
 :::
+
+## Test a pull request preview
+
+When a pull request has a preview image, its GitHub conversation contains a comment with the exact `pr-<number>` image tag and test instructions. The comment is updated whenever a new preview image is built.
+
+To test the image with an existing Compose setup:
+
+1. Back up `./config`.
+2. Temporarily change the Aurral service image to the preview tag from the pull request comment.
+3. Run `docker compose pull aurral && docker compose up -d aurral`.
+4. Exercise the behavior changed by the pull request.
+5. Change the image back to `latest` when finished.
 
 ## Start Aurral
 

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -51,7 +51,7 @@ To test the image with an existing Compose setup:
 2. Temporarily change the Aurral service image to the preview tag from the pull request comment.
 3. Run `docker compose pull aurral && docker compose up -d aurral`.
 4. Exercise the behavior changed by the pull request.
-5. Change the image back to `latest` when finished.
+5. Restore the image reference that was configured before testing.
 
 ## Start Aurral
 

--- a/scripts/notify-github-status.sh
+++ b/scripts/notify-github-status.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 status="${1:-}"
 repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-head_sha="${GITHUB_SHA:?GITHUB_SHA is required}"
+head_sha="${HEAD_SHA:-${GITHUB_SHA:?GITHUB_SHA is required}}"
 owner="${repository%%/*}"
 repo="${repository#*/}"
 
@@ -19,7 +19,7 @@ case "${status}" in
   stable)
     release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
     release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
-    base_tag="$(printf '%s\n' "${stable_tags}" | awk -v exclude="${release_tag}" '$0 != exclude' | sort -V | tail -n1)"
+    base_tag="$(printf '%s\n' "${stable_tags}" | awk 'NF' | sort -V | awk -v target="${release_tag}" '$0 == target { print previous; found=1; exit } { previous=$0 } END { if (!found) print previous }')"
     ;;
   *)
     echo "Usage: $0 nightly|stable" >&2
@@ -86,6 +86,21 @@ for pull_number in "${!pull_numbers[@]}"; do
   done <<< "${closing_issues}"
 done
 
+set_status_label() {
+  local target_number="$1"
+  local add_label="$2"
+  local remove_label="$3"
+
+  gh api \
+    --method POST \
+    "repos/${repository}/issues/${target_number}/labels" \
+    -f "labels[]=${add_label}" >/dev/null
+  gh api \
+    --method DELETE \
+    "repos/${repository}/issues/${target_number}/labels/${remove_label}" \
+    >/dev/null 2>&1 || true
+}
+
 for target_number in $(printf '%s\n' "${!target_numbers[@]}" | sort -n); do
   comment_state="$(gh api --paginate \
     "repos/${repository}/issues/${target_number}/comments" \
@@ -99,10 +114,7 @@ for target_number in $(printf '%s\n' "${!target_numbers[@]}" | sort -n); do
   fi
 
   if [ "${status}" = "nightly" ]; then
-    gh issue edit "${target_number}" \
-      --repo "${repository}" \
-      --add-label nightly \
-      --remove-label released >/dev/null
+    set_status_label "${target_number}" nightly released
     comment_body="$(cat <<EOF
 <!-- aurral-release-status -->
 ### Available on nightly
@@ -113,15 +125,12 @@ A linked pull request was merged into \`main\` and is now included in the latest
 docker pull ghcr.io/${repository}:nightly
 \`\`\`
 
-Build: \`${nightly_version}\`  
-[View the nightly workflow](https://github.com/${repository}/actions/runs/${GITHUB_RUN_ID}) · [View changes on main](https://github.com/${repository}/commits/main)
+- Build: \`${nightly_version}\`
+- [View the nightly workflow](https://github.com/${repository}/actions/runs/${GITHUB_RUN_ID}) · [View changes on main](https://github.com/${repository}/commits/main)
 EOF
     )"
   else
-    gh issue edit "${target_number}" \
-      --repo "${repository}" \
-      --add-label released \
-      --remove-label nightly >/dev/null
+    set_status_label "${target_number}" released nightly
     comment_body="$(cat <<EOF
 <!-- aurral-release-status -->
 ### Included in stable release ${release_version}

--- a/scripts/notify-github-status.sh
+++ b/scripts/notify-github-status.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status="${1:-}"
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+head_sha="${GITHUB_SHA:?GITHUB_SHA is required}"
+owner="${repository%%/*}"
+repo="${repository#*/}"
+
+stable_tags="$(gh api --paginate \
+  "repos/${repository}/git/matching-refs/tags/v" \
+  --jq '.[].ref | sub("^refs/tags/"; "")')"
+
+case "${status}" in
+  nightly)
+    base_tag="$(printf '%s\n' "${stable_tags}" | sort -V | tail -n1)"
+    nightly_version="${NIGHTLY_VERSION:?NIGHTLY_VERSION is required}"
+    ;;
+  stable)
+    release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
+    release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+    base_tag="$(printf '%s\n' "${stable_tags}" | awk -v exclude="${release_tag}" '$0 != exclude' | sort -V | tail -n1)"
+    ;;
+  *)
+    echo "Usage: $0 nightly|stable" >&2
+    exit 2
+    ;;
+esac
+
+if [ -n "${base_tag}" ]; then
+  commit_shas="$(gh api --paginate \
+    "repos/${repository}/compare/${base_tag}...${head_sha}" \
+    --jq '.commits[].sha')"
+else
+  commit_shas="${head_sha}"
+fi
+
+declare -A pull_numbers=()
+while IFS= read -r commit_sha; do
+  [ -z "${commit_sha}" ] && continue
+  associated_pulls="$(gh api --paginate \
+    "repos/${repository}/commits/${commit_sha}/pulls" \
+    --jq '.[].number')"
+  while IFS= read -r pull_number; do
+    [ -z "${pull_number}" ] && continue
+    pull_numbers["${pull_number}"]=1
+  done <<< "${associated_pulls}"
+done <<< "${commit_shas}"
+
+if [ "${#pull_numbers[@]}" -eq 0 ]; then
+  echo "No merged pull requests found for ${status} notification."
+  exit 0
+fi
+
+gh label create nightly \
+  --repo "${repository}" \
+  --color 0E8A16 \
+  --description "Available in the nightly image but not yet in a stable release." \
+  --force >/dev/null
+gh label create released \
+  --repo "${repository}" \
+  --color 5319E7 \
+  --description "Included in a stable release." \
+  --force >/dev/null
+
+declare -A target_numbers=()
+for pull_number in "${!pull_numbers[@]}"; do
+  target_numbers["${pull_number}"]=1
+  closing_issues="$(gh api graphql \
+    -f query='query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 100) {
+            nodes { number }
+          }
+        }
+      }
+    }' \
+    -f "owner=${owner}" \
+    -f "repo=${repo}" \
+    -F "number=${pull_number}" \
+    --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
+  while IFS= read -r issue_number; do
+    [ -z "${issue_number}" ] && continue
+    target_numbers["${issue_number}"]=1
+  done <<< "${closing_issues}"
+done
+
+for target_number in $(printf '%s\n' "${!target_numbers[@]}" | sort -n); do
+  comment_state="$(gh api --paginate \
+    "repos/${repository}/issues/${target_number}/comments" \
+    --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- aurral-release-status -->"))) | "\(.id)\t\((if (.body | contains("### Included in stable release")) then "stable" else "nightly" end))"' \
+    | awk 'NR == 1 { print }')"
+  comment_id="${comment_state%%$'\t'*}"
+  comment_status="${comment_state#*$'\t'}"
+
+  if [ "${comment_status}" = "${status}" ]; then
+    continue
+  fi
+
+  if [ "${status}" = "nightly" ]; then
+    gh issue edit "${target_number}" \
+      --repo "${repository}" \
+      --add-label nightly \
+      --remove-label released >/dev/null
+    comment_body="$(cat <<EOF
+<!-- aurral-release-status -->
+### Available on nightly
+
+A linked pull request was merged into \`main\` and is now included in the latest nightly build.
+
+\`\`\`bash
+docker pull ghcr.io/${repository}:nightly
+\`\`\`
+
+Build: \`${nightly_version}\`  
+[View the nightly workflow](https://github.com/${repository}/actions/runs/${GITHUB_RUN_ID}) · [View changes on main](https://github.com/${repository}/commits/main)
+EOF
+    )"
+  else
+    gh issue edit "${target_number}" \
+      --repo "${repository}" \
+      --add-label released \
+      --remove-label nightly >/dev/null
+    comment_body="$(cat <<EOF
+<!-- aurral-release-status -->
+### Included in stable release ${release_version}
+
+This change is included in the Aurral ${release_version} release.
+
+\`\`\`bash
+docker pull ghcr.io/${repository}:${release_version}
+\`\`\`
+
+[View the release](https://github.com/${repository}/releases/tag/${release_tag})
+EOF
+    )"
+  fi
+
+  if [ -n "${comment_id}" ]; then
+    gh api \
+      --method PATCH \
+      "repos/${repository}/issues/comments/${comment_id}" \
+      -f "body=${comment_body}" >/dev/null
+  else
+    gh api \
+      --method POST \
+      "repos/${repository}/issues/${target_number}/comments" \
+      -f "body=${comment_body}" >/dev/null
+  fi
+done

--- a/scripts/update-release-readiness.sh
+++ b/scripts/update-release-readiness.sh
@@ -5,7 +5,7 @@ mode="${1:-}"
 repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 owner="${repository%%/*}"
 repo="${repository#*/}"
-head_sha="${GITHUB_SHA:?GITHUB_SHA is required}"
+head_sha="${HEAD_SHA:-${GITHUB_SHA:?GITHUB_SHA is required}}"
 run_id="${GITHUB_RUN_ID:-unknown}"
 readiness_marker='<!-- aurral-release-readiness -->'
 status_marker='<!-- aurral-release-readiness-status -->'
@@ -62,9 +62,36 @@ update_status_comment() {
   fi
 }
 
+write_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+resolve_tag_commit() {
+  local tag_ref="$1"
+  local tag_object tag_type tag_sha
+
+  tag_object="$(gh api "repos/${repository}/git/ref/tags/${tag_ref}" --jq '.object | "\(.type)\t\(.sha)"')"
+  IFS=$'\t' read -r tag_type tag_sha <<< "${tag_object}"
+
+  if [ "${tag_type}" = "tag" ]; then
+    tag_sha="$(gh api "repos/${repository}/git/tags/${tag_sha}" --jq '.object.sha')"
+  fi
+
+  printf '%s\n' "${tag_sha}"
+}
+
 if [ "${mode}" = "check" ]; then
   if [ -n "${RELEASE_TAG:-}" ] && gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-    echo "Stable release ${RELEASE_TAG} already exists; allowing lifecycle reconciliation."
+    published_sha="$(resolve_tag_commit "${RELEASE_TAG}")"
+    if [ "${published_sha}" != "${head_sha}" ]; then
+      echo "Stable release ${RELEASE_TAG} already points to ${published_sha}, not ${head_sha}; refusing to republish release aliases." >&2
+      exit 1
+    fi
+
+    write_output existing_release true
+    echo "Stable release ${RELEASE_TAG} already exists at ${head_sha}; allowing lifecycle reconciliation."
     exit 0
   fi
 
@@ -93,6 +120,7 @@ if [ "${mode}" = "check" ]; then
     exit 1
   fi
 
+  write_output existing_release false
   echo "Release readiness approved for ${head_sha}."
   exit 0
 fi
@@ -109,7 +137,7 @@ case "${mode}" in
   stable)
     release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
     release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
-    base_tag="$(printf '%s\n' "${stable_tags}" | awk -v exclude="${release_tag}" 'NF && $0 != exclude' | sort -V | tail -n1)"
+    base_tag="$(printf '%s\n' "${stable_tags}" | awk 'NF' | sort -V | awk -v target="${release_tag}" '$0 == target { print previous; found=1; exit } { previous=$0 } END { if (!found) print previous }')"
     ;;
   *)
     echo "Usage: $0 nightly|stable|check" >&2
@@ -118,73 +146,79 @@ case "${mode}" in
 esac
 
 if [ -n "${base_tag}" ]; then
-  commit_shas="$(gh api --paginate \
-    "repos/${repository}/compare/${base_tag}...${head_sha}" \
-    --jq '.commits[].sha')"
-  change_range="${base_tag}...${head_sha:0:7}"
   change_url="https://github.com/${repository}/compare/${base_tag}...${head_sha}"
 else
-  commit_shas="${head_sha}"
-  change_range="${head_sha:0:7}"
   change_url="https://github.com/${repository}/commit/${head_sha}"
 fi
 
-declare -A pull_numbers=()
-while IFS= read -r commit_sha; do
-  [ -z "${commit_sha}" ] && continue
-  associated_pulls="$(gh api --paginate \
-    "repos/${repository}/commits/${commit_sha}/pulls" \
-    --jq '.[].number')"
-  while IFS= read -r pull_number; do
-    [ -z "${pull_number}" ] && continue
-    pull_numbers["${pull_number}"]=1
-  done <<< "${associated_pulls}"
-done <<< "${commit_shas}"
+if [ "${mode}" = "nightly" ]; then
+  if [ -n "${base_tag}" ]; then
+    commit_shas="$(gh api --paginate \
+      "repos/${repository}/compare/${base_tag}...${head_sha}" \
+      --jq '.commits[].sha')"
+    change_range="${base_tag}...${head_sha:0:7}"
+  else
+    commit_shas="${head_sha}"
+    change_range="${head_sha:0:7}"
+  fi
 
-if [ "${mode}" = "nightly" ] && [ "${#pull_numbers[@]}" -eq 0 ]; then
-  echo "No merged pull requests found; no release-readiness issue is needed."
-  exit 0
-fi
+  declare -A pull_numbers=()
+  while IFS= read -r commit_sha; do
+    [ -z "${commit_sha}" ] && continue
+    associated_pulls="$(gh api --paginate \
+      "repos/${repository}/commits/${commit_sha}/pulls" \
+      --jq '.[].number')"
+    while IFS= read -r pull_number; do
+      [ -z "${pull_number}" ] && continue
+      pull_numbers["${pull_number}"]=1
+    done <<< "${associated_pulls}"
+  done <<< "${commit_shas}"
 
-declare -A issue_numbers=()
-for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
-  closing_issues="$(gh api graphql \
-    -f query='query($owner: String!, $repo: String!, $number: Int!) {
-      repository(owner: $owner, name: $repo) {
-        pullRequest(number: $number) {
-          closingIssuesReferences(first: 100) {
-            nodes { number }
+  if [ "${#pull_numbers[@]}" -eq 0 ]; then
+    echo "No merged pull requests found; no release-readiness issue is needed."
+    exit 0
+  fi
+
+  declare -A issue_numbers=()
+  for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
+    closing_issues="$(gh api graphql \
+      -f query='query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            closingIssuesReferences(first: 100) {
+              nodes { number }
+            }
           }
         }
-      }
-    }' \
-    -f "owner=${owner}" \
-    -f "repo=${repo}" \
-    -F "number=${pull_number}" \
-    --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
-  while IFS= read -r issue_number; do
-    [ -z "${issue_number}" ] && continue
-    issue_numbers["${issue_number}"]=1
-  done <<< "${closing_issues}"
-done
+      }' \
+      -f "owner=${owner}" \
+      -f "repo=${repo}" \
+      -F "number=${pull_number}" \
+      --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
+    while IFS= read -r issue_number; do
+      [ -z "${issue_number}" ] && continue
+      issue_numbers["${issue_number}"]=1
+    done <<< "${closing_issues}"
+  done
 
-pull_list=""
-for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
-  pull_line="$(gh api \
-    "repos/${repository}/pulls/${pull_number}" \
-    --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
-  pull_list+="${pull_line}"$'\n'
-done
-pull_list="${pull_list%$'\n'}"
+  pull_list=""
+  for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
+    pull_line="$(gh api \
+      "repos/${repository}/pulls/${pull_number}" \
+      --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
+    pull_list+="${pull_line}"$'\n'
+  done
+  pull_list="${pull_list%$'\n'}"
 
-issue_list=""
-for issue_number in $(printf '%s\n' "${!issue_numbers[@]}" | sort -n); do
-  issue_line="$(gh api \
-    "repos/${repository}/issues/${issue_number}" \
-    --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
-  issue_list+="${issue_line}"$'\n'
-done
-issue_list="${issue_list%$'\n'}"
+  issue_list=""
+  for issue_number in $(printf '%s\n' "${!issue_numbers[@]}" | sort -n); do
+    issue_line="$(gh api \
+      "repos/${repository}/issues/${issue_number}" \
+      --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
+    issue_list+="${issue_line}"$'\n'
+  done
+  issue_list="${issue_list%$'\n'}"
+fi
 
 if [ "${mode}" = "nightly" ]; then
   ensure_labels
@@ -262,6 +296,17 @@ if [ -z "${readiness_issue}" ]; then
   exit 0
 fi
 
+previous_status_comment="$(find_status_comment "${readiness_issue}")"
+previous_status_body=""
+if [ -n "${previous_status_comment}" ]; then
+  previous_status_body="$(gh api "repos/${repository}/issues/comments/${previous_status_comment}" --jq '.body')"
+fi
+preserved_status_body="${previous_status_body#${status_marker}}"
+preserved_status_body="${preserved_status_body//### Current nightly candidate/### Included changes at release}"
+if [ -z "${preserved_status_body}" ]; then
+  preserved_status_body=$'\n### Included changes at release\n\nThe previous nightly status comment was unavailable; use the linked change range above.'
+fi
+
 status_body="$(cat <<EOF
 ${status_marker}
 ### Released
@@ -272,6 +317,8 @@ The readiness candidate was published as stable release \`${release_version}\`.
 - Source commit: \`${head_sha}\`
 - [View the release](https://github.com/${repository}/releases/tag/${release_tag})
 - [View the included changes](${change_url})
+
+${preserved_status_body}
 EOF
   )"
 update_status_comment "${readiness_issue}" "${status_body}"

--- a/scripts/update-release-readiness.sh
+++ b/scripts/update-release-readiness.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+owner="${repository%%/*}"
+repo="${repository#*/}"
+head_sha="${GITHUB_SHA:?GITHUB_SHA is required}"
+run_id="${GITHUB_RUN_ID:-unknown}"
+readiness_marker='<!-- aurral-release-readiness -->'
+status_marker='<!-- aurral-release-readiness-status -->'
+
+ensure_labels() {
+  gh label create release-readiness \
+    --repo "${repository}" \
+    --color FBCA04 \
+    --description "Tracks testing and approval for the next stable release." \
+    --force >/dev/null
+  gh label create release-ready \
+    --repo "${repository}" \
+    --color 0E8A16 \
+    --description "Release readiness checks are complete for the current main commit." \
+    --force >/dev/null
+  gh label create released \
+    --repo "${repository}" \
+    --color 5319E7 \
+    --description "Included in a stable release." \
+    --force >/dev/null
+}
+
+find_open_record() {
+  gh api --paginate \
+    "repos/${repository}/issues?state=open&labels=release-readiness&per_page=100" \
+    --jq '.[] | select(.pull_request == null and ((.body // "") | contains("<!-- aurral-release-readiness -->"))) | .number' \
+    | awk 'NR == 1 { print }'
+}
+
+find_status_comment() {
+  local issue_number="$1"
+  gh api --paginate \
+    "repos/${repository}/issues/${issue_number}/comments" \
+    --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body // "") | contains("<!-- aurral-release-readiness-status -->"))) | .id' \
+    | awk 'NR == 1 { print }'
+}
+
+update_status_comment() {
+  local issue_number="$1"
+  local body="$2"
+  local comment_id
+  comment_id="$(find_status_comment "${issue_number}")"
+
+  if [ -n "${comment_id}" ]; then
+    gh api \
+      --method PATCH \
+      "repos/${repository}/issues/comments/${comment_id}" \
+      -f "body=${body}" >/dev/null
+  else
+    gh api \
+      --method POST \
+      "repos/${repository}/issues/${issue_number}/comments" \
+      -f "body=${body}" >/dev/null
+  fi
+}
+
+if [ "${mode}" = "check" ]; then
+  if [ -n "${RELEASE_TAG:-}" ] && gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+    echo "Stable release ${RELEASE_TAG} already exists; allowing lifecycle reconciliation."
+    exit 0
+  fi
+
+  readiness_issue="$(find_open_record)"
+  if [ -z "${readiness_issue}" ]; then
+    echo "No open release-readiness issue was found. Run a successful nightly build first." >&2
+    exit 1
+  fi
+
+  labels="$(gh api "repos/${repository}/issues/${readiness_issue}" --jq '.labels[].name')"
+  if ! printf '%s\n' "${labels}" | grep -Fxq release-ready; then
+    issue_url="$(gh api "repos/${repository}/issues/${readiness_issue}" --jq '.html_url')"
+    echo "Release readiness issue ${issue_url} is not marked release-ready." >&2
+    echo "Complete its checklist and apply the release-ready label before publishing." >&2
+    exit 1
+  fi
+
+  status_comment="$(find_status_comment "${readiness_issue}")"
+  status_body=""
+  if [ -n "${status_comment}" ]; then
+    status_body="$(gh api "repos/${repository}/issues/comments/${status_comment}" --jq '.body')"
+  fi
+  if [[ "${status_body}" != *"Source commit: \`${head_sha}\`"* ]]; then
+    echo "Release readiness is not recorded against current main ${head_sha}." >&2
+    echo "Wait for the nightly build for this commit, then retest and reapply release-ready." >&2
+    exit 1
+  fi
+
+  echo "Release readiness approved for ${head_sha}."
+  exit 0
+fi
+
+stable_tags="$(gh api --paginate \
+  "repos/${repository}/git/matching-refs/tags/v" \
+  --jq '.[].ref | sub("^refs/tags/"; "")')"
+
+case "${mode}" in
+  nightly)
+    nightly_version="${NIGHTLY_VERSION:?NIGHTLY_VERSION is required}"
+    base_tag="$(printf '%s\n' "${stable_tags}" | awk 'NF' | sort -V | tail -n1)"
+    ;;
+  stable)
+    release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
+    release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+    base_tag="$(printf '%s\n' "${stable_tags}" | awk -v exclude="${release_tag}" 'NF && $0 != exclude' | sort -V | tail -n1)"
+    ;;
+  *)
+    echo "Usage: $0 nightly|stable|check" >&2
+    exit 2
+    ;;
+esac
+
+if [ -n "${base_tag}" ]; then
+  commit_shas="$(gh api --paginate \
+    "repos/${repository}/compare/${base_tag}...${head_sha}" \
+    --jq '.commits[].sha')"
+  change_range="${base_tag}...${head_sha:0:7}"
+  change_url="https://github.com/${repository}/compare/${base_tag}...${head_sha}"
+else
+  commit_shas="${head_sha}"
+  change_range="${head_sha:0:7}"
+  change_url="https://github.com/${repository}/commit/${head_sha}"
+fi
+
+declare -A pull_numbers=()
+while IFS= read -r commit_sha; do
+  [ -z "${commit_sha}" ] && continue
+  associated_pulls="$(gh api --paginate \
+    "repos/${repository}/commits/${commit_sha}/pulls" \
+    --jq '.[].number')"
+  while IFS= read -r pull_number; do
+    [ -z "${pull_number}" ] && continue
+    pull_numbers["${pull_number}"]=1
+  done <<< "${associated_pulls}"
+done <<< "${commit_shas}"
+
+if [ "${mode}" = "nightly" ] && [ "${#pull_numbers[@]}" -eq 0 ]; then
+  echo "No merged pull requests found; no release-readiness issue is needed."
+  exit 0
+fi
+
+declare -A issue_numbers=()
+for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
+  closing_issues="$(gh api graphql \
+    -f query='query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 100) {
+            nodes { number }
+          }
+        }
+      }
+    }' \
+    -f "owner=${owner}" \
+    -f "repo=${repo}" \
+    -F "number=${pull_number}" \
+    --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
+  while IFS= read -r issue_number; do
+    [ -z "${issue_number}" ] && continue
+    issue_numbers["${issue_number}"]=1
+  done <<< "${closing_issues}"
+done
+
+pull_list=""
+for pull_number in $(printf '%s\n' "${!pull_numbers[@]}" | sort -n); do
+  pull_line="$(gh api \
+    "repos/${repository}/pulls/${pull_number}" \
+    --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
+  pull_list+="${pull_line}"$'\n'
+done
+pull_list="${pull_list%$'\n'}"
+
+issue_list=""
+for issue_number in $(printf '%s\n' "${!issue_numbers[@]}" | sort -n); do
+  issue_line="$(gh api \
+    "repos/${repository}/issues/${issue_number}" \
+    --jq '"- [#\(.number)](\(.html_url)) \(.title)"')"
+  issue_list+="${issue_line}"$'\n'
+done
+issue_list="${issue_list%$'\n'}"
+
+if [ "${mode}" = "nightly" ]; then
+  ensure_labels
+  readiness_issue="$(find_open_record)"
+  if [ -z "${readiness_issue}" ]; then
+    readiness_body="$(cat <<EOF
+${readiness_marker}
+# Release readiness: next stable
+
+This issue tracks user-level testing for the next Aurral stable release.
+
+The automation updates the candidate and included-change status comment below. Keep manual test evidence and decisions in this issue. Apply the \`release-ready\` label only after the checklist and required testing are complete for the current source commit.
+
+## Maintainer checklist
+
+- [ ] Nightly validation passed
+- [ ] Affected areas tested against the current nightly build
+- [ ] Upgrade, migration, and rollback behavior checked where applicable
+- [ ] No blocking nightly issues remain
+- [ ] Release approved
+
+## Test evidence
+
+Add comments with the tester, date, exact nightly build, affected area, and result.
+EOF
+    )"
+    readiness_issue="$(gh api \
+      --method POST \
+      "repos/${repository}/issues" \
+      -f "title=Release readiness: next stable" \
+      -f "body=${readiness_body}" \
+      --jq '.number')"
+    gh issue edit "${readiness_issue}" --repo "${repository}" --add-label release-readiness >/dev/null
+  else
+    previous_status_comment="$(find_status_comment "${readiness_issue}")"
+    previous_status_body=""
+    if [ -n "${previous_status_comment}" ]; then
+      previous_status_body="$(gh api "repos/${repository}/issues/comments/${previous_status_comment}" --jq '.body')"
+    fi
+    if [[ "${previous_status_body}" != *"Source commit: \`${head_sha}\`"* ]]; then
+      gh issue edit "${readiness_issue}" --repo "${repository}" --remove-label release-ready >/dev/null
+    fi
+  fi
+
+  status_body="$(cat <<EOF
+${status_marker}
+### Current nightly candidate
+
+- Image: \`ghcr.io/${repository}:nightly\`
+- Build: \`${nightly_version}\`
+- Source commit: \`${head_sha}\`
+- Changes: [\`${change_range}\`](${change_url})
+- [View the nightly workflow](https://github.com/${repository}/actions/runs/${run_id})
+
+### Included pull requests
+
+${pull_list}
+
+### Linked closing issues
+
+${issue_list:-None}
+
+The candidate above is the build that should be used for readiness testing. A nightly built from a newer source commit replaces this status and revokes the \`release-ready\` label until the current candidate is retested.
+EOF
+  )"
+  update_status_comment "${readiness_issue}" "${status_body}"
+  echo "Updated release-readiness issue #${readiness_issue}."
+  exit 0
+fi
+
+ensure_labels
+readiness_issue="$(find_open_record)"
+if [ -z "${readiness_issue}" ]; then
+  echo "No open release-readiness issue found after stable release; nothing to close."
+  exit 0
+fi
+
+status_body="$(cat <<EOF
+${status_marker}
+### Released
+
+The readiness candidate was published as stable release \`${release_version}\`.
+
+- Stable image: \`ghcr.io/${repository}:${release_version}\`
+- Source commit: \`${head_sha}\`
+- [View the release](https://github.com/${repository}/releases/tag/${release_tag})
+- [View the included changes](${change_url})
+EOF
+  )"
+update_status_comment "${readiness_issue}" "${status_body}"
+gh issue edit "${readiness_issue}" \
+  --repo "${repository}" \
+  --title "Release readiness: ${release_version}" \
+  --add-label released \
+  --remove-label release-ready >/dev/null
+gh issue close "${readiness_issue}" --repo "${repository}" >/dev/null
+echo "Closed release-readiness issue #${readiness_issue} for ${release_version}."


### PR DESCRIPTION
## Summary

Adds release-readiness tracking, preview image comments, nightly and stable release status notifications, and manual nightly reconciliation. Updates release documentation and removes obsolete Lidarr root-folder guidance and tests.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change