### PR TITLE
ci: install noto color emoji fonts for validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,19 +22,19 @@ jobs:
 
       - name: Ensure validation runtime dependencies
         run: |
-          if command -v fc-match >/dev/null 2>&1 && command -v ffmpeg >/dev/null 2>&1; then
+          if command -v fc-match >/dev/null 2>&1 && command -v ffmpeg >/dev/null 2>&1 && [ "$(fc-match -f '%{family}' 'Noto Color Emoji')" = "Noto Color Emoji" ]; then
             exit 0
           fi
 
           if [ "$(id -u)" -eq 0 ]; then
             apt-get update
-            apt-get install -y ffmpeg fontconfig fonts-dejavu-core
+            apt-get install -y ffmpeg fontconfig fonts-dejavu-core fonts-noto-color-emoji
           elif command -v sudo >/dev/null 2>&1; then
             sudo apt-get update
-            sudo apt-get install -y ffmpeg fontconfig fonts-dejavu-core
+            sudo apt-get install -y ffmpeg fontconfig fonts-dejavu-core fonts-noto-color-emoji
           else
             echo "ffmpeg and fontconfig are required for validation."
-            echo "Install ffmpeg, fontconfig, and fonts-dejavu-core on the runner."
+            echo "Install ffmpeg, fontconfig, fonts-dejavu-core, and fonts-noto-color-emoji on the runner."
             exit 1
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gosu \
     fontconfig \
     fonts-dejavu-core \
+    fonts-noto-color-emoji \
     python3 \
     ffmpeg \
     ca-certificates \


### PR DESCRIPTION
## Summary

Install Noto Color Emoji fonts in the validation runtime and Docker image so emoji rendering checks use the expected font consistently.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): CI, Docker/upgrade
- Automated coverage: Validation runtime dependency checks verify that Noto Color Emoji is installed and available through fontconfig.
- Manual steps and expected result: Run the validation workflow and confirm dependency setup succeeds with Noto Color Emoji available.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change