### PR TITLE
fix(lidarr): resolve numeric artist ids before follow-up calls

### DIFF
--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -161,6 +161,113 @@ test("album-only artist add queues a search for the selected album", async (t) =
   assert.equal(postedArtist.addOptions.searchForMissingAlbums, true);
 });
 
+test("artist add resolves a non-numeric Lidarr response ID before follow-up calls", async (t) => {
+  const artistMbid = "f1693075-b637-49f8-8d0e-8cee8bec77cb";
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url);
+    if (request.method === "POST" && request.url === "/api/v1/artist") {
+      response.writeHead(201, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: artistMbid,
+          foreignArtistId: artistMbid,
+          artistName: "Lena Raine",
+          monitored: false,
+        }),
+      );
+      return;
+    }
+    if (request.method === "GET" && request.url === "/api/v1/artist") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify([
+          {
+            id: 42,
+            foreignArtistId: artistMbid,
+            artistName: "Lena Raine",
+            monitored: false,
+          },
+        ]),
+      );
+      return;
+    }
+    if (request.method === "GET" && request.url === `/api/v1/artist/${artistMbid}`) {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          message: `The input string '${artistMbid}' was not in a correct format.`,
+        }),
+      );
+      return;
+    }
+    if (request.method === "GET" && request.url === "/api/v1/artist/42") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: 42,
+          foreignArtistId: artistMbid,
+          artistName: "Lena Raine",
+          monitored: false,
+        }),
+      );
+      return;
+    }
+    if (request.method === "PUT" && request.url === "/api/v1/artist/42") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: 42,
+          foreignArtistId: artistMbid,
+          artistName: "Lena Raine",
+          monitored: true,
+        }),
+      );
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+
+  const artist = await client.addArtist(artistMbid, "Lena Raine", {
+    metadataProfileId: 1,
+  });
+
+  assert.equal(artist.id, 42);
+  assert.equal(requests.includes(`/api/v1/artist/${artistMbid}`), false);
+  assert.deepEqual(requests, [
+    "/api/v1/artist",
+    "/api/v1/artist",
+    "/api/v1/artist/42",
+    "/api/v1/artist/42",
+  ]);
+
+  client._httpAgent.destroy();
+  client._httpsAgent.destroy();
+  client._httpsInsecureAgent.destroy();
+});
+
 test("Lidarr cooldown permits only one half-open recovery request", async (t) => {
   const firstRequest = Promise.withResolvers();
   const releaseFirst = Promise.withResolvers();

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -164,6 +164,7 @@ test("album-only artist add queues a search for the selected album", async (t) =
 test("artist add resolves a non-numeric Lidarr response ID before follow-up calls", async (t) => {
   const artistMbid = "f1693075-b637-49f8-8d0e-8cee8bec77cb";
   const requests = [];
+  let updatePayload;
   const server = http.createServer((request, response) => {
     requests.push(request.url);
     if (request.method === "POST" && request.url === "/api/v1/artist") {
@@ -214,15 +215,23 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
       return;
     }
     if (request.method === "PUT" && request.url === "/api/v1/artist/42") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(
-        JSON.stringify({
-          id: 42,
-          foreignArtistId: artistMbid,
-          artistName: "Lena Raine",
-          monitored: true,
-        }),
-      );
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        updatePayload = JSON.parse(body);
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            id: 42,
+            foreignArtistId: artistMbid,
+            artistName: "Lena Raine",
+            monitored: true,
+          }),
+        );
+      });
       return;
     }
     response.writeHead(404);
@@ -255,6 +264,8 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   });
 
   assert.equal(artist.id, 42);
+  assert.equal(artist.monitored, true);
+  assert.equal(updatePayload.monitored, true);
   assert.equal(requests.includes(`/api/v1/artist/${artistMbid}`), false);
   assert.deepEqual(requests, [
     "/api/v1/artist",
@@ -266,6 +277,106 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   client._httpAgent.destroy();
   client._httpsAgent.destroy();
   client._httpsInsecureAgent.destroy();
+});
+
+test("artist add fails when Lidarr cannot resolve a numeric ID", async (t) => {
+  const artistMbid = "f1693075-b637-49f8-8d0e-8cee8bec77cb";
+  const client = new LidarrClient();
+  t.after(() => {
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+
+  let postCount = 0;
+  let lookupCount = 0;
+  client.request = async (endpoint, method, _payload, _skipConfigUpdate, options) => {
+    if (endpoint === "/artist" && method === "POST") {
+      postCount += 1;
+      return {
+        id: artistMbid,
+        foreignArtistId: artistMbid,
+        artistName: "Lena Raine",
+      };
+    }
+    if (endpoint === "/artist" && method === "GET") {
+      lookupCount += 1;
+      if (lookupCount === 2) {
+        assert.equal(options.forceRefresh, true);
+      }
+      return [];
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  await assert.rejects(
+    client.addArtist(artistMbid, "Lena Raine", {
+      metadataProfileId: 1,
+      monitorOption: "all",
+    }),
+    /numeric artist ID/,
+  );
+
+  assert.equal(postCount, 1);
+  assert.equal(lookupCount, 2);
+});
+
+test("artist add does not retry creation after monitoring fails", async (t) => {
+  const client = new LidarrClient();
+  t.after(() => {
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+
+  let postCount = 0;
+  client.request = async (endpoint, method = "GET") => {
+    if (endpoint === "/artist" && method === "POST") {
+      postCount += 1;
+      return {
+        id: 42,
+        foreignArtistId: "artist-mbid",
+        artistName: "Lena Raine",
+        monitored: false,
+      };
+    }
+    if (endpoint === "/artist/42" && method === "GET") {
+      return {
+        id: 42,
+        foreignArtistId: "artist-mbid",
+        artistName: "Lena Raine",
+        monitored: false,
+      };
+    }
+    if (endpoint === "/artist/42" && method === "PUT") {
+      throw new Error("monitoring failed");
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  await assert.rejects(
+    client.addArtist("artist-mbid", "Lena Raine", {
+      metadataProfileId: 1,
+      monitorOption: "all",
+    }),
+    /monitoring failed/,
+  );
+
+  assert.equal(postCount, 1);
 });
 
 test("Lidarr cooldown permits only one half-open recovery request", async (t) => {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -882,10 +882,13 @@ export class LibraryManager {
 
   mapLidarrArtist(lidarrArtist) {
     const artistPath = lidarrArtist.path ?? null;
+    const artistId = Number(lidarrArtist.id);
+    const normalizedArtistId =
+      Number.isSafeInteger(artistId) && artistId > 0 ? String(artistId) : null;
     const monitorOption = lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none";
     const normalizedMonitorOption = monitorOption || "none";
     return {
-      id: lidarrArtist.id?.toString() || lidarrArtist.foreignArtistId,
+      id: normalizedArtistId,
       mbid: lidarrArtist.foreignArtistId,
       foreignArtistId: lidarrArtist.foreignArtistId,
       artistName: lidarrArtist.artistName,

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -45,6 +45,11 @@ function normalizeProfileId(value) {
   return Math.trunc(parsed);
 }
 
+function normalizeLidarrArtistId(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? String(parsed) : null;
+}
+
 function normalizeMonitorOption(value) {
   const option = String(value || "none").trim();
   return VALID_MONITOR_OPTIONS.has(option) ? option : "none";
@@ -948,6 +953,14 @@ export class LidarrClient {
       },
     };
 
+    const resolveAddedArtist = async (artist) => {
+      if (normalizeLidarrArtistId(artist?.id)) {
+        return artist;
+      }
+      const resolvedArtist = await this.getArtistByMbid(mbid);
+      return normalizeLidarrArtistId(resolvedArtist?.id) ? resolvedArtist : artist;
+    };
+
     const ensureArtistMonitored = async (artist) => {
       if (albumOnly && options.triggerSearch === true) {
         logger.info("library", "Queued Lidarr album search with artist add", {
@@ -955,15 +968,16 @@ export class LidarrClient {
           albumMbid,
         });
       }
-      if (!artist?.id || artist.monitored === true) {
+      const artistId = normalizeLidarrArtistId(artist?.id);
+      if (!artistId || artist.monitored === true) {
         return artist;
       }
-      return this.updateArtistMonitoring(artist.id, monitoring.option);
+      return this.updateArtistMonitoring(artistId, monitoring.option);
     };
 
     try {
       const result = await this.request("/artist", "POST", lidarrArtist);
-      return ensureArtistMonitored(result);
+      return ensureArtistMonitored(await resolveAddedArtist(result));
     } catch (error) {
       if (requestedMonitorOption !== "all") {
         throw error;
@@ -977,12 +991,16 @@ export class LidarrClient {
         },
       };
       const result = await this.request("/artist", "POST", fallbackArtist);
-      return ensureArtistMonitored(result);
+      return ensureArtistMonitored(await resolveAddedArtist(result));
     }
   }
 
   async getArtist(artistId) {
-    return this.request(`/artist/${artistId}`);
+    const normalizedArtistId = normalizeLidarrArtistId(artistId);
+    if (!normalizedArtistId) {
+      throw new Error(`Lidarr artist ID must be numeric: ${artistId}`);
+    }
+    return this.request(`/artist/${normalizedArtistId}`);
   }
 
   async getArtistByMbid(mbid) {
@@ -1030,18 +1048,26 @@ export class LidarrClient {
   }
 
   async updateArtist(artistId, updates) {
-    const artist = await this.getArtist(artistId);
+    const normalizedArtistId = normalizeLidarrArtistId(artistId);
+    if (!normalizedArtistId) {
+      throw new Error(`Lidarr artist ID must be numeric: ${artistId}`);
+    }
+    const artist = await this.getArtist(normalizedArtistId);
 
     const updated = {
       ...artist,
       ...updates,
     };
 
-    return this.request(`/artist/${artistId}`, "PUT", updated);
+    return this.request(`/artist/${normalizedArtistId}`, "PUT", updated);
   }
 
   async updateArtistMonitoring(artistId, monitorOption) {
-    const artist = await this.getArtist(artistId);
+    const normalizedArtistId = normalizeLidarrArtistId(artistId);
+    if (!normalizedArtistId) {
+      throw new Error(`Lidarr artist ID must be numeric: ${artistId}`);
+    }
+    const artist = await this.getArtist(normalizedArtistId);
     const monitoring = getArtistMonitoringPayload(monitorOption);
 
     const updated = {
@@ -1056,7 +1082,7 @@ export class LidarrClient {
     };
 
     try {
-      return await this.request(`/artist/${artistId}`, "PUT", updated);
+      return await this.request(`/artist/${normalizedArtistId}`, "PUT", updated);
     } catch (error) {
       if (monitoring.option !== "all") {
         throw error;
@@ -1069,7 +1095,7 @@ export class LidarrClient {
           monitor: "existing",
         },
       };
-      return this.request(`/artist/${artistId}`, "PUT", fallbackUpdated);
+      return this.request(`/artist/${normalizedArtistId}`, "PUT", fallbackUpdated);
     }
   }
 

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -957,8 +957,14 @@ export class LidarrClient {
       if (normalizeLidarrArtistId(artist?.id)) {
         return artist;
       }
-      const resolvedArtist = await this.getArtistByMbid(mbid);
-      return normalizeLidarrArtistId(resolvedArtist?.id) ? resolvedArtist : artist;
+      let resolvedArtist = await this.getArtistByMbid(mbid);
+      if (!normalizeLidarrArtistId(resolvedArtist?.id)) {
+        resolvedArtist = await this.getArtistByMbid(mbid, { forceRefresh: true });
+      }
+      if (!normalizeLidarrArtistId(resolvedArtist?.id)) {
+        throw new Error(`Lidarr add did not return a numeric artist ID for ${mbid}`);
+      }
+      return resolvedArtist;
     };
 
     const ensureArtistMonitored = async (artist) => {
@@ -975,9 +981,9 @@ export class LidarrClient {
       return this.updateArtistMonitoring(artistId, monitoring.option);
     };
 
+    let result;
     try {
-      const result = await this.request("/artist", "POST", lidarrArtist);
-      return ensureArtistMonitored(await resolveAddedArtist(result));
+      result = await this.request("/artist", "POST", lidarrArtist);
     } catch (error) {
       if (requestedMonitorOption !== "all") {
         throw error;
@@ -990,9 +996,9 @@ export class LidarrClient {
           monitor: "existing",
         },
       };
-      const result = await this.request("/artist", "POST", fallbackArtist);
-      return ensureArtistMonitored(await resolveAddedArtist(result));
+      result = await this.request("/artist", "POST", fallbackArtist);
     }
+    return ensureArtistMonitored(await resolveAddedArtist(result));
   }
 
   async getArtist(artistId) {
@@ -1003,39 +1009,51 @@ export class LidarrClient {
     return this.request(`/artist/${normalizedArtistId}`);
   }
 
-  async getArtistByMbid(mbid) {
+  async getArtistByMbid(mbid, { forceRefresh = false } = {}) {
     const normalizedMbid = String(mbid || "").trim();
     if (!normalizedMbid) return null;
 
-    const cachedArtist = this._getArtistByMbidCacheEntry(normalizedMbid);
-    if (cachedArtist !== undefined) {
-      return cachedArtist;
+    if (forceRefresh) {
+      this._artistByMbidCache.delete(normalizedMbid);
+    } else {
+      const cachedArtist = this._getArtistByMbidCacheEntry(normalizedMbid);
+      if (cachedArtist !== undefined) {
+        return cachedArtist;
+      }
+
+      if (this._artistListCache && Date.now() - this._artistListCache.at < LIDARR_LIST_CACHE_MS) {
+        const artists = Array.isArray(this._artistListCache.data)
+          ? this._artistListCache.data
+          : [];
+        this._populateArtistIndexes(artists);
+        const artist = artists.find((entry) => entry?.foreignArtistId === normalizedMbid) || null;
+        this._setArtistByMbidCacheEntry(normalizedMbid, artist);
+        return artist;
+      }
     }
 
-    if (this._artistListCache && Date.now() - this._artistListCache.at < LIDARR_LIST_CACHE_MS) {
-      const artists = Array.isArray(this._artistListCache.data) ? this._artistListCache.data : [];
-      this._populateArtistIndexes(artists);
-      const artist = artists.find((entry) => entry?.foreignArtistId === normalizedMbid) || null;
-      this._setArtistByMbidCacheEntry(normalizedMbid, artist);
-      return artist;
-    }
-
-    const inflight = this._artistByMbidInflight.get(normalizedMbid);
-    if (inflight) {
-      return inflight;
+    if (!forceRefresh) {
+      const inflight = this._artistByMbidInflight.get(normalizedMbid);
+      if (inflight) {
+        return inflight;
+      }
     }
 
     const startedAt = Date.now();
-    const requestPromise = this.request("/artist")
+    const requestPromise = this.request("/artist", "GET", null, false, { forceRefresh })
       .then((artists) => {
         const list = Array.isArray(artists) ? artists : [];
         this._populateArtistIndexes(list);
         const artist = list.find((entry) => entry?.foreignArtistId === normalizedMbid) || null;
-        this._setArtistByMbidCacheEntry(normalizedMbid, artist);
+        if (artist || !forceRefresh) {
+          this._setArtistByMbidCacheEntry(normalizedMbid, artist);
+        }
         return artist;
       })
       .finally(() => {
-        this._artistByMbidInflight.delete(normalizedMbid);
+        if (!forceRefresh) {
+          this._artistByMbidInflight.delete(normalizedMbid);
+        }
         const durationMs = Date.now() - startedAt;
         logger.debug("api", "Lidarr getArtistByMbid completed", {
           mbid: normalizedMbid,
@@ -1043,7 +1061,9 @@ export class LidarrClient {
         });
       });
 
-    this._artistByMbidInflight.set(normalizedMbid, requestPromise);
+    if (!forceRefresh) {
+      this._artistByMbidInflight.set(normalizedMbid, requestPromise);
+    }
     return requestPromise;
   }
 


### PR DESCRIPTION
## Summary

Normalize Lidarr artist IDs to positive numeric values before follow-up requests. When an artist-add response contains a non-numeric ID, resolve the artist by MBID before monitoring or update calls. Add regression coverage for this response format.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Lidarr integration, library management
- Automated coverage: Added a circuit test covering non-numeric artist IDs returned by the add endpoint and numeric ID resolution by MBID.
- Manual steps and expected result: Add an artist through Lidarr integration and verify follow-up monitoring requests use the resolved numeric artist ID.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change