### PR TITLE
feat(navidrome): create playlists library when settings save

### DIFF
--- a/.tests/auth/navidrome-settings.int.test.js
+++ b/.tests/auth/navidrome-settings.int.test.js
@@ -50,8 +50,16 @@ test.before(async () => {
 
   navidrome = http.createServer((req, res) => {
     const url = new URL(req.url || "/", "http://127.0.0.1");
-    navidromeRequests.push(url);
+    navidromeRequests.push({ method: req.method, url });
     res.writeHead(200, { "Content-Type": "application/json" });
+    if (url.pathname === "/auth/login") {
+      res.end(JSON.stringify({ token: "test-token" }));
+      return;
+    }
+    if (url.pathname === "/api/library" && req.method === "GET") {
+      res.end(JSON.stringify([]));
+      return;
+    }
     res.end(JSON.stringify({ "subsonic-response": { status: "ok", version: "1.16.1" } }));
   });
   await new Promise((resolve) => navidrome.listen(0, "127.0.0.1", resolve));
@@ -86,6 +94,11 @@ test("admin can update and test Navidrome after onboarding", async () => {
   assert.equal(saved.response.status, 200, JSON.stringify(saved.payload));
   assert.equal(saved.payload.integrations.navidrome.url, navidromeUrl);
   assert.equal(saved.payload.integrations.navidrome.username, "local-user");
+  assert.ok(
+    navidromeRequests.some(
+      ({ method, url }) => method === "POST" && url.pathname === "/api/library",
+    ),
+  );
 
   const tested = await apiFetch("/api/settings/navidrome/test", {
     method: "POST",
@@ -96,9 +109,9 @@ test("admin can update and test Navidrome after onboarding", async () => {
     success: true,
     message: "Connection successful",
   });
-  assert.equal(navidromeRequests.length, 1);
-  assert.equal(navidromeRequests[0].pathname, "/rest/ping");
-  assert.equal(navidromeRequests[0].searchParams.get("u"), "local-user");
+  const pingRequests = navidromeRequests.filter(({ url }) => url.pathname === "/rest/ping");
+  assert.equal(pingRequests.length, 1);
+  assert.equal(pingRequests[0].url.searchParams.get("u"), "local-user");
 });
 
 test("admin can configure persistent yt-dlp staging outside the download folder", async () => {

--- a/.tests/auth/navidrome-settings.int.test.js
+++ b/.tests/auth/navidrome-settings.int.test.js
@@ -50,17 +50,31 @@ test.before(async () => {
 
   navidrome = http.createServer((req, res) => {
     const url = new URL(req.url || "/", "http://127.0.0.1");
-    navidromeRequests.push({ method: req.method, url });
-    res.writeHead(200, { "Content-Type": "application/json" });
-    if (url.pathname === "/auth/login") {
-      res.end(JSON.stringify({ token: "test-token" }));
-      return;
-    }
-    if (url.pathname === "/api/library" && req.method === "GET") {
-      res.end(JSON.stringify([]));
-      return;
-    }
-    res.end(JSON.stringify({ "subsonic-response": { status: "ok", version: "1.16.1" } }));
+    let requestBody = "";
+    req.on("data", (chunk) => {
+      requestBody += chunk;
+    });
+    req.on("end", () => {
+      let body = null;
+      try {
+        body = requestBody ? JSON.parse(requestBody) : null;
+      } catch {}
+      navidromeRequests.push({ method: req.method, url, body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (url.pathname === "/auth/login") {
+        res.end(JSON.stringify({ token: "test-token" }));
+        return;
+      }
+      if (url.pathname === "/api/library" && req.method === "GET") {
+        res.end(JSON.stringify([]));
+        return;
+      }
+      if (url.pathname === "/api/library" && req.method === "POST") {
+        res.end(JSON.stringify({ id: "library-1", ...body }));
+        return;
+      }
+      res.end(JSON.stringify({ "subsonic-response": { status: "ok", version: "1.16.1" } }));
+    });
   });
   await new Promise((resolve) => navidrome.listen(0, "127.0.0.1", resolve));
   navidromeUrl = `http://127.0.0.1:${navidrome.address().port}`;
@@ -94,11 +108,13 @@ test("admin can update and test Navidrome after onboarding", async () => {
   assert.equal(saved.response.status, 200, JSON.stringify(saved.payload));
   assert.equal(saved.payload.integrations.navidrome.url, navidromeUrl);
   assert.equal(saved.payload.integrations.navidrome.username, "local-user");
-  assert.ok(
-    navidromeRequests.some(
-      ({ method, url }) => method === "POST" && url.pathname === "/api/library",
-    ),
+  const libraryRequest = navidromeRequests.find(
+    ({ method, url }) => method === "POST" && url.pathname === "/api/library",
   );
+  assert.deepEqual(libraryRequest?.body, {
+    name: "Aurral Playlists",
+    path: path.join(isolatedState.baseDir, "weekly-flow", "aurral-weekly-flow"),
+  });
 
   const tested = await apiFetch("/api/settings/navidrome/test", {
     method: "POST",

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -371,6 +371,14 @@ export function registerGeneral(router) {
       }
 
       dbOps.updateSettings(updatedSettings);
+      if (integrations?.navidrome) {
+        const { playlistManager } = await import(
+          "../../../services/weeklyFlow/weeklyFlowPlaylistManager.js"
+        );
+        playlistManager.updateConfig(false);
+        await playlistManager.ensureSmartPlaylists();
+        playlistManager.scheduleScanLibrary(true);
+      }
       const reconciled = reconcileLocalNetworkBypassSetting().settings;
       if (
         localBypassWasEnabled &&

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -30,7 +30,7 @@ For path design, hardlinks, and permissions, use the Servarr guides:
 2. Set a folder under the media root.
 3. Connect Lidarr.
 4. Run **Test library access**.
-5. If you use Navidrome, add the Aurral downloads path as a music folder.
+5. If you use Navidrome, mount the Aurral downloads path at the same container path and connect Navidrome in Aurral. Aurral creates its Navidrome library automatically.
 6. If you use Plex, let Aurral register the downloads path.
 
 For example, set the downloads path to `/data/downloads/aurral`.
@@ -59,7 +59,7 @@ This example uses the standard Servarr layout. You can use a different layout if
 | Aurral         | `/data:/data`    | Same mount. Set Downloads Folder in the UI.          |
 | slskd          | `/data:/data`    | Same mount that Lidarr uses                         |
 | SABnzbd/NZBGet | `/data:/data`    | Same mount that Lidarr uses                         |
-| Navidrome      | `/data:/data:ro` | Scan Lidarr library **and** Aurral's downloads path |
+| Navidrome      | `/data:/data:ro` | Reads the Lidarr library and Aurral's downloads path |
 | Plex           | `/data:/data`    | Reads Aurral's `aurral-weekly-flow` tree            |
 
 App state stays in `./config:/config` and is not shared.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -11,11 +11,27 @@ Aurral also writes M3U playlists for your flows and static playlists.
 
 ## Setup
 
-1. Use the Lidarr media mount in Aurral and Navidrome. See [Match Lidarr](/getting-started/storage/).
-2. In Navidrome, scan the Lidarr library.
-3. Add the Aurral Downloads Folder to the Navidrome scan. For example, use `/data/downloads/aurral`.
-4. Connect Navidrome in **Settings > Playback > Navidrome**.
-5. Let Aurral create its library and playlist files under `aurral-weekly-flow`.
+1. Mount the same media volume in Aurral and Navidrome at the same container path. For the usual `/data` layout:
+
+   ```yaml
+   # Aurral
+   volumes:
+     - data:/data
+
+   # Navidrome
+   volumes:
+     - data:/data:ro
+   ```
+
+   If Navidrome already uses `/music`, also mount the Aurral folder at the path Aurral uses:
+
+   ```yaml
+   - data/downloads/aurral:/data/downloads/aurral:ro
+   ```
+
+2. Set Aurral's **Downloads Folder > Path** to a folder under `/data`, such as `/data/downloads/aurral`.
+3. Connect Navidrome in **Settings > Playback > Navidrome** and save.
+4. Aurral creates the **Aurral Playlists** library, writes its playlist files under `aurral-weekly-flow`, and requests a Navidrome scan. You do not need to create this library manually in Navidrome.
 
 Aurral configures Navidrome through its API. Navidrome must also have access to the audio files on disk.
 


### PR DESCRIPTION
## Summary

Create the Aurral Playlists library automatically when Navidrome settings are saved, request a library scan, and update setup documentation to reflect the new workflow.

## Linked issues

None

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Navidrome integration, settings, documentation
- Automated coverage: Updated Navidrome settings integration test to verify library creation and connection testing
- Manual steps and expected result: Save Navidrome settings and verify that the Aurral Playlists library is created and a library scan is requested.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navidrome settings now automatically create or update smart playlists and trigger a library scan.
  * Aurral now creates the Navidrome library and playlists after connection.

* **Documentation**
  * Updated Navidrome setup instructions to clarify shared media paths, download paths, and connection requirements.
  * Removed obsolete manual library and scan configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->