### PR TITLE
fix(update-indicator): check nightly releases more often

### DIFF
--- a/frontend/src/components/UpdateIndicator.jsx
+++ b/frontend/src/components/UpdateIndicator.jsx
@@ -7,6 +7,7 @@ import {
 } from "../../../lib/release-version";
 
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const NIGHTLY_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000;
 const MAX_NIGHTLY_NOTES = 8;
 
 async function fetchJson(url) {
@@ -45,6 +46,7 @@ const UpdateIndicator = ({ currentVersion, visible = true }) => {
   const repo = import.meta.env.VITE_GITHUB_REPO || "lklynet/aurral";
   const releaseChannel = (import.meta.env.VITE_RELEASE_CHANNEL || "stable").toLowerCase();
   const isNightly = releaseChannel === "nightly";
+  const checkIntervalMs = isNightly ? NIGHTLY_CHECK_INTERVAL_MS : CHECK_INTERVAL_MS;
   const cacheKey = useMemo(
     () => `aurral:updateCache:${repo}:${releaseChannel}`,
     [releaseChannel, repo],
@@ -120,7 +122,7 @@ const UpdateIndicator = ({ currentVersion, visible = true }) => {
       const checkMeta = readStorage(checkMetaKey);
       if (
         checkMeta?.lastCheckedAt &&
-        Date.now() - Number(checkMeta.lastCheckedAt) < CHECK_INTERVAL_MS &&
+        Date.now() - Number(checkMeta.lastCheckedAt) < checkIntervalMs &&
         cached?.sourceVersion === resolvedVersion
       ) {
         return;
@@ -145,12 +147,12 @@ const UpdateIndicator = ({ currentVersion, visible = true }) => {
     };
 
     checkForUpdate();
-    const intervalId = setInterval(checkForUpdate, CHECK_INTERVAL_MS);
+    const intervalId = setInterval(checkForUpdate, checkIntervalMs);
     return () => {
       active = false;
       clearInterval(intervalId);
     };
-  }, [cacheKey, checkMetaKey, isNightly, releaseChannel, repo, resolvedVersion, visible]);
+  }, [cacheKey, checkIntervalMs, checkMetaKey, isNightly, releaseChannel, repo, resolvedVersion, visible]);
 
   useEffect(() => {
     if (!menuOpen) return undefined;


### PR DESCRIPTION
## Summary

Use a two-hour update check interval for nightly releases while keeping stable releases on the existing six-hour interval.

## Linked issues

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): UI, update indicator
- Automated coverage: Existing update indicator behavior and release-channel logic
- Manual steps and expected result: Run a nightly build and verify update checks repeat every two hours; stable builds should continue checking every six hours.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly release-channel updates are now checked more frequently, every two hours instead of every six hours.
  * Update checks now consistently follow the selected schedule for throttling and recurring checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->