### PR TITLE
ci(github): label linked issues as in-progress

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -132,6 +132,14 @@ jobs:
             -F "number=${PR_NUMBER}" \
             --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
 
+          if [ -n "${CLOSING_ISSUES}" ]; then
+            gh label create in-progress \
+              --repo "${REPOSITORY}" \
+              --color FBCA04 \
+              --description "Linked pull request is open and being worked on." \
+              --force >/dev/null
+          fi
+
           while IFS= read -r issue_number; do
             [ -z "${issue_number}" ] && continue
 
@@ -174,6 +182,11 @@ jobs:
                 "repos/${REPOSITORY}/issues/${issue_number}/comments" \
                 -f "body=${ISSUE_COMMENT_BODY}" >/dev/null
             fi
+
+            gh api \
+              --method POST \
+              "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              -f "labels[]=in-progress" >/dev/null
           done <<< "${CLOSING_ISSUES}"
 
   delete-image:
@@ -250,4 +263,9 @@ jobs:
                 "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
                 -f "body=${COMMENT_BODY}" >/dev/null
             fi
+
+            gh api \
+              --method DELETE \
+              "repos/${REPOSITORY}/issues/${issue_number}/labels/in-progress" \
+              >/dev/null 2>&1 || true
           done <<< "${CLOSING_ISSUES}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -264,8 +264,15 @@ jobs:
                 -f "body=${COMMENT_BODY}" >/dev/null
             fi
 
-            gh api \
-              --method DELETE \
-              "repos/${REPOSITORY}/issues/${issue_number}/labels/in-progress" \
-              >/dev/null 2>&1 || true
+            if ! DELETE_OUTPUT="$(gh api \
+                --method DELETE \
+                "repos/${REPOSITORY}/issues/${issue_number}/labels/in-progress" \
+                --include \
+                --silent 2>&1)"; then
+              DELETE_STATUS="$(printf '%s\n' "${DELETE_OUTPUT}" | awk 'NR == 1 { print $2; exit }')"
+              if [ "${DELETE_STATUS}" != "404" ]; then
+                printf '%s\n' "${DELETE_OUTPUT}" >&2
+                exit 1
+              fi
+            fi
           done <<< "${CLOSING_ISSUES}"

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -45,7 +45,7 @@ Aurral checks for a newer build in your channel and shows a banner when one exis
 
 When a pull request has a preview image, its GitHub conversation contains a comment with the exact `pr-<number>` image tag and test instructions. The comment is updated whenever a new preview image is built.
 
-If the pull request is linked to an issue, that issue also receives the preview image and test instructions. The issue comment is updated for new images and invalidated when the pull request closes.
+If the pull request is linked to an issue, that issue also receives the preview image and test instructions, and the `in-progress` label. The issue comment is updated for new images and invalidated when the pull request closes. The `in-progress` label is removed when the pull request closes, and later replaced by `nightly` or `released` after merge.
 
 To test the image with an existing Compose setup:
 

--- a/scripts/notify-github-status.sh
+++ b/scripts/notify-github-status.sh
@@ -95,10 +95,12 @@ set_status_label() {
     --method POST \
     "repos/${repository}/issues/${target_number}/labels" \
     -f "labels[]=${add_label}" >/dev/null
-  gh api \
-    --method DELETE \
-    "repos/${repository}/issues/${target_number}/labels/${remove_label}" \
-    >/dev/null 2>&1 || true
+  for label in "${remove_label}" in-progress; do
+    gh api \
+      --method DELETE \
+      "repos/${repository}/issues/${target_number}/labels/${label}" \
+      >/dev/null 2>&1 || true
+  done
 }
 
 for target_number in $(printf '%s\n' "${!target_numbers[@]}" | sort -n); do

--- a/scripts/notify-github-status.sh
+++ b/scripts/notify-github-status.sh
@@ -86,6 +86,29 @@ for pull_number in "${!pull_numbers[@]}"; do
   done <<< "${closing_issues}"
 done
 
+remove_issue_label() {
+  local target_number="$1"
+  local label="$2"
+  local output
+  local status
+
+  if output="$(gh api \
+      --method DELETE \
+      "repos/${repository}/issues/${target_number}/labels/${label}" \
+      --include \
+      --silent 2>&1)"; then
+    return 0
+  fi
+
+  status="$(printf '%s\n' "${output}" | awk 'NR == 1 { print $2; exit }')"
+  if [ "${status}" = "404" ]; then
+    return 0
+  fi
+
+  printf '%s\n' "${output}" >&2
+  return 1
+}
+
 set_status_label() {
   local target_number="$1"
   local add_label="$2"
@@ -96,10 +119,7 @@ set_status_label() {
     "repos/${repository}/issues/${target_number}/labels" \
     -f "labels[]=${add_label}" >/dev/null
   for label in "${remove_label}" in-progress; do
-    gh api \
-      --method DELETE \
-      "repos/${repository}/issues/${target_number}/labels/${label}" \
-      >/dev/null 2>&1 || true
+    remove_issue_label "${target_number}" "${label}"
   done
 }
 


### PR DESCRIPTION
## Summary

Update preview workflows to apply an `in-progress` label to issues linked from open pull requests and remove it when the pull request closes. Extend status notifications to clear the label during status transitions, and document the behavior.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): GitHub workflows, issue labels, Docker preview documentation
- Automated coverage: CI workflow and shell script changes validated by CI
- Manual steps and expected result: Open a preview pull request linked to an issue and verify the issue receives the `in-progress` label; close or merge the pull request and verify the label is removed and subsequent status labels are applied.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request previews now update linked issues with preview details and an `in-progress` status.
  * The status is automatically removed when the pull request closes, then replaced with `nightly` or `released` after merging.
* **Documentation**
  * Updated Docker and preview documentation to explain linked-issue updates and status-label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->