### PR TITLE
docs: document nightly Docker image channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ docker compose up -d
 
 Open `http://localhost:3001`, create your admin account, and connect Lidarr.
 
+Want the latest merged changes? Use `ghcr.io/lklynet/aurral:nightly`. Nightly
+builds may be less stable than releases; see the [Docker image channels](https://docs.aurral.org/getting-started/docker/#which-image-tag-to-use).
+
 For a stack with Lidarr, slskd, and Navidrome, see [`docker-compose.example.yml`](docker-compose.example.yml). For Plex, see the [Plex setup guide](https://docs.aurral.org/integrations/plex/).
 
 ## Documentation


### PR DESCRIPTION
## Summary

Documented the `ghcr.io/lklynet/aurral:nightly` Docker image channel in the README, including its stability caveat and link to image channel guidance.

## Linked issues

Not linked to an issue.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): docs
- Automated coverage: Not applicable; documentation-only change.
- Manual steps and expected result: Review the README Docker instructions and confirm the nightly image tag and documentation link are accurate.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change