### PR TITLE
docs(storage): clarify shared filesystem and mount setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /data:/data
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config
 ```
 
-Change `/data:/data` to the **same host media path Lidarr already mounts**. If Lidarr's stack works, Aurral's filesystem is already right. Then set the Downloads Folder path in the UI. See [Match Lidarr](https://docs.aurral.org/getting-started/storage/).
+Set `MEDIA_ROOT` to the **same host media path that Lidarr already mounts**. Keep `/data` as the container path and use that same mapping for your download clients and Navidrome or Plex. Then set Aurral's Downloads Folder to a container path such as `/data/downloads/aurral`. See [Filesystem and mounts](https://docs.aurral.org/getting-started/storage/).
 
 ```bash
 docker compose up -d

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,7 +8,7 @@ services:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
     volumes:
-      - /data:/data
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config
 
   lidarr:
@@ -20,7 +20,7 @@ services:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
     volumes:
-      - /data:/data
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config/lidarr:/config
 
   slskd:
@@ -29,7 +29,7 @@ services:
     ports:
       - "5030:5030"
     volumes:
-      - /data:/data
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config/slskd:/app
 
   navidrome:
@@ -41,5 +41,5 @@ services:
       - ND_SCANNER_PURGEMISSING=always
       - ND_DATA=/config
     volumes:
-      - /data:/data:ro
+      - ${MEDIA_ROOT:-/srv/media}:/data:ro
       - ./data/navidrome:/config

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -88,4 +88,4 @@ environment:
   - TRUST_PROXY=true
 ```
 
-For mounts and path mappings, see [Match Lidarr](/getting-started/storage/).
+For mounts and path mappings, see [Filesystem and mounts](/getting-started/storage/).

--- a/docs/src/content/docs/admin/storage.mdx
+++ b/docs/src/content/docs/admin/storage.mdx
@@ -1,18 +1,18 @@
 ---
 title: Storage and backups
-description: App data, media mounts, and what to back up.
+description: Aurral app data, shared media mounts, and what to back up.
 ---
 
-Aurral keeps app state and generated music separate.
+Aurral keeps app state and generated music separate. It also needs compatible filesystem views of Lidarr, your download clients, and Navidrome or Plex.
 
-For mounts, follow [Match Lidarr](/getting-started/storage/). Use the Lidarr media root and set the downloads path in the UI.
+For the complete mount model, follow [Filesystem and mounts](/getting-started/storage/). Use the Lidarr media root and set the Downloads Folder to a path inside Aurral, such as `/data/downloads/aurral`.
 
 ## Storage locations
 
 | Path                             | Contains                                                                                                                                                                   |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/config`                        | Database, settings, users, sessions, cache state, playlist jobs, and the default yt-dlp staging directory. Mount it with `./config:/config`. Do not share it with other apps. |
-| `/data` (or Lidarr's media root) | Shared library and downloads. Same mount Lidarr uses.                                                                                                                      |
+| `/data` (or Lidarr's media root) | Shared library and downloads. Mount the same host media root here in Aurral, Lidarr, download clients, and playback servers.                                                      |
 | Downloads Folder                 | Generated flows, imported playlists, and playlist files. Set in **Settings > Download Clients > Downloads Folder > Path** (for example `/data/downloads/aurral`).          |
 
 :::note
@@ -23,7 +23,7 @@ For mounts, follow [Match Lidarr](/getting-started/storage/). Use the Lidarr med
 
 - Back up the mounted `/config` folder.
 - Back up the Downloads Folder if you want to keep generated playlists after a rebuild.
-- Back up the Compose file and `.env` file.
+- Back up the Compose file and the environment file that contains your host paths.
 
 yt-dlp stages downloads in `/config/_staging` by default. You can mount another persistent path and select it under **Settings > Download Clients > yt-dlp > Staging path**. Keep it outside media-server libraries to avoid scanner activity while files are incomplete.
 

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -31,10 +31,13 @@ description: Common setup and runtime issues.
 
 ## Files do not appear in Navidrome
 
-- Make sure that Aurral mounts the same media root as Lidarr ([Match Lidarr](/getting-started/storage/)).
+- Make sure that Aurral mounts the same media root as Lidarr ([Filesystem and mounts](/getting-started/storage/)).
 - Make sure that **Settings > Download Clients > Downloads Folder > Path** is under that mount.
+- In **Settings > Playback > Navidrome**, test and save the Navidrome connection.
 - Make sure that Navidrome scans Aurral's downloads path and not only Lidarr's library.
-- Review the [Navidrome missing-track setting](/integrations/navidrome/#recommended-navidrome-setting).
+- Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file under `aurral-weekly-flow`, then wait for the Navidrome scan.
+- If the library is missing, check that the Navidrome account can manage libraries through its API.
+- Review the [Navidrome missing-track setting](/integrations/navidrome/#remove-missing-tracks).
 
 ## Library reuse or download handoff fails on Windows
 
@@ -53,7 +56,7 @@ Completed slskd or Usenet files can also remain in their source folders. **Test 
 - For NZBGet on Windows, open **Settings > Download Clients > NZBGet**.
 - Set **Completed download path** if Aurral cannot detect the folder automatically.
 
-See [Match Lidarr: Windows and mixed Docker setups](/getting-started/storage/#windows-and-mixed-docker-setups).
+See [Filesystem and mounts: Windows and mixed Docker setups](/getting-started/storage/#windows-and-mixed-docker-setups).
 
 ## Library access fails on a folder that is not your root folder
 
@@ -81,7 +84,7 @@ The path problem is common when Aurral runs in Docker and Navidrome runs on Wind
 
 Leave **Use Navidrome paths in M3U files** off when Navidrome runs in Docker with the same mounts as Aurral.
 
-See [Navidrome: Mixed Windows and Docker](/integrations/navidrome/#mixed-windows-and-docker-navidrome).
+See [Navidrome: Different Navidrome paths](/integrations/navidrome/#different-navidrome-paths).
 
 ## Plex playlists are empty or tracks are missing
 
@@ -89,7 +92,7 @@ See [Navidrome: Mixed Windows and Docker](/integrations/navidrome/#mixed-windows
 
 - Make sure that Plex can read the flow download tree.
 - The Plex container or host must contain this path: `<downloads>/aurral-weekly-flow/<flow-id>/...`.
-- If Plex and Aurral use different mounts, set **Settings → Playback → Plex → Plex Aurral Library path** to the folder that Plex sees.
+- If Plex and Aurral use different mounts, set **Settings > Playback > Plex > Plex Aurral Library path** to the folder that Plex sees.
 - Leave **Plex Aurral Library path** blank if both apps use the same path prefix.
 - Save the settings.
 - Select **Sync to Plex now** again.

--- a/docs/src/content/docs/admin/users.mdx
+++ b/docs/src/content/docs/admin/users.mdx
@@ -92,7 +92,7 @@ Proxy-created users cannot use local password login until an admin sets a passwo
 
 ## Per-user Plex accounts
 
-Each user can link their own flow and shared playlists to their own Plex account instead of the shared admin Plex connection. From a user's **Manage** dialog in **Settings → Users**, admins link a Plex Home managed user; anyone can also self-link their own invited/friend Plex account from their **Profile** page. See [Plex → Per-user Plex accounts](/integrations/plex/#per-user-plex-accounts) for the full setup steps.
+Each user can link their own flow and shared playlists to their own Plex account instead of the shared admin Plex connection. From a user's **Manage** dialog in **Settings > Users**, admins link a Plex Home managed user; anyone can also self-link their own invited/friend Plex account from their **Profile** page. See [Plex - Per-user Plex accounts](/integrations/plex/#per-user-plex-accounts) for the full setup steps.
 
 ## Reset admin password
 

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -1,13 +1,16 @@
 ---
-title: Docker Setup
-description: Run Aurral with Docker as a Lidarr companion.
+title: Docker setup
+description: Run Aurral in Docker and connect it to the shared media filesystem.
 ---
 
-Aurral runs in Docker. It needs a `/config` mount for app data.
+Aurral runs in Docker. It needs two mounts:
 
-Aurral also needs the **same media root that Lidarr uses**. Most installations use `/data`.
+- `/config` for Aurral's database, settings, users, and jobs.
+- A shared media mount for the Lidarr library, completed downloads, and Aurral output.
 
-## Minimal compose file
+Read [Filesystem and mounts](/getting-started/storage/) before you create the Compose file. Aurral must share a media mount with Lidarr, your download clients, and Navidrome or Plex.
+
+## Minimal Compose file
 
 ```yaml
 services:
@@ -20,43 +23,15 @@ services:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
     volumes:
-      - /data:/data
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config
 ```
 
-Point `/data:/data` at the host path that Lidarr mounts. `./config` holds Aurral's database, settings, and encrypted secrets.
+Replace `/srv/media` with the host directory that Lidarr already uses. Keep `:/data` as the container side of the mount if the other services use the recommended layout.
 
-## Which image tag to use
+For example, the host folder `/srv/media/downloads/aurral` is `/data/downloads/aurral` inside Aurral. Set the Downloads Folder to the container path in **Settings > Download Clients**, not to the host path.
 
-| Tag | Contents | Use it when |
-| --- | --- | --- |
-| `latest` | The newest stable release | You want a tested release. This is the default. |
-| `2.1.0`, `2.1`, `2` | An exact version, or the newest release in that line | You pin versions or need to roll back to a known build |
-| `nightly` | Every change merged since the last release | You want fixes and features early and can report bugs |
-| `pr-<number>` | The current preview image for an open pull request | You were asked to test a proposed change |
-
-Aurral checks for a newer build in your channel and shows a banner when one exists. Non-stable channels also mark the sidebar:
-
-- `nightly` shows a night-sky backdrop behind the sidebar logo.
-- `pr-<number>` preview images show a blueprint backdrop behind the sidebar logo.
-
-:::caution
-`nightly` is untested by users until you run it. Back up `./config` before switching to it, and report anything broken.
-:::
-
-## Test a pull request preview
-
-When a pull request has a preview image, its GitHub conversation contains a comment with the exact `pr-<number>` image tag and test instructions. The comment is updated whenever a new preview image is built.
-
-If the pull request is linked to an issue, that issue also receives the preview image and test instructions, and the `in-progress` label. The issue comment is updated for new images and invalidated when the pull request closes. The `in-progress` label is removed when the pull request closes, and later replaced by `nightly` or `released` after merge.
-
-To test the image with an existing Compose setup:
-
-1. Back up `./config`.
-2. Temporarily change the Aurral service image to the preview tag from the pull request comment.
-3. Run `docker compose pull aurral && docker compose up -d aurral`.
-4. Exercise the behavior changed by the pull request.
-5. Restore the image reference that was configured before testing.
+`/config` is only for Aurral. Do not share it with another service.
 
 ## Start Aurral
 
@@ -65,28 +40,41 @@ docker compose up -d
 ```
 
 1. Open `http://localhost:3001`.
-2. Create your admin account.
+2. Create the admin account.
 3. Connect Lidarr.
+4. Set the Downloads Folder path and run the storage checks.
 
-## What the mounts do
+Continue with [First run](/getting-started/first-run/).
 
-| Mount             | Container path | Purpose                                        |
-| ----------------- | -------------- | ---------------------------------------------- |
-| Lidarr media root | `/data`        | Same path view as Lidarr for the library and downloads |
-| Host config dir   | `/config`      | Aurral database, settings, users, and jobs     |
+## Which image tag to use
 
-Set the downloads path in **Settings > Download Clients > Downloads Folder > Path**. For example, use `/data/downloads/aurral`.
+| Tag | Contents | Use it when |
+| --- | --- | --- |
+| `latest` | The newest stable release | You want a tested release. |
+| `2.1.0`, `2.1`, `2` | An exact version, or the newest release in that line | You pin versions or need to roll back. |
+| `nightly` | Every change merged since the last release | You want fixes and features early and can report bugs. |
+| `pr-<number>` | The preview image for an open pull request | You were asked to test a proposed change. |
 
-The downloads path must be under the media mount.
+Aurral checks for a newer build in your channel and shows a banner when one exists. Non-stable channels also mark the sidebar.
 
-:::note
-`/config` replaces the older `/app/backend/data` path from Aurral v1. At startup, Aurral automatically detects existing databases in either location.
+:::caution
+`nightly` is not a stable release. Back up `./config` before switching to it.
 :::
 
-## Full stack
+## Test a pull request preview
 
-Use [`docker-compose.example.yml`](https://github.com/lklynet/aurral/blob/main/docker-compose.example.yml) for a stack with Lidarr, slskd, and Navidrome.
+When a pull request has a preview image, its GitHub conversation contains the exact `pr-<number>` image tag and test instructions.
 
-Match Lidarr's media mount. See [Match Lidarr](/getting-started/storage/) for details and Servarr links.
+1. Back up `./config`.
+2. Temporarily change the Aurral image to the preview tag.
+3. Run `docker compose pull aurral && docker compose up -d aurral`.
+4. Test the behavior changed by the pull request.
+5. Restore the image reference that you used before testing.
 
-Next: [Match Lidarr](/getting-started/storage/)
+## Full stack example
+
+Use [`docker-compose.example.yml`](https://github.com/lklynet/aurral/blob/main/docker-compose.example.yml) for Aurral, Lidarr, slskd, and Navidrome. It uses one `${MEDIA_ROOT:-/srv/media}:/data` mount for the media services.
+
+For Plex, see the [Plex setup guide](/integrations/plex/).
+
+Next: [Filesystem and mounts](/getting-started/storage/)

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -1,40 +1,40 @@
 ---
 title: First run
-description: Create your admin account, connect Lidarr, then finish setup in Settings.
+description: Create your admin account, connect Lidarr, and verify the filesystem before playback setup.
 ---
 
-First, create your admin account. Then, connect Lidarr.
-
-Use Settings for all other setup tasks.
+First, create the admin account and connect Lidarr. Then configure the filesystem before you connect a download client or playback server.
 
 ![Aurral Lidarr connection settings](../../../assets/screenshots/settings-lidarr.webp)
 
+## Before first run
+
+Complete [Filesystem and mounts](/getting-started/storage/) first. The short version is:
+
+- Mount the same host media root in Aurral, Lidarr, and the services you use.
+- Use the same container path, normally `/data`.
+- Keep Aurral's `/config` mount separate.
+
 ## First-run steps
 
-1. Create your admin account.
-2. If necessary, enable **Auto-login on local network**.
-3. Enter the Lidarr URL and API key.
-4. Test the Lidarr connection.
-5. Open Aurral.
+1. Open Aurral and create your admin account.
+2. Open **Settings > Lidarr**.
+3. Enter the Lidarr URL that Aurral can reach. In one Docker Compose network this is often `http://lidarr:8686`.
+4. Enter the Lidarr API key and select **Test connection**.
+5. Open **Settings > Download Clients**.
+6. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
+7. Open **Settings > System**, select **Run Checks** under **Storage Health**, and fix failed checks.
+8. Open **Settings > Lidarr** and select **Test library access**.
+9. Connect the download clients and playback server that you use.
 
-If Lidarr is operational, match its media mount. See [Match Lidarr](/getting-started/storage/).
+The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral can read the files and write the Downloads Folder.
 
-## After first-run setup
+## Configure the other services
 
-Configure these in Settings when you need them:
+- **Download clients:** Open **Settings > Download Clients**. Connect slskd, SABnzbd, or NZBGet and make sure their completed path is under the shared media mount. The built-in yt-dlp source needs no separate service.
+- **Navidrome:** Open **Settings > Playback > Navidrome** and connect it. Aurral creates its playlist library when a flow or playlist produces output. See [Navidrome](/integrations/navidrome/).
+- **Plex:** Open **Settings > Playback > Plex**, connect Plex, and select **Sync to Plex now** after a flow downloads tracks. See [Plex](/integrations/plex/).
 
-- **Settings > Download Clients > Downloads Folder**: path under your Lidarr media root (for example `/data/downloads/aurral`).
-- **Settings > Lidarr**: quality profile, monitoring, community guide, library access check.
-- **Settings > Download Clients** or **Indexers**: yt-dlp, slskd, Prowlarr, SABnzbd, or NZBGet.
-- **Settings > Playback**: Navidrome or Plex.
-- **Settings > Connect**: Last.fm API key and Ticketmaster.
-- **Settings > Discover**: recommendation refresh and discovery mode.
-- **Profile**: listening-history provider (ListenBrainz by default until you add Last.fm or Koito).
-
-## Per-user setup
-
-Each user can customize their Profile. Each user can also customize the Discover layout.
-
-Admins use Settings to manage integrations, download clients, notifications, and user permissions.
+If any service uses a different path, see [Path mismatches](/getting-started/storage/#when-paths-cannot-match). Do not add a path mapping until the local folder is mounted inside Aurral.
 
 Next: [Discover](/using/discover/)

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -1,103 +1,225 @@
 ---
-title: Match Lidarr
-description: Mount Aurral like Lidarr. Same media root, same path view.
+title: Filesystem and mounts
+description: Give Aurral, Lidarr, download clients, and playback servers compatible filesystem views.
 ---
 
-Aurral is a **Lidarr companion**. Aurral uses the Lidarr storage layout.
+Aurral is a bridge between several applications. It needs a network connection to each application and, for media work, access to the same files.
 
-If your player sees the Lidarr library, mount the same media root into Aurral.
+An API test does not test file access. Aurral can connect to Lidarr, Navidrome, Plex, or a download client and still fail to read or move files if the mounts are wrong.
 
-## The rule
+:::caution
+The recommended setup is one shared media mount, with the same container path in every container. Use path mappings only when you cannot use the same path.
+:::
 
-Mount the same media volume Lidarr uses, at the same container path. Most stacks use `/data:/data`.
+## What Aurral connects to
 
-```yaml
-volumes:
-  - /data:/data
-  - ./config:/config
-```
+| Connection | Aurral needs from the service | Recommended filesystem setup |
+| --- | --- | --- |
+| Lidarr | URL, API key, and the paths reported for library files | Mount the same media root in Aurral and Lidarr at the same container path. Aurral reads the files that Lidarr reports. |
+| Download clients | API access and readable completed-download paths | Mount the same media root in Aurral and the client at the same container path. Aurral imports completed files into its Downloads Folder. |
+| Navidrome | URL, username, password, and access to Aurral's downloaded files | Mount the Aurral Downloads Folder in Navidrome. Use the same container path when possible. |
+| Plex | Plex account, server URL, and access to Aurral's downloaded files | Mount the Aurral Downloads Folder in Plex. Leave **Plex Aurral Library path** blank when both containers use the same path. |
 
-`/config` is Aurral-only (database, settings, secrets). Do not share it with Lidarr.
+The built-in **yt-dlp** source is part of Aurral. It does not need another container. It stages files in `/config/_staging` by default, then imports completed files into the Downloads Folder.
 
-For path design, hardlinks, and permissions, use the Servarr guides:
+## The recommended layout
 
-- [Servarr Docker Guide](https://wiki.servarr.com/docker-guide): one common volume, consistent paths
-- [Lidarr Docker notes](https://lidarr.audio/#downloads-v1-docker): same `/data` advice for Lidarr images
+Choose one directory on the Docker host as the media root. The example uses `/srv/media`. Your host path can be different.
 
-## After the mount
-
-1. Open **Settings > Download Clients > Downloads Folder > Path**.
-2. Set a folder under the media root.
-3. Connect Lidarr.
-4. Run **Test library access**.
-5. If you use Navidrome, mount the Aurral downloads path at the same container path and connect Navidrome in Aurral. Aurral creates its Navidrome library automatically.
-6. If you use Plex, let Aurral register the downloads path.
-
-For example, set the downloads path to `/data/downloads/aurral`.
-
-A scan of only the Lidarr library does not include Aurral output.
-
-yt-dlp writes directly into that downloads path. If Lidarr shares `/data` with slskd or Usenet, Aurral can see the completed folders.
-
-## Example layout
-
-This example uses the standard Servarr layout. You can use a different layout if all containers see the same paths.
-
-```
-/data/
-|-- music/                 # Lidarr root folder
+```text
+/srv/media/                         # Docker host
+|-- music/                          # Lidarr root folder
 \-- downloads/
-    |-- slskd/complete/    # slskd finished downloads (if used)
-    |-- nzbget/completed/  # optional Usenet completed
-    \-- aurral/            # Aurral Downloads Folder path
-        \-- aurral-weekly-flow/
+    |-- slskd/complete/             # optional Soulseek completed files
+    |-- usenet/complete/            # optional SABnzbd or NZBGet files
+    \-- aurral/                     # Aurral Downloads Folder
+        \-- aurral-weekly-flow/     # generated tracks and playlists
 ```
 
-| Service        | Mount            | Notes                                               |
-| -------------- | ---------------- | --------------------------------------------------- |
-| Lidarr         | `/data:/data`    | Root folder, for example, `/data/music`              |
-| Aurral         | `/data:/data`    | Same mount. Set Downloads Folder in the UI.          |
-| slskd          | `/data:/data`    | Same mount that Lidarr uses                         |
-| SABnzbd/NZBGet | `/data:/data`    | Same mount that Lidarr uses                         |
-| Navidrome      | `/data:/data:ro` | Reads the Lidarr library and Aurral's downloads path |
-| Plex           | `/data:/data`    | Reads Aurral's `aurral-weekly-flow` tree            |
+Use the same host directory in every media-service mount:
 
-App state stays in `./config:/config` and is not shared.
+| Container | Docker volume | Access | Why |
+| --- | --- | --- | --- |
+| Aurral | `${MEDIA_ROOT:-/srv/media}:/data` | read/write | Reads Lidarr and client files and writes playlist downloads. |
+| Lidarr | `${MEDIA_ROOT:-/srv/media}:/data` | read/write | Reads the library and moves completed downloads into `/data/music`. |
+| slskd, SABnzbd, or NZBGet | `${MEDIA_ROOT:-/srv/media}:/data` | read/write | Writes completed downloads under `/data/downloads`. |
+| Navidrome | `${MEDIA_ROOT:-/srv/media}:/data:ro` | read-only | Scans and plays the library and Aurral downloads. |
+| Plex | `${MEDIA_ROOT:-/srv/media}:/data:ro` | read-only | Scans Aurral downloads. |
 
-## Windows and mixed Docker setups
+`MEDIA_ROOT` is a host path. `/data` is a path inside each container. The left side of a Docker volume is the host; the right side is the container.
 
-If Lidarr runs on Windows, it can report a path such as `N:\Music\...`. Aurral cannot read this path in Docker.
+For example, this host folder:
 
-Mount the Windows folder into Aurral:
+```text
+/srv/media/downloads/aurral
+```
+
+is this path inside Aurral, Lidarr, Navidrome, and Plex:
+
+```text
+/data/downloads/aurral
+```
+
+Use `/data/...` in application settings. Do not enter `/srv/media/...` in Aurral when `/srv/media` is only the host side of the mount.
+
+## Docker mounts
+
+The important part of a Compose file is the volume mapping. Repeat the media mapping for every service that must read or write media.
 
 ```yaml
 services:
   aurral:
     volumes:
-      - N:/ServerFolders/Music:/music
+      - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config
+
+  lidarr:
+    volumes:
+      - ${MEDIA_ROOT:-/srv/media}:/data
+
+  download-client:
+    volumes:
+      - ${MEDIA_ROOT:-/srv/media}:/data
+
+  navidrome:
+    volumes:
+      - ${MEDIA_ROOT:-/srv/media}:/data:ro
+
+  plex:
+    volumes:
+      - ${MEDIA_ROOT:-/srv/media}:/data:ro
 ```
 
-Example mapping: map the remote path `N:/ServerFolders/Music` to the local path `/music`.
+`./config:/config` is only for Aurral's database, settings, users, and jobs. Do not share `/config` with Lidarr, Navidrome, Plex, or a download client.
 
-Add this mapping under **Settings > Download Clients > Remote Path Mappings**.
+The containers can use different Docker networks and service URLs. They must still be able to see the media files through compatible mounts.
 
-You can also set `PATH_MAPPINGS=N:/ServerFolders/Music|/music` in the Compose file. Aurral applies the value at runtime.
+## Set the paths in each application
 
-You can edit the mapping in the UI after Aurral starts.
+After you add the mounts, use the container paths shown below.
 
-Then run **Settings > Lidarr > Test library access**.
+| Application | Setting | Recommended value |
+| --- | --- | --- |
+| Lidarr | Root folder | `/data/music` |
+| slskd | Completed download folder | `/data/downloads/slskd/complete` |
+| SABnzbd or NZBGet | Completed download folder | `/data/downloads/usenet/complete` |
+| Aurral | **Settings > Download Clients > Downloads Folder > Path** | `/data/downloads/aurral` |
+| Navidrome | Aurral playlist library | Aurral creates `/data/downloads/aurral/aurral-weekly-flow` through the API. |
+| Plex | Aurral library | Aurral creates the library through the API at the path Plex uses for the Aurral Downloads Folder. |
 
-:::note
-Compose `PATH_MAPPINGS` do not appear as environment fields in the UI. Use **Settings > Download Clients > Remote Path Mappings** to view or edit them.
-:::
+The exact download-client folder names are not important. The important rules are:
 
-## When the player sees different paths
+- The client writes completed files somewhere under the shared media mount.
+- Aurral can read that same path.
+- Aurral's Downloads Folder is writable and is also mounted in the playback server.
 
-If Navidrome uses different paths, enable **Use Navidrome paths in M3U files** under **Settings > Playback > Navidrome**.
+## Setup order
 
-If Plex uses different paths, set **Plex Aurral Library path** under **Settings > Playback > Plex**.
+Follow this order. It makes each filesystem connection easy to check.
 
-See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/).
+1. Choose the host media root, such as `/srv/media`.
+2. Mount that same host directory in Aurral, Lidarr, every download client, and the playback server you use.
+3. Use `/data/...` paths inside the containers. Set the Lidarr root folder and the completed download folders.
+4. Start the services.
+5. In Aurral, open **Settings > Lidarr**, enter the URL and API key, and select **Test connection**.
+6. In Aurral, open **Settings > Download Clients** and set **Downloads Folder > Path** to a writable folder under `/data`, such as `/data/downloads/aurral`.
+7. Connect and test each download client that you use.
+8. Open **Settings > System > Storage Health** and select **Run Checks**. Fix any failed library, download, or transfer check.
+9. Open **Settings > Playback**, connect Navidrome or Plex, and follow the path rules below.
+
+## Verify the two connections
+
+Use these checks in order:
+
+1. **API check:** each integration's **Test connection** button must pass.
+2. **File check:** **Settings > Lidarr > Test library access** and **Settings > System > Storage Health** must be able to read the paths.
+3. **Output check:** after a flow or playlist downloads a track, the file must exist under:
+
+   ```text
+   /data/downloads/aurral/aurral-weekly-flow/
+   ```
+
+4. **Playback check:** Navidrome or Plex must have that folder in its own filesystem and must scan it.
+
+If the API check passes but the file check fails, do not change the API URL. Fix the volume mapping, permissions, or path mapping.
+
+## When paths cannot match
+
+Different container paths can work, but each mismatch needs its own setting. A path mapping translates a path; it does not mount a folder or grant access to it.
+
+### Paths reported by Lidarr or download clients
+
+Use **Settings > Download Clients > Remote Path Mappings**. Enter:
+
+- **Remote Path**: the absolute path reported by the other application.
+- **Local Path**: the path for the same folder inside Aurral.
+- **Source**: the application that reports the path, such as **Lidarr**, **slskd**, **NZBGet**, or **SABnzbd**.
+
+Example:
+
+| | Value |
+| --- | --- |
+| Source | Lidarr |
+| Remote Path | `/downloads/music` |
+| Local Path | `/data/music` |
+
+The local path must exist inside the Aurral container. If it does not, add or correct the Docker mount first.
+
+For a native Windows service, the remote path can be `N:\ServerFolders\Music`. Mount that host folder in Aurral, then map the Windows path to the Aurral container path. Run **Test library access** after saving the mapping.
+
+### Navidrome sees a different path
+
+This is a separate mapping. It changes paths in generated `.m3u` files; it does not help Aurral read Lidarr or download-client paths.
+
+1. Open **Settings > Playback > Navidrome**.
+2. Enable **Use Navidrome paths in M3U files**.
+3. Add a mapping with **Aurral Path** set to the path Aurral uses and **Navidrome Path** set to the path Navidrome uses.
+
+Example:
+
+| | Value |
+| --- | --- |
+| Aurral Path | `/data/downloads/aurral` |
+| Navidrome Path | `/music/aurral` |
+
+Leave this setting off when both containers use `/data` for the same host folder.
+
+### Plex sees a different path
+
+This is also separate from Aurral's Remote Path Mappings.
+
+1. Open **Settings > Playback > Plex**.
+2. Set **Plex Aurral Library path** to the Downloads Folder path as Plex sees it.
+3. Do not include `/aurral-weekly-flow`; Aurral adds that folder.
+4. Save the settings and select **Sync to Plex now**.
+
+Example:
+
+| Aurral uses | Plex sees | Plex Aurral Library path |
+| --- | --- | --- |
+| `/data/downloads/aurral` | `/music/aurral` | `/music/aurral` |
+
+Leave **Plex Aurral Library path** blank when Aurral and Plex use the same path.
+
+## Windows and mixed Docker setups
+
+The same rule applies when one service runs on Windows:
+
+1. Mount the Windows media folder into Aurral.
+2. Add a **Remote Path Mapping** from the Windows path reported by Lidarr or the download client to the Aurral container path.
+3. If Navidrome also runs on Windows, add a separate Navidrome M3U mapping so generated playlists contain Windows paths.
+4. If Plex sees a different path, set **Plex Aurral Library path** to the Plex path.
+
+Do not use one mapping for all three jobs. A Lidarr mapping, a Navidrome M3U mapping, and the Plex library path solve different path translations.
+
+## Common incorrect layouts
+
+- Mounting only the Lidarr music folder in Aurral. Aurral can read the library but cannot read completed downloads or write playlist downloads.
+- Mounting only the Aurral downloads folder in Navidrome or Plex while expecting those services to play reused Lidarr tracks. Mount the Lidarr library too, or configure a separate library for it.
+- Using the host path in Aurral settings. Aurral needs the container path, such as `/data/downloads/aurral`.
+- Adding a path mapping before mounting the folder. A mapping cannot make an absent folder readable.
+- Creating a Navidrome or Plex library at the host path. The service must use the path inside its own container, such as `/data/downloads/aurral` or `/music/aurral`.
+
+For permissions and hardlinks, see the [Servarr Docker Guide](https://wiki.servarr.com/docker-guide).
 
 Next: [First run](/getting-started/first-run/)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ Aurral is a self-hosted companion for music discovery. It adds recommendations, 
 ## Get started
 
 1. [Install Aurral with Docker](/getting-started/docker/).
-2. [Match Lidarr's media mount](/getting-started/storage/) so Aurral can find existing files.
+2. [Set up the shared filesystem](/getting-started/storage/) so Aurral can read existing files and connect its downloads to your playback server.
 3. [Complete first-run setup](/getting-started/first-run/).
 4. Connect the services that you use.
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -1,9 +1,16 @@
 ---
 title: Lidarr
-description: Connect Lidarr for library management and requests.
+description: Connect Lidarr for library management, requests, and library file access.
 ---
 
 Aurral requires Lidarr. Aurral adds artists and albums, reads library state, and shows queue and history status through Lidarr.
+
+The Lidarr integration has two parts:
+
+1. Aurral connects to the Lidarr API.
+2. Aurral reads the library files at the paths that Lidarr reports.
+
+The API connection can pass while the file connection fails. Mount the same media root in Aurral and Lidarr at the same container path. See [Filesystem and mounts](/getting-started/storage/).
 
 ## Connection
 
@@ -22,23 +29,15 @@ Aurral sends MusicBrainz artist IDs to Lidarr. If Lidarr uses a provider such as
 
 ## Library access check
 
-Aurral tests file access at each path that Lidarr reports. If the test fails, mount the Lidarr media root in Aurral.
-
-See [Match Lidarr](/getting-started/storage/).
+Aurral tests file access at paths that Lidarr reports. If the test fails, mount the Lidarr media root in Aurral. The recommended layout uses `/data` in both containers, with a Lidarr root folder such as `/data/music`.
 
 The check samples a track from an artist inside a root folder. It falls back to an artist outside them and then reports that the artist was left behind by a root folder change.
 
 See [Library access fails on a folder that is not your root folder](/admin/troubleshooting/#library-access-fails-on-a-folder-that-is-not-your-root-folder).
 
-In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports.
+In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports. If that path differs from the path inside Aurral, add a mapping under **Settings > Download Clients > Remote Path Mappings** with **Source** set to **Lidarr**.
 
-If Aurral mounts that folder at a different path, add a mapping under **Settings > Download Clients > Remote Path Mappings**.
-
-Path mappings let Aurral read files. If Navidrome uses a different path, enable **Use Navidrome paths in M3U files**.
-
-Add a Navidrome mapping so that `.m3u` files use the correct paths.
-
-See [Navidrome](/integrations/navidrome/#mixed-windows-and-docker-navidrome).
+This mapping only helps Aurral read Lidarr files. It does not change paths in Navidrome `.m3u` files. Configure Navidrome paths under **Settings > Playback > Navidrome**. See [Path mismatches](/getting-started/storage/#when-paths-cannot-match).
 
 ## Safety
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -1,100 +1,103 @@
 ---
 title: Navidrome
-description: Stream generated playlists and flow libraries.
+description: Connect Navidrome to play Aurral downloads and generated playlists.
 ---
 
-Navidrome is optional. Aurral creates an **Aurral Playlists** library at the `aurral-weekly-flow` path.
+Navidrome is optional. Aurral connects to Navidrome through its API and writes playlist files to the Aurral download tree. Navidrome must also be able to read that tree on disk.
 
-Aurral also writes M3U playlists for your flows and static playlists.
+This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
-![Aurral in-app playback](../../../assets/screenshots/playback.webp)
+See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
+
+```yaml
+# Aurral
+volumes:
+  - /srv/media:/data
+  - ./config:/config
+
+# Navidrome
+volumes:
+  - /srv/media:/data:ro
+```
 
 ## Setup
 
-1. Mount the same media volume in Aurral and Navidrome at the same container path. For the usual `/data` layout:
+1. Mount the same media root in Aurral and Navidrome at the same container path.
+2. Set Aurral's **Settings > Download Clients > Downloads Folder > Path** to a folder under that path, for example `/data/downloads/aurral`.
+3. Make sure Navidrome can read both `/data/music` and `/data/downloads/aurral` if you want to play reused Lidarr tracks as well as new Aurral downloads.
+4. Open **Settings > Playback > Navidrome** in Aurral.
+5. Enter the Navidrome URL, username, and password. Select **Test connection**, then save.
+6. Run a flow or update a playlist so Aurral can create or update the **Aurral Playlists** library and request a Navidrome scan.
 
-   ```yaml
-   # Aurral
-   volumes:
-     - data:/data
+Aurral creates the **Aurral Playlists** library at:
 
-   # Navidrome
-   volumes:
-     - data:/data:ro
-   ```
-
-   If Navidrome already uses `/music`, also mount the Aurral folder at the path Aurral uses:
-
-   ```yaml
-   - data/downloads/aurral:/data/downloads/aurral:ro
-   ```
-
-2. Set Aurral's **Downloads Folder > Path** to a folder under `/data`, such as `/data/downloads/aurral`.
-3. Connect Navidrome in **Settings > Playback > Navidrome** and save.
-4. Aurral creates the **Aurral Playlists** library, writes its playlist files under `aurral-weekly-flow`, and requests a Navidrome scan. You do not need to create this library manually in Navidrome.
-
-Aurral configures Navidrome through its API. Navidrome must also have access to the audio files on disk.
-
-Aurral embeds playlist metadata into new yt-dlp downloads. On startup, it also repairs older yt-dlp M4A files that have missing or incorrect title, artist, or album tags, then schedules a Navidrome library scan.
-
-## Mixed Windows and Docker Navidrome
-
-Aurral writes M3U playlists under `aurral-weekly-flow` with one track path per line. Navidrome must be able to open those paths on its filesystem.
-
-| Navidrome deployment | Playlist path mode | Setting |
-| -------------------- | ------------------ | ------- |
-| Docker, same mounts as Aurral | **local** (default) | Leave **Use Navidrome paths in M3U files** off |
-| Docker, different mount path than Aurral | **remote** | Enable the Navidrome setting and add a path mapping, or set `M3U_PATH_MODE=remote` plus `M3U_PATH_MAPPINGS` |
-| Native Windows while Aurral is in Docker | **remote** | Enable the Navidrome setting and add a path mapping, or set `M3U_PATH_MODE=remote` plus `M3U_PATH_MAPPINGS` |
-
-### What remote mode does
-
-Path mappings translate Lidarr Windows paths into Aurral container paths. Aurral can then read the files.
-
-For example, `N:\ServerFolders\Music\Music\Artist\track.mp3` becomes `/music/Music/Artist/track.mp3` in Docker.
-
-By default, M3U files use Aurral's container paths. Navidrome cannot resolve `/music/...` if it runs natively on Windows.
-
-The same problem occurs if the Navidrome container uses a different path for the files. Playlists can appear, but tracks do not play.
-
-**Use Navidrome paths in M3U files** changes paths only in M3U files. You can also set `M3U_PATH_MODE=remote`.
-
-Aurral still uses container paths for file checks, reuse, and repairs.
-
-### Example (Aurral in Docker, Navidrome on Windows)
-
-```yaml
-services:
-  aurral:
-    environment:
-      - PATH_MAPPINGS=N:/ServerFolders/Music|/music
-      - M3U_PATH_MODE=remote
-      - M3U_PATH_MAPPINGS=/music|N:/ServerFolders/Music
-    volumes:
-      - N:/ServerFolders/Music:/music
-      - ./config:/config
+```text
+/data/downloads/aurral/aurral-weekly-flow
 ```
 
-Set **Downloads Folder > Path** to a path under `/music`. For example, use `/music/Aurral`.
+You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
 
-After you enable remote mode, refresh each affected playlist.
+Navidrome must have permission to manage libraries through its API. If Aurral cannot create the library, use **Settings > System > Storage Health** for the exact path and error, then check the Navidrome account permissions and mount.
 
-Run the flow again. For a shared playlist, edit the playlist and then save it.
+## Existing Lidarr library
 
-See also [Match Lidarr: Windows and mixed Docker setups](/getting-started/storage/#windows-and-mixed-docker-setups).
+Aurral does not copy your Lidarr library into the Aurral playlist folder. If a playlist reuses tracks that already exist in Lidarr, Navidrome must also scan the Lidarr root folder, such as `/data/music`.
 
-## Recommended Navidrome setting
+Add `/data/music` as a normal Navidrome music library if it is not already present. The automatically managed **Aurral Playlists** library is for Aurral's generated download tree.
+
+## Different Navidrome paths
+
+Use matching container paths when possible. A different path affects two things:
+
+- the path Navidrome uses for its music library;
+- the paths written into Aurral's `.m3u` files.
+
+The **Use Navidrome paths in M3U files** setting only changes the second item. It does not mount a folder and it does not make an incorrect Navidrome library path valid.
+
+If Aurral uses `/data/downloads/aurral` and Navidrome uses `/music/aurral` for the same host folder:
+
+1. Mount the same host folder in both containers.
+2. Make sure the Aurral playlist library exists in Navidrome at the path Navidrome can read. If automatic library creation used the Aurral path, correct the library path in Navidrome.
+3. In Aurral, open **Settings > Playback > Navidrome**.
+4. Enable **Use Navidrome paths in M3U files**.
+5. Add this mapping:
+
+   | | Value |
+   | --- | --- |
+   | Aurral Path | `/data/downloads/aurral` |
+   | Navidrome Path | `/music/aurral` |
+
+6. Save the settings and refresh the affected playlist. Run the flow again, or edit and save a shared playlist, to rewrite its `.m3u` file.
+
+For a native Windows Navidrome installation, use the Windows path as **Navidrome Path**, for example `N:/ServerFolders/Music/Aurral`. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) if Aurral cannot read paths reported by Lidarr or a download client.
+
+## Generated playlists and scans
+
+Aurral stores generated `.m3u` files under:
+
+```text
+/data/downloads/aurral/aurral-weekly-flow/_playlists/
+```
+
+Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
+
+- confirm that a track exists under `aurral-weekly-flow`;
+- confirm that the Navidrome library path points to that folder;
+- run a Navidrome scan or save the Aurral Navidrome settings;
+- wait for the scan to finish.
+
+## Remove missing tracks
+
+For Weekly Flow, set this Navidrome environment variable:
 
 ```bash
 ND_SCANNER_PURGEMISSING=always
 ```
 
-`ND_SCANNER_PURGEMISSING=always` removes old flow entries after a flow changes.
+This removes old flow entries after a flow changes.
 
 :::caution
-`ND_SCANNER_PURGEMISSING=always` also removes other missing Navidrome files. It removes their ratings, play counts, and playlist entries.
-
-Use this setting only when missing files will not return.
+`ND_SCANNER_PURGEMISSING=always` also removes other missing Navidrome files. It can remove their ratings, play counts, and playlist entries. Use it only when missing files will not return.
 :::
 
-For Plex and Plexamp instead, see [Plex](/integrations/plex/).
+For Plex and Plexamp, see [Plex](/integrations/plex/).

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -1,17 +1,30 @@
 ---
 title: Plex
-description: Flow and playlist playback in Plex and Plexamp.
+description: Connect Plex to scan Aurral downloads and create Plexamp playlists.
 ---
 
-Plex is optional. Aurral creates an **Aurral** music library in Plex Media Server. It scans your flow downloads.
+Plex is optional. Aurral connects to the Plex API and creates an **Aurral** music library in Plex Media Server. Plex must also be able to read Aurral's downloaded files on disk.
 
 Aurral also builds Plex playlists for each enabled flow and shared playlist. The playlists appear in Plex and Plexamp.
 
 Plex does not read Aurral's `.m3u` files. Playlist sync uses the Plex API after Plex indexes the audio files on disk.
 
+See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Plex:
+
+```yaml
+# Aurral
+volumes:
+  - /srv/media:/data
+  - ./config:/config
+
+# Plex
+volumes:
+  - /srv/media:/data:ro
+```
+
 ## Setup
 
-1. Match Lidarr's media mount so Plex can read Aurral's Downloads Folder tree ([Match Lidarr](/getting-started/storage/)).
+1. Mount the same host media root in Plex that Aurral and Lidarr use.
 2. Open **Settings > Playback > Plex**.
 3. Select **Connect Plex account**.
 4. Approve the PIN in the Plex pop-up window.
@@ -22,6 +35,8 @@ Plex does not read Aurral's `.m3u` files. Playlist sync uses the Plex API after 
 9. After a flow downloads tracks, select **Sync to Plex now**.
 
 Aurral registers the library at `<plex-visible-downloads>/aurral-weekly-flow`. Track files are in flow subfolders under that path.
+
+You do not need to create this library manually in Plex. The library can be empty until a flow finishes downloading tracks. Plex can take several minutes to scan the files.
 
 Navidrome M3U playlists are in `aurral-weekly-flow/_playlists/`. Plex does not use these files.
 
@@ -51,22 +66,22 @@ Enter the downloads folder as Plex sees it. Aurral adds `/aurral-weekly-flow` wh
 | `/data/downloads/aurral`    | `/data/downloads/aurral`       | Leave blank                |
 | `/music/Aurral` (in Docker) | `/data/media` (Plex container) | `/data/media`              |
 
-**Browse** shows folders as Aurral sees them. If Plex's mount differs, type Plex's path manually.
+**Browse** shows folders as Aurral sees them. If Plex's mount differs, type Plex's path manually as Plex sees it. The folder must also exist inside the Plex container.
 
 **Plex Aurral Library path** matches the Plex and Aurral library roots. This setting is not the same as the Navidrome M3U path setting.
 
 ## Reusing tracks from an existing library
 
-If a flow includes songs you already have somewhere else in Plex — for example, in the library Lidarr manages — Aurral can add them straight into its playlists instead of downloading duplicates.
+If a flow includes songs you already have somewhere else in Plex - for example, in the library Lidarr manages - Aurral can add them straight into its playlists instead of downloading duplicates.
 
 This setting controls whether a reused song can appear in the Plex playlist. Aurral avoids re-downloading a song it finds via Lidarr or another flow regardless of this setting, but without it Aurral can't find that song in Plex, so it's left out of the playlist even though it wasn't re-downloaded.
 
-To set it up, open **Settings → Playback → Plex → Main library** and pick the Plex library section where those songs already live. Aurral checks automatically whether it can already read that library directly:
+To set it up, open **Settings > Playback > Plex > Main library** and pick the Plex library section where those songs already live. Aurral checks automatically whether it can already read that library directly:
 
 - If it can, nothing further is needed.
-- If it can't (Plex and Aurral see that library at different paths), enter the equivalent local path — Aurral shows the exact path Plex reported, so there's no guessing.
+- If it can't (Plex and Aurral see that library at different paths), enter the equivalent local path - Aurral shows the exact path Plex reported, so there is no guessing.
 
-Aurral only reads from this library — it never writes to it, rescans it, or modifies anything there. A reused track is the *same* Plex item as the one in your main library, not a copy — a rating or play recorded on it anywhere reflects everywhere it appears.
+Aurral only reads from this library - it never writes to it, rescans it, or modifies anything there. A reused track is the *same* Plex item as the one in your main library, not a copy - a rating or play recorded on it anywhere reflects everywhere it appears.
 
 ## Sync behavior
 
@@ -86,44 +101,44 @@ Aurral tracks each playlist it manages by Plex's own internal ID, not by name. I
 
 A flow or shared playlist adopted from a Discover preset carries that preset's description into Plex, written to the playlist's summary field. A flow created manually has no description, and nothing is written for it.
 
-Adopting a Discover preset — including an editorial/genre preset like "80s Anthems" — creates a record attributed to you. Someone else in your household who wants the same preset adopts it themselves from Discover, creating their own separate copy. If you're not the admin and haven't linked your own Plex account, nothing is created in Plex for that adoption until you link (see below).
+Adopting a Discover preset - including an editorial/genre preset like "80s Anthems" - creates a record attributed to you. Someone else in your household who wants the same preset adopts it themselves from Discover, creating their own separate copy. If you are not the admin and have not linked your own Plex account, nothing is created in Plex for that adoption until you link (see below).
 
 ## Per-user Plex accounts
 
-The admin's own flows and shared playlists write into the single Plex account connected above. Each other Aurral user links their own Plex identity so their flows land in their own Plex account instead — the admin's account only ever contains what the admin themselves adopted.
+The admin's own flows and shared playlists write into the single Plex account connected above. Each other Aurral user links their own Plex identity so their flows land in their own Plex account instead - the admin's account only ever contains what the admin themselves adopted.
 
 Linking is required for a non-admin user's content to sync to Plex: until they link, their flows and playlists work normally in Aurral (downloads, Navidrome, etc.), but nothing is created for them in Plex. Once they link, the next sync creates it there automatically.
 
 There are two ways to link, depending on how that person accesses your Plex server:
 
-### Managed (Plex Home) users — admin sets this up
+### Managed (Plex Home) users - admin sets this up
 
-If your household uses Plex Home managed users (sub-accounts with no separate Plex.tv login), an admin links them from **Settings → Users**:
+If your household uses Plex Home managed users (sub-accounts with no separate Plex.tv login), an admin links them from **Settings > Users**:
 
 1. Open the user's **Manage** dialog.
 2. Under **Plex Account**, click **Link managed Plex user**.
 3. Pick the matching Plex Home user from the list (populated from the admin's own Plex connection above) and click **Link**.
 
-Only an admin can do this — only the admin's own Plex connection can see and authorize Plex Home members.
+Only an admin can do this - only the admin's own Plex connection can see and authorize Plex Home members.
 
-### Invited/friend accounts — anyone can self-link
+### Invited/friend accounts - anyone can self-link
 
-If someone was invited as a friend to your Plex server (they sign in with their own Plex.tv email/login), they can link their own account from **Profile → Plex Account**:
+If someone was invited as a friend to your Plex server (they sign in with their own Plex.tv email/login), they can link their own account from **Profile > Plex Account**:
 
 1. Click **Connect Plex account**.
 2. Approve the PIN in the Plex popup, the same flow as the admin connection above.
 
-This can only ever link the signed-in Aurral user's own Plex account — nobody can link a Plex account into someone else's Aurral profile.
+This can only ever link the signed-in Aurral user's own Plex account - nobody can link a Plex account into someone else's Aurral profile.
 
 ### Effect of linking
 
-Once linked, that person's flow and shared playlists are created under their own Plex account. The shared **Aurral** library itself (creation, scanning, track indexing) stays on the single admin connection — only playlist ownership changes per user.
+Once linked, that person's flow and shared playlists are created under their own Plex account. The shared **Aurral** library itself (creation, scanning, track indexing) stays on the single admin connection - only playlist ownership changes per user.
 
 If a linked account's Plex token stops working, Aurral tries once to silently reconnect a managed user using the admin's current connection; a self-linked friend account has to reconnect manually from their Profile page. Only that person's Plex playlist stops updating until reconnected.
 
 ### Unlinking and switching accounts
 
-Unlinking a user removes the Plex playlists Aurral created under their linked account. Switching a user from one Plex identity to another (managed to self-linked, or to a different account of either type) does the same for the identity being replaced. Re-authorizing the *same* account — for example, an admin re-picking the same Home user to repair a broken link — does not trigger this.
+Unlinking a user removes the Plex playlists Aurral created under their linked account. Switching a user from one Plex identity to another (managed to self-linked, or to a different account of either type) does the same for the identity being replaced. Re-authorizing the *same* account - for example, an admin re-picking the same Home user to repair a broken link - does not trigger this.
 
 Deleting a flow or shared playlist from Aurral entirely also removes every Plex playlist it created for it.
 
@@ -140,13 +155,13 @@ services:
 
   plex:
     volumes:
-      - /srv/media:/data
+      - /srv/media:/data:ro
 ```
 
-Set the Downloads Folder path in the UI (for example, `/data/downloads/aurral`). You do not have to add the folder in Plex.
+Set the Downloads Folder path in Aurral (for example, `/data/downloads/aurral`). You do not have to add the folder manually in Plex.
 
 Aurral creates the **Aurral** library through the API.
 
 If Aurral uses remote path mappings for Lidarr reuse on Windows, that affects how Aurral reads files internally. It does not replace **Plex Aurral Library path**.
 
-See [Match Lidarr](/getting-started/storage/) and [Troubleshooting: Plex](/admin/troubleshooting/#plex-playlists-are-empty-or-tracks-are-missing).
+See [Filesystem and mounts](/getting-started/storage/) and [Troubleshooting: Plex](/admin/troubleshooting/#plex-playlists-are-empty-or-tracks-are-missing).

--- a/docs/src/content/docs/integrations/slskd.mdx
+++ b/docs/src/content/docs/integrations/slskd.mdx
@@ -9,10 +9,10 @@ slskd downloads flow and playlist tracks from Soulseek. Aurral can also use [Use
 
 ## Setup
 
-1. If Lidarr uses slskd on a shared `/data` mount, give Aurral that same mount ([Match Lidarr](/getting-started/storage/)).
+1. Mount the same media root in Aurral and slskd at the same container path. See [Filesystem and mounts](/getting-started/storage/).
 2. Connect slskd in **Settings > Download Clients > slskd**.
 
-Aurral moves completed files from slskd into your Downloads Folder path.
+Aurral uses the slskd API and reads the completed files from the path slskd reports. It then moves those files into your Downloads Folder path.
 
 If slskd runs on Windows and reports host paths, mount the parent folder into Aurral. For example, slskd can report `N:\...`.
 

--- a/docs/src/content/docs/integrations/usenet.mdx
+++ b/docs/src/content/docs/integrations/usenet.mdx
@@ -16,7 +16,7 @@ Enable and connect both components:
 
 1. Run Prowlarr with at least one Usenet audio indexer configured.
 2. Run SABnzbd or NZBGet with a category Aurral can use (default `aurral`).
-3. Match Lidarr's media mount so Aurral can read completed files ([Match Lidarr](/getting-started/storage/)).
+3. Mount the same media root in Aurral and SABnzbd or NZBGet at the same container path so Aurral can read completed files ([Filesystem and mounts](/getting-started/storage/)).
 4. Open **Settings > Indexers**.
 5. Enable **Prowlarr**.
 6. Enter the Prowlarr URL and API key.

--- a/docs/src/content/docs/using/flows.mdx
+++ b/docs/src/content/docs/using/flows.mdx
@@ -63,15 +63,15 @@ Focus is a dedicated fourth source. It does not change Discover, Library, or Tre
 
 - **Genre tags** tell Focus which genres to target.
 - **Related artists** tell Focus which similarity seeds to target.
-- **Release year(s)** limits Focus picks to a from–to year range. Leave blank for no year limit.
+- **Release year(s)** limits Focus picks to a from-to year range. Leave blank for no year limit.
 - If you enable Focus, add at least one genre tag or related artist.
 - If you disable Focus, Aurral saves your tags, artists, and year range but does not use them.
 
 Year range examples:
 
-- `1980`–`1989` for a decade
-- `2020`–blank for that year and later
-- blank–`2000` for that year and earlier
+- `1980`-`1989` for a decade
+- `2020`-blank for that year and later
+- blank-`2000` for that year and earlier
 
 Aurral resolves release years from metadata when needed. Focus tracks without a known year are skipped while a year range is set. Discover, Library, and Trending ignore the year range.
 

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -191,7 +191,7 @@ Aurral prefers static playlists and Lidarr files. Multiple playlists can use one
 
 Before Aurral removes a playlist, it moves the other file references. Navidrome does not show duplicate files.
 
-Lidarr-aware reuse requires Aurral to read the files at the paths Lidarr reports. Match Lidarr's media mount (for example `/data:/data` with root `/data/music`). See [Match Lidarr](/getting-started/storage/).
+Lidarr-aware reuse requires Aurral to read the files at the paths Lidarr reports. Mount the same media root at the same container path (for example `/data:/data` with root `/data/music`). See [Filesystem and mounts](/getting-started/storage/).
 
 If Lidarr runs on Windows and Aurral runs in Docker, run **Test library access** in **Settings > Lidarr**.
 
@@ -199,4 +199,4 @@ Use the reported path to add a mapping under **Settings > Download Clients > Rem
 
 If Navidrome uses a different path for reused Lidarr files, enable **Use Navidrome paths in M3U files**.
 
-Add a Navidrome path mapping so `.m3u` files use paths that Navidrome can open. See [Navidrome](/integrations/navidrome/#mixed-windows-and-docker-navidrome).
+Add a Navidrome path mapping so `.m3u` files use paths that Navidrome can open. See [Navidrome](/integrations/navidrome/#different-navidrome-paths).

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -46,7 +46,7 @@ See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/) for pl
 
 See [yt-dlp](/integrations/ytdlp/), [slskd](/integrations/slskd/), and [Usenet](/integrations/usenet/) for download setup.
 
-See [Match Lidarr](/getting-started/storage/) for storage setup.
+See [Filesystem and mounts](/getting-started/storage/) for storage setup.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Clarify shared filesystem requirements, Docker mounts, path mappings, storage checks, and playback integration setup across the documentation and example Compose configuration.

## Linked issues

Not linked.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): documentation, Docker/storage setup, integrations
- Automated coverage: Not applicable; documentation and example configuration changes only.
- Manual steps and expected result: Review the updated Docker, storage, first-run, integration, and troubleshooting guides for consistent `/data` mount instructions and path-mapping guidance.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for configuring shared filesystem mounts across Aurral, Lidarr, download clients, Navidrome, Plex, and Docker.
  * Clarified host-versus-container paths, `/data` and `/config` mounts, path mappings, permissions, storage checks, and troubleshooting.
  * Expanded setup instructions for first-run configuration, downloads, playback services, library access, and Plex accounts.
  * Updated Docker examples to support a configurable media root, defaulting to `/srv/media`.
  * Refined navigation, terminology, links, and year-range examples throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->