### PR TITLE
fix(artists): preserve canonical IDs for Lidarr artists

### DIFF
--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -2,13 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
+import { dbOps } from "../../backend/db/helpers/index.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
 
 const artist = {
   id: 1,
   name: "Library Artist",
   foreignArtistId: "artist-mbid",
 };
+const providerArtist = {
+  id: 2,
+  artistName: "Library Artist",
+  foreignArtistId: "1182@deezer",
+};
+const canonicalMbid = "c2f6e8d3-2e6d-4d0a-ae60-4f8c5b2d7a91";
 
 const buildAlbum = ({ id, title, releaseDate }) => ({
   id,
@@ -85,5 +93,37 @@ test("recent missing releases keep upcoming albums by default for the Discover r
     );
   } finally {
     lidarrClient.isConfigured = originalIsConfigured;
+  }
+});
+
+test("recent missing releases backfill direct Lidarr artists before mapping", async (t) => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  lidarrClient.isConfigured = () => true;
+  t.mock.method(libraryManager, "backfillLidarrArtistMappings", async (artists) => {
+    assert.equal(artists[0], providerArtist);
+    dbOps.setLidarrArtistIdMap(canonicalMbid, providerArtist.foreignArtistId);
+  });
+
+  try {
+    const releases = await getRecentMissingReleases(10, {
+      artists: [providerArtist],
+      albums: [
+        {
+          ...buildAlbum({
+            id: 3,
+            title: "Backfilled Album",
+            releaseDate: "2026-06-11",
+          }),
+          artistId: providerArtist.id,
+        },
+      ],
+      now: "2026-06-15T12:00:00Z",
+    });
+
+    assert.equal(releases[0].artistMbid, canonicalMbid);
+    assert.equal(releases[0].foreignArtistId, providerArtist.foreignArtistId);
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    dbOps.deleteLidarrArtistIdMap(canonicalMbid);
   }
 });

--- a/.tests/library/artist-identities.test.js
+++ b/.tests/library/artist-identities.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { dbOps } from "../../backend/db/helpers/index.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
+
+const canonicalMbid = "b1f5d7e2-1d5c-4c9f-9d5f-3e7b4c1a2f68";
+const providerArtistId = "1182@deezer";
+
+test.after(() => {
+  dbOps.deleteLidarrArtistIdMap(canonicalMbid);
+});
+
+test("mapped Lidarr artists expose canonical and provider IDs separately", () => {
+  dbOps.setLidarrArtistIdMap(canonicalMbid, providerArtistId);
+
+  const artist = libraryManager.mapLidarrArtist({
+    id: 42,
+    foreignArtistId: providerArtistId,
+    artistName: "Arctic Monkeys",
+  });
+
+  assert.equal(artist.mbid, canonicalMbid);
+  assert.equal(artist.foreignArtistId, providerArtistId);
+});
+
+test("unmapped provider IDs are not exposed as canonical MBIDs", () => {
+  const artist = libraryManager.mapLidarrArtist({
+    id: 43,
+    foreignArtistId: "999999@deezer",
+    artistName: "Unmapped Artist",
+  });
+
+  assert.equal(artist.mbid, null);
+  assert.equal(artist.foreignArtistId, "999999@deezer");
+});

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -166,8 +166,7 @@ export function registerDetails(router) {
       }
 
       if (lidarrArtist) {
-        const artistMbid =
-          override?.musicbrainzId || lidarrArtist.foreignArtistId || mbid;
+        const artistMbid = override?.musicbrainzId || mbid;
         const metadataArtist = coreOnly
           ? null
           : await getArtistByMbid(artistMbid).catch(() => null);

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -59,6 +59,7 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
 
   const artistsById = new Map();
   if (Array.isArray(artists)) {
+    await libraryManager.backfillLidarrArtistMappings(artists);
     artists.forEach((artist) => {
       if (artist?.id != null) {
         const mappedArtist = libraryManager.mapLidarrArtist(artist);

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -61,8 +61,10 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
   if (Array.isArray(artists)) {
     artists.forEach((artist) => {
       if (artist?.id != null) {
-        artistsById.set(artist.id, artist);
-        artistsById.set(String(artist.id), artist);
+        const mappedArtist = libraryManager.mapLidarrArtist(artist);
+        mappedArtist.artistName = mappedArtist.artistName || artist.name || null;
+        artistsById.set(artist.id, mappedArtist);
+        artistsById.set(String(artist.id), mappedArtist);
       }
     });
   }
@@ -91,8 +93,8 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
       return {
         ...mapped,
         artistName: mapped.artistName || artist.artistName || artist.name || null,
-        artistMbid: artist.foreignArtistId || artist.mbid || null,
-        foreignArtistId: artist.foreignArtistId || artist.mbid || null,
+        artistMbid: artist.mbid || null,
+        foreignArtistId: artist.foreignArtistId || null,
       };
     })
     .filter(Boolean)

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1,4 +1,5 @@
 import path from "path";
+import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
 const normalizeTypeName = (value) =>
@@ -18,7 +19,10 @@ const getTypeName = (item) => {
 import {
   musicbrainzRequest,
   musicbrainzGetArtistReleaseGroups,
+  musicbrainzGetArtistIdentityByMbid,
+  musicbrainzResolveArtistMbidByName,
 } from "./apiClients/index.js";
+import { mapWithConcurrency } from "./discovery/helpers.js";
 import { logger } from "./logger.js";
 import { runMonitoringRepairSequence } from "./libraryMonitoringRepair.js";
 const LIDARR_RETRY_MS = 60000;
@@ -36,6 +40,7 @@ const _tracksCache = new Map();
 let _playbackQueueCache = null;
 const _artistMonitoringRepairs = new Map();
 const _albumAddInflight = new Map();
+const _artistMappingInflight = new Map();
 const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
   "Album already exists in Lidarr under a different artist";
 
@@ -739,6 +744,7 @@ export class LibraryManager {
     }
     try {
       const lidarrArtist = await lidarr.getArtist(id);
+      await this.backfillLidarrArtistMappings([lidarrArtist]);
       return this.mapLidarrArtist(lidarrArtist);
     } catch (error) {
       return null;
@@ -831,6 +837,7 @@ export class LibraryManager {
         if (!Array.isArray(lidarrArtists)) {
           return _cachedArtists;
         }
+        await this.backfillLidarrArtistMappings(lidarrArtists);
         _cachedArtists = lidarrArtists.map((a) => this.mapLidarrArtist(a));
         import("../../services/unifiedSearchService.js").then(({ clearSearchContextCache }) => clearSearchContextCache()).catch(() => {});
         return _cachedArtists;
@@ -883,6 +890,7 @@ export class LibraryManager {
           try {
             const lidarrArtists = await lidarr.request("/artist");
             if (Array.isArray(lidarrArtists)) {
+              await this.backfillLidarrArtistMappings(lidarrArtists);
               _cachedArtists = lidarrArtists.map((a) => this.mapLidarrArtist(a));
               _lastFullArtistFetchAt = Date.now();
             }
@@ -892,6 +900,7 @@ export class LibraryManager {
       }
       const picked = artistIds.sort(() => 0.5 - Math.random()).slice(0, normalizedLimit);
       const artists = await Promise.all(picked.map((id) => lidarr.getArtist(id).catch(() => null)));
+      await this.backfillLidarrArtistMappings(artists.filter(Boolean));
       const mapped = artists.filter(Boolean).map((artist) => this.mapLidarrArtist(artist));
       if (mapped.length >= normalizedLimit) return mapped;
       if (Array.isArray(_cachedArtists) && _cachedArtists.length > 0) {
@@ -915,15 +924,17 @@ export class LibraryManager {
   mapLidarrArtist(lidarrArtist) {
     const artistPath = lidarrArtist.path ?? null;
     const artistId = Number(lidarrArtist.id);
-    const mappedMbid = dbOps.getLidarrArtistMbid(lidarrArtist.foreignArtistId);
-    const foreignArtistId = mappedMbid || lidarrArtist.foreignArtistId;
+    const foreignArtistId = String(lidarrArtist.foreignArtistId || "").trim() || null;
+    const mappedMbid = dbOps.getLidarrArtistMbid(foreignArtistId);
+    const mbid =
+      mappedMbid || (foreignArtistId && UUID_REGEX.test(foreignArtistId) ? foreignArtistId : null);
     const normalizedArtistId =
       Number.isSafeInteger(artistId) && artistId > 0 ? String(artistId) : null;
     const monitorOption = lidarrArtist.monitor || lidarrArtist.addOptions?.monitor || "none";
     const normalizedMonitorOption = monitorOption || "none";
     return {
       id: normalizedArtistId,
-      mbid: foreignArtistId,
+      mbid,
       foreignArtistId,
       artistName: lidarrArtist.artistName,
       path: artistPath,
@@ -942,6 +953,70 @@ export class LibraryManager {
         sizeOnDisk: 0,
       },
     };
+  }
+
+  async resolveLidarrArtistMbid(lidarrArtist) {
+    const providerId = String(lidarrArtist?.foreignArtistId || "").trim();
+    const artistName = String(lidarrArtist?.artistName || "").trim();
+    if (!providerId || !artistName || UUID_REGEX.test(providerId)) return null;
+
+    const existingMbid = dbOps.getLidarrArtistMbid(providerId);
+    if (existingMbid) return existingMbid;
+
+    const mbid = await musicbrainzResolveArtistMbidByName(artistName);
+    if (!UUID_REGEX.test(String(mbid || ""))) return null;
+
+    const identity = await musicbrainzGetArtistIdentityByMbid(mbid);
+    const identityName = String(identity?.name || "").trim();
+    const providerIds = Array.isArray(identity?.providerIds) ? identity.providerIds : [];
+    const matchesProviderId = providerIds.some(
+      (value) => String(value || "").trim().toLowerCase() === providerId.toLowerCase(),
+    );
+    if (!identityName || identityName.toLowerCase() !== artistName.toLowerCase() || !matchesProviderId) {
+      return null;
+    }
+
+    try {
+      dbOps.setLidarrArtistIdMap(mbid, providerId);
+      return mbid;
+    } catch (error) {
+      if (error?.code !== "LIDARR_ARTIST_ID_CONFLICT") throw error;
+      return null;
+    }
+  }
+
+  async backfillLidarrArtistMappings(lidarrArtists) {
+    const candidates = [];
+    const seen = new Set();
+    for (const artist of Array.isArray(lidarrArtists) ? lidarrArtists : []) {
+      const providerId = String(artist?.foreignArtistId || "").trim();
+      if (
+        !providerId ||
+        UUID_REGEX.test(providerId) ||
+        seen.has(providerId) ||
+        dbOps.getLidarrArtistMbid(providerId)
+      ) {
+        continue;
+      }
+      seen.add(providerId);
+      candidates.push(artist);
+    }
+
+    await mapWithConcurrency(candidates, 2, (artist) => {
+      const providerId = String(artist?.foreignArtistId || "").trim();
+      let mappingRequest = _artistMappingInflight.get(providerId);
+      if (!mappingRequest) {
+        mappingRequest = this.resolveLidarrArtistMbid(artist)
+          .catch(() => null)
+          .finally(() => {
+            if (_artistMappingInflight.get(providerId) === mappingRequest) {
+              _artistMappingInflight.delete(providerId);
+            }
+          });
+        _artistMappingInflight.set(providerId, mappingRequest);
+      }
+      return mappingRequest;
+    });
   }
 
   async updateArtist(mbid, updates) {

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -25,7 +25,7 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 
 ## Metadata providers
 
-Aurral sends MusicBrainz artist IDs to Lidarr. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
+Aurral keeps the MusicBrainz UUID for artist routes and stores Lidarr's provider ID separately. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. Existing provider-ID artists are verified and backfilled when Aurral reads the library. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
 
 ## Library access check
 

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -384,7 +384,7 @@ function DiscoverPage() {
       }
     }
     for (const artist of recentlyAdded) {
-      const id = artist?.foreignArtistId || artist?.mbid || artist?.id;
+      const id = artist?.mbid;
       if (id) ids.add(id);
     }
     return [...ids];
@@ -483,7 +483,7 @@ function DiscoverPage() {
         <DiscoverRail key="recentlyAdded" title="Recently Added">
           <>
             {recentlyAdded.slice(0, DISCOVER_PREVIEW_ITEM_LIMIT).map((artist) => {
-              const artistId = artist.foreignArtistId || artist.mbid || artist.id;
+              const artistId = artist.mbid || null;
               return (
                 <div key={`artist-${artist.id}`} className="artist-discover-shelf-card">
                   <ArtistCard

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -17,7 +17,7 @@ const getArtistName = (artist) =>
   String(artist?.artistName || artist?.sortName || artist?.name || "").trim();
 
 const getArtistRouteId = (artist) =>
-  String(artist?.foreignArtistId || artist?.mbid || artist?.id || "").trim();
+  String(artist?.mbid || "").trim();
 
 const letterKeyFor = (artist) => {
   const letter = (getArtistName(artist)[0] || "#").toUpperCase();


### PR DESCRIPTION
## Summary

Keep MusicBrainz UUIDs separate from Lidarr provider artist IDs, backfill verified mappings, and use canonical IDs for artist routes and discovery. Add coverage for mapped and unmapped provider IDs.

## Linked issues

Not provided.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Lidarr integration, artist library, discovery, artist routes
- Automated coverage: Added artist identity tests covering mapped and unmapped Lidarr provider IDs
- Manual steps and expected result: Verify Lidarr artists retain canonical MusicBrainz routes while provider IDs remain available for Lidarr operations.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Lidarr artist identity handling by preserving MusicBrainz IDs separately from provider IDs.
  * Enhanced artist routes, library lookups, discovery results, and recent releases for more consistent navigation and display.
  * Automatically verifies and backfills missing artist identity mappings.

* **Documentation**
  * Updated Lidarr integration guidance to explain artist ID handling and mapping verification.

* **Tests**
  * Added coverage for mapped and unmapped Lidarr artist identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->