### PR TITLE
fix(container): preserve supplementary group in ci

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,15 +110,24 @@ jobs:
             --build-arg "APP_VERSION=ci-${GITHUB_SHA}" \
             --tag "$IMAGE" \
             .
-          docker run --detach --name "$CONTAINER" "$IMAGE"
+          docker run --detach --name "$CONTAINER" --env PUID=3007 --env PGID=3001 "$IMAGE"
 
+          ready=0
           for i in {1..30}; do
             if docker exec "$CONTAINER" node -e \
               'fetch("http://127.0.0.1:3001/api/health").then((response) => { if (!response.ok) process.exit(1); })'; then
-              exit 0
+              ready=1
+              break
             fi
             sleep 2
           done
 
+          if [ "$ready" -ne 1 ]; then
+            docker logs "$CONTAINER"
+            exit 1
+          fi
+
+          docker exec "$CONTAINER" node --input-type=module -e \
+            'import fs from "node:fs/promises"; const status = await fs.readFile("/proc/1/status", "utf8"); const groups = status.match(/^Groups:\s*(.*)$/m)?.[1].trim().split(/\s+/).filter(Boolean) || []; if (!groups.includes("3001")) { console.error(status); process.exit(1); }'
+
           docker logs "$CONTAINER"
-          exit 1

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -104,7 +104,7 @@ if [ "$(id -u)" = "0" ]; then
     mkdir -p "$AURRAL_DATA_DIR"
     chown -R "$target_uid:$target_gid" /config /app/backend/data "$AURRAL_DATA_DIR"
 
-    exec gosu "$target_uid:$target_gid" env AURRAL_DATA_DIR="$AURRAL_DATA_DIR" "$@"
+    exec setpriv --reuid "$target_uid" --regid "$target_gid" --groups "$target_gid" env AURRAL_DATA_DIR="$AURRAL_DATA_DIR" "$@"
 fi
 
 if [ -z "${AURRAL_DATA_DIR:-}" ]; then


### PR DESCRIPTION
## Summary

Updated the container entrypoint to preserve the configured supplementary group when switching from root, and added CI coverage for non-root group membership and startup failures. Simplified the filesystem and mounts documentation to emphasize shared container paths.

## Linked issues

Not specified.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Docker/container runtime, CI, documentation
- Automated coverage: CI builds and starts the image with `PUID=3007` and `PGID=3001`, verifies health, and checks that PID 1 retains supplementary group `3001`.
- Manual steps and expected result: Run the container with configured non-root UID/GID and verify it starts successfully with access to mounted files through the configured group.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup reliability by applying the configured user and group permissions consistently.
  * Enhanced production readiness checks to detect unsuccessful health checks and verify the container’s process group.
  * Added clearer failure logging when the container does not become ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->