### PR TITLE
feat(ci): notify discord about releases and previews

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update release readiness record
+        id: readiness
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
@@ -79,3 +80,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
         run: bash scripts/notify-github-status.sh nightly
+
+      - name: Notify Discord nightly channel
+        env:
+          DISCORD_WEBHOOK_NIGHTLY: ${{ secrets.DISCORD_WEBHOOK_NIGHTLY }}
+          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
+          CHANGE_URL: ${{ steps.readiness.outputs.change_url }}
+          CHANGE_RANGE: ${{ steps.readiness.outputs.change_range }}
+          READINESS_ISSUE: ${{ steps.readiness.outputs.readiness_issue }}
+        run: bash scripts/notify-discord.sh nightly

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,6 +70,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Comment preview image on pull request and linked issues
+        id: preview-comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_TAG: pr-${{ github.event.number }}
@@ -103,6 +104,7 @@ jobs:
             "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- aurral-preview-image -->"))) | .id' | head -n1)"
 
+          FIRST_PREVIEW=false
           if [ -n "${COMMENT_ID}" ]; then
             gh api \
               --method PATCH \
@@ -112,7 +114,9 @@ jobs:
             gh pr comment "${PR_NUMBER}" \
               --repo "${REPOSITORY}" \
               --body "${COMMENT_BODY}" >/dev/null
+            FIRST_PREVIEW=true
           fi
+          echo "first_preview=${FIRST_PREVIEW}" >> "${GITHUB_OUTPUT}"
 
           OWNER="${REPOSITORY%%/*}"
           REPO="${REPOSITORY#*/}"
@@ -188,6 +192,15 @@ jobs:
               "repos/${REPOSITORY}/issues/${issue_number}/labels" \
               -f "labels[]=in-progress" >/dev/null
           done <<< "${CLOSING_ISSUES}"
+
+      - name: Notify Discord previews channel
+        if: steps.preview-comment.outputs.first_preview == 'true'
+        env:
+          DISCORD_WEBHOOK_PREVIEWS: ${{ secrets.DISCORD_WEBHOOK_PREVIEWS }}
+          IMAGE_TAG: pr-${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash scripts/notify-discord.sh previews
 
   delete-image:
     if: >-

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -65,3 +65,10 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: bash scripts/notify-github-status.sh stable
+
+      - name: Notify Discord releases channel
+        env:
+          DISCORD_WEBHOOK_RELEASES: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: bash scripts/notify-discord.sh releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,3 +239,10 @@ jobs:
           RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
         run: bash scripts/notify-github-status.sh stable
+
+      - name: Notify Discord releases channel
+        env:
+          DISCORD_WEBHOOK_RELEASES: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
+        run: bash scripts/notify-discord.sh releases

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+channel="${1:-}"
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+case "${channel}" in
+  releases)
+    webhook_url="${DISCORD_WEBHOOK_RELEASES:-}"
+    ;;
+  nightly)
+    webhook_url="${DISCORD_WEBHOOK_NIGHTLY:-}"
+    ;;
+  previews)
+    webhook_url="${DISCORD_WEBHOOK_PREVIEWS:-}"
+    ;;
+  *)
+    echo "Usage: $0 releases|nightly|previews" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "${webhook_url}" ]; then
+  echo "Discord webhook for ${channel} is not configured; skipping."
+  exit 0
+fi
+
+case "${channel}" in
+  releases)
+    release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+    release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
+    title="Aurral ${release_version} released"
+    url="https://github.com/${repository}/releases/tag/${release_tag}"
+    description="$(cat <<EOF
+Stable release \`${release_version}\` is published.
+
+\`\`\`
+docker pull ghcr.io/${repository}:${release_version}
+docker pull ghcr.io/${repository}:latest
+\`\`\`
+
+${url}
+EOF
+)"
+    ;;
+  nightly)
+    nightly_version="${NIGHTLY_VERSION:?NIGHTLY_VERSION is required}"
+    head_sha="${HEAD_SHA:-${GITHUB_SHA:?GITHUB_SHA is required}}"
+    run_id="${GITHUB_RUN_ID:-}"
+    change_url="${CHANGE_URL:-}"
+    change_range="${CHANGE_RANGE:-}"
+    readiness_issue="${READINESS_ISSUE:-}"
+    title="Nightly ${nightly_version}"
+    url="https://github.com/${repository}/actions/runs/${run_id}"
+    description="$(cat <<EOF
+\`ghcr.io/${repository}:nightly\` was rebuilt from \`${head_sha:0:7}\`.
+
+\`\`\`
+docker pull ghcr.io/${repository}:nightly
+\`\`\`
+EOF
+)"
+    if [ -n "${change_range}" ] && [ -n "${change_url}" ]; then
+      description+=$'\n'"Changes: [\`${change_range}\`](${change_url})"
+    fi
+    if [ -n "${readiness_issue}" ]; then
+      description+=$'\n'"Release readiness: https://github.com/${repository}/issues/${readiness_issue}"
+    fi
+    description+=$'\n'"Give feedback in #testing."
+    ;;
+  previews)
+    pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+    pr_title="${PR_TITLE:?PR_TITLE is required}"
+    image_tag="${IMAGE_TAG:?IMAGE_TAG is required}"
+    title="Preview ready: #${pr_number}"
+    url="https://github.com/${repository}/pull/${pr_number}"
+    description="$(cat <<EOF
+**${pr_title}**
+
+First preview image for this pull request is ready.
+
+\`\`\`
+docker pull ghcr.io/${repository}:${image_tag}
+\`\`\`
+
+How to test: see #testing.
+${url}
+EOF
+)"
+    ;;
+esac
+
+payload="$(
+  DISCORD_EMBED_TITLE="${title}" \
+  DISCORD_EMBED_DESCRIPTION="${description}" \
+  DISCORD_EMBED_URL="${url}" \
+  python3 -c 'import json, os; print(json.dumps({"embeds":[{"title": os.environ["DISCORD_EMBED_TITLE"], "description": os.environ["DISCORD_EMBED_DESCRIPTION"], "url": os.environ["DISCORD_EMBED_URL"]}]}))'
+)"
+
+http_code="$(curl -sS -o /tmp/aurral-discord-response.txt -w '%{http_code}' \
+  -H 'Content-Type: application/json' \
+  -d "${payload}" \
+  "${webhook_url}")"
+
+if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+  echo "Discord webhook for ${channel} returned HTTP ${http_code}:" >&2
+  cat /tmp/aurral-discord-response.txt >&2 || true
+  exit 1
+fi
+
+echo "Posted Discord notification to ${channel}."

--- a/scripts/update-release-readiness.sh
+++ b/scripts/update-release-readiness.sh
@@ -68,6 +68,32 @@ write_output() {
   fi
 }
 
+pin_issue() {
+  local issue_number="$1"
+  local err
+  if err="$(gh issue pin "${issue_number}" --repo "${repository}" 2>&1)"; then
+    return 0
+  fi
+  if printf '%s\n' "${err}" | grep -qi 'already pinned'; then
+    return 0
+  fi
+  printf '%s\n' "${err}" >&2
+  return 1
+}
+
+unpin_issue() {
+  local issue_number="$1"
+  local err
+  if err="$(gh issue unpin "${issue_number}" --repo "${repository}" 2>&1)"; then
+    return 0
+  fi
+  if printf '%s\n' "${err}" | grep -qi 'not pinned'; then
+    return 0
+  fi
+  printf '%s\n' "${err}" >&2
+  return 1
+}
+
 resolve_tag_commit() {
   local tag_ref="$1"
   local tag_object tag_type tag_sha
@@ -263,6 +289,8 @@ EOF
     fi
   fi
 
+  pin_issue "${readiness_issue}"
+
   status_body="$(cat <<EOF
 ${status_marker}
 ### Current nightly candidate
@@ -285,6 +313,9 @@ The candidate above is the build that should be used for readiness testing. A ni
 EOF
   )"
   update_status_comment "${readiness_issue}" "${status_body}"
+  write_output readiness_issue "${readiness_issue}"
+  write_output change_url "${change_url}"
+  write_output change_range "${change_range}"
   echo "Updated release-readiness issue #${readiness_issue}."
   exit 0
 fi
@@ -328,4 +359,5 @@ gh issue edit "${readiness_issue}" \
   --add-label released \
   --remove-label release-ready >/dev/null
 gh issue close "${readiness_issue}" --repo "${repository}" >/dev/null
+unpin_issue "${readiness_issue}"
 echo "Closed release-readiness issue #${readiness_issue} for ${release_version}."


### PR DESCRIPTION
## Summary

Add Discord notifications for stable releases, nightly builds, and first pull-request preview images. Export release-readiness metadata so nightly notifications can link to relevant changes and readiness issues, and keep the readiness issue pinned until release.

## Linked issues

- None

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): CI workflows, release readiness, Discord notifications
- Automated coverage: Existing workflow execution and shell-script validation
- Manual steps and expected result: Configure the Discord webhook secrets and run release, nightly, and preview workflows; each notification is posted to the appropriate channel, and missing webhooks skip cleanly.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord notifications for nightly builds, preview publications, stable releases, and release updates.
  * Notifications include relevant release, preview, and pull request details.
  * Release-readiness issues are now automatically pinned during nightly processing and unpinned after stable release completion.
* **Bug Fixes**
  * Improved handling of issues that are already pinned or unpinned.
  * Added notification validation and failure reporting for unsuccessful deliveries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->