### PR TITLE
Route personal PR validation to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     uses: ./.github/workflows/validate.yml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,13 +3,16 @@ name: Validate
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: validate-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'lklynet' && 'aurral-personal' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## What changed

- Add the `aurral-personal` runner label to the repository runner.
- Route only PRs authored by `lklynet` to that label; all other validation and all non-PR workflows remain on `ubuntu-latest`.
- Set explicit read-only `contents` permissions for PR validation.
- Require workflow approval for all external contributors.

## Security review

Before approving an outside PR workflow, inspect every file under `.github/workflows/`. The runner is intentionally only used by the validation job and receives no repository secrets.

## Verification

- Proxmox runner is online and labeled `aurral-personal`.
- GitHub Actions approval policy is `all_external_contributors`.
- `git diff --check` passed.
- Existing required check name remains `validate / validate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks with read-only repository access permissions.
  * Adjusted validation runner selection for specific pull request authors while preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->