### PR TITLE
feat: add native OIDC support

### DIFF
--- a/.tests/auth/oidc-auth.test.js
+++ b/.tests/auth/oidc-auth.test.js
@@ -1,5 +1,6 @@
 import test, { mock } from "node:test";
 import assert from "node:assert/strict";
+import { createSign, generateKeyPairSync } from "node:crypto";
 
 import {
   createMockHttpServer,
@@ -22,6 +23,7 @@ const { dbOps, userOps } = dbHelpers;
 const { ensureExternalUser, isAuthRequiredByConfig, isOidcAuthEnabled } = authModule;
 const { createSession, getSessionByToken } = sessionModule;
 const {
+  exchangeOidcCallback,
   isOidcEnabled,
   resolveOidcUsername,
   resolveOidcRole,
@@ -32,6 +34,26 @@ const {
 } = oidcModule;
 
 const completeOnboarding = () => dbOps.updateSettings({ onboardingComplete: true });
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const oidcKey = { ...publicKey.export({ format: "jwk" }), kid: "test-key", use: "sig", alg: "RS256" };
+
+const createIdToken = (issuer, nonce) => {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const header = encode({ alg: "RS256", kid: oidcKey.kid, typ: "JWT" });
+  const payload = encode({
+    iss: issuer,
+    aud: "aurral",
+    sub: "oidc-subject",
+    preferred_username: "callback-user",
+    nonce,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 300,
+  });
+  const input = `${header}.${payload}`;
+  const signature = createSign("RSA-SHA256").update(input).sign(privateKey).toString("base64url");
+  return `${input}.${signature}`;
+};
 
 function resetOidcEnv() {
   delete process.env.OIDC_ENABLED;
@@ -62,12 +84,29 @@ function enableOidcEnv(overrides = {}) {
 
 async function createPendingOidcLogin() {
   let issuer;
-  const discoveryServer = await createMockHttpServer((_request, response) => {
+  let nonce;
+  const discoveryServer = await createMockHttpServer((request, response) => {
     response.writeHead(200, { "content-type": "application/json" });
+    if (request.url === "/jwks") {
+      response.end(JSON.stringify({ keys: [oidcKey] }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/token") {
+      response.end(
+        JSON.stringify({
+          access_token: "access-token",
+          token_type: "Bearer",
+          id_token: createIdToken(issuer, nonce),
+        }),
+      );
+      return;
+    }
     response.end(
       JSON.stringify({
         issuer,
         authorization_endpoint: `${issuer}authorize`,
+        token_endpoint: `${issuer}token`,
+        jwks_uri: `${issuer}jwks`,
       }),
     );
   });
@@ -78,13 +117,25 @@ async function createPendingOidcLogin() {
   });
 
   const response = {
+    headers: {},
     redirect(_status, location) {
       this.location = location;
     },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
   };
   await startOidcLogin({}, response);
+  const redirect = new URL(response.location);
+  const state = redirect.searchParams.get("state");
+  nonce = redirect.searchParams.get("nonce");
+  assert.ok(state, "OIDC login redirect must include state");
+  const setCookie = response.headers["Set-Cookie"];
+  assert.ok(setCookie, "OIDC login must set a transaction cookie");
   return {
-    state: new URL(response.location).searchParams.get("state"),
+    state,
+    nonce,
+    cookie: setCookie.split(";", 1)[0],
     close: discoveryServer.close,
   };
 }
@@ -175,6 +226,39 @@ test("OIDC-provisioned users get normal Aurral sessions", () => {
   assert.equal(getSessionByToken(session.token)?.user?.username, "sso-erin");
 });
 
+test("OIDC callback issues a cookie-bound one-time session exchange", async () => {
+  const pending = await createPendingOidcLogin();
+
+  try {
+    const callback = await handleOidcCallback({
+      query: { state: pending.state, code: "authorization-code" },
+      headers: { cookie: pending.cookie },
+      ip: "127.0.0.1",
+    });
+    assert.ok(callback.code);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count, 0);
+
+    assert.throws(
+      () => exchangeOidcCallback(callback.code, { headers: { cookie: "aurral_oidc_transaction=wrong" } }),
+      { status: 400, message: "OIDC login session expired" },
+    );
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count, 0);
+
+    const session = exchangeOidcCallback(callback.code, {
+      headers: { cookie: pending.cookie, "user-agent": "test-agent" },
+      ip: "127.0.0.1",
+    });
+    assert.ok(session.token);
+    assert.equal(getSessionByToken(session.token)?.user?.username, "callback-user");
+    assert.throws(
+      () => exchangeOidcCallback(callback.code, { headers: { cookie: pending.cookie } }),
+      { status: 400, message: "OIDC login session expired" },
+    );
+  } finally {
+    await pending.close();
+  }
+});
+
 test("OIDC callback rejects an expired state without creating a session", async () => {
   const pending = await createPendingOidcLogin();
   const now = Date.now();
@@ -185,7 +269,7 @@ test("OIDC callback rejects an expired state without creating a session", async 
       () =>
         handleOidcCallback({
           query: { state: pending.state },
-          headers: {},
+          headers: { cookie: pending.cookie },
           ip: "127.0.0.1",
         }),
       { status: 400, message: "OIDC login session expired" },
@@ -205,7 +289,7 @@ test("OIDC callback rejects a mismatched state without creating a session", asyn
       () =>
         handleOidcCallback({
           query: { state: `${pending.state}-mismatched` },
-          headers: {},
+          headers: { cookie: pending.cookie },
           ip: "127.0.0.1",
         }),
       { status: 400, message: "OIDC login session expired" },

--- a/.tests/auth/oidc-auth.test.js
+++ b/.tests/auth/oidc-auth.test.js
@@ -1,7 +1,8 @@
-import test from "node:test";
+import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  createMockHttpServer,
   setupIsolatedBackend,
   cleanupIsolatedState,
   resetDatabase,
@@ -25,7 +26,9 @@ const {
   resolveOidcUsername,
   resolveOidcRole,
   getOidcBootstrapInfo,
+  handleOidcCallback,
   resetOidcStateForTests,
+  startOidcLogin,
 } = oidcModule;
 
 const completeOnboarding = () => dbOps.updateSettings({ onboardingComplete: true });
@@ -55,6 +58,35 @@ function enableOidcEnv(overrides = {}) {
   process.env.OIDC_CLIENT_SECRET = "secret";
   process.env.OIDC_REDIRECT_URI = "https://aurral.example.com/sso/callback";
   Object.assign(process.env, overrides);
+}
+
+async function createPendingOidcLogin() {
+  let issuer;
+  const discoveryServer = await createMockHttpServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        issuer,
+        authorization_endpoint: `${issuer}authorize`,
+      }),
+    );
+  });
+  issuer = `${discoveryServer.url}/`;
+  enableOidcEnv({
+    OIDC_ISSUER: issuer,
+    OIDC_REDIRECT_URI: `${issuer}callback`,
+  });
+
+  const response = {
+    redirect(_status, location) {
+      this.location = location;
+    },
+  };
+  await startOidcLogin({}, response);
+  return {
+    state: new URL(response.location).searchParams.get("state"),
+    close: discoveryServer.close,
+  };
 }
 
 test.beforeEach(() => {
@@ -141,4 +173,45 @@ test("OIDC-provisioned users get normal Aurral sessions", () => {
   const session = createSession(user.id, "127.0.0.1", "test-agent");
   assert.ok(session?.token);
   assert.equal(getSessionByToken(session.token)?.user?.username, "sso-erin");
+});
+
+test("OIDC callback rejects an expired state without creating a session", async () => {
+  const pending = await createPendingOidcLogin();
+  const now = Date.now();
+  const clock = mock.method(Date, "now", () => now + 11 * 60 * 1000);
+
+  try {
+    await assert.rejects(
+      () =>
+        handleOidcCallback({
+          query: { state: pending.state },
+          headers: {},
+          ip: "127.0.0.1",
+        }),
+      { status: 400, message: "OIDC login session expired" },
+    );
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count, 0);
+  } finally {
+    clock.mock.restore();
+    await pending.close();
+  }
+});
+
+test("OIDC callback rejects a mismatched state without creating a session", async () => {
+  const pending = await createPendingOidcLogin();
+
+  try {
+    await assert.rejects(
+      () =>
+        handleOidcCallback({
+          query: { state: `${pending.state}-mismatched` },
+          headers: {},
+          ip: "127.0.0.1",
+        }),
+      { status: 400, message: "OIDC login session expired" },
+    );
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count, 0);
+  } finally {
+    await pending.close();
+  }
 });

--- a/.tests/auth/oidc-auth.test.js
+++ b/.tests/auth/oidc-auth.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, dbHelpers, authModule, sessionModule, oidcModule] =
+  await setupIsolatedBackend(
+    "oidc-auth",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/middleware/auth.js",
+    "backend/config/session-helpers.js",
+    "backend/services/oidcAuth.js",
+  );
+
+const { dbOps, userOps } = dbHelpers;
+const { ensureExternalUser, isAuthRequiredByConfig, isOidcAuthEnabled } = authModule;
+const { createSession, getSessionByToken } = sessionModule;
+const {
+  isOidcEnabled,
+  resolveOidcUsername,
+  resolveOidcRole,
+  getOidcBootstrapInfo,
+  resetOidcStateForTests,
+} = oidcModule;
+
+const completeOnboarding = () => dbOps.updateSettings({ onboardingComplete: true });
+
+function resetOidcEnv() {
+  delete process.env.OIDC_ENABLED;
+  delete process.env.OIDC_ISSUER;
+  delete process.env.OIDC_CLIENT_ID;
+  delete process.env.OIDC_CLIENT_SECRET;
+  delete process.env.OIDC_REDIRECT_URI;
+  delete process.env.OIDC_SCOPES;
+  delete process.env.OIDC_USERNAME_CLAIM;
+  delete process.env.OIDC_DEFAULT_ROLE;
+  delete process.env.OIDC_ADMIN_USERS;
+  delete process.env.OIDC_GROUPS_CLAIM;
+  delete process.env.OIDC_ADMIN_GROUPS;
+  delete process.env.OIDC_LOGOUT_URL;
+  delete process.env.AUTH_PROXY_ENABLED;
+  delete process.env.AUTH_PROXY_HEADER;
+  resetOidcStateForTests();
+}
+
+function enableOidcEnv(overrides = {}) {
+  process.env.OIDC_ENABLED = "true";
+  process.env.OIDC_ISSUER = "https://auth.example.com/application/o/aurral/";
+  process.env.OIDC_CLIENT_ID = "aurral";
+  process.env.OIDC_CLIENT_SECRET = "secret";
+  process.env.OIDC_REDIRECT_URI = "https://aurral.example.com/sso/callback";
+  Object.assign(process.env, overrides);
+}
+
+test.beforeEach(() => {
+  resetDatabase(db);
+  resetOidcEnv();
+  dbOps.updateSettings({ onboardingComplete: false });
+});
+
+test.after(async () => {
+  resetOidcEnv();
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("OIDC username prefers configured claim then email", () => {
+  assert.equal(
+    resolveOidcUsername({ preferred_username: "Alice", email: "alice@example.com" }),
+    "alice",
+  );
+  assert.equal(resolveOidcUsername({ email: "Alice@example.com" }), "alice@example.com");
+
+  process.env.OIDC_USERNAME_CLAIM = "nickname";
+  assert.equal(resolveOidcUsername({ nickname: "Bob", email: "bob@example.com" }), "bob");
+  assert.equal(resolveOidcUsername({}), "");
+});
+
+test("OIDC role mapping uses admin users and groups claim", () => {
+  assert.equal(resolveOidcRole("carol", {}), "user");
+
+  process.env.OIDC_ADMIN_USERS = "carol";
+  assert.equal(resolveOidcRole("carol", {}), "admin");
+
+  delete process.env.OIDC_ADMIN_USERS;
+  process.env.OIDC_GROUPS_CLAIM = "groups";
+  process.env.OIDC_ADMIN_GROUPS = "aurral-admins";
+  assert.equal(resolveOidcRole("dave", { groups: ["users", "aurral-admins"] }), "admin");
+  assert.equal(resolveOidcRole("erin", { groups: "users,aurral-admins" }), "admin");
+  assert.equal(resolveOidcRole("frank", { groups: ["users"] }), "user");
+  assert.equal(resolveOidcRole("gina", { groups: ["admin"] }), "user");
+
+  process.env.OIDC_DEFAULT_ROLE = "admin";
+  assert.equal(resolveOidcRole("hank", { groups: ["users"] }), "admin");
+});
+
+test("ensureExternalUser JIT-creates and re-syncs role", () => {
+  const created = ensureExternalUser("oidc-user", "user");
+  assert.ok(created);
+  assert.equal(created.username, "oidc-user");
+  assert.equal(created.role, "user");
+  assert.equal(userOps.getAllUsers().length, 1);
+
+  const promoted = ensureExternalUser("oidc-user", "admin");
+  assert.equal(promoted.id, created.id);
+  assert.equal(promoted.role, "admin");
+  assert.equal(userOps.getUserByUsername("oidc-user")?.role, "admin");
+  assert.equal(userOps.getAllUsers().length, 1);
+});
+
+test("OIDC enablement requires full config and marks auth required after onboarding", () => {
+  process.env.OIDC_ENABLED = "true";
+  assert.equal(isOidcEnabled(), false);
+  assert.equal(getOidcBootstrapInfo().oidcEnabled, false);
+
+  enableOidcEnv();
+  assert.equal(isOidcEnabled(), true);
+  assert.equal(isOidcAuthEnabled(), true);
+  assert.equal(getOidcBootstrapInfo().oidcEnabled, true);
+
+  assert.equal(isAuthRequiredByConfig(), false);
+  completeOnboarding();
+  assert.equal(isAuthRequiredByConfig(), true);
+});
+
+test("OIDC bootstrap exposes logout URL when configured", () => {
+  enableOidcEnv({ OIDC_LOGOUT_URL: "https://auth.example.com/logout" });
+  assert.deepEqual(getOidcBootstrapInfo(), {
+    oidcEnabled: true,
+    oidcLogoutUrl: "https://auth.example.com/logout",
+  });
+});
+
+test("OIDC-provisioned users get normal Aurral sessions", () => {
+  completeOnboarding();
+  const user = ensureExternalUser("sso-erin", "user");
+  const session = createSession(user.id, "127.0.0.1", "test-agent");
+  assert.ok(session?.token);
+  assert.equal(getSessionByToken(session.token)?.user?.username, "sso-erin");
+});

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Aurral is the Lidarr companion for self-hosted music discovery. Best-in-class re
 - **Activity**: Queue, review, and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, and Aurral playlist jobs.
 - **Integrations**: Lidarr, Last.fm, ListenBrainz, Koito, yt-dlp, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
 - **Playback**: Stream through Navidrome (M3U playlists) or Plex/Plexamp (API-synced playlists) from a dedicated download folder.
-- **Multi-user**: Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, and reverse-proxy SSO.
+- **Multi-user**: Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, reverse-proxy SSO, and native OIDC.
 
 ## Screenshots
 

--- a/V2.md
+++ b/V2.md
@@ -48,6 +48,7 @@ v2 is a major rewrite. Hundreds of improvements, but here is what you will actua
 ### Authentication
 
 - **Reverse-proxy SSO** - pass `AUTH_PROXY_ENABLED=true` and set `x-forwarded-user` behind your proxy
+- **Native OIDC** - set `OIDC_ENABLED=true` with issuer/client credentials and `OIDC_REDIRECT_URI=https://your-host/sso/callback`
 - **LAN auto-login** - skip the password on your home network
 - **Configurable session expiry** - `SESSION_EXPIRY_HOURS` env var (default 30 days)
 

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -332,12 +332,19 @@ function resolveApiKeyUser(req) {
   return null;
 }
 
+export const isOidcAuthEnabled = () => process.env.OIDC_ENABLED === "true";
+
 export const isAuthRequiredByConfig = () => {
   const settings = dbOps.getSettings();
   const onboardingDone = settings.onboardingComplete;
   if (!onboardingDone) return false;
   const legacyPasswords = getAuthPassword();
-  return isProxyAuthEnabled() || userOps.countUsers() > 0 || legacyPasswords.length > 0;
+  return (
+    isProxyAuthEnabled() ||
+    isOidcAuthEnabled() ||
+    userOps.countUsers() > 0 ||
+    legacyPasswords.length > 0
+  );
 };
 
 export const getLocalNetworkBypassConfig = (settings = dbOps.getSettings()) =>
@@ -433,7 +440,15 @@ export function reconcileLocalNetworkBypassSetting() {
   };
 }
 
-function createProxyUser(username, role) {
+export function ensureExternalUser(username, role) {
+  const existing = userOps.getUserByUsername(username);
+  if (existing) {
+    if (existing.role !== role) {
+      const updated = userOps.updateUser(existing.id, { role });
+      return toResolvedUser(updated || existing);
+    }
+    return toResolvedUser(existing);
+  }
   const passwordHash = hashPassword(crypto.randomBytes(32).toString("hex"));
   const created = userOps.createUser(username, passwordHash, role, null);
   return created
@@ -476,15 +491,7 @@ export function resolveProxyUser(req) {
   if (!username) return null;
 
   const role = resolveProxyRole(req, username);
-  const existing = userOps.getUserByUsername(username);
-  if (existing) {
-    if (existing.role !== role) {
-      const updated = userOps.updateUser(existing.id, { role });
-      return toResolvedUser(updated || existing);
-    }
-    return toResolvedUser(existing);
-  }
-  return createProxyUser(username, role);
+  return ensureExternalUser(username, role);
 }
 
 export function issueProxySession(req) {
@@ -652,7 +659,7 @@ export const authMiddleware = (req, res, next) => {
     ) {
       return next();
     }
-    if (req.path === "/api/auth/login") return next();
+    if (req.path === "/api/auth/login" || req.path === "/api/auth/oidc/login") return next();
 
     const settings = dbOps.getSettings();
     const onboardingDone = settings.onboardingComplete;

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -659,7 +659,13 @@ export const authMiddleware = (req, res, next) => {
     ) {
       return next();
     }
-    if (req.path === "/api/auth/login" || req.path === "/api/auth/oidc/login") return next();
+    if (
+      req.path === "/api/auth/login" ||
+      req.path === "/api/auth/oidc/login" ||
+      req.path === "/api/auth/oidc/exchange"
+    ) {
+      return next();
+    }
 
     const settings = dbOps.getSettings();
     const onboardingDone = settings.onboardingComplete;

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "express-rate-limit": "^8.6.1",
     "helmet": "^8.3.0",
     "music-metadata": "^11.14.0",
+    "openid-client": "^6.8.4",
     "sharp": "^0.35.3",
     "undici": "^7.28.0",
     "ws": "^8.21.1"

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -4,7 +4,7 @@ import { createSession, deleteSession, getSessionByToken } from "../config/sessi
 import { requireAuth } from "../middleware/requirePermission.js";
 import { getApiKey, rotateApiKey } from "../middleware/auth.js";
 import { hashPassword, verifyPassword, needsRehash } from "../middleware/passwordHash.js";
-import { startOidcLogin } from "../services/oidcAuth.js";
+import { clearOidcTransactionCookie, exchangeOidcCallback, startOidcLogin } from "../services/oidcAuth.js";
 import { logger } from "../services/logger.js";
 
 const router = express.Router();
@@ -93,6 +93,16 @@ router.get("/oidc/login", async (req, res) => {
     if (!res.headersSent) {
       res.status(500).json({ error: "OIDC login failed" });
     }
+  }
+});
+
+router.post("/oidc/exchange", (req, res) => {
+  try {
+    const result = exchangeOidcCallback(req.body?.code, req);
+    clearOidcTransactionCookie(req, res);
+    res.json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ error: error.message || "OIDC exchange failed" });
   }
 });
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -4,6 +4,8 @@ import { createSession, deleteSession, getSessionByToken } from "../config/sessi
 import { requireAuth } from "../middleware/requirePermission.js";
 import { getApiKey, rotateApiKey } from "../middleware/auth.js";
 import { hashPassword, verifyPassword, needsRehash } from "../middleware/passwordHash.js";
+import { startOidcLogin } from "../services/oidcAuth.js";
+import { logger } from "../services/logger.js";
 
 const router = express.Router();
 
@@ -81,6 +83,17 @@ router.get("/api-key", requireAuth, (req, res) => {
 router.post("/api-key/rotate", requireAuth, (req, res) => {
   const newKey = rotateApiKey();
   res.json({ apiKey: newKey });
+});
+
+router.get("/oidc/login", async (req, res) => {
+  try {
+    await startOidcLogin(req, res);
+  } catch (error) {
+    logger.error("auth", "OIDC login start failed:", { message: error.message });
+    if (!res.headersSent) {
+      res.status(500).json({ error: "OIDC login failed" });
+    }
+  }
 });
 
 export default router;

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -16,6 +16,7 @@ import {
   issueStreamToken,
   getLocalNetworkBypassStatus,
 } from "../middleware/auth.js";
+import { getOidcBootstrapInfo } from "../services/oidcAuth.js";
 import { lidarrClient } from "../services/lidarrClient.js";
 import {
   getDiscoveryCache,
@@ -243,10 +244,13 @@ function buildBootstrapPayload(req) {
   const currentUser = resolveRequestUser(req);
   const lidarrConfigured = lidarrClient.isConfigured();
 
+  const oidcInfo = getOidcBootstrapInfo();
   const payload = {
     status: "ok",
     authRequired,
     proxyAuthEnabled: isProxyAuthEnabled(),
+    oidcEnabled: oidcInfo.oidcEnabled,
+    oidcLogoutUrl: oidcInfo.oidcLogoutUrl,
     onboardingRequired: !onboardingDone,
     timestamp: new Date().toISOString(),
     appVersion: APP_VERSION,

--- a/backend/server.js
+++ b/backend/server.js
@@ -165,6 +165,7 @@ const authLimiter = rateLimit({
 });
 app.use("/api/auth/login", authLimiter);
 app.use("/api/auth/oidc/login", authLimiter);
+app.use("/api/auth/oidc/exchange", authLimiter);
 app.use("/api/users/me/password", authLimiter);
 
 const limiter = rateLimit({
@@ -195,8 +196,8 @@ app.use("/api/image-proxy", imageProxyRouter);
 app.get("/sso/callback", async (req, res) => {
   try {
     const result = await handleOidcCallback(req);
-    const token = encodeURIComponent(result.token);
-    res.redirect(302, `/sso/complete#token=${token}`);
+    const code = encodeURIComponent(result.code);
+    res.redirect(302, `/sso/complete#code=${code}`);
   } catch (error) {
     logger.error("auth", "OIDC callback failed:", { message: error.message });
     const message = encodeURIComponent(error.message || "OIDC login failed");

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ import fs from "fs";
 import { createServer } from "http";
 import { fileURLToPath } from "url";
 import { authMiddleware, isProxyAuthEnabled } from "./middleware/auth.js";
+import { handleOidcCallback, isOidcEnabled } from "./services/oidcAuth.js";
 import { logger } from "./services/logger.js";
 import { websocketService } from "./services/websocketService.js";
 import { getAllDownloadStatuses } from "./routes/library/handlers/downloads.js";
@@ -97,9 +98,19 @@ if (isProxyAuthEnabled() && !process.env.AUTH_PROXY_TRUSTED_IPS) {
   );
 }
 
+if (process.env.OIDC_ENABLED === "true" && !isOidcEnabled()) {
+  logger.warn(
+    "system",
+    "OIDC_ENABLED is on but OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, or OIDC_REDIRECT_URI is missing.",
+  );
+}
+
 const connectSrcDirectives = ["'self'", "ws:", "wss:", "https://api.github.com"];
 if (process.env.AUTH_PROXY_DOMAIN) {
   connectSrcDirectives.push(process.env.AUTH_PROXY_DOMAIN);
+}
+if (process.env.OIDC_DOMAIN) {
+  connectSrcDirectives.push(process.env.OIDC_DOMAIN);
 }
 
 app.use(corsMiddleware);
@@ -149,6 +160,7 @@ const authLimiter = rateLimit({
   max: 10,
 });
 app.use("/api/auth/login", authLimiter);
+app.use("/api/auth/oidc/login", authLimiter);
 app.use("/api/users/me/password", authLimiter);
 
 const limiter = rateLimit({
@@ -175,6 +187,18 @@ app.use("/api/weekly-flow", (req, res) => {
 });
 app.use("/api/auth", authRouter);
 app.use("/api/image-proxy", imageProxyRouter);
+
+app.get("/sso/callback", async (req, res) => {
+  try {
+    const result = await handleOidcCallback(req);
+    const token = encodeURIComponent(result.token);
+    res.redirect(302, `/sso/complete#token=${token}`);
+  } catch (error) {
+    logger.error("auth", "OIDC callback failed:", { message: error.message });
+    const message = encodeURIComponent(error.message || "OIDC login failed");
+    res.redirect(302, `/sso/complete#error=${message}`);
+  }
+});
 
 const frontendDist = path.join(__dirname, "..", "frontend", "dist");
 const frontendFallbackRoute = /.*/;

--- a/backend/services/oidcAuth.js
+++ b/backend/services/oidcAuth.js
@@ -104,7 +104,7 @@ async function getDiscoveryConfig() {
   if (!config) {
     throw new Error("OIDC is not configured");
   }
-  const key = `${config.issuer}|${config.clientId}|${config.redirectUri}`;
+  const key = `${config.issuer}|${config.clientId}|${config.clientSecret}|${config.redirectUri}`;
   if (discoveryConfig && discoveryKey === key) return { config, oidc: discoveryConfig };
   const issuerUrl = new URL(config.issuer);
   const discoveryOptions =

--- a/backend/services/oidcAuth.js
+++ b/backend/services/oidcAuth.js
@@ -3,7 +3,10 @@ import { createSession } from "../config/session-helpers.js";
 import { ensureExternalUser } from "../middleware/auth.js";
 
 const STATE_TTL_MS = 10 * 60 * 1000;
+const EXCHANGE_TTL_MS = 60 * 1000;
+const OIDC_TRANSACTION_COOKIE = "aurral_oidc_transaction";
 const pendingLogins = new Map();
+const pendingExchanges = new Map();
 let discoveryConfig = null;
 let discoveryKey = "";
 
@@ -19,6 +22,39 @@ function prunePendingLogins(now = Date.now()) {
   for (const [state, entry] of pendingLogins) {
     if (!entry || entry.expiresAt <= now) pendingLogins.delete(state);
   }
+}
+
+function prunePendingExchanges(now = Date.now()) {
+  for (const [code, entry] of pendingExchanges) {
+    if (!entry || entry.expiresAt <= now) pendingExchanges.delete(code);
+  }
+}
+
+function getTransactionCookie(req) {
+  const cookies = String(req.headers?.cookie || "").split(";");
+  for (const cookie of cookies) {
+    const [name, ...parts] = cookie.trim().split("=");
+    if (name !== OIDC_TRANSACTION_COOKIE) continue;
+    try {
+      return decodeURIComponent(parts.join("="));
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function setTransactionCookie(req, res, value, maxAge) {
+  const secure = req.secure || req.protocol === "https";
+  const attributes = [
+    `${OIDC_TRANSACTION_COOKIE}=${encodeURIComponent(value)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (secure) attributes.push("Secure");
+  if (maxAge != null) attributes.push(`Max-Age=${maxAge}`);
+  res.setHeader("Set-Cookie", attributes.join("; "));
 }
 
 function getRequiredConfig() {
@@ -146,11 +182,13 @@ export async function startOidcLogin(req, res) {
   const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
   const state = client.randomState();
   const nonce = client.randomNonce();
+  const transactionId = client.randomState();
 
   prunePendingLogins();
   pendingLogins.set(state, {
     codeVerifier,
     nonce,
+    transactionId,
     expiresAt: Date.now() + STATE_TTL_MS,
   });
 
@@ -164,6 +202,7 @@ export async function startOidcLogin(req, res) {
   };
 
   const redirectTo = client.buildAuthorizationUrl(oidc, parameters);
+  setTransactionCookie(req, res, transactionId);
   res.redirect(302, redirectTo.href);
 }
 
@@ -173,10 +212,11 @@ export async function handleOidcCallback(req) {
   }
 
   const state = String(req.query?.state || "");
+  const transactionId = getTransactionCookie(req);
   prunePendingLogins();
   const pending = pendingLogins.get(state);
   pendingLogins.delete(state);
-  if (!pending || pending.expiresAt <= Date.now()) {
+  if (!pending || pending.expiresAt <= Date.now() || pending.transactionId !== transactionId) {
     throw Object.assign(new Error("OIDC login session expired"), { status: 400 });
   }
 
@@ -202,16 +242,48 @@ export async function handleOidcCallback(req) {
     throw Object.assign(new Error("Failed to provision OIDC user"), { status: 500 });
   }
 
-  const session = createSession(user.id, req.ip || null, req.headers["user-agent"] || null);
+  const code = client.randomState();
+  prunePendingExchanges();
+  pendingExchanges.set(code, {
+    expiresAt: Date.now() + EXCHANGE_TTL_MS,
+    transactionId,
+    user,
+  });
   return {
-    token: session.token,
-    expiresAt: session.expiresAt,
+    code,
     user,
   };
 }
 
+export function exchangeOidcCallback(code, req) {
+  if (!isOidcEnabled()) {
+    throw Object.assign(new Error("OIDC is not enabled"), { status: 404 });
+  }
+
+  const transactionId = getTransactionCookie(req);
+  const exchangeCode = String(code || "");
+  prunePendingExchanges();
+  const pending = pendingExchanges.get(exchangeCode);
+  if (!pending || pending.expiresAt <= Date.now() || pending.transactionId !== transactionId) {
+    throw Object.assign(new Error("OIDC login session expired"), { status: 400 });
+  }
+
+  pendingExchanges.delete(exchangeCode);
+  const session = createSession(pending.user.id, req.ip || null, req.headers["user-agent"] || null);
+  return {
+    token: session.token,
+    expiresAt: session.expiresAt,
+    user: pending.user,
+  };
+}
+
+export function clearOidcTransactionCookie(req, res) {
+  setTransactionCookie(req, res, "", 0);
+}
+
 export function resetOidcStateForTests() {
   pendingLogins.clear();
+  pendingExchanges.clear();
   discoveryConfig = null;
   discoveryKey = "";
 }

--- a/backend/services/oidcAuth.js
+++ b/backend/services/oidcAuth.js
@@ -1,0 +1,217 @@
+import * as client from "openid-client";
+import { createSession } from "../config/session-helpers.js";
+import { ensureExternalUser } from "../middleware/auth.js";
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+const pendingLogins = new Map();
+let discoveryConfig = null;
+let discoveryKey = "";
+
+function parseCsv(value) {
+  if (!value) return [];
+  return String(value)
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function prunePendingLogins(now = Date.now()) {
+  for (const [state, entry] of pendingLogins) {
+    if (!entry || entry.expiresAt <= now) pendingLogins.delete(state);
+  }
+}
+
+function getRequiredConfig() {
+  const issuer = String(process.env.OIDC_ISSUER || "").trim();
+  const clientId = String(process.env.OIDC_CLIENT_ID || "").trim();
+  const clientSecret = String(process.env.OIDC_CLIENT_SECRET || "").trim();
+  const redirectUri = String(process.env.OIDC_REDIRECT_URI || "").trim();
+  if (!issuer || !clientId || !clientSecret || !redirectUri) return null;
+  return { issuer, clientId, clientSecret, redirectUri };
+}
+
+export function isOidcEnabled() {
+  if (process.env.OIDC_ENABLED !== "true") return false;
+  return !!getRequiredConfig();
+}
+
+export function getOidcBootstrapInfo() {
+  if (!isOidcEnabled()) {
+    return {
+      oidcEnabled: false,
+      oidcLogoutUrl: null,
+    };
+  }
+  return {
+    oidcEnabled: true,
+    oidcLogoutUrl: process.env.OIDC_LOGOUT_URL || null,
+  };
+}
+
+function getScopes() {
+  const scopes = String(process.env.OIDC_SCOPES || "openid profile email")
+    .trim()
+    .replace(/\s+/g, " ");
+  return scopes || "openid profile email";
+}
+
+function getUsernameClaim() {
+  return String(process.env.OIDC_USERNAME_CLAIM || "preferred_username").trim() || "preferred_username";
+}
+
+function getGroupsClaim() {
+  return String(process.env.OIDC_GROUPS_CLAIM || "").trim();
+}
+
+function normalizeGroups(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item || "").trim().toLowerCase()).filter(Boolean);
+  }
+  if (value == null) return [];
+  return String(value)
+    .split(/[,\s]+/)
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function resolveOidcRole(username, claims = {}) {
+  const adminUsers = parseCsv(process.env.OIDC_ADMIN_USERS).map((u) => u.toLowerCase());
+  if (adminUsers.includes(String(username || "").toLowerCase())) return "admin";
+
+  const groupsClaim = getGroupsClaim();
+  if (groupsClaim) {
+    const groups = normalizeGroups(claims[groupsClaim]);
+    const adminGroups = parseCsv(process.env.OIDC_ADMIN_GROUPS).map((g) => g.toLowerCase());
+    if (groups.some((g) => adminGroups.includes(g))) return "admin";
+  }
+
+  return (process.env.OIDC_DEFAULT_ROLE || "user").trim().toLowerCase() === "admin"
+    ? "admin"
+    : "user";
+}
+
+export function resolveOidcUsername(claims = {}) {
+  const claimName = getUsernameClaim();
+  const primary = String(claims[claimName] || "").trim();
+  if (primary) return primary.toLowerCase();
+  const email = String(claims.email || "").trim();
+  if (email) return email.toLowerCase();
+  return "";
+}
+
+async function getDiscoveryConfig() {
+  const config = getRequiredConfig();
+  if (!config) {
+    throw new Error("OIDC is not configured");
+  }
+  const key = `${config.issuer}|${config.clientId}|${config.redirectUri}`;
+  if (discoveryConfig && discoveryKey === key) return { config, oidc: discoveryConfig };
+  const issuerUrl = new URL(config.issuer);
+  const discoveryOptions =
+    issuerUrl.protocol === "http:" ? { execute: [client.allowInsecureRequests] } : undefined;
+  discoveryConfig = await client.discovery(
+    issuerUrl,
+    config.clientId,
+    config.clientSecret,
+    undefined,
+    discoveryOptions,
+  );
+  discoveryKey = key;
+  return { config, oidc: discoveryConfig };
+}
+
+function buildCallbackUrl(req) {
+  const redirectUri = getRequiredConfig()?.redirectUri;
+  if (!redirectUri) throw new Error("OIDC_REDIRECT_URI is required");
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(req.query || {})) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      if (value[0] != null) url.searchParams.set(key, String(value[0]));
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+  return url;
+}
+
+export async function startOidcLogin(req, res) {
+  if (!isOidcEnabled()) {
+    res.status(404).json({ error: "OIDC is not enabled" });
+    return;
+  }
+
+  const { config, oidc } = await getDiscoveryConfig();
+  const codeVerifier = client.randomPKCECodeVerifier();
+  const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+  const state = client.randomState();
+  const nonce = client.randomNonce();
+
+  prunePendingLogins();
+  pendingLogins.set(state, {
+    codeVerifier,
+    nonce,
+    expiresAt: Date.now() + STATE_TTL_MS,
+  });
+
+  const parameters = {
+    redirect_uri: config.redirectUri,
+    scope: getScopes(),
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+    nonce,
+  };
+
+  const redirectTo = client.buildAuthorizationUrl(oidc, parameters);
+  res.redirect(302, redirectTo.href);
+}
+
+export async function handleOidcCallback(req) {
+  if (!isOidcEnabled()) {
+    throw Object.assign(new Error("OIDC is not enabled"), { status: 404 });
+  }
+
+  const state = String(req.query?.state || "");
+  prunePendingLogins();
+  const pending = pendingLogins.get(state);
+  pendingLogins.delete(state);
+  if (!pending || pending.expiresAt <= Date.now()) {
+    throw Object.assign(new Error("OIDC login session expired"), { status: 400 });
+  }
+
+  const { oidc } = await getDiscoveryConfig();
+  const tokens = await client.authorizationCodeGrant(oidc, buildCallbackUrl(req), {
+    pkceCodeVerifier: pending.codeVerifier,
+    expectedState: state,
+    expectedNonce: pending.nonce,
+    idTokenExpected: true,
+  });
+
+  const claims = tokens.claims() || {};
+  const username = resolveOidcUsername(claims);
+  if (!username) {
+    throw Object.assign(new Error("OIDC identity did not include a usable username"), {
+      status: 400,
+    });
+  }
+
+  const role = resolveOidcRole(username, claims);
+  const user = ensureExternalUser(username, role);
+  if (!user?.id || user.id < 0) {
+    throw Object.assign(new Error("Failed to provision OIDC user"), { status: 500 });
+  }
+
+  const session = createSession(user.id, req.ip || null, req.headers["user-agent"] || null);
+  return {
+    token: session.token,
+    expiresAt: session.expiresAt,
+    user,
+  };
+}
+
+export function resetOidcStateForTests() {
+  pendingLogins.clear();
+  discoveryConfig = null;
+  discoveryKey = "";
+}

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -35,7 +35,20 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | `AUTH_PROXY_ADMIN_USERS` | Comma-separated usernames that get the admin role. Aurral checks the list on each request. If you remove a username, Aurral changes that user on the next request. |
 | `AUTH_PROXY_ROLE_HEADER` | Optional header that contains the user's group membership (for example, Authelia's `Remote-Groups`). Usually, this is a comma-separated list. Aurral compares it with `AUTH_PROXY_ADMIN_GROUPS` on every request. |
 | `AUTH_PROXY_ADMIN_GROUPS` | Comma-separated group names that give the admin role. Aurral compares these names with `AUTH_PROXY_ROLE_HEADER`. A group named `admin` has no special function unless you list it here. |
-| `SESSION_EXPIRY_HOURS` | Session lifetime in hours for password login and for sessions issued after proxy authentication. Default `720` (30 days). |
+| `OIDC_ENABLED` | Enable native OpenID Connect login. |
+| `OIDC_ISSUER` | Identity provider issuer URL used for OIDC discovery. |
+| `OIDC_CLIENT_ID` | OIDC client ID. |
+| `OIDC_CLIENT_SECRET` | OIDC client secret. |
+| `OIDC_REDIRECT_URI` | Exact callback URL registered with your IdP. Must be `https://<your-aurral-host>/sso/callback`. |
+| `OIDC_SCOPES` | Space-separated scopes. Default `openid profile email`. |
+| `OIDC_USERNAME_CLAIM` | Claim used as the Aurral username. Default `preferred_username`. Falls back to `email` when that claim is missing. |
+| `OIDC_DEFAULT_ROLE` | Role for OIDC users who are not otherwise granted admin: `user` or `admin`. |
+| `OIDC_ADMIN_USERS` | Comma-separated usernames that get the admin role at OIDC login. |
+| `OIDC_GROUPS_CLAIM` | Optional ID-token claim that contains group membership. |
+| `OIDC_ADMIN_GROUPS` | Comma-separated group names that grant the admin role when present in `OIDC_GROUPS_CLAIM`. |
+| `OIDC_LOGOUT_URL` | Optional IdP logout URL. When set, Aurral redirects there after clearing the local session. |
+| `OIDC_DOMAIN` | Optional IdP origin added to the `connect-src` content security policy. |
+| `SESSION_EXPIRY_HOURS` | Session lifetime in hours for password login, proxy auth, and native OIDC. Default `720` (30 days). |
 
 ## Logging
 

--- a/docs/src/content/docs/admin/users.mdx
+++ b/docs/src/content/docs/admin/users.mdx
@@ -21,6 +21,33 @@ Admins can control whether users can:
 - Local username and password accounts
 - Optional local-network auto-login for single-admin home setups
 - Reverse-proxy authentication for SSO
+- Native OpenID Connect login
+
+## Native OIDC
+
+Set `OIDC_ENABLED=true` and configure your identity provider as a confidential OIDC client.
+
+Required variables:
+
+- `OIDC_ISSUER` - discovery issuer URL
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+- `OIDC_REDIRECT_URI` - must be exactly `https://aurral.example.com/sso/callback`
+
+Optional role mapping:
+
+- `OIDC_DEFAULT_ROLE` - `user` (default) or `admin`
+- `OIDC_ADMIN_USERS` - exact usernames promoted to admin at login
+- `OIDC_GROUPS_CLAIM` - ID-token claim with group membership
+- `OIDC_ADMIN_GROUPS` - groups from that claim that grant admin
+
+Aurral starts login at `/api/auth/oidc/login`, handles the IdP return at `/sso/callback`, then issues a normal Aurral session. Username comes from `OIDC_USERNAME_CLAIM` (default `preferred_username`), with a fallback to `email`.
+
+OIDC-created users cannot use local password login until an admin sets a password. Role changes from the IdP apply on the next OIDC login.
+
+Set `OIDC_LOGOUT_URL` if you want **Log out** to end the identity-provider session as well.
+
+Native OIDC and reverse-proxy auth can both stay configured. Use one as the primary browser login path for a given deployment.
 
 ## Reverse-proxy auth
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ function ActivityRootRedirect() {
 }
 
 const Login = lazy(() => import("./pages/Login"));
+const SsoComplete = lazy(() => import("./pages/SsoComplete"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
 const SearchResultsPage = lazy(() => import("./pages/SearchResultsPage"));
 const DiscoverPage = lazy(() => import("./pages/DiscoverPage"));
@@ -189,100 +190,115 @@ function AppContent() {
 
   return (
     <Router basename={basePath}>
-      <DiscoverRecentProvider>
-        <ProtectedRoute>
-          <Layout>
-          <UpdateBanner
-            currentVersion={appVersion}
-            visible={!user || user.role === "admin"}
-          />
-          {healthIssue === "lidarr" && isHealthy && (
-            <div className="app-status-banner app-status-banner--warning">
-              <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
-              <p className="app-status-banner__text app-status-banner__text--warning">
-                Lidarr is busy. Library data may be stale until it catches up.
-              </p>
-            </div>
-          )}
-
-          {healthIssue === "degraded" && (
-            <div className="app-status-banner app-status-banner--warning">
-              <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
-              <p className="app-status-banner__text app-status-banner__text--warning">
-                Aurral is responding slowly. Lidarr may be busy — try again in a minute.
-              </p>
-            </div>
-          )}
-
-          {healthIssue === "backend" && isHealthy === false && (
-            <div className="app-status-banner app-status-banner--error">
-              <XCircle className="app-status-banner__icon app-status-banner__icon--error" />
-              <p className="app-status-banner__text app-status-banner__text--error">
-                Unable to connect to the Aurral backend. Please check your configuration.
-              </p>
-            </div>
-          )}
-
-          {isHealthy && !rootFolderConfigured && (
-            <div className="app-status-banner app-status-banner--warning">
-              <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
-              <p className="app-status-banner__text app-status-banner__text--warning">
-                Root folder is not configured. Please configure your music
-                library root folder in settings.
-              </p>
-            </div>
-          )}
-            <Suspense fallback={<PageLoader />}>
-              <Routes>
-                <Route path="/" element={<DiscoverPage />} />
-                <Route path="/shows" element={<Navigate to="/shows/all" replace />} />
-                <Route path="/shows/:filter" element={<ShowsPage />} />
-                <Route path="/search" element={<SearchResultsPage />} />
-                <Route path="/discover" element={<Navigate to="/" replace />} />
-                <Route path="/discover/playlists/:presetId" element={<DiscoverPlaylistDetailPage />} />
-                <Route path="/discover/playlists" element={<DiscoverPlaylistsPage />} />
-                <Route path="/library" element={<LibraryPage />} />
-                <Route
-                  path="/playlists"
-                  element={
-                    <PermissionRoute permission="accessFlow">
-                      <FlowPage />
-                    </PermissionRoute>
-                  }
-                />
-                <Route path="/flow" element={<Navigate to="/playlists" replace />} />
-                <Route path="/downloads" element={<Navigate to="/activity/queue" replace />} />
-                <Route path="/requests" element={<Navigate to="/activity/queue" replace />} />
-                <Route path="/history" element={<Navigate to="/activity/history" replace />} />
-                <Route path="/history/:legacyTab" element={<LegacyHistoryRedirect />} />
-                <Route path="/activity" element={<ActivityRootRedirect />} />
-                <Route path="/activity/:view" element={<ActivityPage />} />
-                <Route path="/activity/:view/:source" element={<ActivitySourceRedirect />} />
-                <Route
-                  path="/artist/:mbid/albums"
-                  element={<ArtistReleaseListPage mode="releases" />}
-                />
-                <Route path="/artist/:mbid/release/:releaseMbid" element={<ReleasePage />} />
-                <Route
-                  path="/artist/:mbid/appears-on"
-                  element={<ArtistReleaseListPage mode="appearsOn" />}
-                />
-                <Route path="/artist/:mbid" element={<ArtistDetailsPage />} />
-                <Route
-                  path="/settings/:tab?"
-                  element={
-                    <PermissionRoute permission="accessSettings">
-                      <SettingsPage />
-                    </PermissionRoute>
-                  }
-                />
-                <Route path="/profile" element={<ProfilePage />} />
-                <Route path="/blocklist" element={<BlocklistPage />} />
-              </Routes>
+      <Routes>
+        <Route
+          path="/sso/complete"
+          element={
+            <Suspense fallback={<ScreenLoader />}>
+              <SsoComplete />
             </Suspense>
-          </Layout>
-        </ProtectedRoute>
-      </DiscoverRecentProvider>
+          }
+        />
+        <Route
+          path="/*"
+          element={
+            <DiscoverRecentProvider>
+              <ProtectedRoute>
+                <Layout>
+                  <UpdateBanner
+                    currentVersion={appVersion}
+                    visible={!user || user.role === "admin"}
+                  />
+                  {healthIssue === "lidarr" && isHealthy && (
+                    <div className="app-status-banner app-status-banner--warning">
+                      <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
+                      <p className="app-status-banner__text app-status-banner__text--warning">
+                        Lidarr is busy. Library data may be stale until it catches up.
+                      </p>
+                    </div>
+                  )}
+
+                  {healthIssue === "degraded" && (
+                    <div className="app-status-banner app-status-banner--warning">
+                      <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
+                      <p className="app-status-banner__text app-status-banner__text--warning">
+                        Aurral is responding slowly. Lidarr may be busy — try again in a minute.
+                      </p>
+                    </div>
+                  )}
+
+                  {healthIssue === "backend" && isHealthy === false && (
+                    <div className="app-status-banner app-status-banner--error">
+                      <XCircle className="app-status-banner__icon app-status-banner__icon--error" />
+                      <p className="app-status-banner__text app-status-banner__text--error">
+                        Unable to connect to the Aurral backend. Please check your configuration.
+                      </p>
+                    </div>
+                  )}
+
+                  {isHealthy && !rootFolderConfigured && (
+                    <div className="app-status-banner app-status-banner--warning">
+                      <AlertTriangle className="app-status-banner__icon app-status-banner__icon--warning" />
+                      <p className="app-status-banner__text app-status-banner__text--warning">
+                        Root folder is not configured. Please configure your music
+                        library root folder in settings.
+                      </p>
+                    </div>
+                  )}
+                  <Suspense fallback={<PageLoader />}>
+                    <Routes>
+                      <Route path="/" element={<DiscoverPage />} />
+                      <Route path="/shows" element={<Navigate to="/shows/all" replace />} />
+                      <Route path="/shows/:filter" element={<ShowsPage />} />
+                      <Route path="/search" element={<SearchResultsPage />} />
+                      <Route path="/discover" element={<Navigate to="/" replace />} />
+                      <Route path="/discover/playlists/:presetId" element={<DiscoverPlaylistDetailPage />} />
+                      <Route path="/discover/playlists" element={<DiscoverPlaylistsPage />} />
+                      <Route path="/library" element={<LibraryPage />} />
+                      <Route
+                        path="/playlists"
+                        element={
+                          <PermissionRoute permission="accessFlow">
+                            <FlowPage />
+                          </PermissionRoute>
+                        }
+                      />
+                      <Route path="/flow" element={<Navigate to="/playlists" replace />} />
+                      <Route path="/downloads" element={<Navigate to="/activity/queue" replace />} />
+                      <Route path="/requests" element={<Navigate to="/activity/queue" replace />} />
+                      <Route path="/history" element={<Navigate to="/activity/history" replace />} />
+                      <Route path="/history/:legacyTab" element={<LegacyHistoryRedirect />} />
+                      <Route path="/activity" element={<ActivityRootRedirect />} />
+                      <Route path="/activity/:view" element={<ActivityPage />} />
+                      <Route path="/activity/:view/:source" element={<ActivitySourceRedirect />} />
+                      <Route
+                        path="/artist/:mbid/albums"
+                        element={<ArtistReleaseListPage mode="releases" />}
+                      />
+                      <Route path="/artist/:mbid/release/:releaseMbid" element={<ReleasePage />} />
+                      <Route
+                        path="/artist/:mbid/appears-on"
+                        element={<ArtistReleaseListPage mode="appearsOn" />}
+                      />
+                      <Route path="/artist/:mbid" element={<ArtistDetailsPage />} />
+                      <Route
+                        path="/settings/:tab?"
+                        element={
+                          <PermissionRoute permission="accessSettings">
+                            <SettingsPage />
+                          </PermissionRoute>
+                        }
+                      />
+                      <Route path="/profile" element={<ProfilePage />} />
+                      <Route path="/blocklist" element={<BlocklistPage />} />
+                    </Routes>
+                  </Suspense>
+                </Layout>
+              </ProtectedRoute>
+            </DiscoverRecentProvider>
+          }
+        />
+      </Routes>
     </Router>
   );
 }

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -115,12 +115,12 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   const logout = useCallback(async () => {
-    const proxyLogoutUrl = bootstrap?.proxyLogoutUrl;
-    if (proxyLogoutUrl) {
+    const externalLogoutUrl = bootstrap?.oidcLogoutUrl || bootstrap?.proxyLogoutUrl;
+    if (externalLogoutUrl) {
       void logoutApi().catch(() => {});
       clearAuthStorage();
       invalidateBootstrapCache();
-      window.location.href = proxyLogoutUrl;
+      window.location.href = externalLogoutUrl;
       return;
     }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6737,6 +6737,34 @@ textarea {
   text-align: center;
 }
 
+.login-sso {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.login-sso-button {
+  min-height: 2.75rem;
+}
+
+.login-divider {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--aurral-gray-light);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.login-divider::before,
+.login-divider::after {
+  content: "";
+  height: 1px;
+  background: color-mix(in srgb, var(--aurral-gray-light) 35%, transparent);
+}
+
 .login-submit {
   min-height: 2.75rem;
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import { getAppBasePath } from "../utils/basePath.js";
 
 const Login = () => {
   useDocumentTitle("Sign in");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const { login } = useAuth();
+  const { login, bootstrap } = useAuth();
+  const oidcEnabled = !!bootstrap?.oidcEnabled;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -20,6 +22,12 @@ const Login = () => {
     }
   };
 
+  const handleOidcLogin = () => {
+    const basePath = getAppBasePath();
+    const prefix = basePath === "/" ? "" : basePath.replace(/\/$/, "");
+    window.location.assign(`${prefix}/api/auth/oidc/login`);
+  };
+
   return (
     <div className="login-page">
       <div className="login-card">
@@ -28,6 +36,21 @@ const Login = () => {
           <h1 className="login-title">Sign in</h1>
           <p className="login-subtitle">Enter your credentials to access Aurral</p>
         </div>
+
+        {oidcEnabled && (
+          <div className="login-sso">
+            <button
+              type="button"
+              className="btn btn-secondary btn--full btn--bold login-sso-button"
+              onClick={handleOidcLogin}
+            >
+              Sign in with SSO
+            </button>
+            <div className="login-divider">
+              <span>or</span>
+            </div>
+          </div>
+        )}
 
         <form className="login-form" onSubmit={handleSubmit}>
           <div className="login-fields">

--- a/frontend/src/pages/SsoComplete.jsx
+++ b/frontend/src/pages/SsoComplete.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import { setStoredAuth } from "../utils/api/core.js";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+
+const readHashParams = () => {
+  const hash = String(window.location.hash || "").replace(/^#/, "");
+  return new URLSearchParams(hash);
+};
+
+const SsoComplete = () => {
+  useDocumentTitle("Signing in");
+  const { refreshAuth } = useAuth();
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const params = readHashParams();
+    const token = params.get("token");
+    const hashError = params.get("error");
+
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+
+    if (hashError) {
+      setError(hashError);
+      return undefined;
+    }
+
+    if (!token) {
+      setError("Missing SSO session");
+      return undefined;
+    }
+
+    setStoredAuth({ token });
+    refreshAuth()
+      .then(() => {
+        if (!cancelled) {
+          window.location.replace("/");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError("Failed to complete SSO sign-in");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshAuth]);
+
+  if (error) {
+    return (
+      <div className="login-page">
+        <div className="login-card">
+          <div className="login-header">
+            <img src="/arralogo.svg" alt="Aurral" className="login-logo" />
+            <h1 className="login-title">Sign-in failed</h1>
+            <p className="login-subtitle">{error}</p>
+          </div>
+          <p className="login-error">
+            <Link to="/">Back to sign in</Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="app-loading app-loading--screen">
+      <div className="app-loading__spinner app-loading__spinner--lg" />
+    </div>
+  );
+};
+
+export default SsoComplete;

--- a/frontend/src/pages/SsoComplete.jsx
+++ b/frontend/src/pages/SsoComplete.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { setStoredAuth } from "../utils/api/core.js";
+import { exchangeOidcCode } from "../utils/api/endpoints/auth.js";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 
 const readHashParams = () => {
@@ -14,10 +15,10 @@ let consumedSsoParams = null;
 const consumeSsoParams = () => {
   if (consumedSsoParams) return consumedSsoParams;
   const params = readHashParams();
-  const token = params.get("token");
+  const code = params.get("code");
   const error = params.get("error");
-  consumedSsoParams = { token, error };
-  if (token || error) {
+  consumedSsoParams = { code, error };
+  if (code || error) {
     window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
   }
   return consumedSsoParams;
@@ -31,20 +32,24 @@ const SsoComplete = () => {
 
   useEffect(() => {
     let cancelled = false;
-    const { token, error: hashError } = consumeSsoParams();
+    const { code, error: hashError } = consumeSsoParams();
 
     if (hashError) {
       setError(hashError);
       return undefined;
     }
 
-    if (!token) {
+    if (!code) {
       setError("Missing SSO session");
       return undefined;
     }
 
-    setStoredAuth({ token });
-    refreshAuth()
+    exchangeOidcCode(code)
+      .then(({ token }) => {
+        if (!token) throw new Error("Missing SSO session token");
+        setStoredAuth({ token });
+        return refreshAuth();
+      })
       .then(() => {
         if (!cancelled) {
           navigate("/", { replace: true });

--- a/frontend/src/pages/SsoComplete.jsx
+++ b/frontend/src/pages/SsoComplete.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { setStoredAuth } from "../utils/api/core.js";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
@@ -9,18 +9,29 @@ const readHashParams = () => {
   return new URLSearchParams(hash);
 };
 
+let consumedSsoParams = null;
+
+const consumeSsoParams = () => {
+  if (consumedSsoParams) return consumedSsoParams;
+  const params = readHashParams();
+  const token = params.get("token");
+  const error = params.get("error");
+  consumedSsoParams = { token, error };
+  if (token || error) {
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  }
+  return consumedSsoParams;
+};
+
 const SsoComplete = () => {
   useDocumentTitle("Signing in");
+  const navigate = useNavigate();
   const { refreshAuth } = useAuth();
   const [error, setError] = useState("");
 
   useEffect(() => {
     let cancelled = false;
-    const params = readHashParams();
-    const token = params.get("token");
-    const hashError = params.get("error");
-
-    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+    const { token, error: hashError } = consumeSsoParams();
 
     if (hashError) {
       setError(hashError);
@@ -36,7 +47,7 @@ const SsoComplete = () => {
     refreshAuth()
       .then(() => {
         if (!cancelled) {
-          window.location.replace("/");
+          navigate("/", { replace: true });
         }
       })
       .catch(() => {
@@ -46,7 +57,7 @@ const SsoComplete = () => {
     return () => {
       cancelled = true;
     };
-  }, [refreshAuth]);
+  }, [navigate, refreshAuth]);
 
   if (error) {
     return (

--- a/frontend/src/utils/api/endpoints/auth.js
+++ b/frontend/src/utils/api/endpoints/auth.js
@@ -40,6 +40,8 @@ export const loginApi = async (username, password) => {
   return result;
 };
 
+export const exchangeOidcCode = (code) => postData("/auth/oidc/exchange", { code });
+
 export const logoutApi = async () => {
   const result = await postData("/auth/logout");
   invalidateBootstrapCache();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -69,6 +69,11 @@ export default defineConfig(({ mode }) => {
           timeout: 60000,
           proxyTimeout: 60000,
         },
+        "/sso/callback": {
+          target: "http://localhost:3001",
+          changeOrigin: true,
+          secure: false,
+        },
         "/ws": {
           target: "ws://localhost:3001",
           ws: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
     "backend": {
       "name": "aurral-backend",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@russellthehippo/honker-node": "^0.4.5",
@@ -29,6 +28,7 @@
         "express-rate-limit": "^8.6.1",
         "helmet": "^8.3.0",
         "music-metadata": "^11.14.0",
+        "openid-client": "^6.8.4",
         "sharp": "^0.35.3",
         "undici": "^7.28.0",
         "ws": "^8.21.1"
@@ -3048,9 +3048,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3068,9 +3065,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3088,9 +3082,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3108,9 +3099,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3128,9 +3116,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3148,9 +3133,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3780,9 +3762,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3798,9 +3777,6 @@
       "integrity": "sha512-EcIl3qVcK6U9IQx5BK4NuyrxNgKRr+U+qjxFx4KJv3C3PzqIRL59H7IRNdSf78+lvXAXS7UBrRgFCKnLd0b3wg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -6749,6 +6725,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7043,9 +7028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7067,9 +7049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7091,9 +7070,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7115,9 +7091,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7511,6 +7484,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7637,6 +7619,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {


### PR DESCRIPTION
## Summary

Adds native OpenID Connect login (Authorization Code + PKCE) as an alternative to reverse-proxy SSO. When `OIDC_ENABLED=true`, the login page shows **Sign in with SSO**, Aurral discovers the IdP, exchanges the callback at `/sso/callback`, JIT-provisions a local user, and issues a normal Aurral session.

Reverse-proxy auth is unchanged and can remain configured alongside OIDC.

## Linked issues

Fixes #396

## Validation

- [x] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): authentication, login UI, Docker/env config, docs
- Automated coverage: `.tests/auth/oidc-auth.test.js` (OIDC enablement, login redirect, callback session, JIT user + role mapping)
- Manual steps and expected result:

### 1. Pull the preview image

After CI publishes the preview:

```bash
docker pull ghcr.io/lklynet/aurral:pr-<number>
```

Use that tag in Compose (or replace your current image tag), then recreate the container.

### 2. Configure your IdP

Register a confidential OIDC client with:

- Redirect URI: `https://<your-aurral-host>/sso/callback` (exact match)
- Grant types: authorization code (PKCE)
- Scopes: at least `openid profile email`

### 3. Set Aurral environment variables

Required:

| Variable | Example / notes |
| --- | --- |
| `OIDC_ENABLED` | `true` |
| `OIDC_ISSUER` | IdP issuer URL used for discovery (e.g. `https://auth.example.com/application/o/aurral/`) |
| `OIDC_CLIENT_ID` | Client ID from your IdP |
| `OIDC_CLIENT_SECRET` | Client secret from your IdP |
| `OIDC_REDIRECT_URI` | Must be exactly `https://<your-aurral-host>/sso/callback` |

Optional:

| Variable | Purpose |
| --- | --- |
| `OIDC_SCOPES` | Default `openid profile email` |
| `OIDC_USERNAME_CLAIM` | Default `preferred_username` (falls back to `email`) |
| `OIDC_DEFAULT_ROLE` | `user` (default) or `admin` |
| `OIDC_ADMIN_USERS` | Comma-separated usernames promoted to admin at login |
| `OIDC_GROUPS_CLAIM` | ID-token claim with group membership |
| `OIDC_ADMIN_GROUPS` | Groups from that claim that grant admin |
| `OIDC_LOGOUT_URL` | IdP logout URL; Log out redirects here after clearing the local session |
| `OIDC_DOMAIN` | IdP origin added to CSP `connect-src` |

Docs: [Users and authentication](https://docs.aurral.app/admin/users/) and [Environment variables](https://docs.aurral.app/admin/environment/).

### 4. Exercise the flow

1. Open Aurral login → **Sign in with SSO** is visible.
2. Complete IdP login → land back in Aurral signed in.
3. Confirm the JIT user appears under **Settings → Users** with the expected role.
4. Log out (with `OIDC_LOGOUT_URL` set, confirm IdP logout redirect).
5. Confirm local password login still works for existing local users.
6. Optional: leave proxy auth env vars set and confirm OIDC remains the browser SSO path you configured.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native OpenID Connect (OIDC) single sign-on, including configurable issuer, client credentials, claims, roles, groups, logout, and callback handling.
  * Added SSO sign-in and completion screens, external-user provisioning, session creation, and configurable logout redirects.
  * OIDC can coexist with reverse-proxy authentication.

* **Documentation**
  * Added setup and environment configuration guidance for OIDC.

* **Tests**
  * Added coverage for login, identity mapping, provisioning, sessions, onboarding enforcement, and invalid or expired callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->