### PR TITLE
ci(dependabot): keep major updates out of dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,20 @@ updates:
     groups:
       root-production:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       root-tooling:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       root-transitive:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -30,6 +39,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -43,3 +55,6 @@ updates:
       root-docker:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Limit Dependabot groups (npm, GitHub Actions, Docker) to `minor` and `patch` updates
- Leave major upgrades ungrouped so each opens its own PR and cannot poison a weekly batch like #510

## Test plan
- [ ] After merge, comment `@dependabot recreate` on #510
- [ ] Confirm Dependabot reopens production updates without bundling `better-sqlite3` / `undici` majors into the same group PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update grouping to include only minor and patch releases.
  * Major dependency updates will now be handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->