### PR TITLE
fix(sidebar): limit stage backdrop blend to Discover

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -258,6 +258,9 @@ function Sidebar({ mode, width = 208 }) {
 
   const getNavGroupClassName = (item, active) => {
     const classes = ["sidebar-nav-group"];
+    if (item.section === "discover") {
+      classes.push("sidebar-nav-group--discover");
+    }
     if (active && (item.subnav?.length || item.section === "discover") && !isIcons) {
       classes.push("is-expanded");
     } else if (active) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1159,17 +1159,10 @@ textarea {
   background: rgba(255, 255, 255, 0.04);
 }
 
-<<<<<<< HEAD
 .sidebar-shell--nightly .sidebar-nav-group--discover.is-expanded,
 .sidebar-shell--nightly .sidebar-nav-group--discover.is-active-row,
 .sidebar-shell--preview .sidebar-nav-group--discover.is-expanded,
 .sidebar-shell--preview .sidebar-nav-group--discover.is-active-row {
-=======
-.sidebar-shell--nightly .sidebar-nav-group.is-expanded,
-.sidebar-shell--nightly .sidebar-nav-group.is-active-row,
-.sidebar-shell--preview .sidebar-nav-group.is-expanded,
-.sidebar-shell--preview .sidebar-nav-group.is-active-row {
->>>>>>> origin/main
   background: linear-gradient(
     to bottom,
     transparent 0,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1159,10 +1159,10 @@ textarea {
   background: rgba(255, 255, 255, 0.04);
 }
 
-.sidebar-shell--nightly .sidebar-nav-group.is-expanded,
-.sidebar-shell--nightly .sidebar-nav-group.is-active-row,
-.sidebar-shell--preview .sidebar-nav-group.is-expanded,
-.sidebar-shell--preview .sidebar-nav-group.is-active-row {
+.sidebar-shell--nightly .sidebar-nav-group--discover.is-expanded,
+.sidebar-shell--nightly .sidebar-nav-group--discover.is-active-row,
+.sidebar-shell--preview .sidebar-nav-group--discover.is-expanded,
+.sidebar-shell--preview .sidebar-nav-group--discover.is-active-row {
   background: linear-gradient(
     to bottom,
     transparent 0,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1159,6 +1159,18 @@ textarea {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.sidebar-shell--nightly .sidebar-nav-group.is-expanded,
+.sidebar-shell--nightly .sidebar-nav-group.is-active-row,
+.sidebar-shell--preview .sidebar-nav-group.is-expanded,
+.sidebar-shell--preview .sidebar-nav-group.is-active-row {
+  background: linear-gradient(
+    to bottom,
+    transparent 0,
+    rgba(255, 255, 255, 0.04) 2.75rem,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+}
+
 .sidebar-nav-group.is-expanded::before,
 .sidebar-nav-group.is-active-row::before,
 .sidebar-settings-group.is-expanded::before {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,9 +3047,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3067,9 +3064,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3087,9 +3081,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3107,9 +3098,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3127,9 +3115,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3147,9 +3132,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3779,9 +3761,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3797,9 +3776,6 @@
       "integrity": "sha512-EcIl3qVcK6U9IQx5BK4NuyrxNgKRr+U+qjxFx4KJv3C3PzqIRL59H7IRNdSf78+lvXAXS7UBrRgFCKnLd0b3wg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -7042,9 +7018,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7066,9 +7039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7090,9 +7060,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7114,9 +7081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary
- Soften the active Discover row only under nightly/preview stage backdrops so it no longer cuts a hard line through the sky/blueprint art
- Leave other expanded sidebar groups (Shows, Activity, etc.) on the normal flat active fill

## Test plan
- [ ] Run with `VITE_RELEASE_CHANNEL=nightly` (or preview)
- [ ] Open Discover in the sidebar and confirm the stage backdrop blends cleanly into the active Discover group
- [ ] Open Shows (or another expanded section) and confirm it still uses the normal flat active background with no top fade


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sidebar styling for the Discover section.
  * Limited nightly and preview gradient backgrounds to the Discover section when it is expanded or active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->