### PR TITLE
feat: add configurable date and time formatting

### DIFF
--- a/.tests/frontend/date-time-format.test.js
+++ b/.tests/frontend/date-time-format.test.js
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  formatDate,
   formatDateTime,
+  formatTime,
   setDateTimeFormat,
 } from "../../frontend/src/utils/dateTime.js";
 import { dbOps } from "../../backend/db/helpers/index.js";
@@ -11,9 +13,15 @@ test("formats dates in the selected international order", () => {
 
   setDateTimeFormat("day-first");
   assert.equal(formatDateTime(date), "14:05 09/08/2026");
+  assert.equal(
+    formatDateTime(date, { month: "short", day: "numeric", hour: "numeric" }),
+    "14:05 09/08/2026",
+  );
+  assert.equal(formatTime(date, { hour: "numeric", minute: "2-digit" }), "14:05");
 
   setDateTimeFormat("year-first");
   assert.equal(formatDateTime(date), "2026/08/09 14:05");
+  assert.equal(formatDate(date, { month: "numeric", day: "numeric" }), "2026/08/09");
 
   setDateTimeFormat("browser");
 });

--- a/.tests/frontend/date-time-format.test.js
+++ b/.tests/frontend/date-time-format.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatDateTime,
+  setDateTimeFormat,
+} from "../../frontend/src/utils/dateTime.js";
+import { dbOps } from "../../backend/db/helpers/index.js";
+
+test("formats dates in the selected international order", () => {
+  const date = new Date(2026, 7, 9, 14, 5);
+
+  setDateTimeFormat("day-first");
+  assert.equal(formatDateTime(date), "14:05 09/08/2026");
+
+  setDateTimeFormat("year-first");
+  assert.equal(formatDateTime(date), "2026/08/09 14:05");
+
+  setDateTimeFormat("browser");
+});
+
+test("persists the application date and time format", () => {
+  dbOps.updateSettings({ dateTimeFormat: "year-first" });
+  assert.equal(dbOps.getSettings().dateTimeFormat, "year-first");
+});

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -16,9 +16,13 @@ export const APP_VERSION = resolveAppVersion({
   envValue: process.env.APP_VERSION,
   cwd: process.cwd(),
 });
+export const DATE_TIME_FORMATS = ["browser", "day-first", "year-first"];
+export const normalizeDateTimeFormat = (value) =>
+  DATE_TIME_FORMATS.includes(value) ? value : "browser";
 
 export const defaultData = {
   settings: {
+    dateTimeFormat: "browser",
     integrations: {
       navidrome: {
         url: "",

--- a/backend/db/helpers/settings.js
+++ b/backend/db/helpers/settings.js
@@ -16,6 +16,7 @@ import {
   syncM3uPathMode,
 } from "../../services/playlistM3uPaths.js";
 import { normalizeExistingFileMode } from "../../services/weeklyFlow/weeklyFlowFileReuse.js";
+import { normalizeDateTimeFormat } from "../../config/constants.js";
 
 const getSettingStmt = db.prepare("SELECT value FROM settings WHERE key = ?");
 const upsertSettingStmt = db.prepare(
@@ -113,6 +114,7 @@ export const dbOps = {
     );
     const encKey = getOrCreateEncryptionKey();
     const quality = getSettingStmt.get("quality")?.value;
+    const dateTimeFormat = getSettingStmt.get("dateTimeFormat")?.value;
     const queueCleaner = dbHelpers.parseJSON(
       getSettingStmt.get("queueCleaner")?.value
     );
@@ -150,6 +152,7 @@ export const dbOps = {
     const result = {
       integrations: decryptIntegrations(integrations, encKey) || {},
       quality: quality || "standard",
+      dateTimeFormat: normalizeDateTimeFormat(dateTimeFormat),
       queueCleaner: queueCleaner || {},
       security:
         security && typeof security === "object"
@@ -231,6 +234,12 @@ export const dbOps = {
       }
       if (settings.quality) {
         upsertSettingStmt.run("quality", settings.quality);
+      }
+      if (settings.dateTimeFormat !== undefined) {
+        upsertSettingStmt.run(
+          "dateTimeFormat",
+          normalizeDateTimeFormat(settings.dateTimeFormat),
+        );
       }
       if (settings.queueCleaner) {
         upsertSettingStmt.run(

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -253,6 +253,7 @@ function buildBootstrapPayload(req) {
     oidcEnabled: oidcInfo.oidcEnabled,
     oidcLogoutUrl: oidcInfo.oidcLogoutUrl,
     onboardingRequired: !onboardingDone,
+    dateTimeFormat: settings.dateTimeFormat,
     timestamp: new Date().toISOString(),
     appVersion: APP_VERSION,
   };

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -1,5 +1,6 @@
 import { dbOps } from "../../../db/helpers/index.js";
 import {
+  DATE_TIME_FORMATS,
   DEFAULT_METADATA_BASE_URL,
   defaultData,
 } from "../../../config/constants.js";
@@ -101,7 +102,12 @@ export function registerGeneral(router) {
         security,
         playlistArtwork,
         inbox,
+        dateTimeFormat,
       } = req.body;
+
+      if (dateTimeFormat !== undefined && !DATE_TIME_FORMATS.includes(dateTimeFormat)) {
+        return res.status(400).json({ error: "Invalid date and time format" });
+      }
 
       const currentSettings = dbOps.getSettings();
       const localBypassWasEnabled =
@@ -327,6 +333,10 @@ export function registerGeneral(router) {
       }
       const updatedSettings = {
         ...currentSettings,
+        dateTimeFormat:
+          dateTimeFormat !== undefined
+            ? dateTimeFormat
+            : currentSettings.dateTimeFormat || defaultData.settings.dateTimeFormat,
         quality:
           quality !== undefined ? quality : currentSettings.quality || "standard",
         rootFolderPath:

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -69,7 +69,7 @@ Settings contains the admin configuration. The page has these tabs:
 
 | Tab                  | What it covers                                                      |
 | -------------------- | ------------------------------------------------------------------- |
-| **System**           | Downloads folder, path mappings, general settings, cover art        |
+| **System**           | Runtime details, date and time format, and API access                |
 | **Tasks**            | Active and stale worker task management                             |
 | **Lidarr**           | Lidarr connection, profiles, tags, library access check             |
 | **Indexers**         | Prowlarr connection, indexer management, search priorities          |
@@ -81,5 +81,8 @@ Settings contains the admin configuration. The page has these tabs:
 
 Settings and Profile changes save automatically after you edit them. Connection tests and sync
 actions remain separate actions.
+
+Administrators can set dates and times to the browser default, day-first format, or year-first
+format under **Settings > System > Display**. The selected format applies to all users.
 
 Advanced metadata settings are available at `/settings/metadata`. They do not appear in the main settings navigation.

--- a/frontend/src/components/DiscoveryStatusPill.jsx
+++ b/frontend/src/components/DiscoveryStatusPill.jsx
@@ -1,4 +1,5 @@
 import { Loader, Clock } from "lucide-react";
+import { formatDate } from "../utils/dateTime.js";
 
 export default function DiscoveryStatusPill({
   isUpdating = false,
@@ -29,7 +30,7 @@ export default function DiscoveryStatusPill({
     return (
       <span className="artist-discover-hero__updated">
         <Clock className="artist-discover-hero__updated-icon" />
-        Updated {new Date(lastUpdated).toLocaleDateString()}
+        Updated {formatDate(new Date(lastUpdated))}
       </span>
     );
   }

--- a/frontend/src/components/ShowCard.jsx
+++ b/frontend/src/components/ShowCard.jsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { Clock, MapPin, Music } from "lucide-react";
+import { formatDate, formatTime } from "../utils/dateTime.js";
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
@@ -21,7 +22,7 @@ const formatShowTime = (value) => {
   if (!match) return value;
   const [, hour, minute] = match;
   const parsed = new Date(2000, 0, 1, Number(hour), Number(minute));
-  return parsed.toLocaleTimeString(undefined, {
+  return formatTime(parsed, {
     hour: "numeric",
     minute: "2-digit",
   });
@@ -31,7 +32,7 @@ const formatShowDate = (show) => {
   if (!show?.date && !show?.dateTime) return null;
   const parsed = parseShowDate(show.date) || parseShowDate(show.dateTime);
   if (!parsed) return show.date || null;
-  const dateLabel = parsed.toLocaleDateString(undefined, {
+  const dateLabel = formatDate(parsed, {
     month: "short",
     day: "numeric",
     year: "numeric",

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -11,6 +11,7 @@ import {
   loginApi,
   logoutApi,
 } from "../utils/api/endpoints/auth.js";
+import { setDateTimeFormat } from "../utils/dateTime.js";
 
 const AuthContext = createContext(null);
 
@@ -24,6 +25,7 @@ export const AuthProvider = ({ children }) => {
   const [bootstrap, setBootstrap] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authResolvedRef = useRef(false);
+  setDateTimeFormat(bootstrap?.dateTimeFormat);
 
   const checkAuthStatus = useCallback(async () => {
     try {

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -25,12 +25,12 @@ export const AuthProvider = ({ children }) => {
   const [bootstrap, setBootstrap] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authResolvedRef = useRef(false);
-  setDateTimeFormat(bootstrap?.dateTimeFormat);
 
   const checkAuthStatus = useCallback(async () => {
     try {
       const bootstrap = await getBootstrapStatus();
       authResolvedRef.current = true;
+      setDateTimeFormat(bootstrap.dateTimeFormat);
       setBootstrap(bootstrap);
       if (bootstrap.token) setStoredAuth({ token: bootstrap.token });
       const isOnboarding = !!bootstrap.onboardingRequired;
@@ -115,7 +115,9 @@ export const AuthProvider = ({ children }) => {
       setUser(result.user || null);
       setIsAuthenticated(true);
       try {
-        setBootstrap(await getBootstrapStatus());
+        const bootstrap = await getBootstrapStatus();
+        setDateTimeFormat(bootstrap.dateTimeFormat);
+        setBootstrap(bootstrap);
       } catch {}
       return true;
     } catch {

--- a/frontend/src/pages/ArtistDetails/utils.js
+++ b/frontend/src/pages/ArtistDetails/utils.js
@@ -3,6 +3,7 @@ import {
 } from "./constants";
 import { TAG_COLORS } from "../discoverUtils";
 import { shouldTriggerAlbumSearch } from "../../utils/albumAddAction.js";
+import { formatDate } from "../../utils/dateTime.js";
 
 export const readReleaseListViewMode = () => {
   if (typeof window === "undefined") return "grid";
@@ -196,7 +197,7 @@ export const formatReleaseDate = (releaseGroupOrAlbum) => {
     const [, year, month, day] = match;
     const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
     if (!Number.isNaN(date.getTime())) {
-      return date.toLocaleDateString(undefined, {
+      return formatDate(date, {
         year: "numeric",
         month: "short",
         day: "numeric",

--- a/frontend/src/pages/DiscoverCards.jsx
+++ b/frontend/src/pages/DiscoverCards.jsx
@@ -7,6 +7,7 @@ import AddActionButton from "../components/AddActionButton";
 import { ArtistContextMenu } from "../components/ArtistContextMenu";
 import SearchLibraryCheck from "../components/SearchLibraryCheck";
 import { getReleaseNavigationTarget } from "../utils/searchNavigation";
+import { formatDate } from "../utils/dateTime.js";
 const parseCalendarDate = (value) => {
   if (!value) return null;
   const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -24,7 +25,7 @@ const formatReleaseStatus = (releaseDate) => {
   if (!date) return null;
   const today = new Date();
   const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const formattedDate = date.toLocaleDateString();
+  const formattedDate = formatDate(date);
   if (date.getTime() === todayStart.getTime()) {
     return "Released today";
   }

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -35,6 +35,7 @@ import {
 } from "./discoverUtils";
 import { useDiscoverData } from "./useDiscoverData";
 import { useLibraryNews } from "../hooks/useLibraryNews";
+import { formatDate } from "../utils/dateTime.js";
 const getArtistId = (artist) => getArtistRecordId(artist);
 
 function DiscoverPage() {
@@ -508,9 +509,9 @@ function DiscoverPage() {
                       image: getLibraryArtistImage(artist),
                       type: "Artist",
                       metaText: "",
-                      subtitle: `Added ${new Date(
-                        artist.added || artist.addedAt,
-                      ).toLocaleDateString()}`,
+                      subtitle: `Added ${formatDate(
+                        new Date(artist.added || artist.addedAt),
+                      )}`,
                     }}
                   />
                 </div>

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -65,6 +65,8 @@ function SettingsPage() {
           <SettingsSystemTab
             key="settings-system"
             health={data.health}
+            settings={data.settings}
+            updateSettings={data.updateSettings}
             showSuccess={showSuccess}
             showError={showError}
           />

--- a/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
@@ -4,6 +4,7 @@ import { RefreshCw, Trash2, X } from "lucide-react";
 import PillToggle from "../../../components/PillToggle";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { SettingsArrFieldSet, SettingsArrFormGroup } from "./arr/SettingsArrLayout";
+import { formatDateTime } from "../../../utils/dateTime.js";
 
 const AUTO_REFRESH_OPTIONS = [
   { value: 24, label: "Daily" },
@@ -257,7 +258,7 @@ export function SettingsDiscoverTab({
               <dt className="arr-meta-term">Last updated</dt>
               <dd className="arr-meta-value">
                 {health?.discovery?.lastUpdated
-                  ? new Date(health.discovery.lastUpdated).toLocaleString()
+                  ? formatDateTime(new Date(health.discovery.lastUpdated))
                   : "—"}
               </dd>
             </div>

--- a/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import { AlertCircle, Check, Copy, RotateCcw } from "lucide-react";
 import { getApiKey, rotateApiKey } from "../../../utils/api/endpoints/auth";
 import { SettingsSystemSection } from "./SettingsStorageSection";
+import { SettingsSelect } from "./SettingsField";
+import { setDateTimeFormat } from "../../../utils/dateTime.js";
 
-export function SettingsSystemTab({ health, showSuccess, showError }) {
+export function SettingsSystemTab({ health, settings, updateSettings, showSuccess, showError }) {
   const [apiKey, setApiKey] = useState(null);
   const [loading, setLoading] = useState(true);
   const [rotating, setRotating] = useState(false);
@@ -55,6 +57,37 @@ export function SettingsSystemTab({ health, showSuccess, showError }) {
   return (
     <div className="arr-page settings-system">
       <SettingsSystemSection health={health} />
+
+      <section className="settings-system__section">
+        <div className="settings-system__section-header">
+          <h2 className="settings-system__section-title">Display</h2>
+        </div>
+        <div className="settings-system__rows">
+          <div className="settings-system__row">
+            <div className="settings-system__copy">
+              <label className="settings-system__label" htmlFor="date-time-format">
+                Date and time format
+              </label>
+              <p className="settings-system__description">
+                Set the date and 24-hour time order for all users.
+              </p>
+            </div>
+            <SettingsSelect
+              id="date-time-format"
+              value={settings.dateTimeFormat}
+              onChange={(event) => {
+                const dateTimeFormat = event.target.value;
+                setDateTimeFormat(dateTimeFormat);
+                updateSettings({ ...settings, dateTimeFormat });
+              }}
+            >
+              <option value="browser">Browser default</option>
+              <option value="day-first">14:30 09/08/2026</option>
+              <option value="year-first">2026/08/09 14:30</option>
+            </SettingsSelect>
+          </div>
+        </div>
+      </section>
 
       <section className="settings-system__section settings-system__api-section">
         <div className="settings-system__section-header">

--- a/frontend/src/pages/Settings/components/StorageHealthDashboard.jsx
+++ b/frontend/src/pages/Settings/components/StorageHealthDashboard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { formatDateTime } from "../../../utils/dateTime.js";
 
 const STATUS_LABELS = {
   pass: "PASS",
@@ -12,7 +13,7 @@ function formatCheckedAt(value) {
   if (!value) return null;
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString();
+  return formatDateTime(date);
 }
 
 function defaultExpandedBySection(sections) {

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -23,6 +23,7 @@ import {
 } from "../utils";
 
 const defaultSettings = {
+  dateTimeFormat: "browser",
   rootFolderPath: "",
   downloadFolderPath: "",
   pathMappings: [],

--- a/frontend/src/pages/Settings/settingsTabsConfig.js
+++ b/frontend/src/pages/Settings/settingsTabsConfig.js
@@ -32,7 +32,7 @@ export const SETTINGS_NAV_TABS = SETTINGS_TABS.filter((tab) => !tab.hidden);
 
 const SETTINGS_SEARCH_METADATA = {
   system: {
-    sections: ["Runtime", "Data", "API Key", "More Info"],
+    sections: ["Runtime", "Data", "Display", "API Key", "More Info"],
     services: {
       Runtime: "version uptime host platform",
       Database: "sqlite data runtime",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -1,4 +1,5 @@
 import { allReleaseTypes } from "./constants";
+import { normalizeDateTimeFormat } from "../../utils/dateTime.js";
 
 export const LEGACY_METADATA_BASE_URL = "https://brainzmash.kell.ly";
 export const DEFAULT_METADATA_BASE_URL = "https://lidarrapi.brainzmash.cc";
@@ -35,6 +36,7 @@ export const normalizeSettings = (savedSettings) => {
       : "photo";
   return {
     ...savedSettings,
+    dateTimeFormat: normalizeDateTimeFormat(savedSettings.dateTimeFormat),
     downloadFolderPath: String(savedSettings.downloadFolderPath || "").trim(),
     pathMappings: Array.isArray(savedSettings.pathMappings) ? savedSettings.pathMappings : [],
     playlistArtwork: {

--- a/frontend/src/pages/activity/activityListUtils.js
+++ b/frontend/src/pages/activity/activityListUtils.js
@@ -1,3 +1,5 @@
+import { formatDate, formatTime } from "../../utils/dateTime.js";
+
 const getRequestIdentity = (request) =>
   String(
     request?.id ||
@@ -60,7 +62,7 @@ export const mergeActivityRequests = (previousRequests, nextRequests) => {
 export const formatTimelineTime = (value) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleTimeString(undefined, {
+  return formatTime(date, {
     hour: "numeric",
     minute: "2-digit",
   });
@@ -109,7 +111,7 @@ const formatDateGroupLabel = (value) => {
   );
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
-  return date.toLocaleDateString(undefined, {
+  return formatDate(date, {
     weekday: "long",
     month: "long",
     day: "numeric",

--- a/frontend/src/pages/flows/flowPageUtils.js
+++ b/frontend/src/pages/flows/flowPageUtils.js
@@ -1,4 +1,5 @@
 import { parseFlowTimestamp } from "./flowStats";
+import { formatDate } from "../../utils/dateTime.js";
 
 export const DEFAULT_MIX = { discover: 34, mix: 33, trending: 33, focus: 0 };
 export const DEFAULT_SIZE = 30;
@@ -61,7 +62,7 @@ export function formatFlowLastRunShort(lastRunAt) {
   if (!Number.isFinite(timestamp) || timestamp <= 0) return null;
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return null;
-  return `${date.getMonth() + 1}/${date.getDate()}`;
+  return formatDate(date, { month: "numeric", day: "numeric" });
 }
 
 export const slugifyFilePart = (value, fallback = "flow") => {

--- a/frontend/src/pages/flows/flowStats.js
+++ b/frontend/src/pages/flows/flowStats.js
@@ -1,3 +1,5 @@
+import { formatDateTime } from "../../utils/dateTime.js";
+
 export const RELEASE_RADAR_PRESET_ID = "release-radar";
 
 export const isReleaseRadarFlow = (flow) =>
@@ -58,7 +60,7 @@ export const formatFlowLastRun = (lastRunAt) => {
   if (!Number.isFinite(timestamp) || timestamp <= 0) return null;
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString(undefined, {
+  return formatDateTime(date, {
     month: "short",
     day: "numeric",
     hour: "numeric",

--- a/frontend/src/utils/dateTime.js
+++ b/frontend/src/utils/dateTime.js
@@ -18,30 +18,34 @@ const getLocale = () => {
 const pad = (value) => String(value).padStart(2, "0");
 
 export const formatDate = (date, options) => {
-  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+  if (currentFormat === "browser" || Number.isNaN(date.getTime())) {
     return date.toLocaleDateString(getLocale(), options);
   }
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
+  const utc = options?.timeZone === "UTC";
+  const year = utc ? date.getUTCFullYear() : date.getFullYear();
+  const month = pad((utc ? date.getUTCMonth() : date.getMonth()) + 1);
+  const day = pad(utc ? date.getUTCDate() : date.getDate());
   return currentFormat === "day-first"
     ? `${day}/${month}/${year}`
     : `${year}/${month}/${day}`;
 };
 
 export const formatTime = (date, options) => {
-  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+  if (currentFormat === "browser" || Number.isNaN(date.getTime())) {
     return date.toLocaleTimeString(getLocale(), options);
   }
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  const utc = options?.timeZone === "UTC";
+  return `${pad(utc ? date.getUTCHours() : date.getHours())}:${pad(
+    utc ? date.getUTCMinutes() : date.getMinutes(),
+  )}`;
 };
 
 export const formatDateTime = (date, options) => {
-  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+  if (currentFormat === "browser" || Number.isNaN(date.getTime())) {
     return date.toLocaleString(getLocale(), options);
   }
-  const datePart = formatDate(date);
-  const timePart = formatTime(date);
+  const datePart = formatDate(date, options);
+  const timePart = formatTime(date, options);
   return currentFormat === "day-first"
     ? `${timePart} ${datePart}`
     : `${datePart} ${timePart}`;

--- a/frontend/src/utils/dateTime.js
+++ b/frontend/src/utils/dateTime.js
@@ -1,0 +1,48 @@
+export const DATE_TIME_FORMATS = ["browser", "day-first", "year-first"];
+
+let currentFormat = "browser";
+
+export const normalizeDateTimeFormat = (value) =>
+  DATE_TIME_FORMATS.includes(value) ? value : "browser";
+
+export const setDateTimeFormat = (value) => {
+  currentFormat = normalizeDateTimeFormat(value);
+};
+
+const getLocale = () => {
+  if (currentFormat === "day-first") return "en-GB";
+  if (currentFormat === "year-first") return "ja-JP";
+  return undefined;
+};
+
+const pad = (value) => String(value).padStart(2, "0");
+
+export const formatDate = (date, options) => {
+  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+    return date.toLocaleDateString(getLocale(), options);
+  }
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  return currentFormat === "day-first"
+    ? `${day}/${month}/${year}`
+    : `${year}/${month}/${day}`;
+};
+
+export const formatTime = (date, options) => {
+  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+    return date.toLocaleTimeString(getLocale(), options);
+  }
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+export const formatDateTime = (date, options) => {
+  if (options || currentFormat === "browser" || Number.isNaN(date.getTime())) {
+    return date.toLocaleString(getLocale(), options);
+  }
+  const datePart = formatDate(date);
+  const timePart = formatTime(date);
+  return currentFormat === "day-first"
+    ? `${timePart} ${datePart}`
+    : `${datePart} ${timePart}`;
+};


### PR DESCRIPTION
## Summary

- Add application-wide browser, day-first, and year-first date/time display options.
- Apply the selected format across discovery, shows, activity, artist details, flows, and system dashboards.
- Persist the setting and expose it through the bootstrap response for all users.
- Document the new Settings > System > Display control.

Closes #551

## Validation

- `node --test --import ./.tests/setup-env.js .tests/frontend/date-time-format.test.js`
- `npm run lint`
- `npm run build`
- `npm run docs:build`

The collaborative browser preview was unavailable, so automated validation replaced the visual click-through.

## Release impact

Minor, backward-compatible feature.