### PR TITLE
fix(sidebar): prevent stage discover row overlap

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1159,6 +1159,18 @@ textarea {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.sidebar-shell--nightly .sidebar-nav-group.is-expanded,
+.sidebar-shell--nightly .sidebar-nav-group.is-active-row,
+.sidebar-shell--preview .sidebar-nav-group.is-expanded,
+.sidebar-shell--preview .sidebar-nav-group.is-active-row {
+  background: linear-gradient(
+    to bottom,
+    transparent 0,
+    rgba(255, 255, 255, 0.04) 2.75rem,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+}
+
 .sidebar-nav-group.is-expanded::before,
 .sidebar-nav-group.is-active-row::before,
 .sidebar-settings-group.is-expanded::before {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,9 +3047,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3067,9 +3064,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3087,9 +3081,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3107,9 +3098,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3127,9 +3115,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3147,9 +3132,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3779,9 +3761,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3797,9 +3776,6 @@
       "integrity": "sha512-EcIl3qVcK6U9IQx5BK4NuyrxNgKRr+U+qjxFx4KJv3C3PzqIRL59H7IRNdSf78+lvXAXS7UBrRgFCKnLd0b3wg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -7042,9 +7018,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7066,9 +7039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7090,9 +7060,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7114,9 +7081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Adds a gradient background for expanded and active sidebar groups in nightly and preview environments to prevent the Stage Discover row from overlapping. Also updates the lockfile metadata.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): UI, sidebar
- Automated coverage: Existing frontend checks, if applicable
- Manual steps and expected result: Open the sidebar in nightly or preview, expand or activate a navigation group, and verify the Stage Discover row does not overlap adjacent content.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Nightly/Preview sidebar navigation styling.
  * Expanded or active navigation groups now feature a subtle vertical gradient for clearer visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->