### PR TITLE
refactor(playback): define playback destination contract

### DIFF
--- a/.tests/playback/playback-destination.test.js
+++ b/.tests/playback/playback-destination.test.js
@@ -9,7 +9,7 @@ import {
   playbackOperationSuccess,
 } from "../../backend/services/playback/playbackDestination.js";
 
-test("playlist snapshots keep Aurral identity separate from display names", () => {
+test("playlist snapshots keep Aurral identity and exact paths", () => {
   const first = createPlaybackPlaylistSnapshot({
     entityId: "flow-1",
     ownerUserId: 7,
@@ -17,7 +17,7 @@ test("playlist snapshots keep Aurral identity separate from display names", () =
     description: "A mix for the morning",
     tracks: [
       {
-        path: "/music/Artist/Album/Track.flac",
+        path: " /music/Artist/Album/Track.flac ",
         title: "Track",
         artist: "Artist",
         album: "Album",
@@ -31,7 +31,7 @@ test("playlist snapshots keep Aurral identity separate from display names", () =
   assert.deepEqual(createPlaybackPlaylistIdentity(first), createPlaybackPlaylistIdentity(renamed));
   assert.equal(first.description, "A mix for the morning");
   assert.deepEqual(first.tracks[0], {
-    path: "/music/Artist/Album/Track.flac",
+    path: " /music/Artist/Album/Track.flac ",
     title: "Track",
     artist: "Artist",
     album: "Album",

--- a/.tests/playback/playback-destination.test.js
+++ b/.tests/playback/playback-destination.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertPlaybackDestination,
+  createPlaybackPlaylistIdentity,
+  createPlaybackPlaylistSnapshot,
+  playbackOperationFailure,
+  playbackOperationSuccess,
+} from "../../backend/services/playback/playbackDestination.js";
+
+test("playlist snapshots keep Aurral identity separate from display names", () => {
+  const first = createPlaybackPlaylistSnapshot({
+    entityId: "flow-1",
+    ownerUserId: 7,
+    displayName: "Morning Mix",
+    description: "A mix for the morning",
+    tracks: [
+      {
+        path: "/music/Artist/Album/Track.flac",
+        title: "Track",
+        artist: "Artist",
+        album: "Album",
+        durationMs: 245000,
+        mbid: "recording-mbid",
+      },
+    ],
+  });
+  const renamed = createPlaybackPlaylistSnapshot({ ...first, displayName: "Early Mix" });
+
+  assert.deepEqual(createPlaybackPlaylistIdentity(first), createPlaybackPlaylistIdentity(renamed));
+  assert.equal(first.description, "A mix for the morning");
+  assert.deepEqual(first.tracks[0], {
+    path: "/music/Artist/Album/Track.flac",
+    title: "Track",
+    artist: "Artist",
+    album: "Album",
+    durationMs: 245000,
+    mbid: "recording-mbid",
+  });
+  assert.ok(Object.isFrozen(first));
+  assert.ok(Object.isFrozen(first.tracks));
+  assert.ok(Object.isFrozen(first.tracks[0]));
+});
+
+test("a playback destination can be exercised without a playlist manager", async () => {
+  const published = [];
+  const deleted = [];
+  const destination = assertPlaybackDestination({
+    async testConnection() {
+      return playbackOperationSuccess();
+    },
+    async ensureLibrary() {
+      return playbackOperationSuccess();
+    },
+    async publishPlaylist(snapshot) {
+      published.push(snapshot);
+      return playbackOperationSuccess();
+    },
+    async deletePlaylist(identity) {
+      deleted.push(identity);
+      return playbackOperationSuccess();
+    },
+    async requestScan() {
+      return playbackOperationSuccess();
+    },
+  });
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: "playlist-1",
+    ownerUserId: null,
+    displayName: "Shared Playlist",
+    tracks: [{ path: "/music/track.flac", title: "Track", artist: "Artist" }],
+  });
+
+  assert.deepEqual(await destination.publishPlaylist(snapshot), { ok: true });
+  assert.deepEqual(await destination.deletePlaylist(createPlaybackPlaylistIdentity(snapshot)), {
+    ok: true,
+  });
+  assert.deepEqual(published, [snapshot]);
+  assert.deepEqual(deleted, [{ entityId: "playlist-1", ownerUserId: null }]);
+});
+
+test("operation failures are structured and invalid destinations fail early", () => {
+  assert.deepEqual(
+    playbackOperationFailure({
+      code: "DESTINATION_UNAVAILABLE",
+      message: "The destination did not respond",
+      retryable: true,
+    }),
+    {
+      ok: false,
+      error: {
+        code: "DESTINATION_UNAVAILABLE",
+        message: "The destination did not respond",
+        retryable: true,
+      },
+    },
+  );
+  assert.throws(
+    () => assertPlaybackDestination({ testConnection() {} }),
+    /PlaybackDestination\.ensureLibrary must be a function/,
+  );
+  assert.throws(
+    () =>
+      createPlaybackPlaylistSnapshot({
+        entityId: "flow-1",
+        displayName: "Broken",
+        tracks: [{ path: "", title: "Track", artist: "Artist" }],
+      }),
+    /tracks\[0\]\.path must be a non-empty string/,
+  );
+});

--- a/backend/services/playback/playbackDestination.js
+++ b/backend/services/playback/playbackDestination.js
@@ -1,0 +1,99 @@
+const REQUIRED_METHODS = [
+  "testConnection",
+  "ensureLibrary",
+  "publishPlaylist",
+  "deletePlaylist",
+  "requestScan",
+];
+
+const requireText = (value, field) => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`${field} must be a non-empty string`);
+  }
+  return value.trim();
+};
+
+const optionalText = (value, field) => {
+  if (value == null) return null;
+  return requireText(value, field);
+};
+
+const normalizeOwnerUserId = (value) => {
+  if (value == null) return null;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError("ownerUserId must be a positive integer or null");
+  }
+  return value;
+};
+
+export function createPlaybackPlaylistIdentity({ entityId, ownerUserId = null } = {}) {
+  return Object.freeze({
+    entityId: requireText(entityId, "entityId"),
+    ownerUserId: normalizeOwnerUserId(ownerUserId),
+  });
+}
+
+export function createPlaybackPlaylistSnapshot({
+  entityId,
+  ownerUserId = null,
+  displayName,
+  description = null,
+  tracks,
+} = {}) {
+  if (!Array.isArray(tracks)) {
+    throw new TypeError("tracks must be an array");
+  }
+  const identity = createPlaybackPlaylistIdentity({ entityId, ownerUserId });
+  const normalizedTracks = tracks.map((track, index) => {
+    const normalized = {
+      path: requireText(track?.path, `tracks[${index}].path`),
+      title: requireText(track?.title, `tracks[${index}].title`),
+      artist: requireText(track?.artist, `tracks[${index}].artist`),
+    };
+    const album = optionalText(track?.album, `tracks[${index}].album`);
+    const mbid = optionalText(track?.mbid, `tracks[${index}].mbid`);
+    if (album) normalized.album = album;
+    if (mbid) normalized.mbid = mbid;
+    if (track?.durationMs != null) {
+      if (!Number.isFinite(track.durationMs) || track.durationMs < 0) {
+        throw new TypeError(`tracks[${index}].durationMs must be a non-negative number`);
+      }
+      normalized.durationMs = track.durationMs;
+    }
+    return Object.freeze(normalized);
+  });
+  const normalizedDescription = optionalText(description, "description");
+  return Object.freeze({
+    ...identity,
+    displayName: requireText(displayName, "displayName"),
+    ...(normalizedDescription ? { description: normalizedDescription } : {}),
+    tracks: Object.freeze(normalizedTracks),
+  });
+}
+
+export function playbackOperationSuccess() {
+  return Object.freeze({ ok: true });
+}
+
+export function playbackOperationFailure({ code, message, retryable = false } = {}) {
+  return Object.freeze({
+    ok: false,
+    error: Object.freeze({
+      code: requireText(code, "code"),
+      message: requireText(message, "message"),
+      retryable: retryable === true,
+    }),
+  });
+}
+
+export function assertPlaybackDestination(destination) {
+  if (!destination || (typeof destination !== "object" && typeof destination !== "function")) {
+    throw new TypeError("PlaybackDestination must be an object");
+  }
+  for (const method of REQUIRED_METHODS) {
+    if (typeof destination[method] !== "function") {
+      throw new TypeError(`PlaybackDestination.${method} must be a function`);
+    }
+  }
+  return destination;
+}

--- a/backend/services/playback/playbackDestination.js
+++ b/backend/services/playback/playbackDestination.js
@@ -45,8 +45,10 @@ export function createPlaybackPlaylistSnapshot({
   }
   const identity = createPlaybackPlaylistIdentity({ entityId, ownerUserId });
   const normalizedTracks = tracks.map((track, index) => {
+    const trackPath = track?.path;
+    requireText(trackPath, `tracks[${index}].path`);
     const normalized = {
-      path: requireText(track?.path, `tracks[${index}].path`),
+      path: trackPath,
       title: requireText(track?.title, `tracks[${index}].title`),
       artist: requireText(track?.artist, `tracks[${index}].artist`),
     };

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -30,7 +30,7 @@ A playlist snapshot contains:
 - An optional `description`
 - An ordered `tracks` array
 
-Each track contains its Aurral-readable local `path`, `title`, and `artist`. It can also contain `album`, `durationMs`, and a recording `mbid`. The snapshot is immutable. Each adapter converts local paths to its destination paths or track IDs.
+Each track contains its exact Aurral-readable local `path`, `title`, and `artist`. Path validation does not trim valid filename whitespace. A track can also contain `album`, `durationMs`, and a recording `mbid`. The snapshot is immutable. Each adapter converts local paths to its destination paths or track IDs.
 
 Destination adapters own their names, authentication, configuration, vendor IDs, stored pointers, owner policy, and detailed connection state. Callers only use the contract values above.
 

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -1,0 +1,51 @@
+# Playback destination seam
+
+- Status: Accepted
+- Date: 2026-08-10
+- Issue: [#534](https://github.com/lklynet/aurral/issues/534)
+
+## Context
+
+`WeeklyFlowPlaylistManager` currently controls playlist files, Navidrome, and Plex. Navidrome reads track paths from M3U files. Plex resolves track paths to Plex track IDs and stores Plex playlist pointers. Both destinations publish the same Aurral playlists, but their configuration and identity rules are different.
+
+## Decision
+
+`backend/services/playback/playbackDestination.js` is the seam between playlist orchestration and playback destinations. A destination is an object with these methods:
+
+- `testConnection()`
+- `ensureLibrary()`
+- `publishPlaylist(snapshot)`
+- `deletePlaylist(identity)`
+- `requestScan()`
+
+Each method returns a promise for one operation result. Success is `{ ok: true }`. Failure is `{ ok: false, error: { code, message, retryable } }`. A destination must not return credentials, vendor IDs, stored pointers, or Settings form values.
+
+The playlist identity is `entityId + ownerUserId`. `ownerUserId` is `null` for a global playlist. The display name is not part of the identity. A rename must publish the same identity with a new display name.
+
+A playlist snapshot contains:
+
+- `entityId`
+- `ownerUserId`
+- `displayName`
+- An optional `description`
+- An ordered `tracks` array
+
+Each track contains its Aurral-readable local `path`, `title`, and `artist`. It can also contain `album`, `durationMs`, and a recording `mbid`. The snapshot is immutable. Each adapter converts local paths to its destination paths or track IDs.
+
+Destination adapters own their names, authentication, configuration, vendor IDs, stored pointers, owner policy, and detailed connection state. Callers only use the contract values above.
+
+## Compatibility
+
+The Navidrome adapter can write snapshot paths to M3U files after it applies Navidrome path mappings. It can keep Navidrome file naming and playlist deletion rules inside the adapter.
+
+The Plex adapter can resolve snapshot paths to Plex rating keys. It can keep section IDs, user tokens, playlist pointers, and owner-specific titles inside the adapter.
+
+This decision does not change current Navidrome or Plex behavior. Later roadmap issues will move each existing flow behind this seam.
+
+## Deliberate non-goals
+
+- Do not add a generic integration host.
+- Do not add plugin loading or uploaded code.
+- Do not migrate Navidrome from M3U files to the Subsonic API.
+- Do not make Settings forms part of this contract.
+- Do not move current destination behavior in this issue.


### PR DESCRIPTION
## Summary

- Add the validated, immutable path-first playlist snapshot and stable `entityId + ownerUserId` identity.
- Define the five-method playback destination contract and structured operation results.
- Record how the seam represents the current Navidrome M3U and Plex flows without changing their behavior.

This establishes the smallest executable seam required for the ordered playback roadmap. There is no user-visible behavior change.

## Linked issues

Closes #534

## Validation

- [x] CI passes
- [x] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [x] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Backend playback architecture and developer documentation
- Automated coverage: Added focused Node tests for playlist identity, snapshot data, destination conformance, standalone adapter use, and structured failures
- Manual steps and expected result: Not required because this change does not connect the contract to runtime behavior

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational support for consistent playback destinations, including playlist identities, snapshots, and standardized operation results.
  * Added validation for playback destination data and supported operations.

* **Bug Fixes**
  * Improved handling of invalid destinations, track paths, and failed playback operations with structured results.

* **Documentation**
  * Documented the playback destination architecture and compatibility expectations for supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->