### PR TITLE
feat(sidebar): add release channel backdrops

### DIFF
--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -35,7 +35,10 @@ Point `/data:/data` at the host path that Lidarr mounts. `./config` holds Aurral
 | `nightly` | Every change merged since the last release | You want fixes and features early and can report bugs |
 | `pr-<number>` | The current preview image for an open pull request | You were asked to test a proposed change |
 
-Aurral checks for a newer build in your channel and shows a banner when one exists.
+Aurral checks for a newer build in your channel and shows a banner when one exists. Non-stable channels also mark the sidebar:
+
+- `nightly` shows a night-sky backdrop behind the sidebar logo.
+- `pr-<number>` preview images show a blueprint backdrop behind the sidebar logo.
 
 :::caution
 `nightly` is untested by users until you run it. Back up `./config` before switching to it, and report anything broken.

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -16,8 +16,12 @@ import {
   getDiscoverRecentPageLinkState,
 } from "../utils/discoverRecentNavigation";
 import { useStorageHealth } from "../hooks/useStorageHealth";
+import SidebarStageBackdrop, {
+  resolveSidebarStageBackdropVariant,
+} from "./SidebarStageBackdrop";
 
 function Sidebar({ mode, width = 208 }) {
+  const stageBackdropVariant = resolveSidebarStageBackdropVariant();
   const location = useLocation();
   const { user, bootstrap } = useAuth();
   const hasFlowAccess = user?.role === "admin" || !!user?.permissions?.accessFlow;
@@ -264,11 +268,14 @@ function Sidebar({ mode, width = 208 }) {
 
   return (
     <aside
-      className={`sidebar-shell ${translateClass}`}
+      className={`sidebar-shell ${translateClass}${
+        stageBackdropVariant ? ` sidebar-shell--${stageBackdropVariant}` : ""
+      }`}
       style={{
         width: `${width}px`,
       }}
     >
+      {stageBackdropVariant ? <SidebarStageBackdrop variant={stageBackdropVariant} /> : null}
       <div className="sidebar-logo-row">
         <Link to="/" className="sidebar-logo-link">
           <img src="/arralogo.svg" alt="Aurral Logo" className="sidebar-logo" />

--- a/frontend/src/components/SidebarStageBackdrop.jsx
+++ b/frontend/src/components/SidebarStageBackdrop.jsx
@@ -1,0 +1,294 @@
+import { useId } from "react";
+
+const STAGE_BACKDROP_VIEW_BOX = "0 0 8192 96";
+
+const NIGHTLY_STARS = [
+  { cx: 14, cy: 10, r: 0.6, opacity: 0.85 },
+  { cx: 38, cy: 22, r: 0.4, opacity: 0.55 },
+  { cx: 58, cy: 8, r: 0.5, opacity: 0.7 },
+  { cx: 84, cy: 16, r: 0.4, opacity: 0.5 },
+  { cx: 104, cy: 7, r: 0.6, opacity: 0.8 },
+  { cx: 126, cy: 20, r: 0.4, opacity: 0.55 },
+  { cx: 148, cy: 11, r: 0.5, opacity: 0.7 },
+  { cx: 170, cy: 24, r: 0.4, opacity: 0.5 },
+  { cx: 192, cy: 9, r: 0.6, opacity: 0.8 },
+  { cx: 214, cy: 18, r: 0.4, opacity: 0.55 },
+  { cx: 236, cy: 8, r: 0.5, opacity: 0.7 },
+  { cx: 258, cy: 20, r: 0.45, opacity: 0.6 },
+  { cx: 278, cy: 11, r: 0.55, opacity: 0.75 },
+  { cx: 26, cy: 34, r: 0.4, opacity: 0.45 },
+  { cx: 118, cy: 34, r: 0.4, opacity: 0.45 },
+  { cx: 202, cy: 32, r: 0.4, opacity: 0.5 },
+  { cx: 268, cy: 34, r: 0.4, opacity: 0.45 },
+];
+
+const NIGHTLY_SPARKLES = [
+  { x: 70, y: 28 },
+  { x: 160, y: 36 },
+  { x: 246, y: 26 },
+];
+
+export function resolveSidebarStageBackdropVariant(
+  channel = import.meta.env.VITE_RELEASE_CHANNEL,
+) {
+  const normalized = String(channel || "stable").trim().toLowerCase();
+  if (normalized === "nightly") return "nightly";
+  if (normalized === "preview") return "preview";
+  return null;
+}
+
+function NightlySkyArt() {
+  const idPrefix = useId().replaceAll(":", "");
+  const skyId = `${idPrefix}-stage-night-sky`;
+  const glowId = `${idPrefix}-stage-night-glow`;
+  const cloudId = `${idPrefix}-stage-night-cloud`;
+  const softId = `${idPrefix}-stage-night-soft`;
+  const starsId = `${idPrefix}-stage-night-stars`;
+  const glowsId = `${idPrefix}-stage-night-glows`;
+
+  return (
+    <svg
+      className="sidebar-stage-backdrop__art"
+      fill="none"
+      preserveAspectRatio="xMinYMin slice"
+      viewBox={STAGE_BACKDROP_VIEW_BOX}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id={skyId}
+          x1="24"
+          y1="0"
+          x2="264"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+          spreadMethod="reflect"
+        >
+          <stop stopColor="#07152F" />
+          <stop offset="0.5" stopColor="#151443" />
+          <stop offset="1" stopColor="#32155B" />
+        </linearGradient>
+        <radialGradient
+          id={glowId}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(216 18) rotate(137) scale(120 84)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#5165D8" stopOpacity="0.4" />
+          <stop offset="0.5" stopColor="#283075" stopOpacity="0.16" />
+          <stop offset="1" stopColor="#111635" stopOpacity="0" />
+        </radialGradient>
+        <linearGradient id={cloudId} x1="0" y1="60" x2="288" y2="96" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#4EA4FF" stopOpacity="0.5" />
+          <stop offset="0.52" stopColor="#696FEA" stopOpacity="0.62" />
+          <stop offset="1" stopColor="#A85BEA" stopOpacity="0.5" />
+        </linearGradient>
+        <filter id={softId} x="-24" y="-24" width="336" height="144" filterUnits="userSpaceOnUse">
+          <feGaussianBlur stdDeviation="4" />
+        </filter>
+        <pattern id={starsId} width="288" height="96" patternUnits="userSpaceOnUse">
+          <g fill="#E4EAFF">
+            {NIGHTLY_STARS.map((star) => (
+              <circle
+                key={`${star.cx}-${star.cy}`}
+                cx={star.cx}
+                cy={star.cy}
+                r={star.r}
+                fillOpacity={star.opacity}
+              />
+            ))}
+          </g>
+          <g stroke="#C8D7FF" strokeLinecap="round" strokeOpacity="0.7" strokeWidth="0.6">
+            {NIGHTLY_SPARKLES.map((sparkle) => (
+              <g key={`${sparkle.x}-${sparkle.y}`}>
+                <path d={`M${sparkle.x - 1.5} ${sparkle.y}H${sparkle.x + 1.5}`} />
+                <path d={`M${sparkle.x} ${sparkle.y - 1.5}V${sparkle.y + 1.5}`} />
+              </g>
+            ))}
+          </g>
+        </pattern>
+        <pattern id={glowsId} width="640" height="96" patternUnits="userSpaceOnUse">
+          <rect width="640" height="96" fill={`url(#${glowId})`} />
+        </pattern>
+      </defs>
+
+      <rect width="100%" height="96" fill={`url(#${skyId})`} />
+      <rect width="100%" height="96" fill={`url(#${glowsId})`} />
+      <rect width="100%" height="96" fill={`url(#${starsId})`} />
+
+      <g filter={`url(#${softId})`}>
+        <path
+          d="M-12 88C-12 74 0 63 14 63C18 50 30 41 44 41C58 41 70 49 74 62C79 57 86 54 94 54C110 54 123 66 124 82C132 83 138 88 141 96H-12V88Z"
+          fill={`url(#${cloudId})`}
+        />
+      </g>
+      <g filter={`url(#${softId})`}>
+        <path
+          d="M150 96C151 84 161 75 173 75C176 64 186 57 198 57C210 57 220 64 223 75C231 75 238 80 241 87C250 87 257 91 260 96H150Z"
+          fill={`url(#${cloudId})`}
+          fillOpacity="0.8"
+        />
+      </g>
+    </svg>
+  );
+}
+
+function PreviewBlueprintArt() {
+  const idPrefix = useId().replaceAll(":", "");
+  const paperId = `${idPrefix}-stage-bp-paper`;
+  const glowId = `${idPrefix}-stage-bp-glow`;
+  const celesteGlowId = `${idPrefix}-stage-bp-glow-celeste`;
+  const violetGlowId = `${idPrefix}-stage-bp-glow-violet`;
+  const minorGridId = `${idPrefix}-stage-bp-grid-minor`;
+  const majorGridId = `${idPrefix}-stage-bp-grid-major`;
+  const rulerId = `${idPrefix}-stage-bp-ruler`;
+  const glowsId = `${idPrefix}-stage-bp-glows`;
+  const annotationsId = `${idPrefix}-stage-bp-annotations`;
+
+  return (
+    <svg
+      className="sidebar-stage-backdrop__art sidebar-stage-backdrop__art--blueprint"
+      fill="none"
+      preserveAspectRatio="xMinYMin slice"
+      viewBox={STAGE_BACKDROP_VIEW_BOX}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id={paperId}
+          x1="60"
+          y1="0"
+          x2="220"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+          spreadMethod="reflect"
+        >
+          <stop style={{ stopColor: "var(--stage-bp-bottom)" }} />
+          <stop offset="0.5" style={{ stopColor: "var(--stage-bp-mid)" }} />
+          <stop offset="1" style={{ stopColor: "var(--stage-bp-top)" }} />
+        </linearGradient>
+        <radialGradient
+          id={glowId}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(216 14) rotate(137) scale(120 84)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#D4F6FF" stopOpacity="0.4" />
+          <stop offset="0.52" stopColor="#65C8FF" stopOpacity="0.16" />
+          <stop offset="1" stopColor="#276AF1" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id={celesteGlowId}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(474 44) rotate(166) scale(156 92)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#D2FFFF" stopOpacity="0.34" />
+          <stop offset="0.5" stopColor="#48DCF5" stopOpacity="0.18" />
+          <stop offset="1" stopColor="#277EF1" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id={violetGlowId}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(704 18) rotate(145) scale(132 88)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#D9D8FF" stopOpacity="0.3" />
+          <stop offset="0.52" stopColor="#7C8BFF" stopOpacity="0.14" />
+          <stop offset="1" stopColor="#3155DF" stopOpacity="0" />
+        </radialGradient>
+        <pattern id={minorGridId} width="8" height="8" patternUnits="userSpaceOnUse">
+          <path d="M8 0H0V8" stroke="#EAF6FF" strokeOpacity="0.14" strokeWidth="0.5" />
+        </pattern>
+        <pattern id={majorGridId} width="32" height="32" patternUnits="userSpaceOnUse">
+          <path d="M32 0H0V32" stroke="#EAF6FF" strokeOpacity="0.26" strokeWidth="0.6" />
+        </pattern>
+        <pattern id={rulerId} width="32" height="6" patternUnits="userSpaceOnUse">
+          <path
+            d="M4 0V2.5M12 0V2.5M20 0V4M28 0V2.5"
+            stroke="#DDF7FF"
+            strokeOpacity="0.5"
+            strokeWidth="0.5"
+          />
+        </pattern>
+        <pattern id={glowsId} width="768" height="96" patternUnits="userSpaceOnUse">
+          <rect width="768" height="96" fill={`url(#${glowId})`} />
+          <rect width="768" height="96" fill={`url(#${celesteGlowId})`} />
+          <rect width="768" height="96" fill={`url(#${violetGlowId})`} />
+        </pattern>
+        <pattern id={annotationsId} width="768" height="96" patternUnits="userSpaceOnUse">
+          <g stroke="#DDF7FF" strokeLinecap="round" strokeOpacity="0.6" strokeWidth="0.7">
+            <path d="M180 64H264" strokeDasharray="5 4" />
+            <path d="M180 61V67M264 61V67" />
+            <path d="M276 10V44" strokeDasharray="4 4" strokeOpacity="0.5" />
+            <path d="M273 10H279M273 44H279" strokeOpacity="0.5" />
+            <path d="M348 30H428" strokeDasharray="3.5 5" strokeOpacity="0.5" />
+            <path d="M348 27V33M428 27V33" strokeOpacity="0.5" />
+            <path d="M512 48V80" strokeDasharray="5 3" strokeOpacity="0.45" />
+            <path d="M509 48H515M509 80H515" strokeOpacity="0.45" />
+            <path d="M590 70H724" strokeDasharray="7 4" strokeOpacity="0.55" />
+            <path d="M590 67V73M724 67V73" strokeOpacity="0.55" />
+          </g>
+
+          <g stroke="#DDF7FF" strokeLinecap="round" strokeOpacity="0.55" strokeWidth="0.6">
+            <g>
+              <path d="M34 60L38 64M38 60L34 64" />
+            </g>
+            <g>
+              <path d="M228 26H234M231 23V29" />
+            </g>
+            <g>
+              <path d="M143 51H149M146 48V54" />
+            </g>
+            <g>
+              <path d="M316 16L322 22M322 16L316 22" />
+            </g>
+            <g>
+              <path d="M468 70H476M472 66V74" />
+            </g>
+            <g>
+              <path d="M558 28L564 34M564 28L558 34" />
+            </g>
+            <g>
+              <path d="M742 44H750M746 40V48" />
+            </g>
+          </g>
+
+          <g stroke="#DDF7FF" strokeOpacity="0.35" strokeWidth="0.6">
+            <circle cx="196" cy="38" r="13" strokeDasharray="3.5 4" />
+            <path d="M196 33V43M191 38H201" strokeOpacity="0.6" strokeWidth="0.4" />
+            <circle cx="414" cy="64" r="10" strokeDasharray="2.5 3.5" />
+            <path d="M414 60V68M410 64H418" strokeOpacity="0.6" strokeWidth="0.4" />
+            <circle cx="648" cy="32" r="15" strokeDasharray="4 5" />
+            <path d="M648 26V38M642 32H654" strokeOpacity="0.6" strokeWidth="0.4" />
+          </g>
+        </pattern>
+      </defs>
+
+      <rect width="100%" height="96" fill={`url(#${paperId})`} />
+      <rect width="100%" height="96" fill={`url(#${glowsId})`} />
+      <rect width="100%" height="96" fill={`url(#${minorGridId})`} />
+      <rect width="100%" height="96" fill={`url(#${majorGridId})`} />
+      <rect width="100%" height="6" fill={`url(#${rulerId})`} />
+      <rect width="100%" height="96" fill={`url(#${annotationsId})`} />
+    </svg>
+  );
+}
+
+export default function SidebarStageBackdrop({ variant }) {
+  return (
+    <div className="sidebar-stage-backdrop" aria-hidden="true">
+      {variant === "preview" ? <PreviewBlueprintArt /> : <NightlySkyArt />}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -988,6 +988,54 @@ textarea {
     width 0.3s ease;
 }
 
+.sidebar-shell--nightly,
+.sidebar-shell--preview {
+  --sidebar-stage-fade: var(--aurral-surface);
+}
+
+.sidebar-stage-backdrop {
+  pointer-events: none;
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  z-index: 0;
+  height: 5rem;
+  overflow: hidden;
+  user-select: none;
+  --stage-fade: var(--sidebar-stage-fade, var(--aurral-surface));
+  mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 92%);
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 92%);
+}
+
+.sidebar-stage-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 28%,
+    color-mix(in srgb, var(--stage-fade) 10%, transparent) 40%,
+    color-mix(in srgb, var(--stage-fade) 30%, transparent) 52%,
+    color-mix(in srgb, var(--stage-fade) 58%, transparent) 64%,
+    color-mix(in srgb, var(--stage-fade) 82%, transparent) 75%,
+    color-mix(in srgb, var(--stage-fade) 96%, transparent) 85%,
+    var(--stage-fade) 93%
+  );
+}
+
+.sidebar-stage-backdrop__art {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar-stage-backdrop__art--blueprint {
+  --stage-bp-top: #3a7ad1;
+  --stage-bp-mid: #2050ae;
+  --stage-bp-bottom: #101f6e;
+}
+
 [data-resizing] .sidebar-shell,
 [data-resizing] .app-content {
   transition: none;
@@ -1034,6 +1082,7 @@ textarea {
 
 .sidebar-logo-row {
   position: relative;
+  z-index: 1;
   display: flex;
   height: 3.25rem;
   align-items: center;
@@ -1042,6 +1091,8 @@ textarea {
 }
 
 .sidebar-logo-link {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1060,6 +1111,8 @@ textarea {
 }
 
 .sidebar-body {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex: 1;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Add nightly night-sky and PR preview blueprint backdrops behind the sidebar logo, with documentation explaining the visual channel indicators.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): UI, docs
- Automated coverage: Existing frontend checks cover the affected application code.
- Manual steps and expected result: Run Aurral with `VITE_RELEASE_CHANNEL=nightly` and `preview`; confirm the corresponding backdrop appears behind the sidebar logo. Confirm stable builds show no backdrop.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinctive sidebar backdrops for nightly builds and pull request previews.
  - Nightly builds feature a night-sky design, while preview builds use a blueprint-style design.
  - Preserved existing sidebar navigation and layout behavior.

- **Documentation**
  - Updated Docker documentation to explain the new sidebar visuals for non-stable image channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->