### PR TITLE
fix(deployment): defer public-only DNS lookup callbacks

### DIFF
--- a/.tests/helpers/api-client-utils.test.js
+++ b/.tests/helpers/api-client-utils.test.js
@@ -46,20 +46,43 @@ test("fetch transport failures expose axios-compatible request metadata", async 
   }
 });
 
-test("public-only transport rejects unreachable IPv6 without an uncaught exception", () => {
+test("public-only transport rejects socket failures without an uncaught exception", () => {
   const moduleUrl = new URL("../../lib/axiosFetch.js", import.meta.url).href;
   const result = spawnSync(process.execPath, ["--input-type=module", "--eval", `
     import dns from "node:dns/promises";
-    dns.lookup = async () => [{ address: "2001:db8::1", family: 6 }];
+    import net from "node:net";
+
+    let publicLookups = 0;
+    dns.lookup = async () => {
+      publicLookups += 1;
+      return [{ address: "203.0.113.1", family: 4 }];
+    };
+    net.Socket.prototype.connect = function (options) {
+      options.lookup(options.hostname || options.host, { all: false }, () => {
+        this.emit("error", Object.assign(new Error("injected transport failure"), {
+          code: "EINJECTED",
+        }));
+      });
+      return this;
+    };
+
     const { default: axios } = await import(${JSON.stringify(moduleUrl)});
     try {
       await axios.get("https://example.test", { publicOnly: true, timeout: 1000 });
       process.exitCode = 2;
     } catch (error) {
-      console.log(error.cause?.code || error.code);
+      console.log(JSON.stringify({
+        code: error.cause?.code || error.code,
+        publicLookups,
+        request: error.request,
+      }));
     }
   `], { encoding: "utf8" });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(result.stdout.trim(), "ENETUNREACH");
+  assert.deepEqual(JSON.parse(result.stdout), {
+    code: "EINJECTED",
+    publicLookups: 1,
+    request: { method: "GET", url: "https://example.test" },
+  });
 });

--- a/.tests/helpers/api-client-utils.test.js
+++ b/.tests/helpers/api-client-utils.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import createCache from "../../backend/services/apiClients/simpleCache.js";
 import createRateLimiter from "../../backend/services/apiClients/rateLimiter.js";
@@ -43,4 +44,22 @@ test("fetch transport failures expose axios-compatible request metadata", async 
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("public-only transport rejects unreachable IPv6 without an uncaught exception", () => {
+  const moduleUrl = new URL("../../lib/axiosFetch.js", import.meta.url).href;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", `
+    import dns from "node:dns/promises";
+    dns.lookup = async () => [{ address: "2001:db8::1", family: 6 }];
+    const { default: axios } = await import(${JSON.stringify(moduleUrl)});
+    try {
+      await axios.get("https://example.test", { publicOnly: true, timeout: 1000 });
+      process.exitCode = 2;
+    } catch (error) {
+      console.log(error.cause?.code || error.code);
+    }
+  `], { encoding: "utf8" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "ENETUNREACH");
 });

--- a/lib/axiosFetch.js
+++ b/lib/axiosFetch.js
@@ -88,8 +88,10 @@ function removeHeaders(headers, names) {
 async function createPublicDispatcher(url) {
   const { addresses } = await resolvePublicUrl(url);
   const lookup = (_hostname, options, callback) => {
-    if (options?.all) callback(null, addresses);
-    else callback(null, addresses[0].address, addresses[0].family);
+    queueMicrotask(() => {
+      if (options?.all) callback(null, addresses);
+      else callback(null, addresses[0].address, addresses[0].family);
+    });
   };
   return new Agent({ connections: 1, connect: { lookup } });
 }


### PR DESCRIPTION
## Summary

Defer public-only DNS lookup callbacks to prevent uncaught exceptions when unreachable IPv6 addresses are resolved.

## Linked issues

Not linked to an issue.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): deployment networking and Axios transport
- Automated coverage: Added a regression test for unreachable IPv6 addresses with `publicOnly: true`.
- Manual steps and expected result: Exercise public-only HTTPS requests resolving to an unreachable IPv6 address; the request should reject with `ENETUNREACH` without an uncaught exception.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for public-only network requests when connecting to unreachable IPv6 addresses.
  - Prevented uncaught exceptions during failed network lookups.
  - Preserved support for resolving both single and multiple network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->