### PR TITLE
fix(lidarr): accept MusicBrainz artist aliases

### DIFF
--- a/.tests/api-clients/musicbrainz-identity.test.js
+++ b/.tests/api-clients/musicbrainz-identity.test.js
@@ -39,3 +39,26 @@ test("MusicBrainz identity caches definitive missing artists", async (t) => {
   assert.equal(await musicbrainzGetArtistIdentityByMbid(mbid), null);
   assert.equal(attempts, 1);
 });
+
+test("MusicBrainz identity includes artist aliases", async (t) => {
+  const mbid = "alias-identity-test";
+  musicbrainzArtistIdentityCache.flushAll();
+  t.after(() => musicbrainzArtistIdentityCache.flushAll());
+  t.mock.method(axios, "get", async (_url, options) => {
+    assert.equal(options.params.inc, "url-rels+aliases");
+    return {
+      data: {
+        name: "FromSoftware",
+        aliases: [{ name: "From Software" }],
+        relations: [],
+      },
+    };
+  });
+
+  assert.deepEqual(await musicbrainzGetArtistIdentityByMbid(mbid), {
+    mbid,
+    name: "FromSoftware",
+    aliases: ["From Software"],
+    providerIds: [],
+  });
+});

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -440,6 +440,62 @@ test("artist add rejects a MusicBrainz ID and name mismatch", async (t) => {
   assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), null);
 });
 
+test("artist add accepts a MusicBrainz alias when resolving a provider ID", async (t) => {
+  const artistMbid = "c5c3e287-d2a7-497f-a212-e2cfb7bcb90c";
+  const providerArtistId = "181216727@deezer";
+  const client = new LidarrClient();
+  t.after(() => {
+    dbOps.deleteLidarrArtistIdMap(artistMbid);
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  client.resolveArtistAddConfiguration = async () => ({
+    resolved: {
+      rootFolderPath: "/music",
+      qualityProfileId: 1,
+    },
+  });
+  client.resolveCanonicalArtistIdentity = async () => ({
+    name: "FromSoftware",
+    aliases: ["From Software"],
+    providerIds: [providerArtistId],
+  });
+  client.request = async (endpoint, method = "GET", payload) => {
+    if (endpoint === "/artist" && method === "POST") {
+      if (payload.foreignArtistId === artistMbid) {
+        throw new Error(
+          `Lidarr API error: 500 - The input string '${artistMbid}' was not in a correct format.`,
+        );
+      }
+      return {
+        id: 42,
+        foreignArtistId: providerArtistId,
+        artistName: "FromSoftware",
+        monitored: true,
+      };
+    }
+    if (endpoint === "/artist" && method === "GET") {
+      return [{ id: 42, foreignArtistId: providerArtistId, artistName: "FromSoftware" }];
+    }
+    if (
+      endpoint === `/artist/lookup?term=${encodeURIComponent("FromSoftware")}` &&
+      method === "GET"
+    ) {
+      return [{ foreignArtistId: providerArtistId, artistName: "FromSoftware" }];
+    }
+    throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
+  };
+
+  const artist = await client.addArtist(artistMbid, "From Software", {
+    metadataProfileId: 1,
+  });
+
+  assert.equal(artist.id, 42);
+  assert.equal(dbOps.getLidarrArtistIdMap(artistMbid), providerArtistId);
+});
+
 test("artist add succeeds when a provider mapping conflict follows a successful POST", async (t) => {
   const artistMbid = "mapping-conflict-add-mbid";
   const existingMbid = "mapping-conflict-existing-mbid";

--- a/backend/services/apiClients/musicbrainz.js
+++ b/backend/services/apiClients/musicbrainz.js
@@ -328,7 +328,7 @@ export async function musicbrainzGetArtistIdentityByMbid(mbid, { signal } = {}) 
       const response = await axios.get(
         `${MUSICBRAINZ_API}/artist/${encodeURIComponent(normalizedMbid)}`,
         {
-          params: { fmt: "json", inc: "url-rels" },
+          params: { fmt: "json", inc: "url-rels+aliases" },
           headers: { "User-Agent": userAgent },
           timeout: 8000,
           signal,
@@ -339,9 +339,16 @@ export async function musicbrainzGetArtistIdentityByMbid(mbid, { signal } = {}) 
       ]
         .map((relation) => getMusicbrainzProviderId(relation?.url?.resource))
         .filter(Boolean);
+      const name = String(response.data?.name || "").trim() || null;
+      const aliases = Array.isArray(response.data?.aliases)
+        ? response.data.aliases
+            .map((alias) => String(alias?.name || "").trim())
+            .filter(Boolean)
+        : [];
       return {
         mbid: normalizedMbid,
-        name: String(response.data?.name || "").trim() || null,
+        name,
+        aliases: [...new Set(aliases)],
         providerIds: [...new Set(providerIds)],
       };
     });

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -968,11 +968,17 @@ export class LibraryManager {
 
     const identity = await musicbrainzGetArtistIdentityByMbid(mbid);
     const identityName = String(identity?.name || "").trim();
+    const normalizedArtistName = artistName.toLowerCase();
+    const acceptedArtistNames = new Set(
+      [identityName, ...(Array.isArray(identity?.aliases) ? identity.aliases : [])]
+        .map((name) => String(name || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
     const providerIds = Array.isArray(identity?.providerIds) ? identity.providerIds : [];
     const matchesProviderId = providerIds.some(
       (value) => String(value || "").trim().toLowerCase() === providerId.toLowerCase(),
     );
-    if (!identityName || identityName.toLowerCase() !== artistName.toLowerCase() || !matchesProviderId) {
+    if (!identityName || !acceptedArtistNames.has(normalizedArtistName) || !matchesProviderId) {
       return null;
     }
 

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -965,7 +965,12 @@ export class LidarrClient {
       const normalizedArtistName = String(artistName || "")
         .trim()
         .toLowerCase();
-      if (!canonicalName || normalizedArtistName !== canonicalName.toLowerCase()) {
+      const acceptedArtistNames = new Set(
+        [canonicalName, ...(Array.isArray(identity?.aliases) ? identity.aliases : [])]
+          .map((name) => String(name || "").trim().toLowerCase())
+          .filter(Boolean),
+      );
+      if (!canonicalName || !acceptedArtistNames.has(normalizedArtistName)) {
         const error = new Error(
           `MusicBrainz artist name for ${mbid} does not match the requested artist name`,
         );

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -25,7 +25,7 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 
 ## Metadata providers
 
-Aurral keeps the MusicBrainz UUID for artist routes and stores Lidarr's provider ID separately. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. Existing provider-ID artists are verified and backfilled when Aurral reads the library. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
+Aurral keeps the MusicBrainz UUID for artist routes and stores Lidarr's provider ID separately. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, accepts names recorded as MusicBrainz aliases, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. Existing provider-ID artists are verified and backfilled when Aurral reads the library. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
 
 ## Library access check
 


### PR DESCRIPTION
## Summary

Accept MusicBrainz artist aliases when validating and resolving Lidarr artists, with test coverage and updated integration documentation.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Lidarr integration, MusicBrainz API client
- Automated coverage: Added tests for MusicBrainz alias retrieval and Lidarr artist resolution using an alias
- Manual steps and expected result: Add or resolve a Lidarr artist using a MusicBrainz alias; the artist should resolve successfully

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MusicBrainz artist identities now include normalized aliases.
  - Lidarr artist matching accepts recognized MusicBrainz aliases while continuing to verify provider IDs.
- **Bug Fixes**
  - Improved artist creation and metadata-provider resolution for artists submitted under an alias.
- **Documentation**
  - Updated Lidarr integration guidance to explain alias support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->