### PR TITLE
fix(weekly-flow): distinguish queued upgrades and Lidarr tracks

### DIFF
--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -30,6 +30,10 @@ const [
 
 const app = express();
 app.use(express.json());
+app.use((req, _res, next) => {
+  req.user = { role: "admin" };
+  next();
+});
 const router = express.Router();
 registerJobs(router);
 app.use(router);
@@ -90,4 +94,48 @@ test("approving a reviewed download commits it inside the managed playlist libra
     "utf8",
   );
   assert.match(m3u, /Track\.flac/);
+});
+
+test("reports when an upgrade search is already queued for a track", async () => {
+  const playlistId = "c79c1598-699a-4ab3-b8cd-4e570f001f18";
+  flowPlaylistConfig.createSharedPlaylist({
+    id: playlistId,
+    name: "Upgrades",
+    tracks: [{ artistName: "Artist", trackName: "Track", albumName: "Album" }],
+  });
+  dbOps.updateSettings({
+    ...dbOps.getSettings(),
+    integrations: {
+      slskd: { enabled: true, url: "http://127.0.0.1:1", apiKey: "test-key" },
+    },
+  });
+  const finalPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "aurral-weekly-flow",
+    playlistId,
+    "Artist",
+    "Album",
+    "Track.mp3",
+  );
+  await fs.mkdir(path.dirname(finalPath), { recursive: true });
+  await fs.writeFile(finalPath, "audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Track", albumName: "Album" },
+    playlistId,
+  );
+  downloadTracker.setDone(jobId, finalPath, "Album");
+  downloadTracker.updateQuality(jobId, { tier: "mp3-128", format: "mp3" });
+
+  const first = await fetch(`${baseUrl}/quality-upgrades/${playlistId}/${jobId}`, {
+    method: "POST",
+  });
+  const second = await fetch(`${baseUrl}/quality-upgrades/${playlistId}/${jobId}`, {
+    method: "POST",
+  });
+  const payload = await second.json();
+
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200, JSON.stringify(payload));
+  assert.equal(payload.alreadyQueued, true);
+  assert.equal(payload.queued, 0);
 });

--- a/.tests/weekly-flow/download-tracker.test.js
+++ b/.tests/weekly-flow/download-tracker.test.js
@@ -9,9 +9,10 @@ import {
   resetDatabase,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, trackerModule, qualityProfileService] = await setupIsolatedBackend(
+const [isolatedState, { db }, { dbOps }, trackerModule, qualityProfileService] = await setupIsolatedBackend(
   "download-tracker",
   "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
   "backend/services/qualityProfileService.js",
 );
@@ -20,6 +21,7 @@ const { WeeklyFlowDownloadTracker } = trackerModule;
 
 test.beforeEach(async () => {
   await resetDatabase(db);
+  trackerModule.downloadTracker.clearAll();
 });
 
 test.after(async () => {
@@ -143,4 +145,33 @@ test("finalizes an upgrade when optional quality metadata is absent", async () =
   );
   assert.equal(tracker.getJob(upgradeId), null);
   assert.equal(tracker.getJob(sourceId)?.finalPath, finalPath);
+});
+
+test("classifies reused Lidarr files without making them eligible for upgrades", async () => {
+  const tracker = trackerModule.downloadTracker;
+  const lidarrPath = path.join(isolatedState.baseDir, "lidarr", "Song.mp3");
+  await mkdir(path.dirname(lidarrPath), { recursive: true });
+  await writeFile(
+    lidarrPath,
+    Buffer.from(
+      "SUQzBAAAAAAAIlRTU0UAAAAOAAADTGF2ZjYxLjcuMTAzAAAAAAAAAAAAAAD/+5DAAAAAAAAAAAAAAAAAAAAAAABJbmZvAAAADwAAAAIAAATkAKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqr//////////////////////////////////////////////////////////////////wAAAABMYXZjNjEuMTkAAAAAAAAAAAAAAAAkBQcAAAAAAAAE5MAlg1kAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      "base64",
+    ),
+  );
+  dbOps.updateSettings({
+    ...dbOps.getSettings(),
+    downloadFolderPath: path.join(isolatedState.baseDir, "managed"),
+  });
+  const jobId = tracker.addJob({ artistName: "Artist", trackName: "Song" }, "discover");
+  tracker.setDone(jobId, lidarrPath, "Album", "/music/Artist/Album/Song.mp3");
+
+  const result = await qualityProfileService.reclassifyQualityJobs();
+  const job = tracker.getJob(jobId);
+  const decorated = qualityProfileService.decorateJobQuality(job);
+
+  assert.equal(result.classified, 1);
+  assert.equal(job.qualityTier, "mp3-128");
+  assert.equal(decorated.qualityLabel, "MP3 128");
+  assert.equal(decorated.qualityState, "external");
+  assert.equal(await qualityProfileService.queueQualityUpgrade(job), "ineligible");
 });

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -83,8 +83,11 @@ export function registerJobs(router) {
     if (!job || job.playlistType !== playlistId) {
       return res.status(404).json({ error: "Track not found" });
     }
-    const queued = await queueQualityUpgrade(job);
-    if (!queued) {
+    const result = await queueQualityUpgrade(job);
+    if (result === "already-queued") {
+      return res.json({ success: true, queued: 0, alreadyQueued: true, jobId });
+    }
+    if (result !== "queued") {
       return res.status(409).json({ error: "Track is not eligible for an upgrade" });
     }
     return res.json({ success: true, queued: 1, jobId });

--- a/backend/services/qualityProfileService.js
+++ b/backend/services/qualityProfileService.js
@@ -83,8 +83,7 @@ export async function classifyQualityJob(job) {
   if (
     !job?.finalPath ||
     job.status !== "done" ||
-    job.upgradeForJobId ||
-    !isAurralOwnedPath(job.finalPath)
+    job.upgradeForJobId
   ) {
     return null;
   }
@@ -116,8 +115,7 @@ export async function reclassifyQualityJobs({ enqueue = false } = {}) {
     if (
       !job?.finalPath ||
       job.status !== "done" ||
-      job.upgradeForJobId ||
-      !isAurralOwnedPath(job.finalPath)
+      job.upgradeForJobId
     ) {
       continue;
     }
@@ -138,21 +136,24 @@ function hasUpgradeSource() {
 }
 
 export async function queueQualityUpgrade(job) {
-  if (!job?.id || job.status !== "done" || !isAurralOwnedPath(job.finalPath)) return false;
+  if (!job?.id || job.status !== "done" || !isAurralOwnedPath(job.finalPath)) {
+    return "ineligible";
+  }
   if (!job.qualityCheckedAt) await classifyQualityJob(job);
   const current = downloadTracker.getJob(job.id);
   if (getQualityState({ tier: current?.qualityTier }, getQualityProfile()) === "preferred") {
-    return false;
+    return "ineligible";
   }
-  if (!hasUpgradeSource()) return false;
+  if (!hasUpgradeSource()) return "ineligible";
+  if (downloadTracker.findActiveUpgradeJob(current)) return "already-queued";
   const upgradeJobId = downloadTracker.addUpgradeJob(current);
-  if (!upgradeJobId) return false;
+  if (!upgradeJobId) return "ineligible";
   if (!downloadTracker.enqueueDownloadPipeline(upgradeJobId)) {
     downloadTracker.removeJob(upgradeJobId);
-    return false;
+    return "ineligible";
   }
   downloadTracker.markQualityUpgradeChecked(current.id);
-  return true;
+  return "queued";
 }
 
 export async function runQualityUpgradeCheck({ force = false, playlistId = null, limit = 25 } = {}) {
@@ -173,7 +174,7 @@ export async function runQualityUpgradeCheck({ force = false, playlistId = null,
     const current = downloadTracker.getJob(job.id);
     if (getQualityState({ tier: current?.qualityTier }, profile) === "preferred") continue;
     if (!force && Number(current?.qualityUpgradeCheckedAt || 0) > dueBefore) continue;
-    if (await queueQualityUpgrade(current)) queued += 1;
+    if (await queueQualityUpgrade(current) === "queued") queued += 1;
   }
   return queued;
 }

--- a/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
@@ -593,21 +593,22 @@ export class WeeklyFlowDownloadTracker {
     return ids;
   }
 
+  findActiveUpgradeJob(sourceJob) {
+    if (!sourceJob?.finalPath) return null;
+    return [...this.jobs.values()].find((job) => {
+      if (
+        !job.upgradeForJobId ||
+        (job.status !== "pending" && job.status !== "downloading")
+      ) {
+        return false;
+      }
+      return this.jobs.get(job.upgradeForJobId)?.finalPath === sourceJob.finalPath;
+    }) || null;
+  }
+
   addUpgradeJob(sourceJob) {
     if (!sourceJob?.id || sourceJob.status !== "done" || !sourceJob.finalPath) return null;
-    const active = [...this.jobs.values()].some(
-      (job) => {
-        if (
-          !job.upgradeForJobId ||
-          (job.status !== "pending" && job.status !== "downloading")
-        ) {
-          return false;
-        }
-        const activeSource = this.jobs.get(job.upgradeForJobId);
-        return activeSource?.finalPath === sourceJob.finalPath;
-      },
-    );
-    if (active) return null;
+    if (this.findActiveUpgradeJob(sourceJob)) return null;
     const id = this.addJob(sourceJob, "quality-upgrade");
     const job = this.jobs.get(id);
     job.playlistId = sourceJob.playlistId || sourceJob.playlistType;

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -73,7 +73,7 @@ Aurral can use search-result names and bitrate data to order candidates. Aurral 
 
 An unknown final quality is not valid. A quality rejection does not go to **Activity > Review**. Review stays for track identity and duration decisions.
 
-The **Quality** column on the Playlists page shows the measured tier and its profile state.
+The **Quality** column on the Playlists page shows the measured tier and its profile state. It labels a file reused from Lidarr as **Lidarr**.
 
 ## Track upgrades
 
@@ -85,6 +85,8 @@ To start upgrades manually:
 
 - Select **Search for upgrade** on an eligible track.
 - Select **Search for upgrades** from a flow or static playlist menu.
+
+If an upgrade search is already in the queue for a track, Aurral reports that state instead of reporting that the track is not eligible.
 
 A user who can open the playlist can start these searches. Manual searches work when automatic upgrades are off.
 

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -979,8 +979,12 @@ function FlowPage() {
     }
     try {
       if (track.status === "done") {
-        await searchTrackUpgrade(playlistId, jobId);
-        showSuccess(`Searching for an upgrade to ${track.trackName}`);
+        const result = await searchTrackUpgrade(playlistId, jobId);
+        showSuccess(
+          result?.alreadyQueued
+            ? `Upgrade search already queued for ${track.trackName}`
+            : `Searching for an upgrade to ${track.trackName}`,
+        );
       } else if (isFlow) {
         await reSearchFlowTrack(playlistId, jobId);
         showSuccess(`Re-searching ${track.trackName}`);

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -46,12 +46,12 @@ function getTrackQualityMeta(track) {
   } else if (track.qualityFormat && track.qualityBitrateKbps) {
     label = `${track.qualityFormat.toUpperCase()} ${track.qualityBitrateKbps}`;
   }
-  const state = {
+  const state = track.externalPath ? "Lidarr" : ({
     preferred: "Preferred",
     upgrade: "Upgrade",
     "below-floor": "Below floor",
     external: "External",
-  }[track.qualityState] || "";
+  }[track.qualityState] || "");
   return { label, state };
 }
 


### PR DESCRIPTION
## Summary

Distinguish queued quality upgrades from ineligible tracks and label files reused from Lidarr. Add regression coverage for both behaviors.

## Linked issues

None

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): weekly flow, quality upgrades, playlists, UI, documentation
- Automated coverage: Added tests for duplicate queued upgrades and reused Lidarr files.
- Manual steps and expected result: Start an upgrade search twice and confirm the second attempt reports that it is already queued. Verify Lidarr-reused tracks display the Lidarr label and are not eligible for upgrades.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-search requests now clearly indicate whether an upgrade was newly queued or already in progress.
  * Tracks reused from Lidarr are labeled “Lidarr” in playlist quality information.
* **Bug Fixes**
  * Duplicate upgrade requests no longer return an error when an upgrade is already queued.
  * External Lidarr files are correctly classified and excluded from upgrade eligibility checks.
* **Documentation**
  * Updated playlist guidance to explain Lidarr labels and queued upgrade behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->