### PR TITLE
feat: refine surface treatment

### DIFF
--- a/frontend/src/components/ArtistImage.jsx
+++ b/frontend/src/components/ArtistImage.jsx
@@ -237,7 +237,7 @@ const ArtistImage = ({
       <div
         className={`artist-image-root ${className}`}
         style={{
-          background: "linear-gradient(135deg, rgba(33,31,39,1) 0%, rgba(46,43,54,1) 100%)",
+          background: "var(--aurral-surface-mid)",
         }}
       >
         <div className="artist-image-overlay">
@@ -256,9 +256,15 @@ const ArtistImage = ({
   }
 
   return (
-    <div className={`artist-image-root ${className}`} style={{ backgroundColor: "#211f27" }}>
+    <div
+      className={`artist-image-root ${className}`}
+      style={{ backgroundColor: "var(--aurral-surface-mid)" }}
+    >
       {isLoading && showLoading && (
-        <div className="artist-image-overlay" style={{ backgroundColor: "#211f27" }}>
+        <div
+          className="artist-image-overlay"
+          style={{ backgroundColor: "var(--aurral-surface-mid)" }}
+        >
           <Loader className="artist-image-loader animate-spin is-brand" />
         </div>
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,8 @@
   --aurral-danger: #ef4444;
   --aurral-warning: #f59e0b;
   --aurral-focus: rgba(132, 204, 22, 0.42);
+  --aurral-surface-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+  --aurral-sidebar-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.012'/%3E%3C/svg%3E");
   --aurral-border: color-mix(in srgb, var(--aurral-white) 8%, transparent);
   --aurral-border-strong: color-mix(in srgb, var(--aurral-white) 14%, transparent);
   --aurral-space-outer: 0.25rem;
@@ -1426,6 +1428,21 @@ textarea {
   overflow: visible;
   border-radius: var(--aurral-radius-round);
   background: var(--aurral-surface);
+}
+
+.app-shell,
+.app-topbar,
+.app-mobile-nav {
+  background-image: var(--aurral-surface-grain);
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+.sidebar-shell,
+.app-main {
+  background-image: var(--aurral-sidebar-grain);
+  background-repeat: repeat;
+  background-size: 256px 256px;
 }
 
 .global-search__scope-wrap {
@@ -4874,9 +4891,7 @@ textarea {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
-    var(--aurral-surface);
+  background: var(--aurral-surface);
   border-radius: var(--aurral-radius-round);
   transition: border-color 0.18s ease;
 }


### PR DESCRIPTION
## Summary

Refine the application’s visual surface treatment with subtle grain textures across shell, navigation, sidebar, and main content areas. Standardize artist image placeholders and loading overlays on the shared surface color token.

## Linked issues

Not linked to an issue.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): UI, artist images, application surfaces
- Automated coverage: Existing frontend checks; no new automated coverage required for CSS-only visual changes.
- Manual steps and expected result: Review the application shell, top bar, mobile navigation, sidebar, main content, and artist image placeholders. Confirm the grain textures are subtle and consistent, and placeholders use the shared surface color.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image placeholders and loading states with a consistent surface background.
  * Added subtle grain textures across app surfaces, navigation, sidebar, and content areas.
  * Simplified the Discover “View All” media cell appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->