### PR TITLE
fix(weekly-flow): remove playlist name prefixes

### DIFF
--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -86,7 +86,7 @@ test("approving a reviewed download commits it inside the managed playlist libra
   assert.equal(downloadTracker.getJob(jobId)?.finalPath, expectedPath);
   assert.equal(await fs.readFile(expectedPath, "utf8"), "reviewed audio");
   const m3u = await fs.readFile(
-    path.join(playlistManager.libraryRoot, "[AS] Reviewed.m3u"),
+    path.join(playlistManager.libraryRoot, "Reviewed.m3u"),
     "utf8",
   );
   assert.match(m3u, /Track\.flac/);

--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -54,6 +54,23 @@ test("creates flows with normalized scheduling and enforces unique names", () =>
   );
 });
 
+test("rejects flow and shared playlist names that collide across types", () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Rock" });
+  assert.throws(
+    () => flowPlaylistConfig.createSharedPlaylist({ name: "rock" }),
+    /already exists/,
+  );
+
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Jazz" });
+  assert.throws(
+    () => flowPlaylistConfig.createFlow({ name: "Jazz" }),
+    /already exists/,
+  );
+
+  flowPlaylistConfig.deleteFlow(flow.id);
+  flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+});
+
 test("records flow last run time", () => {
   const flow = flowPlaylistConfig.createFlow({
     name: "Morning",

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
@@ -469,36 +469,34 @@ const createSharedPlaylistNameConflictError = (name) => {
   return error;
 };
 
-const assertUniqueFlowName = (flows, nextName, exceptFlowId = null) => {
-  const key = normalizeNameKey(nextName);
-  if (!key) return;
-  const hasConflict = flows.some((flow) => {
-    if (!flow) return false;
-    if (exceptFlowId && flow.id === exceptFlowId) return false;
-    return normalizeNameKey(flow.name) === key;
-  });
-  if (hasConflict) {
-    throw createNameConflictError(String(nextName || "").trim());
-  }
-};
-
 const canUserAccessOwnerScopedEntity = (user, ownerUserId) => {
   if (user?.role === "admin") return true;
   if (!user || ownerUserId == null) return false;
   return Number(user.id) === Number(ownerUserId);
 };
 
-const assertUniqueSharedPlaylistName = (playlists, nextName, exceptPlaylistId = null) => {
+const assertUniqueLibraryName = (
+  nextName,
+  { exceptFlowId = null, exceptPlaylistId = null, conflictAs = "flow" } = {},
+) => {
   const key = normalizeNameKey(nextName);
   if (!key) return;
-  const hasConflict = playlists.some((playlist) => {
+  const displayName = String(nextName || "").trim();
+  const flowConflict = getStoredFlows().some((flow) => {
+    if (!flow) return false;
+    if (exceptFlowId && flow.id === exceptFlowId) return false;
+    return normalizeNameKey(flow.name) === key;
+  });
+  const playlistConflict = getStoredSharedPlaylists().some((playlist) => {
     if (!playlist) return false;
     if (exceptPlaylistId && playlist.id === exceptPlaylistId) return false;
     return normalizeNameKey(playlist.name) === key;
   });
-  if (hasConflict) {
-    throw createSharedPlaylistNameConflictError(String(nextName || "").trim());
+  if (!flowConflict && !playlistConflict) return;
+  if (conflictAs === "shared") {
+    throw createSharedPlaylistNameConflictError(displayName);
   }
+  throw createNameConflictError(displayName);
 };
 
 export const flowPlaylistConfig = {
@@ -561,8 +559,8 @@ export const flowPlaylistConfig = {
     type = null,
     tag = null,
   }) {
+    assertUniqueLibraryName(name, { conflictAs: "flow" });
     const flows = getStoredFlows();
-    assertUniqueFlowName(flows, name);
     const flow = normalizeFlow({
       id: randomUUID(),
       name,
@@ -592,7 +590,10 @@ export const flowPlaylistConfig = {
     if (index === -1) return null;
     const current = flows[index];
     const nextName = updates?.name ?? current.name;
-    assertUniqueFlowName(flows, nextName, flowId);
+    assertUniqueLibraryName(nextName, {
+      exceptFlowId: flowId,
+      conflictAs: "flow",
+    });
     const currentSchedule = normalizeScheduleDays(current.scheduleDays);
     const currentScheduleTime = normalizeScheduleTime(current.scheduleTime);
     const next = normalizeFlow({
@@ -713,8 +714,8 @@ export const flowPlaylistConfig = {
     ownerUserId = null,
     importSource = null,
   }) {
+    assertUniqueLibraryName(name, { conflictAs: "shared" });
     const playlists = getStoredSharedPlaylists();
-    assertUniqueSharedPlaylistName(playlists, name);
     const playlist = normalizeSharedPlaylist({
       id: String(id || "").trim() || randomUUID(),
       name,
@@ -755,7 +756,10 @@ export const flowPlaylistConfig = {
     if (index === -1) return null;
     const current = playlists[index];
     const nextName = updates?.name ?? current.name;
-    assertUniqueSharedPlaylistName(playlists, nextName, playlistId);
+    assertUniqueLibraryName(nextName, {
+      exceptPlaylistId: playlistId,
+      conflictAs: "shared",
+    });
     const next = normalizeSharedPlaylist({
       ...current,
       name: nextName,

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -112,16 +112,16 @@ export class WeeklyFlowPlaylistManager {
   _getFlowPlaylistNames(flowName) {
     const name = String(flowName || "").trim();
     return {
-      current: `[A] ${name}`,
-      legacy: [`Aurral ${name}`],
+      current: name,
+      legacy: [`[A] ${name}`, `Aurral ${name}`],
     };
   }
 
   _getSharedPlaylistNames(playlistName) {
     const name = String(playlistName || "").trim();
     return {
-      current: `[AS] ${name}`,
-      legacy: [`Aurral Shared ${name}`],
+      current: name,
+      legacy: [`[AS] ${name}`, `Aurral Shared ${name}`],
     };
   }
 
@@ -136,7 +136,7 @@ export class WeeklyFlowPlaylistManager {
       const names = this._getSharedPlaylistNames(sharedPlaylist.name);
       return [names.current, ...names.legacy];
     }
-    return [`[A] ${playlistType}`, `Aurral ${playlistType}`];
+    return [playlistType, `[A] ${playlistType}`, `Aurral ${playlistType}`];
   }
 
   async ensurePlaylists() {
@@ -445,7 +445,6 @@ export class WeeklyFlowPlaylistManager {
       this._plexSyncHashes.set(desired, hash);
     };
 
-    // Plex uses the bare flow name; remove any old "[A]"/"[AS]" prefixed names.
     for (const flow of flows) {
       const desired = String(flow.name || "").trim();
       const { current, legacy } = this._getFlowPlaylistNames(flow.name);

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -34,7 +34,7 @@ You can run both at the same time. They use the same download tree but different
 | Playlist format   | `.m3u` files on disk                                   | Regular Plex playlists through the API                     |
 | Library setup     | Scan folders and read M3U                              | Aurral creates an **Aurral** music library through the API |
 | Path mismatch fix | **Use Navidrome paths in M3U files** / `M3U_PATH_MODE` | **Plex downloads path** (optional)                 |
-| Playlist names    | `[A] Flow name`, `[AS] Shared name`                    | Bare flow or playlist name                         |
+| Playlist names    | Bare flow or playlist name                             | Bare flow or playlist name                         |
 
 Navidrome's M3U path settings do not affect Plex.
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -20,6 +20,8 @@ Aurral does not write these files to your main music library.
 
 Flows refresh on a schedule and use your flow settings. Static playlists come from Spotify, JSON files, or exported flow tracklists.
 
+Flow names and static playlist names must be unique across both types. Aurral uses the same bare name for Navidrome and Plex playlists.
+
 If all download sources fail, the track stays in the failed state after an Aurral restart.
 
 Select **Re-search missing** from the playlist menu to try the track again.


### PR DESCRIPTION
## Summary

Remove `[A]` and `[AS]` prefixes from weekly flow and shared playlist names while retaining legacy-name compatibility for existing playlists. Update the approved import test and Plex integration documentation to reflect the bare-name convention.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): weekly flow playlist management, Plex integration, documentation
- Automated coverage: Updated the approved import path test to expect the unprefixed managed playlist name
- Manual steps and expected result: Exercise weekly flow and shared playlist synchronization; verify new playlists use bare names and existing prefixed playlists remain recognized and migrated correctly

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change