### PR TITLE
chore(auth): remove obsolete onboarding security assertions

### DIFF
--- a/.tests/auth/onboarding-lidarr.int.test.js
+++ b/.tests/auth/onboarding-lidarr.int.test.js
@@ -144,7 +144,6 @@ test("POST /api/onboarding/complete requires Lidarr and auto-picks profiles", as
     body: JSON.stringify({
       authUser: "admin",
       authPassword: "password123",
-      security: { localNetworkBypass: { enabled: true } },
       lidarr: {
         url: fakeLidarr.url,
         apiKey: "fake-key",
@@ -159,5 +158,4 @@ test("POST /api/onboarding/complete requires Lidarr and auto-picks profiles", as
   assert.equal(settings.integrations?.lidarr?.apiKey, "fake-key");
   assert.equal(settings.integrations?.lidarr?.qualityProfileId, 1);
   assert.equal(settings.integrations?.lidarr?.metadataProfileId, 2);
-  assert.equal(settings.security?.localNetworkBypass?.enabled, true);
 });


### PR DESCRIPTION
## Summary

Remove obsolete security assertions from the Lidarr onboarding integration test.

## Linked issues

None.

## Validation

- [ ] CI passes
- [x] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): authentication, integration tests
- Automated coverage: Updated `.tests/auth/onboarding-lidarr.int.test.js` to cover the current onboarding request and persisted Lidarr settings.
- Manual steps and expected result: Not required; no application behavior changed.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated onboarding completion coverage to reflect the removal of the local network bypass setting.
  * Continued validating Lidarr setup and profile configuration during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->