### PR TITLE
chore(ci): comment preview images on linked issues

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -116,6 +116,7 @@ jobs:
 
           OWNER="${REPOSITORY%%/*}"
           REPO="${REPOSITORY#*/}"
+          ISSUE_MARKER="aurral-preview-issue-${PR_NUMBER}"
           CLOSING_ISSUES="$(gh api graphql \
             -f query='query($owner: String!, $repo: String!, $number: Int!) {
               repository(owner: $owner, name: $repo) {
@@ -135,7 +136,7 @@ jobs:
             [ -z "${issue_number}" ] && continue
 
             ISSUE_COMMENT_BODY="$(cat <<EOF
-          <!-- aurral-preview-issue -->
+          <!-- ${ISSUE_MARKER} -->
           ## Aurral preview image ready
 
           [Pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}), which is linked to this issue, has a preview image ready to test before it is merged into \`nightly\`. It will be replaced when the pull request changes.
@@ -160,7 +161,7 @@ jobs:
 
             COMMENT_ID="$(gh api --paginate \
               "repos/${REPOSITORY}/issues/${issue_number}/comments" \
-              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- aurral-preview-issue -->"))) | .id' | head -n1)"
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"<!-- ${ISSUE_MARKER} -->\"))) | .id" | head -n1)"
 
             if [ -n "${COMMENT_ID}" ]; then
               gh api \
@@ -183,6 +184,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: write
+      pull-requests: read
       packages: write
     steps:
       - name: Delete preview image
@@ -202,3 +205,49 @@ jobs:
             fi
           done
           echo "No preview image tagged ${IMAGE_TAG}."
+
+      - name: Invalidate linked issue preview comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          OWNER="${REPOSITORY%%/*}"
+          REPO="${REPOSITORY#*/}"
+          ISSUE_MARKER="aurral-preview-issue-${PR_NUMBER}"
+          COMMENT_BODY="$(cat <<EOF
+          <!-- ${ISSUE_MARKER} -->
+          ## Aurral preview image no longer available
+
+          The preview image for [pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}) was retired because the pull request was closed. It is no longer available for testing.
+          EOF
+          )"
+          CLOSING_ISSUES="$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  closingIssuesReferences(first: 100) {
+                    nodes { number }
+                  }
+                }
+              }
+            }' \
+            -f "owner=${OWNER}" \
+            -f "repo=${REPO}" \
+            -F "number=${PR_NUMBER}" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
+
+          while IFS= read -r issue_number; do
+            [ -z "${issue_number}" ] && continue
+
+            COMMENT_ID="$(gh api --paginate \
+              "repos/${REPOSITORY}/issues/${issue_number}/comments" \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"<!-- ${ISSUE_MARKER} -->\"))) | .id" | head -n1)"
+
+            if [ -n "${COMMENT_ID}" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
+                -f "body=${COMMENT_BODY}" >/dev/null
+            fi
+          done <<< "${CLOSING_ISSUES}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      issues: write
       pull-requests: write
       packages: write
     steps:
@@ -68,7 +69,7 @@ jobs:
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Comment preview image on pull request
+      - name: Comment preview image on pull request and linked issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_TAG: pr-${{ github.event.number }}
@@ -112,6 +113,67 @@ jobs:
               --repo "${REPOSITORY}" \
               --body "${COMMENT_BODY}" >/dev/null
           fi
+
+          OWNER="${REPOSITORY%%/*}"
+          REPO="${REPOSITORY#*/}"
+          CLOSING_ISSUES="$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  closingIssuesReferences(first: 100) {
+                    nodes { number }
+                  }
+                }
+              }
+            }' \
+            -f "owner=${OWNER}" \
+            -f "repo=${REPO}" \
+            -F "number=${PR_NUMBER}" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
+
+          while IFS= read -r issue_number; do
+            [ -z "${issue_number}" ] && continue
+
+            ISSUE_COMMENT_BODY="$(cat <<EOF
+          <!-- aurral-preview-issue -->
+          ## Aurral preview image ready
+
+          [Pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}), which is linked to this issue, has a preview image ready to test before it is merged into \`nightly\`. It will be replaced when the pull request changes.
+
+          \`\`\`bash
+          docker pull ghcr.io/${REPOSITORY}:${IMAGE_TAG}
+          \`\`\`
+
+          To test it with your existing Docker Compose setup:
+
+          1. Back up your Aurral config.
+          2. Temporarily change the Aurral service image to \`ghcr.io/${REPOSITORY}:${IMAGE_TAG}\`.
+          3. Run \`docker compose pull aurral && docker compose up -d aurral\`.
+          4. Exercise the behavior changed by the pull request.
+          5. Restore the image reference that was configured before testing.
+
+          Please report your results and approval on the pull request before it is merged into nightly.
+
+          [View the preview workflow run](https://github.com/${REPOSITORY}/actions/runs/${RUN_ID})
+          EOF
+            )"
+
+            COMMENT_ID="$(gh api --paginate \
+              "repos/${REPOSITORY}/issues/${issue_number}/comments" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- aurral-preview-issue -->"))) | .id' | head -n1)"
+
+            if [ -n "${COMMENT_ID}" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
+                -f "body=${ISSUE_COMMENT_BODY}" >/dev/null
+            else
+              gh api \
+                --method POST \
+                "repos/${REPOSITORY}/issues/${issue_number}/comments" \
+                -f "body=${ISSUE_COMMENT_BODY}" >/dev/null
+            fi
+          done <<< "${CLOSING_ISSUES}"
 
   delete-image:
     if: >-

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -45,7 +45,7 @@ Aurral checks for a newer build in your channel and shows a banner when one exis
 
 When a pull request has a preview image, its GitHub conversation contains a comment with the exact `pr-<number>` image tag and test instructions. The comment is updated whenever a new preview image is built.
 
-If the pull request is linked to an issue, that issue also receives the preview image and test instructions.
+If the pull request is linked to an issue, that issue also receives the preview image and test instructions. The issue comment is updated for new images and invalidated when the pull request closes.
 
 To test the image with an existing Compose setup:
 

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -45,6 +45,8 @@ Aurral checks for a newer build in your channel and shows a banner when one exis
 
 When a pull request has a preview image, its GitHub conversation contains a comment with the exact `pr-<number>` image tag and test instructions. The comment is updated whenever a new preview image is built.
 
+If the pull request is linked to an issue, that issue also receives the preview image and test instructions.
+
 To test the image with an existing Compose setup:
 
 1. Back up `./config`.


### PR DESCRIPTION
## Summary

Update the preview workflow to post or update preview image comments on issues linked to a pull request. Document this behavior in the Docker testing guide.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): CI, Docker/upgrade, docs
- Automated coverage: Existing preview workflow execution
- Manual steps and expected result: Open a pull request linked to an issue and verify that the preview workflow creates or updates the issue comment with the preview image tag and testing instructions.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change