### PR TITLE
fix(discord): unify announcements and prevent truncation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,13 +81,10 @@ jobs:
           NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
         run: bash scripts/notify-github-status.sh nightly
 
-      - name: Notify Discord nightly channel
+      - name: Notify Discord announcements channel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_NIGHTLY: ${{ secrets.DISCORD_WEBHOOK_NIGHTLY }}
-          NIGHTLY_VERSION: ${{ steps.version.outputs.value }}
-          CHANGE_URL: ${{ steps.readiness.outputs.change_url }}
-          CHANGE_RANGE: ${{ steps.readiness.outputs.change_range }}
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
           READINESS_ISSUE: ${{ steps.readiness.outputs.readiness_issue }}
           PULL_LIST: ${{ steps.readiness.outputs.pull_list }}
           ISSUE_LIST: ${{ steps.readiness.outputs.issue_list }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -193,11 +193,11 @@ jobs:
               -f "labels[]=in-progress" >/dev/null
           done <<< "${CLOSING_ISSUES}"
 
-      - name: Notify Discord previews channel
+      - name: Notify Discord announcements channel
         if: steps.preview-comment.outputs.first_preview == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_PREVIEWS: ${{ secrets.DISCORD_WEBHOOK_PREVIEWS }}
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
           IMAGE_TAG: pr-${{ github.event.number }}
           PR_NUMBER: ${{ github.event.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -66,11 +66,11 @@ jobs:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: bash scripts/notify-github-status.sh stable
 
-      - name: Notify Discord releases channel
+      - name: Notify Discord announcements channel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.release.outputs.sha }}
-          DISCORD_WEBHOOK_RELEASES: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: bash scripts/notify-discord.sh releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,10 +240,10 @@ jobs:
           RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
         run: bash scripts/notify-github-status.sh stable
 
-      - name: Notify Discord releases channel
+      - name: Notify Discord announcements channel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_RELEASES: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
           RELEASE_TAG: ${{ needs.compute-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.compute-release.outputs.version }}
         run: bash scripts/notify-discord.sh releases

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -7,6 +7,8 @@ owner="${repository%%/*}"
 repo="${repository#*/}"
 max_field_chars=1000
 max_description_chars=3500
+max_embed_chars=6000
+max_embed_fields=25
 
 case "${channel}" in
   releases|nightly|previews)
@@ -61,7 +63,15 @@ add_bullet_fields() {
       field_name="${name}"
       [ "${part}" -gt 1 ] && field_name+=" (continued)"
       add_field "${field_name}" "${chunk}"
-      chunk="${line}"
+      if [ "${#line}" -gt "${max_field_chars}" ]; then
+        part=$((part + 1))
+        field_name="${name}"
+        [ "${part}" -gt 1 ] && field_name+=" (continued)"
+        add_field "${field_name}" "$(truncate_text "${line}" "${max_field_chars}")"
+        chunk=""
+      else
+        chunk="${line}"
+      fi
     else
       chunk="${candidate}"
     fi
@@ -188,6 +198,8 @@ pr_summary_excerpt() {
 }
 
 embed_fields_json='[]'
+embed_field_chars=0
+embed_field_count=0
 description=""
 title=""
 url=""
@@ -195,13 +207,27 @@ url=""
 add_field() {
   local name="$1"
   local value="$2"
+  local available value_limit
   [ -z "${value}" ] && return 0
+
+  if [ "${embed_field_count}" -ge "${max_embed_fields}" ]; then
+    return 0
+  fi
+
+  available=$((max_embed_chars - ${#title} - ${#description} - embed_field_chars - ${#name}))
+  [ "${available}" -le 0 ] && return 0
+  value_limit="${max_field_chars}"
+  [ "${available}" -lt "${value_limit}" ] && value_limit="${available}"
+  value="$(truncate_text "${value}" "${value_limit}")"
+
   embed_fields_json="$(
     EMBED_FIELDS_JSON="${embed_fields_json}" \
     FIELD_NAME="${name}" \
     FIELD_VALUE="${value}" \
     python3 -c 'import json, os; fields=json.loads(os.environ["EMBED_FIELDS_JSON"]); fields.append({"name": os.environ["FIELD_NAME"], "value": os.environ["FIELD_VALUE"], "inline": False}); print(json.dumps(fields))'
   )"
+  embed_field_chars=$((embed_field_chars + ${#name} + ${#value}))
+  embed_field_count=$((embed_field_count + 1))
 }
 
 case "${channel}" in

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -7,17 +7,10 @@ owner="${repository%%/*}"
 repo="${repository#*/}"
 max_field_chars=1000
 max_description_chars=3500
-max_list_items=12
 
 case "${channel}" in
-  releases)
-    webhook_url="${DISCORD_WEBHOOK_RELEASES:-}"
-    ;;
-  nightly)
-    webhook_url="${DISCORD_WEBHOOK_NIGHTLY:-}"
-    ;;
-  previews)
-    webhook_url="${DISCORD_WEBHOOK_PREVIEWS:-}"
+  releases|nightly|previews)
+    webhook_url="${DISCORD_WEBHOOK_ANNOUNCEMENTS:-}"
     ;;
   *)
     echo "Usage: $0 releases|nightly|previews" >&2
@@ -40,38 +33,46 @@ truncate_text() {
   printf '%s…' "${text:0:$((limit - 1))}"
 }
 
-format_bullet_field() {
+add_bullet_fields() {
   local raw="$1"
   local empty_label="$2"
-  local lines=()
-  local line count=0 truncated=0
+  local name="$3"
+  local line candidate chunk="" part=0 field_name
 
   if [ -z "${raw}" ]; then
-    printf '%s' "${empty_label}"
+    add_field "${name}" "${empty_label}"
     return 0
   fi
 
   while IFS= read -r line; do
     [ -z "${line}" ] && continue
-    if [ "${count}" -ge "${max_list_items}" ]; then
-      truncated=$((truncated + 1))
-      continue
+    if [ -n "${chunk}" ]; then
+      candidate="${chunk}"$'\n'"${line}"
+    else
+      candidate="${line}"
     fi
-    lines+=("${line}")
-    count=$((count + 1))
+
+    if [ "${#candidate}" -gt "${max_field_chars}" ]; then
+      if [ -z "${chunk}" ]; then
+        add_field "${name}" "$(truncate_text "${line}" "${max_field_chars}")"
+        continue
+      fi
+      part=$((part + 1))
+      field_name="${name}"
+      [ "${part}" -gt 1 ] && field_name+=" (continued)"
+      add_field "${field_name}" "${chunk}"
+      chunk="${line}"
+    else
+      chunk="${candidate}"
+    fi
   done <<< "${raw}"
 
-  if [ "${#lines[@]}" -eq 0 ]; then
-    printf '%s' "${empty_label}"
-    return 0
+  if [ -n "${chunk}" ]; then
+    part=$((part + 1))
+    field_name="${name}"
+    [ "${part}" -gt 1 ] && field_name+=" (continued)"
+    add_field "${field_name}" "${chunk}"
   fi
-
-  local body
-  body="$(printf '%s\n' "${lines[@]}")"
-  if [ "${truncated}" -gt 0 ]; then
-    body+=$'\n'"…and ${truncated} more"
-  fi
-  truncate_text "${body}" "${max_field_chars}"
 }
 
 collect_merged_pull_lines() {
@@ -208,83 +209,56 @@ case "${channel}" in
     release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
     release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
     head_sha="${HEAD_SHA:-${GITHUB_SHA:-}}"
-    title="Aurral ${release_version} released"
+    title="Aurral ${release_version} is out!"
     url="https://github.com/${repository}/releases/tag/${release_tag}"
     description="$(cat <<EOF
-Stable \`${release_version}\` is published.
-
-\`\`\`
-docker pull ghcr.io/${repository}:${release_version}
-docker pull ghcr.io/${repository}:latest
-\`\`\`
+\`docker pull ghcr.io/${repository}:${release_version}\`
+\`docker pull ghcr.io/${repository}:latest\`
 EOF
 )"
-    release_notes="$(gh release view "${release_tag}" --repo "${repository}" --json body --jq '.body // ""' 2>/dev/null || true)"
-    if [ -n "${release_notes}" ]; then
-      release_notes="$(printf '%s\n' "${release_notes}" | sed -e 's/\r$//' -e '/^<!--/,/-->$/d' | head -n 20)"
-      release_notes="$(truncate_text "$(printf '%s\n' "${release_notes}" | sed '/./,$!d')" 900)"
-      if [ -n "${release_notes}" ]; then
-        add_field "Release notes" "${release_notes}"
-      fi
-    fi
     if [ -n "${head_sha}" ]; then
       base_tag="$(previous_stable_tag "${release_tag}")"
       pull_list="$(collect_merged_pull_lines "${head_sha}" "${base_tag}")"
       issue_list="$(collect_closing_issue_lines_for_pulls "${pull_list}")"
-      add_field "Included pull requests" "$(format_bullet_field "${pull_list}" "None recorded for this release.")"
-      add_field "Linked issues" "$(format_bullet_field "${issue_list}" "None")"
+      add_bullet_fields "${pull_list}" "None recorded for this release." "Included"
+      add_bullet_fields "${issue_list}" "None" "Linked issues"
     fi
     ;;
   nightly)
-    nightly_version="${NIGHTLY_VERSION:?NIGHTLY_VERSION is required}"
     head_sha="${HEAD_SHA:-${GITHUB_SHA:?GITHUB_SHA is required}}"
     run_id="${GITHUB_RUN_ID:-}"
-    change_url="${CHANGE_URL:-}"
-    change_range="${CHANGE_RANGE:-}"
     readiness_issue="${READINESS_ISSUE:-}"
     pull_list="${PULL_LIST:-}"
     issue_list="${ISSUE_LIST:-}"
-    title="Nightly ${nightly_version}"
+    title="A new nightly is out!"
     url="https://github.com/${repository}/actions/runs/${run_id}"
     description="$(cat <<EOF
-\`ghcr.io/${repository}:nightly\` was rebuilt from \`${head_sha:0:7}\`.
-
-\`\`\`
-docker pull ghcr.io/${repository}:nightly
-\`\`\`
+\`docker pull ghcr.io/${repository}:nightly\`
 EOF
 )"
-    if [ -n "${change_range}" ] && [ -n "${change_url}" ]; then
-      description+=$'\n'"Changes since last stable: [\`${change_range}\`](${change_url})"
-    fi
     if [ -n "${readiness_issue}" ]; then
-      description+=$'\n'"Release readiness: https://github.com/${repository}/issues/${readiness_issue}"
+      description+=$'\n\n'"Release readiness: [view the checklist](https://github.com/${repository}/issues/${readiness_issue})"
     fi
-    description+=$'\n'"Give feedback in #testing."
     if [ -z "${pull_list}" ] && [ -n "${head_sha}" ]; then
       base_tag="$(previous_stable_tag)"
       pull_list="$(collect_merged_pull_lines "${head_sha}" "${base_tag}")"
       issue_list="$(collect_closing_issue_lines_for_pulls "${pull_list}")"
     fi
-    add_field "Included since last stable" "$(format_bullet_field "${pull_list}" "No merged pull requests in this range.")"
-    add_field "Linked issues" "$(format_bullet_field "${issue_list}" "None")"
+    add_bullet_fields "${pull_list}" "No merged pull requests in this range." "Included"
+    add_bullet_fields "${issue_list}" "None" "Linked issues"
     ;;
   previews)
     pr_number="${PR_NUMBER:?PR_NUMBER is required}"
     pr_title="${PR_TITLE:?PR_TITLE is required}"
     image_tag="${IMAGE_TAG:?IMAGE_TAG is required}"
-    title="Preview ready: #${pr_number}"
+    title="A new preview is ready to test!"
     url="https://github.com/${repository}/pull/${pr_number}"
     description="$(cat <<EOF
 **${pr_title}**
 
-First preview image for this pull request.
+\`docker pull ghcr.io/${repository}:${image_tag}\`
 
-\`\`\`
-docker pull ghcr.io/${repository}:${image_tag}
-\`\`\`
-
-How to test: see #testing.
+Please test it and share feedback in #testing.
 EOF
 )"
     add_field "What changed" "$(pr_summary_excerpt "${pr_number}")"
@@ -309,7 +283,7 @@ EOF
       -f "repo=${repo}" \
       -F "number=${pr_number}" \
       --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number')"
-    add_field "Linked issues" "$(format_bullet_field "${closing_issues%$'\n'}" "None linked yet")"
+    add_bullet_fields "${closing_issues%$'\n'}" "None linked yet" "Linked issues"
     ;;
 esac
 


### PR DESCRIPTION
## Summary

Unify release, nightly, and preview Discord notifications under the announcements webhook and split long bullet lists across fields to prevent truncation.

## Linked issues

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): CI, integrations
- Automated coverage: Existing notification workflows and shell script execution
- Manual steps and expected result: Trigger release, nightly, and preview notifications; verify they use the announcements webhook and long lists remain complete without Discord field truncation.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release, nightly, and preview notifications are now consolidated in the announcements channel.
  * Notifications display bullet-list content in separate, readable sections, including longer lists without truncation.
  * Updated notification titles and descriptions provide clearer context for releases, previews, and nightly builds.
  * Release notes and select nightly metadata are streamlined for a more focused announcement experience.
  * Linked issues and pull requests are presented in dedicated sections for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->