### PR TITLE
fix(lidarr): retry artist adds with provider IDs

### DIFF
--- a/.tests/api-clients/musicbrainz-identity.test.js
+++ b/.tests/api-clients/musicbrainz-identity.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import axios from "../../lib/axiosFetch.js";
+import {
+  musicbrainzArtistIdentityCache,
+  musicbrainzGetArtistIdentityByMbid,
+} from "../../backend/services/apiClients/musicbrainz.js";
+
+test("MusicBrainz identity retries transient failures instead of caching them for an hour", async (t) => {
+  const mbid = "transient-identity-test";
+  let attempts = 0;
+  musicbrainzArtistIdentityCache.flushAll();
+  t.after(() => musicbrainzArtistIdentityCache.flushAll());
+  t.mock.method(axios, "get", async () => {
+    attempts += 1;
+    const error = new Error("MusicBrainz unavailable");
+    error.response = { status: 503 };
+    throw error;
+  });
+
+  assert.equal(await musicbrainzGetArtistIdentityByMbid(mbid), null);
+  assert.equal(await musicbrainzGetArtistIdentityByMbid(mbid), null);
+  assert.equal(attempts, 2);
+});
+
+test("MusicBrainz identity caches definitive missing artists", async (t) => {
+  const mbid = "missing-identity-test";
+  let attempts = 0;
+  musicbrainzArtistIdentityCache.flushAll();
+  t.after(() => musicbrainzArtistIdentityCache.flushAll());
+  t.mock.method(axios, "get", async () => {
+    attempts += 1;
+    const error = new Error("Artist not found");
+    error.response = { status: 404 };
+    throw error;
+  });
+
+  assert.equal(await musicbrainzGetArtistIdentityByMbid(mbid), null);
+  assert.equal(await musicbrainzGetArtistIdentityByMbid(mbid), null);
+  assert.equal(attempts, 1);
+});

--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -19,6 +19,7 @@ const RESET_TABLES = [
   "deezer_mbid_cache",
   "musicbrainz_artist_mbid_cache",
   "artist_overrides",
+  "lidarr_artist_id_map",
   "settings",
 ];
 

--- a/.tests/helpers/download-folder-config.test.js
+++ b/.tests/helpers/download-folder-config.test.js
@@ -17,7 +17,7 @@ test("resolveEnvDownloadFolder prefers DOWNLOAD_FOLDER", async () => {
   else process.env.DOWNLOAD_FOLDER = previous;
 });
 
-test("default download folder stays inside the writable Aurral data directory", async () => {
+test("default download folder follows the available writable data root", async () => {
   const previousDataDir = process.env.AURRAL_DATA_DIR;
   const previousDownloadFolder = process.env.DOWNLOAD_FOLDER;
   const previousPlaylistFolder = process.env.PLAYLIST_FOLDER;
@@ -32,9 +32,12 @@ test("default download folder stays inside the writable Aurral data directory", 
     const { resolveDefaultPlaylistDownloadRoot } = await import(
       "../../backend/services/downloadFolderConfig.js"
     );
+    const expectedRoot = fs.existsSync("/data")
+      ? "/data/downloads/aurral"
+      : path.join(tempDir, "downloads", "aurral");
     assert.equal(
       resolveDefaultPlaylistDownloadRoot(),
-      path.join(tempDir, "downloads", "aurral"),
+      expectedRoot,
     );
   } finally {
     if (previousDataDir === undefined) delete process.env.AURRAL_DATA_DIR;

--- a/.tests/helpers/download-folder-config.test.js
+++ b/.tests/helpers/download-folder-config.test.js
@@ -23,6 +23,8 @@ test("default download folder follows the available writable data root", async (
   const previousPlaylistFolder = process.env.PLAYLIST_FOLDER;
   const previousWeeklyFlowFolder = process.env.WEEKLY_FLOW_FOLDER;
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aurral-download-default-"));
+  const nonDirectoryPath = path.join(tempDir, "not-a-directory");
+  fs.writeFileSync(nonDirectoryPath, "test");
   process.env.AURRAL_DATA_DIR = tempDir;
   delete process.env.DOWNLOAD_FOLDER;
   delete process.env.PLAYLIST_FOLDER;
@@ -32,12 +34,13 @@ test("default download folder follows the available writable data root", async (
     const { resolveDefaultPlaylistDownloadRoot } = await import(
       "../../backend/services/downloadFolderConfig.js"
     );
-    const expectedRoot = fs.existsSync("/data")
-      ? "/data/downloads/aurral"
-      : path.join(tempDir, "downloads", "aurral");
     assert.equal(
-      resolveDefaultPlaylistDownloadRoot(),
-      expectedRoot,
+      resolveDefaultPlaylistDownloadRoot({ dataRoot: tempDir }),
+      path.join(tempDir, "downloads", "aurral"),
+    );
+    assert.equal(
+      resolveDefaultPlaylistDownloadRoot({ dataRoot: nonDirectoryPath }),
+      path.join(tempDir, "downloads", "aurral"),
     );
   } finally {
     if (previousDataDir === undefined) delete process.env.AURRAL_DATA_DIR;

--- a/.tests/library/album-request-new-artist.test.js
+++ b/.tests/library/album-request-new-artist.test.js
@@ -117,6 +117,7 @@ async function withFakeLidarr(buildState, run) {
   lidarrClient.config = {
     url: `http://127.0.0.1:${port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -7,7 +7,12 @@ import { LidarrClient } from "../../backend/services/lidarrClient.js";
 
 test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   const client = new LidarrClient();
-  client.config = { url: "http://localhost:8686", apiKey: "test", circuitDisabled: false };
+  client.config = {
+    url: "http://localhost:8686",
+    apiKey: "test",
+    allowHttp: true,
+    circuitDisabled: false,
+  };
   client._circuitOpen = true;
   client._circuitOpenedAt = Date.now();
   client._artistListCache = { data: [{ id: 1, artistName: "Test" }], at: 0 };
@@ -16,6 +21,25 @@ test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   const artists = await client.request("/artist", "GET", null, true);
   assert.equal(artists.length, 1);
   assert.equal(artists[0].artistName, "Test");
+});
+
+test("Lidarr refuses API-key requests over HTTP unless explicitly allowed", async (t) => {
+  const client = new LidarrClient();
+  t.after(() => {
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+  client._holdConfig = true;
+  client.config = {
+    url: "http://127.0.0.1:8686",
+    apiKey: "test",
+    allowHttp: false,
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+
+  await assert.rejects(client.request("/artist/lookup?term=Muse"), /require an HTTPS URL/);
 });
 
 test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
@@ -47,6 +71,7 @@ test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -87,6 +112,7 @@ test("getAlbumByMbid selects the matching album from filtered results", async (t
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -132,6 +158,7 @@ test("getAlbumByMbid accepts wrapped Lidarr album results", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -295,6 +322,7 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -343,6 +371,10 @@ test("artist add retries with the active metadata provider ID after a UUID forma
       qualityProfileId: 1,
     },
   });
+  client.resolveCanonicalArtistIdentity = async () => ({
+    name: "Muse",
+    providerIds: ["705@deezer"],
+  });
   client.request = async (endpoint, method = "GET", payload) => {
     requests.push({ endpoint, method });
     if (endpoint === "/artist" && method === "POST") {
@@ -354,16 +386,20 @@ test("artist add retries with the active metadata provider ID after a UUID forma
       providerPayload = payload;
       return {
         id: 42,
-        foreignArtistId: "123@deezer",
+        foreignArtistId: "705@deezer",
         artistName: "Muse",
         monitored: true,
       };
     }
     if (endpoint === "/artist" && method === "GET") {
-      return [{ id: 42, foreignArtistId: "123@deezer", artistName: "Muse" }];
+      return [{ id: 42, foreignArtistId: "705@deezer", artistName: "Muse" }];
     }
     if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {
       return [
+        {
+          foreignArtistId: "999@deezer",
+          artistName: "Muse",
+        },
         {
           foreignArtistId: "123@deezer",
           artistName: "Muse",
@@ -378,8 +414,8 @@ test("artist add retries with the active metadata provider ID after a UUID forma
   });
 
   assert.equal(artist.id, 42);
-  assert.equal(providerPayload.foreignArtistId, "123@deezer");
-  assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), "123@deezer");
+  assert.equal(providerPayload.foreignArtistId, "705@deezer");
+  assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), "705@deezer");
   assert.equal((await client.getArtistByMbid(artistMbid, { forceRefresh: true })).id, 42);
   assert.deepEqual(requests, [
     { endpoint: "/artist", method: "POST" },
@@ -387,6 +423,64 @@ test("artist add retries with the active metadata provider ID after a UUID forma
     { endpoint: "/artist", method: "POST" },
     { endpoint: "/artist", method: "GET" },
   ]);
+});
+
+test("artist add rejects a MusicBrainz ID and name mismatch", async (t) => {
+  const artistMbid = "f1693075-b637-49f8-8d0e-8cee8bec77cb";
+  const client = new LidarrClient();
+  t.after(() => {
+    dbOps.deleteLidarrArtistIdMap(artistMbid);
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+  client.resolveCanonicalArtistIdentity = async () => ({
+    name: "Radiohead",
+    providerIds: ["399@deezer"],
+  });
+  let postCount = 0;
+  client.request = async (endpoint, method = "GET") => {
+    if (endpoint === "/artist" && method === "POST") {
+      postCount += 1;
+      throw new Error(
+        `Lidarr API error: 500 - The input string '${artistMbid}' was not in a correct format.`,
+      );
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  await assert.rejects(
+    client.addArtist(artistMbid, "Muse", { metadataProfileId: 1 }),
+    /does not match the requested artist name/,
+  );
+  assert.equal(postCount, 1);
+  assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), null);
+});
+
+test("Lidarr artist provider mappings reject reverse-ID conflicts", async (t) => {
+  const firstMbid = "mapping-first-mbid";
+  const secondMbid = "mapping-second-mbid";
+  const providerId = "mapping-provider-id@deezer";
+  t.after(() => {
+    dbOps.deleteLidarrArtistIdMap(firstMbid);
+    dbOps.deleteLidarrArtistIdMap(secondMbid);
+  });
+
+  dbOps.setLidarrArtistIdMap(firstMbid, providerId);
+  assert.throws(
+    () => dbOps.setLidarrArtistIdMap(secondMbid, providerId),
+    (error) =>
+      error.code === "LIDARR_ARTIST_ID_CONFLICT" &&
+      /already mapped to another MusicBrainz artist/.test(error.message),
+  );
+  assert.equal(dbOps.getLidarrArtistMbid(providerId), firstMbid);
 });
 
 test("artist add fails when Lidarr cannot resolve a numeric ID", async (t) => {
@@ -514,6 +608,7 @@ test("Lidarr cooldown permits only one half-open recovery request", async (t) =>
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: false,
   };
@@ -560,6 +655,7 @@ test("a failed Lidarr recovery probe reopens the cooldown", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
+    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: false,
   };

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -464,6 +464,51 @@ test("artist add rejects a MusicBrainz ID and name mismatch", async (t) => {
   assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), null);
 });
 
+test("artist add succeeds when a provider mapping conflict follows a successful POST", async (t) => {
+  const artistMbid = "mapping-conflict-add-mbid";
+  const existingMbid = "mapping-conflict-existing-mbid";
+  const providerId = "mapping-conflict-provider@deezer";
+  const client = new LidarrClient();
+  t.after(() => {
+    dbOps.deleteLidarrArtistIdMap(artistMbid);
+    dbOps.deleteLidarrArtistIdMap(existingMbid);
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  dbOps.setLidarrArtistIdMap(existingMbid, providerId);
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+  client.resolveCanonicalArtistIdentity = async () => ({
+    name: "Muse",
+    providerIds: [providerId],
+  });
+  client.request = async (endpoint, method = "GET", payload) => {
+    if (endpoint === "/artist" && method === "POST") {
+      if (payload.foreignArtistId === artistMbid) {
+        throw new Error(
+          `Lidarr API error: 500 - The input string '${artistMbid}' was not in a correct format.`,
+        );
+      }
+      return { id: 42, foreignArtistId: providerId, artistName: "Muse", monitored: true };
+    }
+    if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {
+      return [{ foreignArtistId: providerId, artistName: "Muse" }];
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  const artist = await client.addArtist(artistMbid, "Muse", { metadataProfileId: 1 });
+
+  assert.equal(artist.id, 42);
+  assert.equal(dbOps.getLidarrArtistMbid(providerId), existingMbid);
+});
+
 test("Lidarr artist provider mappings reject reverse-ID conflicts", async (t) => {
   const firstMbid = "mapping-first-mbid";
   const secondMbid = "mapping-second-mbid";

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -495,6 +495,7 @@ test("artist add succeeds when a provider mapping conflict follows a successful 
           `Lidarr API error: 500 - The input string '${artistMbid}' was not in a correct format.`,
         );
       }
+      assert.equal(payload.foreignArtistId, providerId);
       return { id: 42, foreignArtistId: providerId, artistName: "Muse", monitored: true };
     }
     if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import { setTimeout as delay } from "node:timers/promises";
+import { dbOps } from "../../backend/db/helpers/index.js";
 import { LidarrClient } from "../../backend/services/lidarrClient.js";
 
 test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
@@ -322,6 +323,70 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   client._httpAgent.destroy();
   client._httpsAgent.destroy();
   client._httpsInsecureAgent.destroy();
+});
+
+test("artist add retries with the active metadata provider ID after a UUID format error", async (t) => {
+  const artistMbid = "9c9f1380-2516-4fc9-a3e6-f9f61941d090";
+  const requests = [];
+  let providerPayload;
+  const client = new LidarrClient();
+  t.after(() => {
+    dbOps.deleteLidarrArtistIdMap(artistMbid);
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+  client.request = async (endpoint, method = "GET", payload) => {
+    requests.push({ endpoint, method });
+    if (endpoint === "/artist" && method === "POST") {
+      if (payload.foreignArtistId === artistMbid) {
+        throw new Error(
+          `Lidarr API error: 500 - The input string '${artistMbid}' was not in a correct format.`,
+        );
+      }
+      providerPayload = payload;
+      return {
+        id: 42,
+        foreignArtistId: "123@deezer",
+        artistName: "Muse",
+        monitored: true,
+      };
+    }
+    if (endpoint === "/artist" && method === "GET") {
+      return [{ id: 42, foreignArtistId: "123@deezer", artistName: "Muse" }];
+    }
+    if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {
+      return [
+        {
+          foreignArtistId: "123@deezer",
+          artistName: "Muse",
+        },
+      ];
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  const artist = await client.addArtist(artistMbid, "Muse", {
+    metadataProfileId: 1,
+  });
+
+  assert.equal(artist.id, 42);
+  assert.equal(providerPayload.foreignArtistId, "123@deezer");
+  assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), "123@deezer");
+  assert.equal((await client.getArtistByMbid(artistMbid, { forceRefresh: true })).id, 42);
+  assert.deepEqual(requests, [
+    { endpoint: "/artist", method: "POST" },
+    { endpoint: `/artist/lookup?term=${encodeURIComponent("Muse")}`, method: "GET" },
+    { endpoint: "/artist", method: "POST" },
+    { endpoint: "/artist", method: "GET" },
+  ]);
 });
 
 test("artist add fails when Lidarr cannot resolve a numeric ID", async (t) => {

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -132,6 +132,15 @@ db.exec(`
     updated_at INTEGER
   );
 
+  CREATE TABLE IF NOT EXISTS lidarr_artist_id_map (
+    musicbrainz_id TEXT PRIMARY KEY,
+    lidarr_foreign_artist_id TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_lidarr_artist_id_map_foreign_id
+    ON lidarr_artist_id_map (lidarr_foreign_artist_id);
+
   CREATE TABLE IF NOT EXISTS aurral_history (
     id TEXT PRIMARY KEY,
     kind TEXT NOT NULL,

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -220,11 +220,22 @@ const duplicateLidarrArtistIds = db
 
 if (duplicateLidarrArtistIds.length > 0) {
   const deleteDuplicateLidarrArtistId = db.prepare(
-    "DELETE FROM lidarr_artist_id_map WHERE lidarr_foreign_artist_id = ?",
+    `DELETE FROM lidarr_artist_id_map
+     WHERE lidarr_foreign_artist_id = ?
+       AND musicbrainz_id NOT IN (
+         SELECT musicbrainz_id
+         FROM lidarr_artist_id_map
+         WHERE lidarr_foreign_artist_id = ?
+         ORDER BY updated_at DESC, musicbrainz_id ASC
+         LIMIT 1
+       )`,
   );
   db.transaction((duplicates) => {
     for (const duplicate of duplicates) {
-      deleteDuplicateLidarrArtistId.run(duplicate.lidarr_foreign_artist_id);
+      deleteDuplicateLidarrArtistId.run(
+        duplicate.lidarr_foreign_artist_id,
+        duplicate.lidarr_foreign_artist_id,
+      );
     }
   })(duplicateLidarrArtistIds);
 }

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -209,6 +209,32 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_honker_task_runs_job ON honker_task_runs(job_id, queue);
 `);
 
+const duplicateLidarrArtistIds = db
+  .prepare(
+    `SELECT lidarr_foreign_artist_id
+     FROM lidarr_artist_id_map
+     GROUP BY lidarr_foreign_artist_id
+     HAVING COUNT(*) > 1`,
+  )
+  .all();
+
+if (duplicateLidarrArtistIds.length > 0) {
+  const deleteDuplicateLidarrArtistId = db.prepare(
+    "DELETE FROM lidarr_artist_id_map WHERE lidarr_foreign_artist_id = ?",
+  );
+  db.transaction((duplicates) => {
+    for (const duplicate of duplicates) {
+      deleteDuplicateLidarrArtistId.run(duplicate.lidarr_foreign_artist_id);
+    }
+  })(duplicateLidarrArtistIds);
+}
+
+db.exec(`
+  DROP INDEX IF EXISTS idx_lidarr_artist_id_map_foreign_id;
+  CREATE UNIQUE INDEX idx_lidarr_artist_id_map_foreign_id
+    ON lidarr_artist_id_map (lidarr_foreign_artist_id);
+`);
+
 const tableColumns = db
   .prepare("PRAGMA table_info(playlist_download_jobs)")
   .all()

--- a/backend/db/helpers/index.js
+++ b/backend/db/helpers/index.js
@@ -7,11 +7,13 @@ import { userOps } from "./users.js";
 import registerCache from "./cache.js";
 import registerDiscovery from "./discovery.js";
 import registerOverrides from "./overrides.js";
+import registerLidarr from "./lidarr.js";
 import registerHistory from "./history.js";
 
 registerCache(dbOps);
 registerDiscovery(dbOps);
 registerOverrides(dbOps);
+registerLidarr(dbOps);
 registerHistory(dbOps);
 
 export { dbOps, userOps };

--- a/backend/db/helpers/lidarr.js
+++ b/backend/db/helpers/lidarr.js
@@ -7,7 +7,11 @@ const getLidarrArtistMbidStmt = db.prepare(
   "SELECT musicbrainz_id FROM lidarr_artist_id_map WHERE lidarr_foreign_artist_id = ?",
 );
 const setLidarrArtistIdMapStmt = db.prepare(
-  "INSERT OR REPLACE INTO lidarr_artist_id_map (musicbrainz_id, lidarr_foreign_artist_id, updated_at) VALUES (?, ?, ?)",
+  `INSERT INTO lidarr_artist_id_map (musicbrainz_id, lidarr_foreign_artist_id, updated_at)
+   VALUES (?, ?, ?)
+   ON CONFLICT(musicbrainz_id) DO UPDATE SET
+     lidarr_foreign_artist_id = excluded.lidarr_foreign_artist_id,
+     updated_at = excluded.updated_at`,
 );
 const deleteLidarrArtistIdMapStmt = db.prepare(
   "DELETE FROM lidarr_artist_id_map WHERE musicbrainz_id = ?",
@@ -26,8 +30,23 @@ export default function register(dbOps) {
 
   dbOps.setLidarrArtistIdMap = function (musicbrainzId, lidarrForeignArtistId) {
     if (!musicbrainzId || !lidarrForeignArtistId) return null;
+    const existingMbid = getLidarrArtistMbidStmt.get(lidarrForeignArtistId)?.musicbrainz_id;
+    if (existingMbid && existingMbid !== musicbrainzId) {
+      const error = new Error(
+        `Lidarr artist ID "${lidarrForeignArtistId}" is already mapped to another MusicBrainz artist`,
+      );
+      error.code = "LIDARR_ARTIST_ID_CONFLICT";
+      throw error;
+    }
     const updatedAt = Date.now();
-    setLidarrArtistIdMapStmt.run(musicbrainzId, lidarrForeignArtistId, updatedAt);
+    try {
+      setLidarrArtistIdMapStmt.run(musicbrainzId, lidarrForeignArtistId, updatedAt);
+    } catch (error) {
+      if (String(error?.message || "").includes("lidarr_artist_id_map.lidarr_foreign_artist_id")) {
+        error.code = "LIDARR_ARTIST_ID_CONFLICT";
+      }
+      throw error;
+    }
     return { musicbrainzId, lidarrForeignArtistId, updatedAt };
   };
 

--- a/backend/db/helpers/lidarr.js
+++ b/backend/db/helpers/lidarr.js
@@ -1,0 +1,38 @@
+import { db } from "../../config/db-sqlite.js";
+
+const getLidarrArtistIdMapStmt = db.prepare(
+  "SELECT lidarr_foreign_artist_id FROM lidarr_artist_id_map WHERE musicbrainz_id = ?",
+);
+const getLidarrArtistMbidStmt = db.prepare(
+  "SELECT musicbrainz_id FROM lidarr_artist_id_map WHERE lidarr_foreign_artist_id = ?",
+);
+const setLidarrArtistIdMapStmt = db.prepare(
+  "INSERT OR REPLACE INTO lidarr_artist_id_map (musicbrainz_id, lidarr_foreign_artist_id, updated_at) VALUES (?, ?, ?)",
+);
+const deleteLidarrArtistIdMapStmt = db.prepare(
+  "DELETE FROM lidarr_artist_id_map WHERE musicbrainz_id = ?",
+);
+
+export default function register(dbOps) {
+  dbOps.getLidarrArtistIdMap = function (musicbrainzId) {
+    if (!musicbrainzId) return null;
+    return getLidarrArtistIdMapStmt.get(musicbrainzId)?.lidarr_foreign_artist_id || null;
+  };
+
+  dbOps.getLidarrArtistMbid = function (lidarrForeignArtistId) {
+    if (!lidarrForeignArtistId) return null;
+    return getLidarrArtistMbidStmt.get(lidarrForeignArtistId)?.musicbrainz_id || null;
+  };
+
+  dbOps.setLidarrArtistIdMap = function (musicbrainzId, lidarrForeignArtistId) {
+    if (!musicbrainzId || !lidarrForeignArtistId) return null;
+    const updatedAt = Date.now();
+    setLidarrArtistIdMapStmt.run(musicbrainzId, lidarrForeignArtistId, updatedAt);
+    return { musicbrainzId, lidarrForeignArtistId, updatedAt };
+  };
+
+  dbOps.deleteLidarrArtistIdMap = function (musicbrainzId) {
+    if (!musicbrainzId) return null;
+    return deleteLidarrArtistIdMapStmt.run(musicbrainzId);
+  };
+}

--- a/backend/services/apiClients/clearCache.js
+++ b/backend/services/apiClients/clearCache.js
@@ -1,7 +1,11 @@
 import { lastfmCache } from "./lastfm.js";
 import { listenbrainzCache } from "./listenbrainz.js";
 import { deezerArtistCache } from "./deezer.js";
-import { musicbrainzArtistNameCache, musicbrainzReleaseGroupsCache } from "./musicbrainz.js";
+import {
+  musicbrainzArtistIdentityCache,
+  musicbrainzArtistNameCache,
+  musicbrainzReleaseGroupsCache,
+} from "./musicbrainz.js";
 import {
   deezerAlbumCache,
   deezerAlbumTrackCache,
@@ -17,6 +21,7 @@ export function clearApiCaches() {
   listenbrainzCache.flushAll();
   deezerArtistCache.flushAll();
   musicbrainzArtistNameCache.flushAll();
+  musicbrainzArtistIdentityCache.flushAll();
   musicbrainzReleaseGroupsCache.flushAll();
   deezerAlbumCache.flushAll();
   deezerAlbumTrackCache.flushAll();

--- a/backend/services/apiClients/index.js
+++ b/backend/services/apiClients/index.js
@@ -12,6 +12,7 @@ export {
   musicbrainzGetArtistAppearsOnReleaseGroups,
   getMusicbrainzAppearsOnScanState,
   musicbrainzGetArtistNameByMbid,
+  musicbrainzGetArtistIdentityByMbid,
   musicbrainzGetCachedArtistMbidByName,
   musicbrainzResolveArtistMbidByName,
 } from "./musicbrainz.js";

--- a/backend/services/apiClients/musicbrainz.js
+++ b/backend/services/apiClients/musicbrainz.js
@@ -17,6 +17,7 @@ import { getMusicBrainzContact } from "./config.js";
 import { runSharedInflight } from "../sharedInflight.js";
 
 const musicbrainzArtistNameCache = createCache(3600);
+const musicbrainzArtistIdentityCache = createCache(3600);
 const musicbrainzReleaseGroupsCache = createCache(300);
 const musicbrainzInflightRequests = new Map();
 const PRIMARY_RELEASE_TYPES = ["Album", "EP", "Single"];
@@ -297,6 +298,61 @@ export async function musicbrainzGetArtistNameByMbid(mbid, { signal } = {}) {
   }
 }
 
+function getMusicbrainzProviderId(resource) {
+  try {
+    const parsed = new URL(resource);
+    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const artistIndex = segments.findIndex((segment) => segment.toLowerCase() === "artist");
+    const artistId = artistIndex >= 0 ? segments[artistIndex + 1] : "";
+    const numericId = String(artistId || "").match(/^\d+/)?.[0];
+    if (!numericId) return null;
+    if (host === "deezer.com") return `${numericId}@deezer`;
+    if (host === "discogs.com") return `${numericId}@discogs`;
+  } catch {}
+  return null;
+}
+
+export async function musicbrainzGetArtistIdentityByMbid(mbid, { signal } = {}) {
+  const normalizedMbid = String(mbid || "").trim();
+  if (!normalizedMbid) return null;
+  const cached = musicbrainzArtistIdentityCache.get(normalizedMbid);
+  if (cached !== undefined) return cached;
+
+  try {
+    const contact =
+      (getMusicBrainzContact() || "").trim() || "https://github.com/aurral";
+    const userAgent = `${APP_NAME}/${APP_VERSION} ( ${contact} )`;
+    const identity = await mbLimiter.schedule(async () => {
+      signal?.throwIfAborted?.();
+      const response = await axios.get(
+        `${MUSICBRAINZ_API}/artist/${encodeURIComponent(normalizedMbid)}`,
+        {
+          params: { fmt: "json", inc: "url-rels" },
+          headers: { "User-Agent": userAgent },
+          timeout: 8000,
+          signal,
+        },
+      );
+      const providerIds = [
+        ...(Array.isArray(response.data?.relations) ? response.data.relations : []),
+      ]
+        .map((relation) => getMusicbrainzProviderId(relation?.url?.resource))
+        .filter(Boolean);
+      return {
+        mbid: normalizedMbid,
+        name: String(response.data?.name || "").trim() || null,
+        providerIds: [...new Set(providerIds)],
+      };
+    });
+    musicbrainzArtistIdentityCache.set(normalizedMbid, identity);
+    return identity;
+  } catch {
+    musicbrainzArtistIdentityCache.set(normalizedMbid, null);
+    return null;
+  }
+}
+
 function normalizeArtistNameKey(artistName) {
   return String(artistName || "")
     .trim()
@@ -347,5 +403,6 @@ export {
   PRIMARY_RELEASE_TYPES,
   SECONDARY_RELEASE_TYPES,
   musicbrainzArtistNameCache,
+  musicbrainzArtistIdentityCache,
   musicbrainzReleaseGroupsCache,
 };

--- a/backend/services/apiClients/musicbrainz.js
+++ b/backend/services/apiClients/musicbrainz.js
@@ -347,8 +347,10 @@ export async function musicbrainzGetArtistIdentityByMbid(mbid, { signal } = {}) 
     });
     musicbrainzArtistIdentityCache.set(normalizedMbid, identity);
     return identity;
-  } catch {
-    musicbrainzArtistIdentityCache.set(normalizedMbid, null);
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      musicbrainzArtistIdentityCache.set(normalizedMbid, null);
+    }
     return null;
   }
 }

--- a/backend/services/downloadFolderConfig.js
+++ b/backend/services/downloadFolderConfig.js
@@ -27,13 +27,24 @@ export function resolveEnvDownloadFolder() {
   return null;
 }
 
-export function resolveDefaultPlaylistDownloadRoot() {
+function isWritableDirectory(targetPath) {
+  try {
+    return (
+      fs.statSync(targetPath).isDirectory() &&
+      fs.accessSync(targetPath, fs.constants.W_OK | fs.constants.X_OK) === undefined
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function resolveDefaultPlaylistDownloadRoot({ dataRoot = "/data" } = {}) {
   const envDownloadFolder = resolveEnvDownloadFolder();
   if (envDownloadFolder) {
     return envDownloadFolder;
   }
-  if (fs.existsSync("/data")) {
-    return "/data/downloads/aurral";
+  if (isWritableDirectory(dataRoot)) {
+    return path.join(dataRoot, "downloads", "aurral");
   }
   return path.join(resolveAurralDataDir(), "downloads", "aurral");
 }

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -915,14 +915,16 @@ export class LibraryManager {
   mapLidarrArtist(lidarrArtist) {
     const artistPath = lidarrArtist.path ?? null;
     const artistId = Number(lidarrArtist.id);
+    const mappedMbid = dbOps.getLidarrArtistMbid(lidarrArtist.foreignArtistId);
+    const foreignArtistId = mappedMbid || lidarrArtist.foreignArtistId;
     const normalizedArtistId =
       Number.isSafeInteger(artistId) && artistId > 0 ? String(artistId) : null;
     const monitorOption = lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none";
     const normalizedMonitorOption = monitorOption || "none";
     return {
       id: normalizedArtistId,
-      mbid: lidarrArtist.foreignArtistId,
-      foreignArtistId: lidarrArtist.foreignArtistId,
+      mbid: foreignArtistId,
+      foreignArtistId,
       artistName: lidarrArtist.artistName,
       path: artistPath,
       addedAt: lidarrArtist.added || new Date().toISOString(),
@@ -980,6 +982,7 @@ export class LibraryManager {
       const lidarrArtist = await lidarr.getArtistByMbid(mbid);
       if (!lidarrArtist) return { success: false, error: "Artist not found in Lidarr" };
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
+      dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1094,7 +1094,18 @@ export class LidarrClient {
       for (const providerArtistId of providerArtistIds) {
         try {
           result = await postArtist({ ...lidarrArtist, foreignArtistId: providerArtistId });
-          dbOps.setLidarrArtistIdMap(mbid, providerArtistId);
+          try {
+            dbOps.setLidarrArtistIdMap(mbid, providerArtistId);
+          } catch (mappingError) {
+            if (mappingError?.code !== "LIDARR_ARTIST_ID_CONFLICT") {
+              throw mappingError;
+            }
+            logger.warn("library", "Failed to persist Lidarr artist ID mapping", {
+              mbid,
+              providerArtistId,
+              error: mappingError.message,
+            });
+          }
           break;
         } catch (providerAttemptError) {
           if (!isMetadataProviderIdError(providerAttemptError)) {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -5,6 +5,7 @@ import { dbOps } from "../db/helpers/index.js";
 import { logger } from "./logger.js";
 import BoundedMap from "./boundedMap.js";
 import { mapWithConcurrency } from "./discovery/helpers.js";
+import { musicbrainzGetArtistIdentityByMbid } from "./apiClients/musicbrainz.js";
 
 const CIRCUIT_COOLDOWN_MS = 60000;
 const CIRCUIT_FAILURE_THRESHOLD = 3;
@@ -320,12 +321,16 @@ export class LidarrClient {
     const circuitDisabled =
       process.env.LIDARR_CIRCUIT_DISABLED === "true" || process.env.LIDARR_CIRCUIT_DISABLED === "1";
 
+    const allowHttp =
+      process.env.LIDARR_ALLOW_HTTP === "true" || process.env.LIDARR_ALLOW_HTTP === "1";
+
     const newConfig = {
       url: url,
       apiKey: (dbConfig.apiKey || process.env.LIDARR_API_KEY || "").trim(),
       insecure: !!insecure,
       timeoutMs,
       circuitDisabled,
+      allowHttp,
     };
 
     const didConfigChange =
@@ -334,7 +339,8 @@ export class LidarrClient {
       previousConfig.apiKey !== newConfig.apiKey ||
       previousConfig.insecure !== newConfig.insecure ||
       previousConfig.timeoutMs !== newConfig.timeoutMs ||
-      previousConfig.circuitDisabled !== newConfig.circuitDisabled;
+      previousConfig.circuitDisabled !== newConfig.circuitDisabled ||
+      previousConfig.allowHttp !== newConfig.allowHttp;
 
     this.config = newConfig;
     if (didConfigChange) {
@@ -396,6 +402,16 @@ export class LidarrClient {
 
     if (!this.isConfigured(skipConfigUpdate)) {
       throw new Error("Lidarr API key not configured");
+    }
+
+    if (
+      this.config.apiKey &&
+      /^http:/i.test(this.config.url) &&
+      this.config.allowHttp !== true
+    ) {
+      throw new Error(
+        "Lidarr API key requests require an HTTPS URL. Set LIDARR_ALLOW_HTTP=true only for a trusted local network.",
+      );
     }
 
     const now = Date.now();
@@ -958,20 +974,60 @@ export class LidarrClient {
       },
     };
 
-    const resolveMetadataProviderArtistId = async () => {
-      const lookup = await this.request(
-        `/artist/lookup?term=${encodeURIComponent(String(artistName || "").trim())}`,
-      );
-      const normalizedArtistName = String(artistName || "").trim().toLowerCase();
-      const match = (Array.isArray(lookup) ? lookup : []).find((candidate) => {
-        const providerId = String(candidate?.foreignArtistId || "").trim();
-        return (
-          providerId &&
-          providerId !== mbid &&
-          String(candidate?.artistName || "").trim().toLowerCase() === normalizedArtistName
+    const resolveMetadataProviderArtistIds = async () => {
+      const identity = await this.resolveCanonicalArtistIdentity(mbid);
+      const canonicalName = String(identity?.name || "").trim();
+      const normalizedArtistName = String(artistName || "")
+        .trim()
+        .toLowerCase();
+      if (!canonicalName || normalizedArtistName !== canonicalName.toLowerCase()) {
+        const error = new Error(
+          `MusicBrainz artist name for ${mbid} does not match the requested artist name`,
         );
-      });
-      return String(match?.foreignArtistId || "").trim() || null;
+        error.code = "LIDARR_ARTIST_IDENTITY_MISMATCH";
+        throw error;
+      }
+
+      const lookup = await this.request(
+        `/artist/lookup?term=${encodeURIComponent(canonicalName)}`,
+      );
+      const canonicalProviderIds = new Set(
+        (Array.isArray(identity?.providerIds) ? identity.providerIds : []).map((providerId) =>
+          String(providerId || "").trim().toLowerCase(),
+        ),
+      );
+      const lookupProviderIds = [];
+      const lookupProviderSuffixes = new Set();
+      let hasCanonicalLookupMatch = false;
+      for (const candidate of Array.isArray(lookup) ? lookup : []) {
+        const providerId = String(candidate?.foreignArtistId || "").trim();
+        if (
+          providerId &&
+          String(candidate?.artistName || "").trim().toLowerCase() === canonicalName.toLowerCase()
+        ) {
+          hasCanonicalLookupMatch = true;
+          const normalizedProviderId = providerId.toLowerCase();
+          if (canonicalProviderIds.has(normalizedProviderId)) {
+            lookupProviderIds.push(providerId);
+          }
+          const providerSuffix = normalizedProviderId.split("@").pop();
+          if (providerSuffix && providerSuffix !== normalizedProviderId) {
+            lookupProviderSuffixes.add(providerSuffix);
+          }
+        }
+      }
+      if (lookupProviderIds.length > 0) return [...new Set(lookupProviderIds)];
+      if (!hasCanonicalLookupMatch) return [];
+      return (Array.isArray(identity?.providerIds) ? identity.providerIds : []).filter(
+        (providerId) => {
+          const normalizedProviderId = String(providerId || "").trim().toLowerCase();
+          const providerSuffix = normalizedProviderId.split("@").pop();
+          return (
+            normalizedProviderId &&
+            (lookupProviderSuffixes.size === 0 || lookupProviderSuffixes.has(providerSuffix))
+          );
+        },
+      );
     };
 
     const resolveAddedArtist = async (artist) => {
@@ -1028,16 +1084,32 @@ export class LidarrClient {
       if (!isMetadataProviderIdError(error)) {
         throw error;
       }
-      const providerArtistId = await resolveMetadataProviderArtistId();
-      if (!providerArtistId) {
+      const providerArtistIds = await resolveMetadataProviderArtistIds();
+      if (providerArtistIds.length === 0) {
         throw new Error(
           `Lidarr metadata provider could not resolve ${artistName} from its MusicBrainz ID. Search the artist in Lidarr first or use MusicBrainz metadata.`,
         );
       }
-      result = await postArtist({ ...lidarrArtist, foreignArtistId: providerArtistId });
-      dbOps.setLidarrArtistIdMap(mbid, providerArtistId);
+      let providerError = error;
+      for (const providerArtistId of providerArtistIds) {
+        try {
+          result = await postArtist({ ...lidarrArtist, foreignArtistId: providerArtistId });
+          dbOps.setLidarrArtistIdMap(mbid, providerArtistId);
+          break;
+        } catch (providerAttemptError) {
+          if (!isMetadataProviderIdError(providerAttemptError)) {
+            throw providerAttemptError;
+          }
+          providerError = providerAttemptError;
+        }
+      }
+      if (!result) throw providerError;
     }
     return ensureArtistMonitored(await resolveAddedArtist(result));
+  }
+
+  async resolveCanonicalArtistIdentity(mbid) {
+    return musicbrainzGetArtistIdentityByMbid(mbid);
   }
 
   async getArtist(artistId) {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -50,6 +50,11 @@ function normalizeLidarrArtistId(value) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? String(parsed) : null;
 }
 
+function isMetadataProviderIdError(error) {
+  const message = String(error?.message || "").toLowerCase();
+  return message.includes("input string") && message.includes("correct format");
+}
+
 function normalizeMonitorOption(value) {
   const option = String(value || "none").trim();
   return VALID_MONITOR_OPTIONS.has(option) ? option : "none";
@@ -953,6 +958,22 @@ export class LidarrClient {
       },
     };
 
+    const resolveMetadataProviderArtistId = async () => {
+      const lookup = await this.request(
+        `/artist/lookup?term=${encodeURIComponent(String(artistName || "").trim())}`,
+      );
+      const normalizedArtistName = String(artistName || "").trim().toLowerCase();
+      const match = (Array.isArray(lookup) ? lookup : []).find((candidate) => {
+        const providerId = String(candidate?.foreignArtistId || "").trim();
+        return (
+          providerId &&
+          providerId !== mbid &&
+          String(candidate?.artistName || "").trim().toLowerCase() === normalizedArtistName
+        );
+      });
+      return String(match?.foreignArtistId || "").trim() || null;
+    };
+
     const resolveAddedArtist = async (artist) => {
       if (normalizeLidarrArtistId(artist?.id)) {
         return artist;
@@ -981,22 +1002,40 @@ export class LidarrClient {
       return this.updateArtistMonitoring(artistId, monitoring.option);
     };
 
+    const postArtist = async (payload) => {
+      try {
+        return await this.request("/artist", "POST", payload);
+      } catch (error) {
+        if (isMetadataProviderIdError(error) || requestedMonitorOption !== "all") {
+          throw error;
+        }
+        const fallbackArtist = {
+          ...payload,
+          monitor: "existing",
+          addOptions: {
+            ...payload.addOptions,
+            monitor: "existing",
+          },
+        };
+        return this.request("/artist", "POST", fallbackArtist);
+      }
+    };
+
     let result;
     try {
-      result = await this.request("/artist", "POST", lidarrArtist);
+      result = await postArtist(lidarrArtist);
     } catch (error) {
-      if (requestedMonitorOption !== "all") {
+      if (!isMetadataProviderIdError(error)) {
         throw error;
       }
-      const fallbackArtist = {
-        ...lidarrArtist,
-        monitor: "existing",
-        addOptions: {
-          ...lidarrArtist.addOptions,
-          monitor: "existing",
-        },
-      };
-      result = await this.request("/artist", "POST", fallbackArtist);
+      const providerArtistId = await resolveMetadataProviderArtistId();
+      if (!providerArtistId) {
+        throw new Error(
+          `Lidarr metadata provider could not resolve ${artistName} from its MusicBrainz ID. Search the artist in Lidarr first or use MusicBrainz metadata.`,
+        );
+      }
+      result = await postArtist({ ...lidarrArtist, foreignArtistId: providerArtistId });
+      dbOps.setLidarrArtistIdMap(mbid, providerArtistId);
     }
     return ensureArtistMonitored(await resolveAddedArtist(result));
   }
@@ -1012,6 +1051,11 @@ export class LidarrClient {
   async getArtistByMbid(mbid, { forceRefresh = false } = {}) {
     const normalizedMbid = String(mbid || "").trim();
     if (!normalizedMbid) return null;
+    const mappedLidarrArtistId = dbOps.getLidarrArtistIdMap(normalizedMbid);
+
+    const matchesArtistId = (artist) =>
+      artist?.foreignArtistId === normalizedMbid ||
+      (mappedLidarrArtistId && artist?.foreignArtistId === mappedLidarrArtistId);
 
     if (forceRefresh) {
       this._artistByMbidCache.delete(normalizedMbid);
@@ -1026,7 +1070,7 @@ export class LidarrClient {
           ? this._artistListCache.data
           : [];
         this._populateArtistIndexes(artists);
-        const artist = artists.find((entry) => entry?.foreignArtistId === normalizedMbid) || null;
+        const artist = artists.find(matchesArtistId) || null;
         this._setArtistByMbidCacheEntry(normalizedMbid, artist);
         return artist;
       }
@@ -1044,7 +1088,7 @@ export class LidarrClient {
       .then((artists) => {
         const list = Array.isArray(artists) ? artists : [];
         this._populateArtistIndexes(list);
-        const artist = list.find((entry) => entry?.foreignArtistId === normalizedMbid) || null;
+        const artist = list.find(matchesArtistId) || null;
         if (artist || !forceRefresh) {
           this._setArtistByMbidCacheEntry(normalizedMbid, artist);
         }

--- a/backend/services/lidarrTestSession.js
+++ b/backend/services/lidarrTestSession.js
@@ -39,6 +39,7 @@ export async function withTemporaryLidarrClient(url, apiKey, fn) {
     insecure: originalConfig.insecure,
     timeoutMs: originalConfig.timeoutMs,
     circuitDisabled: true,
+    allowHttp: originalConfig.allowHttp,
   };
   lidarrClient.apiPath = "/api/v1";
 

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -12,6 +12,7 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | `PUID` / `PGID` | Run the container as the user that owns mounted folders. |
 | `AURRAL_DATA_DIR` | Override app data directory. Default `/config`. |
 | `DOWNLOAD_FOLDER` | Initial Downloads Folder path. Prefer **Settings > Download Clients > Downloads Folder > Path**. Use an absolute path under your media mount. |
+| `LIDARR_ALLOW_HTTP` | Allow Aurral to send the Lidarr API key over HTTP. Default `false`. Use `true` only for a trusted local network. HTTPS is recommended. |
 
 ## Path mappings
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -16,6 +16,10 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 - Default quality profile, metadata profile, tag, monitoring option, and search-on-add behavior
 - Optional **Davo's Community Lidarr Guide** for quality profiles and file names
 
+## Metadata providers
+
+Aurral sends MusicBrainz artist IDs to Lidarr. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral retries a provider-ID format error with the ID returned by Lidarr's own artist lookup. If that lookup cannot resolve the artist, search for the artist in Lidarr first or use MusicBrainz metadata.
+
 ## Library access check
 
 Aurral tests file access at each path that Lidarr reports. If the test fails, mount the Lidarr media root in Aurral.

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -11,14 +11,14 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 
 ![Aurral Lidarr integration settings](../../../assets/screenshots/settings-lidarr.webp)
 
-- The URL Aurral can reach (often `http://lidarr:8686` in Docker)
+- The URL Aurral can reach (often `http://lidarr:8686` in Docker). When an API key is configured, use HTTPS. For a trusted local HTTP connection, set `LIDARR_ALLOW_HTTP=true` in the Aurral environment.
 - Your Lidarr API key
 - Default quality profile, metadata profile, tag, monitoring option, and search-on-add behavior
 - Optional **Davo's Community Lidarr Guide** for quality profiles and file names
 
 ## Metadata providers
 
-Aurral sends MusicBrainz artist IDs to Lidarr. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral retries a provider-ID format error with the ID returned by Lidarr's own artist lookup. If that lookup cannot resolve the artist, search for the artist in Lidarr first or use MusicBrainz metadata.
+Aurral sends MusicBrainz artist IDs to Lidarr. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
 
 ## Library access check
 


### PR DESCRIPTION
## Summary

Retry Lidarr artist additions with the active metadata provider ID when MusicBrainz IDs are rejected, and persist the mapping for future lookups. Update artist mapping and document provider behavior.

## Linked issues

None.

## Validation

- [x] CI passes
- [x] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Lidarr integration, library management, SQLite database, documentation
- Automated coverage: Added coverage for retrying artist adds with provider IDs and updated download-folder configuration expectations.
- Manual steps and expected result: Add an artist through Lidarr using a non-MusicBrainz metadata provider. The artist should be added successfully, remain discoverable by its MusicBrainz ID, and be removed cleanly with its mapping.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Lidarr artist additions with MusicBrainz identity validation, provider-ID lookup, retry handling, and persistent ID mappings.
  * Artist lookups now remain reliable across cached and newly retrieved results.
* **Bug Fixes**
  * Removing an artist now also clears its associated ID mapping.
  * Download-folder selection now requires a writable directory and falls back safely when needed.
  * Authenticated Lidarr requests now require HTTPS by default, with an optional trusted-network override.
* **Documentation**
  * Added guidance for Lidarr security settings, metadata-provider IDs, and lookup fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->