### PR TITLE
feat(theme): add configurable light and dark themes

### DIFF
--- a/.tests/frontend/theme.test.js
+++ b/.tests/frontend/theme.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  THEME_STORAGE_KEY,
+  getThemePreference,
+  normalizeThemePreference,
+  setThemePreference,
+} from "../../frontend/src/utils/theme.js";
+
+const originalDocument = globalThis.document;
+const originalLocalStorage = globalThis.localStorage;
+
+test.afterEach(() => {
+  globalThis.document = originalDocument;
+  globalThis.localStorage = originalLocalStorage;
+});
+
+test("theme preferences default invalid stored values to system", () => {
+  assert.equal(normalizeThemePreference("light"), "light");
+  assert.equal(normalizeThemePreference("dark"), "dark");
+  assert.equal(normalizeThemePreference("sepia"), "system");
+
+  globalThis.localStorage = { getItem: () => "sepia" };
+  assert.equal(getThemePreference(), "system");
+});
+
+test("theme preferences persist explicit themes and clear the system override", () => {
+  const attributes = new Map();
+  const stored = new Map();
+  globalThis.document = {
+    documentElement: {
+      removeAttribute: (name) => attributes.delete(name),
+      setAttribute: (name, value) => attributes.set(name, value),
+    },
+  };
+  globalThis.localStorage = {
+    getItem: (key) => stored.get(key) ?? null,
+    setItem: (key, value) => stored.set(key, value),
+  };
+
+  assert.equal(setThemePreference("light"), "light");
+  assert.equal(attributes.get("data-theme"), "light");
+  assert.equal(stored.get(THEME_STORAGE_KEY), "light");
+
+  assert.equal(setThemePreference("system"), "system");
+  assert.equal(attributes.has("data-theme"), false);
+  assert.equal(stored.get(THEME_STORAGE_KEY), "system");
+});

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -59,7 +59,11 @@ When you configure Ticketmaster, this section shows nearby concerts for specifie
 
 ![Aurral profile listening history](../../../assets/screenshots/profile-listening.webp)
 
-Profile contains listening history, Lidarr defaults, and personal preferences. Aurral supports Last.fm, ListenBrainz, and Koito history.
+Profile contains appearance, listening history, Lidarr defaults, and personal preferences. Select
+**System**, **Light**, or **Dark** under **Appearance**. System follows the appearance setting of
+your device. Aurral saves the theme on the current device.
+
+Aurral supports Last.fm, ListenBrainz, and Koito history.
 
 ### Settings
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,7 @@
     <meta name="description" content="Self-hosted music discovery for the Lidarr stack" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#030712" media="(prefers-color-scheme: dark)" />
+    <script src="%BASE_URL%theme.js"></script>
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/frontend/public/theme.js
+++ b/frontend/public/theme.js
@@ -1,0 +1,4 @@
+try {
+  const theme = localStorage.getItem("aurralTheme");
+  if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
+} catch {}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -309,12 +309,6 @@ function AppContent() {
 }
 
 function App() {
-  useEffect(() => {
-    const root = window.document.documentElement;
-    root.classList.remove("light");
-    root.classList.add("dark");
-  }, []);
-
   return (
     <ToastProvider>
         <AuthProvider>

--- a/frontend/src/components/SearchTopArtistCard.jsx
+++ b/frontend/src/components/SearchTopArtistCard.jsx
@@ -138,7 +138,7 @@ function SearchTopArtistCard({
         tabIndex={0}
         className={`search-top-artist__main${
           gradientColors ? " search-top-artist__main--gradient" : ""
-        }`}
+        }${gradientColors || backdropSrc ? " search-top-artist__main--overlay" : ""}`}
         style={
           gradientColors
             ? {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,14 +8,15 @@
 }
 
 :root {
+  color-scheme: dark;
   --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --aurral-chrome: #000000;
-  --aurral-surface: #121212;
-  --aurral-text-subtle: #535353;
-  --aurral-text-muted: #b3b3b3;
-  --aurral-text: #ffffff;
-  --aurral-accent: #84cc16;
-  --aurral-accent-contrast: #000000;
+  --aurral-chrome: light-dark(#e5e7eb, #000000);
+  --aurral-surface: light-dark(#ffffff, #121212);
+  --aurral-text-subtle: light-dark(#737373, #535353);
+  --aurral-text-muted: light-dark(#525252, #b3b3b3);
+  --aurral-text: light-dark(#171717, #ffffff);
+  --aurral-accent: light-dark(#4d7c0f, #84cc16);
+  --aurral-accent-contrast: light-dark(#ffffff, #000000);
   --aurral-surface-raised: color-mix(in srgb, var(--aurral-surface) 94%, var(--aurral-text));
   --aurral-surface-popover: color-mix(in srgb, var(--aurral-surface-raised) 94%, var(--aurral-text));
   --aurral-surface-glass: color-mix(in srgb, var(--aurral-surface-popover) 88%, transparent);
@@ -32,15 +33,15 @@
   --aurral-radius: 10px;
   --aurral-radius-sm: 6px;
   --aurral-radius-round: 9999px;
-  --aurral-control-on: #3b82f6;
-  --aurral-control-on-contrast: #07111f;
-  --aurral-info: #60a5fa;
-  --aurral-info-text: #93c5fd;
+  --aurral-control-on: light-dark(#2563eb, #3b82f6);
+  --aurral-control-on-contrast: light-dark(#ffffff, #07111f);
+  --aurral-info: light-dark(#2563eb, #60a5fa);
+  --aurral-info-text: light-dark(#1d4ed8, #93c5fd);
   --aurral-info-soft: color-mix(in srgb, var(--aurral-info) 16%, transparent);
-  --aurral-review: #a78bfa;
-  --aurral-success: #22c55e;
-  --aurral-danger: #ef4444;
-  --aurral-warning: #f59e0b;
+  --aurral-review: light-dark(#7c3aed, #a78bfa);
+  --aurral-success: light-dark(#15803d, #22c55e);
+  --aurral-danger: light-dark(#dc2626, #ef4444);
+  --aurral-warning: light-dark(#b45309, #f59e0b);
   --aurral-ring: color-mix(in srgb, var(--aurral-text) 46%, transparent);
   --aurral-scrim: color-mix(in srgb, var(--aurral-chrome) 72%, transparent);
   --aurral-border: color-mix(in srgb, var(--aurral-text) 8%, transparent);
@@ -56,6 +57,20 @@
   --aurral-space-stack: 0.75rem;
   --aurral-space-card: 0.875rem;
   --aurral-space-header: 0.875rem;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    color-scheme: light;
+  }
 }
 
 *,
@@ -2468,7 +2483,7 @@ textarea {
 
 .global-search__suggestion:hover .global-search__suggestion-meta,
 .global-search__suggestion.is-highlighted .global-search__suggestion-meta {
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--aurral-text-muted);
 }
 
 .global-search__suggestion-actions {
@@ -2846,6 +2861,10 @@ textarea {
   line-height: 0.96;
 }
 
+.artist-hero__content--overlay .artist-hero__title {
+  color: #fff;
+}
+
 .artist-meta-line {
   display: flex;
   flex-wrap: wrap;
@@ -2897,11 +2916,23 @@ textarea {
   backdrop-filter: blur(10px) saturate(1.05);
 }
 
+.artist-hero__content--overlay .artist-tag {
+  border-color: rgb(255 255 255 / 0.18);
+  background: rgb(0 0 0 / 0.58);
+  color: #fff;
+}
+
 .artist-tag:hover,
 .artist-tag--discover:hover {
   border-color: var(--aurral-border-strong);
   background: var(--aurral-surface-hover);
   color: var(--aurral-text);
+}
+
+.artist-hero__content--overlay .artist-tag:hover {
+  border-color: rgb(255 255 255 / 0.3);
+  background: rgb(0 0 0 / 0.72);
+  color: #fff;
 }
 
 .artist-action-bar {
@@ -3811,7 +3842,7 @@ textarea {
   justify-content: center;
   border-radius: var(--aurral-radius-round);
   background: gold;
-  color: var(--aurral-chrome);
+  color: #000;
   text-align: center;
 }
 
@@ -3834,6 +3865,10 @@ textarea {
   inset-inline: 0;
   bottom: 0;
   padding: 1.25rem;
+}
+
+.artist-about-card__body--overlay :is(.artist-about-meta, .artist-about-bio, .artist-modal__subcopy) {
+  color: #fff;
 }
 
 .artist-about-meta {
@@ -3991,7 +4026,7 @@ textarea {
   padding: 0.125rem 0.375rem;
   border-radius: var(--aurral-radius-sm);
   background: rgba(0, 0, 0, 0.7);
-  color: var(--aurral-text);
+  color: #fff;
   font-size: 0.625rem;
   font-weight: 700;
   transform: translate(-10%, 12%);
@@ -4579,7 +4614,7 @@ textarea {
 }
 
 .artist-playlist-menu--search-suggestion .artist-menu-item:disabled {
-  color: rgba(255, 255, 255, 0.52);
+  color: var(--aurral-text-subtle);
 }
 
 .artist-playlist-menu--search-suggestion .artist-playlist-menu__check {
@@ -4937,7 +4972,7 @@ textarea {
   display: flex;
   align-items: center;
   border-radius: var(--aurral-radius-round);
-  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
   padding: 0.25rem 0.5rem;
   color: var(--aurral-text-subtle);
   font-size: 0.75rem;
@@ -5399,7 +5434,7 @@ textarea {
 
 .artist-show-card__title--discover {
   margin-top: 0.25rem;
-  color: var(--aurral-text);
+  color: #fff;
   font-size: 1.65rem;
   font-weight: 700;
   line-height: 0.98;
@@ -5465,7 +5500,7 @@ textarea {
   padding: 0.25rem 0.625rem;
   border-radius: var(--aurral-radius-sm);
   background: rgba(20, 20, 26, 0.82);
-  color: var(--aurral-text);
+  color: #fff;
   font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -5484,7 +5519,7 @@ textarea {
 }
 
 .artist-show-card__body-artist--discover {
-  color: #8a8a8f;
+  color: var(--aurral-text-subtle);
   font-size: 0.75rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -5528,7 +5563,7 @@ textarea {
 }
 
 .artist-view-all-card--discover:hover .artist-media-cell {
-  border-color: rgba(255, 255, 255, 0.3);
+  border-color: var(--aurral-border-strong);
 }
 
 .artist-view-all-card--discover .artist-card-title {
@@ -6035,9 +6070,9 @@ textarea {
   align-items: center;
   gap: 0.25rem;
   border-radius: var(--aurral-radius-round);
-  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
   padding: 0.25rem 0.625rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--aurral-text-muted);
   font-size: 0.75rem;
   font-weight: 500;
   transition:
@@ -6047,8 +6082,8 @@ textarea {
 
 .artist-nearby-badge:hover,
 .artist-nearby-badge.is-open {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.85);
+  background: color-mix(in srgb, var(--aurral-text) 10%, transparent);
+  color: var(--aurral-text);
 }
 
 .artist-nearby-badge__chevron {
@@ -6677,6 +6712,23 @@ textarea {
     opacity 0.18s ease,
     transform 0.18s ease,
     background-color 0.18s ease;
+}
+
+.search-top-artist__main--overlay :is(
+    .search-top-artist__image-wrap,
+    .search-top-artist__name,
+    .search-top-artist__meta-row
+  ) {
+  color: #fff;
+}
+
+.search-top-artist__main--overlay .search-top-artist__eyebrow {
+  color: rgb(255 255 255 / 0.72);
+}
+
+.search-top-artist__main--overlay .search-top-artist__cta {
+  background: rgb(255 255 255 / 0.12);
+  color: #fff;
 }
 
 .search-top-artist__cta-icon {
@@ -7901,7 +7953,7 @@ textarea {
   color: var(--aurral-text-muted);
   font-size: 0.75rem;
   line-height: 1.45;
-  background: rgba(255, 255, 255, 0.04);
+  background: color-mix(in srgb, var(--aurral-text) 4%, transparent);
   border-radius: var(--aurral-radius-sm);
 }
 
@@ -8090,7 +8142,7 @@ textarea {
 .settings-modal__callout {
   margin: 0 0 0.25rem;
   padding: 0.625rem 0.75rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: color-mix(in srgb, var(--aurral-text) 4%, transparent);
   border-radius: var(--aurral-radius-sm);
   font-size: 0.8125rem;
   line-height: 1.45;
@@ -11656,9 +11708,9 @@ textarea {
   inset: 0;
   background: linear-gradient(
     110deg,
-    rgba(255, 255, 255, 0.02) 8%,
-    rgba(255, 255, 255, 0.08) 18%,
-    rgba(255, 255, 255, 0.02) 33%
+    color-mix(in srgb, var(--aurral-text) 2%, transparent) 8%,
+    color-mix(in srgb, var(--aurral-text) 8%, transparent) 18%,
+    color-mix(in srgb, var(--aurral-text) 2%, transparent) 33%
   );
   background-size: 200% 100%;
   animation: shimmer 1.6s linear infinite;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,7 +9,7 @@
 
 :root {
   color-scheme: dark;
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
   --aurral-chrome: light-dark(#e5e7eb, #000000);
   --aurral-surface: light-dark(#ffffff, #121212);
   --aurral-text-subtle: light-dark(#737373, #535353);

--- a/frontend/src/pages/ArtistDetails/ReleasePage.jsx
+++ b/frontend/src/pages/ArtistDetails/ReleasePage.jsx
@@ -528,7 +528,7 @@ function ReleasePage() {
       className="artist-details-page release-page"
       style={
         heroColor
-          ? { background: `linear-gradient(180deg, ${heroColor} 0%, ${heroColor} 120px, #121212 400px)` }
+          ? { background: `linear-gradient(180deg, ${heroColor} 0%, ${heroColor} 120px, var(--aurral-surface) 400px)` }
           : undefined
       }
     >

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsAbout.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsAbout.jsx
@@ -117,7 +117,7 @@ export function ArtistDetailsAbout({
             label: "Lidarr",
             href: lidarrHref,
             logo: toCurrentColorSvg(lidarrLogo),
-            color: "#b3b3b3",
+            color: "var(--aurral-text-muted)",
           }
         : null,
       artist?.name
@@ -126,7 +126,7 @@ export function ArtistDetailsAbout({
             label: "Last.fm",
             href: `https://www.last.fm/music/${encodeURIComponent(artist.name)}`,
             logo: toCurrentColorSvg(lastFmLogo),
-            color: "#b3b3b3",
+            color: "var(--aurral-text-muted)",
           }
         : null,
       artist?.id && UUID_REGEX.test(artist.id)
@@ -135,7 +135,7 @@ export function ArtistDetailsAbout({
             label: "MusicBrainz",
             href: `https://musicbrainz.org/artist/${artist.id}`,
             logo: toCurrentColorSvg(musicBrainzLogo),
-            color: "#b3b3b3",
+            color: "var(--aurral-text-muted)",
           }
         : null,
       artist?.id && UUID_REGEX.test(artist.id)
@@ -144,7 +144,7 @@ export function ArtistDetailsAbout({
             label: "ListenBrainz",
             href: `https://listenbrainz.org/artist/${encodeURIComponent(artist.id)}/`,
             logo: toCurrentColorSvg(listenBrainzLogo),
-            color: "#b3b3b3",
+            color: "var(--aurral-text-muted)",
           }
         : null,
     ].filter(Boolean);
@@ -189,7 +189,9 @@ export function ArtistDetailsAbout({
             </div>
           )}
 
-          <div className="artist-about-card__body">
+          <div
+            className={`artist-about-card__body${aboutImage ? " artist-about-card__body--overlay" : ""}`}
+          >
             <div className="artist-about-meta">
               {artistTypeLabel && <span>{artistTypeLabel}</span>}
               {artist?.disambiguation && <span>{artist.disambiguation}</span>}
@@ -254,7 +256,7 @@ export function ArtistDetailsAbout({
                     {link.logo ? (
                       <span
                         className="artist-external-link__logo"
-                        style={{ color: link.color || "#b3b3b3" }}
+                        style={{ color: link.color || "var(--aurral-text-muted)" }}
                         aria-hidden="true"
                         dangerouslySetInnerHTML={{ __html: link.logo }}
                       />

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsHero.jsx
@@ -55,7 +55,9 @@ export function ArtistDetailsHero({
           <div className="artist-hero__fallback" />
         )}
 
-        <div className="artist-hero__content">
+        <div
+          className={`artist-hero__content${showImage ? " artist-hero__content--overlay" : ""}`}
+        >
           <h1 className="artist-hero__title">{artist.name}</h1>
 
           {visibleTags.length > 0 && (

--- a/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
@@ -258,7 +258,7 @@ export default function DiscoverPlaylistDetailPage() {
     <div
       className="discover-playlist-detail"
       style={{
-        background: `linear-gradient(180deg, ${heroColor} 0%, ${heroColor} 120px, #121212 400px)`,
+        background: `linear-gradient(180deg, ${heroColor} 0%, ${heroColor} 120px, var(--aurral-surface) 400px)`,
       }}
     >
       <div className="discover-playlist-detail__hero">

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import { resetDiscoveryFeedback } from "../../../utils/api/endpoints/discovery.js";
+import {
+  getThemePreference,
+  setThemePreference,
+} from "../../../utils/theme.js";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { PlexSelfLinkSection } from "./PlexSelfLinkSection";
 
@@ -27,6 +31,7 @@ export function SettingsAccountTab({
   profileVariant = false,
 }) {
   const [resettingTastes, setResettingTastes] = useState(false);
+  const [theme, setTheme] = useState(getThemePreference);
 
   const handleResetDiscoveryTastes = async () => {
     if (resettingTastes) return;
@@ -77,6 +82,34 @@ export function SettingsAccountTab({
         className="settings-page__form"
         autoComplete="off"
       >
+        <div className="settings-page__section profile-settings__section">
+          <div className="settings-page__section-intro">
+            <h3 className="settings-page__section-title">Appearance</h3>
+            <p className="settings-page__section-note">
+              Choose how Aurral looks on this device.
+            </p>
+          </div>
+          <fieldset className="settings-page__fields profile-settings__fields">
+            <div className="profile-settings__field">
+              <label className="profile-settings__label" htmlFor="profile-theme">
+                Theme
+              </label>
+              <SettingsSelect
+                id="profile-theme"
+                value={theme}
+                onChange={(event) => setTheme(setThemePreference(event.target.value))}
+              >
+                <option value="system">System</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </SettingsSelect>
+              <p className="settings-page__hint">
+                System follows the appearance setting of your device.
+              </p>
+            </div>
+          </fieldset>
+        </div>
+
         <div className="settings-page__section profile-settings__section">
           <div className="settings-page__section-header">
             <div className="settings-page__section-intro">

--- a/frontend/src/pages/Settings/settingsArr.css
+++ b/frontend/src/pages/Settings/settingsArr.css
@@ -1549,10 +1549,10 @@
 @media (prefers-contrast: more) {
   .settings-arr,
   .arr-portal {
-    --arr-text-muted: #e2e2e2;
-    --arr-control-hover: #4a4a4a;
-    --aurral-border: rgba(255, 255, 255, 0.3);
-    --aurral-border-strong: rgba(255, 255, 255, 0.55);
+    --arr-text-muted: var(--aurral-text);
+    --arr-control-hover: color-mix(in srgb, var(--aurral-text) 18%, var(--aurral-surface));
+    --aurral-border: color-mix(in srgb, var(--aurral-text) 30%, transparent);
+    --aurral-border-strong: color-mix(in srgb, var(--aurral-text) 55%, transparent);
   }
 
   .settings-arr :is(.arr-btn, input, select, textarea):focus-visible,
@@ -1829,7 +1829,7 @@
   border-radius: 0.5rem;
   background: var(--settings-control-surface);
   color: var(--aurral-text);
-  box-shadow: 0 1px 0 rgb(255 255 255 / 0.025);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--aurral-text) 2.5%, transparent);
 }
 
 .settings-arr .arr-textarea,

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -1,0 +1,31 @@
+export const THEME_STORAGE_KEY = "aurralTheme";
+export const THEME_PREFERENCES = ["system", "light", "dark"];
+
+export function normalizeThemePreference(value) {
+  return THEME_PREFERENCES.includes(value) ? value : "system";
+}
+
+export function getThemePreference() {
+  try {
+    return normalizeThemePreference(globalThis.localStorage?.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return "system";
+  }
+}
+
+export function setThemePreference(value) {
+  const preference = normalizeThemePreference(value);
+
+  try {
+    globalThis.localStorage?.setItem(THEME_STORAGE_KEY, preference);
+  } catch {}
+
+  const root = globalThis.document?.documentElement;
+  if (preference === "system") {
+    root?.removeAttribute("data-theme");
+  } else {
+    root?.setAttribute("data-theme", preference);
+  }
+
+  return preference;
+}


### PR DESCRIPTION
## Summary

Adds System, Light, and Dark appearance settings with device-local persistence and theme-aware styling across the frontend. The system preference is applied before the app loads to reduce visual flashing.

## Linked issues

Closes #360

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): UI, settings, themes
- Automated coverage: Node tests cover theme preference normalization, persistence, and system-theme reset behavior.
- Manual steps and expected result: Open profile settings, select System, Light, or Dark, and confirm the appearance updates immediately and persists after reload. Verify artist and playlist imagery retains readable overlay text in both themes.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Appearance settings with System, Light, and Dark theme options.
  * Theme preferences are saved locally and applied when the app starts.
  * Updated the interface with theme-aware colors, contrast, overlays, and backgrounds.
  * Improved hero and artwork presentation across artist and playlist pages.

* **Documentation**
  * Documented appearance themes and supported listening history integrations.

* **Tests**
  * Added coverage for theme preferences, persistence, DOM updates, and system-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->