### PR TITLE
fix(lidarr): allow HTTP API requests

### DIFF
--- a/.tests/library/album-request-new-artist.test.js
+++ b/.tests/library/album-request-new-artist.test.js
@@ -117,7 +117,6 @@ async function withFakeLidarr(buildState, run) {
   lidarrClient.config = {
     url: `http://127.0.0.1:${port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -10,7 +10,6 @@ test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   client.config = {
     url: "http://localhost:8686",
     apiKey: "test",
-    allowHttp: true,
     circuitDisabled: false,
   };
   client._circuitOpen = true;
@@ -21,25 +20,6 @@ test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   const artists = await client.request("/artist", "GET", null, true);
   assert.equal(artists.length, 1);
   assert.equal(artists[0].artistName, "Test");
-});
-
-test("Lidarr refuses API-key requests over HTTP unless explicitly allowed", async (t) => {
-  const client = new LidarrClient();
-  t.after(() => {
-    client._httpAgent.destroy();
-    client._httpsAgent.destroy();
-    client._httpsInsecureAgent.destroy();
-  });
-  client._holdConfig = true;
-  client.config = {
-    url: "http://127.0.0.1:8686",
-    apiKey: "test",
-    allowHttp: false,
-    timeoutMs: 2000,
-    circuitDisabled: true,
-  };
-
-  await assert.rejects(client.request("/artist/lookup?term=Muse"), /require an HTTPS URL/);
 });
 
 test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
@@ -71,7 +51,6 @@ test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -112,7 +91,6 @@ test("getAlbumByMbid selects the matching album from filtered results", async (t
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -158,7 +136,6 @@ test("getAlbumByMbid accepts wrapped Lidarr album results", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -322,7 +299,6 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: true,
   };
@@ -654,7 +630,6 @@ test("Lidarr cooldown permits only one half-open recovery request", async (t) =>
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: false,
   };
@@ -701,7 +676,6 @@ test("a failed Lidarr recovery probe reopens the cooldown", async (t) => {
   client.config = {
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "test",
-    allowHttp: true,
     timeoutMs: 2000,
     circuitDisabled: false,
   };

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -321,16 +321,12 @@ export class LidarrClient {
     const circuitDisabled =
       process.env.LIDARR_CIRCUIT_DISABLED === "true" || process.env.LIDARR_CIRCUIT_DISABLED === "1";
 
-    const allowHttp =
-      process.env.LIDARR_ALLOW_HTTP === "true" || process.env.LIDARR_ALLOW_HTTP === "1";
-
     const newConfig = {
       url: url,
       apiKey: (dbConfig.apiKey || process.env.LIDARR_API_KEY || "").trim(),
       insecure: !!insecure,
       timeoutMs,
       circuitDisabled,
-      allowHttp,
     };
 
     const didConfigChange =
@@ -339,8 +335,7 @@ export class LidarrClient {
       previousConfig.apiKey !== newConfig.apiKey ||
       previousConfig.insecure !== newConfig.insecure ||
       previousConfig.timeoutMs !== newConfig.timeoutMs ||
-      previousConfig.circuitDisabled !== newConfig.circuitDisabled ||
-      previousConfig.allowHttp !== newConfig.allowHttp;
+      previousConfig.circuitDisabled !== newConfig.circuitDisabled;
 
     this.config = newConfig;
     if (didConfigChange) {
@@ -402,16 +397,6 @@ export class LidarrClient {
 
     if (!this.isConfigured(skipConfigUpdate)) {
       throw new Error("Lidarr API key not configured");
-    }
-
-    if (
-      this.config.apiKey &&
-      /^http:/i.test(this.config.url) &&
-      this.config.allowHttp !== true
-    ) {
-      throw new Error(
-        "Lidarr API key requests require an HTTPS URL. Set LIDARR_ALLOW_HTTP=true only for a trusted local network.",
-      );
     }
 
     const now = Date.now();

--- a/backend/services/lidarrTestSession.js
+++ b/backend/services/lidarrTestSession.js
@@ -39,7 +39,6 @@ export async function withTemporaryLidarrClient(url, apiKey, fn) {
     insecure: originalConfig.insecure,
     timeoutMs: originalConfig.timeoutMs,
     circuitDisabled: true,
-    allowHttp: originalConfig.allowHttp,
   };
   lidarrClient.apiPath = "/api/v1";
 

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -12,7 +12,6 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | `PUID` / `PGID` | Run the container as the user that owns mounted folders. |
 | `AURRAL_DATA_DIR` | Override app data directory. Default `/config`. |
 | `DOWNLOAD_FOLDER` | Initial Downloads Folder path. Prefer **Settings > Download Clients > Downloads Folder > Path**. Use an absolute path under your media mount. |
-| `LIDARR_ALLOW_HTTP` | Allow Aurral to send the Lidarr API key over HTTP. Default `false`. Use `true` only for a trusted local network. HTTPS is recommended. |
 
 ## Path mappings
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -18,7 +18,7 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 
 ![Aurral Lidarr integration settings](../../../assets/screenshots/settings-lidarr.webp)
 
-- The URL Aurral can reach (often `http://lidarr:8686` in Docker). When an API key is configured, use HTTPS. For a trusted local HTTP connection, set `LIDARR_ALLOW_HTTP=true` in the Aurral environment.
+- The URL Aurral can reach (often `http://lidarr:8686` in Docker). Aurral supports both HTTP and HTTPS. Use HTTPS when the connection leaves your trusted network.
 - Your Lidarr API key
 - Default quality profile, metadata profile, tag, monitoring option, and search-on-add behavior
 - Optional **Davo's Community Lidarr Guide** for quality profiles and file names


### PR DESCRIPTION
## Summary

Remove the HTTPS-only restriction for Lidarr API requests. Aurral now supports both HTTP and HTTPS connections, with documentation recommending HTTPS outside trusted networks.

## Linked issues

- None

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Lidarr integration, configuration, documentation
- Automated coverage: Updated Lidarr tests to use HTTP without the removed `LIDARR_ALLOW_HTTP` configuration.
- Manual steps and expected result: Configure Lidarr with an HTTP URL and API key; requests complete successfully, and documentation explains when HTTPS is recommended.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Lidarr connection guidance to support both HTTP and HTTPS.
  - Recommended HTTPS for connections outside trusted networks.
  - Removed instructions for the `LIDARR_ALLOW_HTTP` setting.
- **Bug Fixes**
  - Lidarr connections over HTTP are no longer blocked based on API-key usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->