### PR TITLE
fix(release): close linked issues on stable releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
 
 <!-- Use a Conventional Commit title (`feat:`, `fix:`, etc.); merged commit subjects drive release version suggestions. -->
 
+## Linked issues
+
+<!-- Use Fixes #123 or Closes #123 to link. Issues stay open until the change ships in a stable release; merging only puts the fix on nightly. -->
+
 ## Validation
 
 - [ ] CI passes

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,32 @@
+name: Label pull request
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    if: >-
+      github.event.action != 'edited' ||
+      github.event.changes.title != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Label from Conventional Commit title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash scripts/label-pr-from-title.sh

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -222,19 +222,30 @@ jobs:
       - name: Invalidate linked issue preview comments
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
           PR_NUMBER: ${{ github.event.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           OWNER="${REPOSITORY%%/*}"
           REPO="${REPOSITORY#*/}"
           ISSUE_MARKER="aurral-preview-issue-${PR_NUMBER}"
-          COMMENT_BODY="$(cat <<EOF
+          if [ "${PR_MERGED}" = "true" ]; then
+            COMMENT_BODY="$(cat <<EOF
+          <!-- ${ISSUE_MARKER} -->
+          ## Aurral preview image retired
+
+          [Pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}) was merged into \`main\`. The preview image was retired. The change will appear on \`nightly\` after that build succeeds, and linked issues stay open until a stable release includes it.
+          EOF
+            )"
+          else
+            COMMENT_BODY="$(cat <<EOF
           <!-- ${ISSUE_MARKER} -->
           ## Aurral preview image no longer available
 
-          The preview image for [pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}) was retired because the pull request was closed. It is no longer available for testing.
+          The preview image for [pull request #${PR_NUMBER}](https://github.com/${REPOSITORY}/pull/${PR_NUMBER}) was retired because the pull request was closed without merging. It is no longer available for testing.
           EOF
-          )"
+            )"
+          fi
           CLOSING_ISSUES="$(gh api graphql \
             -f query='query($owner: String!, $repo: String!, $number: Int!) {
               repository(owner: $owner, name: $repo) {

--- a/scripts/label-pr-from-title.sh
+++ b/scripts/label-pr-from-title.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+pr_title="${PR_TITLE:?PR_TITLE is required}"
+
+managed_labels=(enhancement bug documentation)
+
+commit_type="$(printf '%s\n' "${pr_title}" | sed -nE 's/^([A-Za-z]+)(\([^)]*\))?\!?:[[:space:]].*/\1/p' | tr '[:upper:]' '[:lower:]')"
+
+if [ -z "${commit_type}" ]; then
+  echo "Pull request #${pr_number} title has no Conventional Commit type; leaving changelog labels unchanged."
+  exit 0
+fi
+
+desired_label=""
+case "${commit_type}" in
+  feat)
+    desired_label=enhancement
+    ;;
+  fix)
+    desired_label=bug
+    ;;
+  docs)
+    desired_label=documentation
+    ;;
+esac
+
+remove_issue_label() {
+  local label="$1"
+  local output
+  local status
+
+  if output="$(gh api \
+      --method DELETE \
+      "repos/${repository}/issues/${pr_number}/labels/${label}" \
+      --include \
+      --silent 2>&1)"; then
+    return 0
+  fi
+
+  status="$(printf '%s\n' "${output}" | awk 'NR == 1 { print $2; exit }')"
+  if [ "${status}" = "404" ]; then
+    return 0
+  fi
+
+  printf '%s\n' "${output}" >&2
+  return 1
+}
+
+if [ -n "${desired_label}" ]; then
+  gh label create "${desired_label}" \
+    --repo "${repository}" \
+    --force >/dev/null
+  gh api \
+    --method POST \
+    "repos/${repository}/issues/${pr_number}/labels" \
+    -f "labels[]=${desired_label}" >/dev/null
+  echo "Labeled pull request #${pr_number} with ${desired_label} from ${commit_type}: title."
+fi
+
+for label in "${managed_labels[@]}"; do
+  if [ "${label}" = "${desired_label}" ]; then
+    continue
+  fi
+  remove_issue_label "${label}"
+done
+
+if [ -z "${desired_label}" ]; then
+  echo "Pull request #${pr_number} type ${commit_type} has no changelog label mapping; removed managed changelog labels if present."
+fi

--- a/scripts/notify-github-status.sh
+++ b/scripts/notify-github-status.sh
@@ -64,6 +64,7 @@ gh label create released \
   --force >/dev/null
 
 declare -A target_numbers=()
+declare -A closing_issue_numbers=()
 for pull_number in "${!pull_numbers[@]}"; do
   target_numbers["${pull_number}"]=1
   closing_issues="$(gh api graphql \
@@ -83,6 +84,7 @@ for pull_number in "${!pull_numbers[@]}"; do
   while IFS= read -r issue_number; do
     [ -z "${issue_number}" ] && continue
     target_numbers["${issue_number}"]=1
+    closing_issue_numbers["${issue_number}"]=1
   done <<< "${closing_issues}"
 done
 
@@ -141,7 +143,7 @@ for target_number in $(printf '%s\n' "${!target_numbers[@]}" | sort -n); do
 <!-- aurral-release-status -->
 ### Available on nightly
 
-A linked pull request was merged into \`main\` and is now included in the latest nightly build.
+A linked pull request was merged into \`main\` and is now included in the latest nightly build. Linked issues stay open until this change ships in a stable release.
 
 \`\`\`bash
 docker pull ghcr.io/${repository}:nightly
@@ -180,3 +182,18 @@ EOF
       -f "body=${comment_body}" >/dev/null
   fi
 done
+
+if [ "${status}" = "stable" ]; then
+  for issue_number in $(printf '%s\n' "${!closing_issue_numbers[@]}" | sort -n); do
+    issue_state="$(gh api \
+      "repos/${repository}/issues/${issue_number}" \
+      --jq 'if .pull_request then "pull" else .state end')"
+    if [ "${issue_state}" != "open" ]; then
+      continue
+    fi
+    gh issue close "${issue_number}" \
+      --repo "${repository}" \
+      --reason completed >/dev/null
+    echo "Closed linked issue #${issue_number} for stable release ${release_version}."
+  done
+fi


### PR DESCRIPTION
## Summary

Update the release status workflow to close linked issues when a stable release ships, while keeping them open for nightly builds.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): release notifications, GitHub issue management
- Automated coverage: Existing release workflow and shell validation
- Manual steps and expected result: Verify nightly releases leave linked issues open and stable releases close eligible linked issues with the completed reason.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly status updates now clarify that linked issues remain open until a stable release.
  * Stable release notifications automatically close linked issues as completed and record the closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->