### PR TITLE
fix(slskd): clarify disconnected network health

### DIFF
--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -674,8 +674,8 @@ async function checkSlskdSection() {
     extraSteps: (connection) => {
       if (connection.soulseekConnected === false) {
         return [
-          healthStep("soulseek", "warn", "Soulseek network is connected", {
-            detail: connection.serverState || "Disconnected",
+          healthStep("soulseek", "warn", "slskd network is not connected", {
+            detail: "slskd is started but the network is not connected",
             fix: "Open slskd, log in, and connect to the Soulseek server before starting downloads.",
           }),
         ];


### PR DESCRIPTION
## Summary

Clarify the slskd health warning when the Soulseek network is disconnected, including a more accurate status message and actionable detail.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): integrations, health checks
- Automated coverage: Existing health-check coverage, if applicable
- Manual steps and expected result: Verify that a disconnected slskd network reports that slskd is started but the network is not connected, with guidance to connect to the Soulseek server.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change