### PR TITLE
refactor(playback): add destination registry

### DIFF
--- a/.tests/playback/playback-destination-registry.test.js
+++ b/.tests/playback/playback-destination-registry.test.js
@@ -19,7 +19,10 @@ function destination(name, configured, result = { ok: true }) {
       if (result instanceof Error) throw result;
       return result;
     },
-    async deletePlaylist() {},
+    async deletePlaylist(identity) {
+      calls.push(["deletePlaylist", identity]);
+      return result;
+    },
     async requestScan() {},
   };
 }
@@ -42,6 +45,13 @@ test("runs zero, one, or multiple configured destinations from settings", async 
   assert.deepEqual(off.calls[0], ["updateConfig", {}]);
   assert.deepEqual(first.calls[0], ["updateConfig", { url: "first" }]);
   assert.deepEqual(second.calls[0], ["updateConfig", { url: "second" }]);
+
+  assert.deepEqual(await registry.run("deletePlaylist", { entityId: "playlist-1" }), [
+    { destination: "First", operation: "deletePlaylist", ok: true },
+    { destination: "Second", operation: "deletePlaylist", ok: true },
+  ]);
+  assert.deepEqual(first.calls.at(-1), ["deletePlaylist", { entityId: "playlist-1" }]);
+  assert.deepEqual(second.calls.at(-1), ["deletePlaylist", { entityId: "playlist-1" }]);
 });
 
 test("records destination failures without blocking other destinations", async (t) => {

--- a/.tests/playback/playback-destination-registry.test.js
+++ b/.tests/playback/playback-destination-registry.test.js
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PlaybackDestinationRegistry } from "../../backend/services/playback/playbackDestinationRegistry.js";
+
+function destination(name, configured, result = { ok: true }) {
+  const calls = [];
+  return {
+    key: name.toLowerCase(),
+    name,
+    calls,
+    isConfigured: () => configured,
+    updateConfig(config) {
+      calls.push(["updateConfig", config]);
+    },
+    async testConnection() {},
+    async ensureLibrary() {},
+    async publishPlaylist(snapshot) {
+      calls.push(["publishPlaylist", snapshot]);
+      if (result instanceof Error) throw result;
+      return result;
+    },
+    async deletePlaylist() {},
+    async requestScan() {},
+  };
+}
+
+test("runs zero, one, or multiple configured destinations from settings", async () => {
+  const off = destination("Off", false);
+  const first = destination("First", true);
+  const second = destination("Second", true);
+  const registry = new PlaybackDestinationRegistry([off, first, second]);
+  registry.updateConfig({ first: { url: "first" }, second: { url: "second" } });
+
+  assert.deepEqual(await new PlaybackDestinationRegistry([off]).run("publishPlaylist", {}), []);
+  assert.deepEqual(await new PlaybackDestinationRegistry([first]).run("publishPlaylist", {}), [
+    { destination: "First", operation: "publishPlaylist", ok: true },
+  ]);
+  assert.deepEqual(await registry.run("publishPlaylist", { entityId: "playlist-1" }), [
+    { destination: "First", operation: "publishPlaylist", ok: true },
+    { destination: "Second", operation: "publishPlaylist", ok: true },
+  ]);
+  assert.deepEqual(off.calls[0], ["updateConfig", {}]);
+  assert.deepEqual(first.calls[0], ["updateConfig", { url: "first" }]);
+  assert.deepEqual(second.calls[0], ["updateConfig", { url: "second" }]);
+});
+
+test("records destination failures without blocking other destinations", async (t) => {
+  t.mock.method(console, "warn", () => {});
+  const rejected = destination("Rejected", true, new Error("offline"));
+  const failed = destination("Failed", true, {
+    ok: false,
+    error: { code: "SCAN_FAILED", message: "busy", retryable: true },
+  });
+  const ready = destination("Ready", true);
+
+  assert.deepEqual(
+    await new PlaybackDestinationRegistry([rejected, failed, ready]).run(
+      "publishPlaylist",
+      {},
+    ),
+    [
+      {
+        destination: "Rejected",
+        operation: "publishPlaylist",
+        ok: false,
+        error: {
+          code: "DESTINATION_OPERATION_FAILED",
+          message: "offline",
+          retryable: true,
+        },
+      },
+      {
+        destination: "Failed",
+        operation: "publishPlaylist",
+        ok: false,
+        error: { code: "SCAN_FAILED", message: "busy", retryable: true },
+      },
+      { destination: "Ready", operation: "publishPlaylist", ok: true },
+    ],
+  );
+});

--- a/.tests/playback/playback-destination-registry.test.js
+++ b/.tests/playback/playback-destination-registry.test.js
@@ -46,10 +46,13 @@ test("runs zero, one, or multiple configured destinations from settings", async 
   assert.deepEqual(first.calls[0], ["updateConfig", { url: "first" }]);
   assert.deepEqual(second.calls[0], ["updateConfig", { url: "second" }]);
 
+  first.isConfigured = () => false;
   assert.deepEqual(await registry.run("deletePlaylist", { entityId: "playlist-1" }), [
+    { destination: "Off", operation: "deletePlaylist", ok: true },
     { destination: "First", operation: "deletePlaylist", ok: true },
     { destination: "Second", operation: "deletePlaylist", ok: true },
   ]);
+  assert.deepEqual(off.calls.at(-1), ["deletePlaylist", { entityId: "playlist-1" }]);
   assert.deepEqual(first.calls.at(-1), ["deletePlaylist", { entityId: "playlist-1" }]);
   assert.deepEqual(second.calls.at(-1), ["deletePlaylist", { entityId: "playlist-1" }]);
 });

--- a/.tests/playback/plex-playback-destination.test.js
+++ b/.tests/playback/plex-playback-destination.test.js
@@ -303,6 +303,7 @@ test("keeps Navidrome and Plex failures isolated when both destinations are conf
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Isolation" });
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
   const calls = [];
+  manager.navidromeDestination.isConfigured = () => true;
   manager.navidromeDestination.ensureLibrary = async () => ({ ok: true });
   manager.navidromeDestination.publishPlaylist = async () => ({
     ok: false,

--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -42,6 +42,16 @@ const server = await new Promise((resolve) => {
 });
 const baseUrl = `http://127.0.0.1:${server.address().port}`;
 
+playlistManager.navidromeDestination.client = {
+  isConfigured: () => true,
+  async ensureWeeklyFlowLibrary() {},
+  async getPlaylists() {
+    return [];
+  },
+  async deletePlaylist() {},
+  async scanLibrary() {},
+};
+
 test.beforeEach(async () => {
   await resetDatabase(db);
   downloadTracker.clearAll();

--- a/.tests/weekly-flow/navidrome-owner-name-prefix.test.js
+++ b/.tests/weekly-flow/navidrome-owner-name-prefix.test.js
@@ -37,7 +37,17 @@ test.after(async () => {
 });
 
 function makeManager() {
-  return new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  manager.navidromeDestination.client = {
+    isConfigured: () => true,
+    async ensureWeeklyFlowLibrary() {},
+    async getPlaylists() {
+      return [];
+    },
+    async deletePlaylist() {},
+    async scanLibrary() {},
+  };
+  return manager;
 }
 
 test("the Navidrome adapter keeps an unowned flow name bare", () => {

--- a/.tests/weekly-flow/playlist-artwork.test.js
+++ b/.tests/weekly-flow/playlist-artwork.test.js
@@ -34,6 +34,20 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
+function makeManager() {
+  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  manager.navidromeDestination.client = {
+    isConfigured: () => true,
+    async ensureWeeklyFlowLibrary() {},
+    async getPlaylists() {
+      return [];
+    },
+    async deletePlaylist() {},
+    async scanLibrary() {},
+  };
+  return manager;
+}
+
 test("writes WebP sidecar artwork for flow and playlist m3u files", async () => {
   const flow = flowPlaylistConfig.createFlow({
     name: "Late Night",
@@ -46,7 +60,7 @@ test("writes WebP sidecar artwork for flow and playlist m3u files", async () => 
     tracks: [{ artistName: "A", trackName: "One" }],
   });
 
-  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = makeManager();
   await manager.ensurePlaylists();
 
   const flowName = manager.getPlaylistName(flow.id);
@@ -82,7 +96,7 @@ test("removes old sidecar artwork when a flow is renamed", async () => {
   });
   flowPlaylistConfig.setEnabled(flow.id, true);
 
-  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = makeManager();
   await manager.ensurePlaylists();
 
   const oldName = manager.getPlaylistName(flow.id);
@@ -112,7 +126,7 @@ test("writes sidecar artwork for draft flows without m3u files", async () => {
     enabled: false,
   });
 
-  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = makeManager();
   await manager.ensurePlaylists();
 
   const playlistName = manager.getPlaylistName(flow.id);
@@ -131,7 +145,7 @@ test("keeps artwork when an enabled flow is disabled", async () => {
   });
   flowPlaylistConfig.setEnabled(flow.id, true);
 
-  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = makeManager();
   await manager.ensurePlaylists();
 
   const base = manager._sanitize(manager.getPlaylistName(flow.id));
@@ -153,7 +167,7 @@ test("does not regenerate artwork after explicit remove until generate", async (
   });
   flowPlaylistConfig.setEnabled(flow.id, true);
 
-  const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  const manager = makeManager();
   await manager.ensurePlaylists();
 
   const flowWebp = path.join(

--- a/.tests/weekly-flow/playlist-m3u.test.js
+++ b/.tests/weekly-flow/playlist-m3u.test.js
@@ -34,6 +34,18 @@ const { syncM3uPathMappings } = m3uPathsModule;
 
 const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
+function enableNavidrome(manager) {
+  manager.navidromeDestination.client = {
+    isConfigured: () => true,
+    async ensureWeeklyFlowLibrary() {},
+    async getPlaylists() {
+      return [];
+    },
+    async deletePlaylist() {},
+    async scanLibrary() {},
+  };
+}
+
 test.beforeEach(async () => {
   await resetDatabase(db);
   downloadTracker.clearAll();
@@ -131,6 +143,7 @@ test("refreshPlaylist writes m3u entries for completed tracks", async () => {
   downloadTracker.setDone(jobId, trackPath, "Album");
 
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  enableNavidrome(manager);
   await manager.refreshPlaylist(playlist.id);
 
   const m3uPath = path.join(
@@ -147,6 +160,7 @@ test("ensurePlaylists continues after one Navidrome playlist fails", async (t) =
   const first = flowPlaylistConfig.createSharedPlaylist({ name: "Isolation Broken" });
   const second = flowPlaylistConfig.createSharedPlaylist({ name: "Isolation Ready" });
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  enableNavidrome(manager);
   const publish = manager.navidromeDestination.publishPlaylist.bind(
     manager.navidromeDestination,
   );
@@ -180,6 +194,7 @@ test("the Navidrome adapter uses stored external paths in remote mode", async ()
 
   process.env.M3U_PATH_MODE = "remote";
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  enableNavidrome(manager);
   await manager.refreshPlaylist(playlist.id);
   const content = await fs.readFile(
     path.join(manager.libraryRoot, `${manager.getPlaylistName(playlist.id)}.m3u`),
@@ -207,6 +222,7 @@ test("the Navidrome adapter uses Navidrome path mappings in remote mode", async 
   downloadTracker.setDone(jobId, localPath, "Album");
   process.env.M3U_PATH_MODE = "remote";
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  enableNavidrome(manager);
   syncM3uPathMappings([
     {
       local: mappedRoot,
@@ -238,6 +254,7 @@ test("the Navidrome adapter falls back to shared path mappings in remote mode", 
 
   process.env.M3U_PATH_MODE = "remote";
   const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  enableNavidrome(manager);
   let content;
   try {
     await manager.refreshPlaylist(playlist.id);

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -36,6 +36,8 @@ function buildM3uContent(tracks, resolveTrackPath) {
 
 export class NavidromePlaybackDestination {
   constructor(weeklyFlowRoot = resolvePlaylistRoot(), { client = null } = {}) {
+    this.key = "navidrome";
+    this.name = "Navidrome";
     this.weeklyFlowRoot = resolvePlaylistRoot(weeklyFlowRoot);
     this.playlistLibraryRoot = path.join(this.weeklyFlowRoot, PLAYLIST_LIBRARY_DIR);
     this.libraryRoot = path.join(this.playlistLibraryRoot, "_playlists");

--- a/backend/services/playback/playbackDestinationRegistry.js
+++ b/backend/services/playback/playbackDestinationRegistry.js
@@ -29,7 +29,9 @@ export class PlaybackDestinationRegistry {
 
   async run(operation, ...args) {
     return Promise.all(
-      this.destinations.filter((destination) => destination.isConfigured()).map(
+      this.destinations.filter(
+        (destination) => operation === "deletePlaylist" || destination.isConfigured(),
+      ).map(
         async (destination) => {
           let result;
           try {

--- a/backend/services/playback/playbackDestinationRegistry.js
+++ b/backend/services/playback/playbackDestinationRegistry.js
@@ -1,0 +1,55 @@
+import {
+  assertPlaybackDestination,
+  playbackOperationFailure,
+} from "./playbackDestination.js";
+
+export class PlaybackDestinationRegistry {
+  constructor(destinations) {
+    this.destinations = destinations.map((destination) => {
+      assertPlaybackDestination(destination);
+      for (const property of ["key", "name"]) {
+        if (typeof destination[property] !== "string" || !destination[property].trim()) {
+          throw new TypeError(`PlaybackDestination.${property} must be a non-empty string`);
+        }
+      }
+      for (const method of ["isConfigured", "updateConfig"]) {
+        if (typeof destination[method] !== "function") {
+          throw new TypeError(`PlaybackDestination.${method} must be a function`);
+        }
+      }
+      return destination;
+    });
+  }
+
+  updateConfig(integrations = {}) {
+    for (const destination of this.destinations) {
+      destination.updateConfig(integrations[destination.key] || {});
+    }
+  }
+
+  async run(operation, ...args) {
+    return Promise.all(
+      this.destinations.filter((destination) => destination.isConfigured()).map(
+        async (destination) => {
+          let result;
+          try {
+            result = await destination[operation](...args);
+          } catch (error) {
+            result = playbackOperationFailure({
+              code: "DESTINATION_OPERATION_FAILED",
+              message: error?.message || `${destination.name} ${operation} failed`,
+              retryable: true,
+            });
+          }
+          if (!result.ok) {
+            console.warn(
+              `[PlaybackDestinationRegistry] ${destination.name} ${operation} failed:`,
+              result.error?.message,
+            );
+          }
+          return { destination: destination.name, operation, ...result };
+        },
+      ),
+    );
+  }
+}

--- a/backend/services/playback/plexPlaybackDestination.js
+++ b/backend/services/playback/plexPlaybackDestination.js
@@ -22,6 +22,8 @@ const SYNC_SKIPPED = Symbol("plex-sync-skipped");
 
 export class PlexPlaybackDestination {
   constructor(weeklyFlowRoot = resolvePlaylistRoot(), { client = null } = {}) {
+    this.key = "plex";
+    this.name = "Plex";
     this.weeklyFlowRoot = resolvePlaylistRoot(weeklyFlowRoot);
     this.playlistLibraryRoot = path.join(this.weeklyFlowRoot, PLAYLIST_LIBRARY_DIR);
     this.client = client;

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -291,6 +291,8 @@ async function runFlowCleanup({ flowId, tokenScope = null, token = null } = {}) 
 async function deleteFlow({ flowId, tokenScope = null, token = null } = {}) {
   const safeFlowId = String(flowId || "").trim();
   if (!safeFlowId) return false;
+  const flow = flowPlaylistConfig.getFlow(safeFlowId);
+  if (!flow) return false;
   if (!isLatestWeeklyFlowOperationToken(tokenScope, token)) {
     return { cancelled: true };
   }
@@ -302,6 +304,7 @@ async function deleteFlow({ flowId, tokenScope = null, token = null } = {}) {
     weeklyFlowWorker.setRetryCyclePaused(safeFlowId, false);
     weeklyFlowWorker.clearPlaylistRunState(safeFlowId);
     playlistManager.updateConfig(false);
+    await playlistManager.deletePlaybackPlaylist(flow);
     await playlistManager.weeklyReset([safeFlowId]);
     downloadTracker.clearByPlaylistType(safeFlowId);
     await playlistManager.cleanupEntityPlexPlaylists(safeFlowId);
@@ -619,6 +622,7 @@ async function deleteSharedPlaylist({ playlistId } = {}) {
   await withPlaylistMutation(safePlaylistId, async () => {
     weeklyFlowWorker.setRetryCyclePaused(safePlaylistId, false);
     playlistManager.updateConfig(false);
+    await playlistManager.deletePlaybackPlaylist(exists);
     await playlistManager.weeklyReset([safePlaylistId]);
     downloadTracker.clearByPlaylistType(safePlaylistId);
     await playlistManager.cleanupEntityPlexPlaylists(safePlaylistId);

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -215,6 +215,16 @@ export class WeeklyFlowPlaylistManager {
     return this.plexDestination.deleteEntityPlaylists(entityId);
   }
 
+  async deletePlaybackPlaylist(entity) {
+    return this.destinationRegistry.run(
+      "deletePlaylist",
+      createPlaybackPlaylistIdentity({
+        entityId: entity.id,
+        ownerUserId: entity.ownerUserId ?? null,
+      }),
+    );
+  }
+
   async syncPlexNow() {
     for (const flow of flowPlaylistConfig.getFlows()) {
       if (flow.enabled) continue;

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -20,6 +20,7 @@ import {
   createPlaybackPlaylistIdentity,
   createPlaybackPlaylistSnapshot,
 } from "../playback/playbackDestination.js";
+import { PlaybackDestinationRegistry } from "../playback/playbackDestinationRegistry.js";
 import { collectPlaybackPlaylistTracks } from "../playback/playbackPlaylistTracks.js";
 import { NavidromePlaybackDestination } from "../playback/navidromePlaybackDestination.js";
 import { PlexPlaybackDestination } from "../playback/plexPlaybackDestination.js";
@@ -41,6 +42,10 @@ export class WeeklyFlowPlaylistManager {
     this.plexDestination = assertPlaybackDestination(
       new PlexPlaybackDestination(this.weeklyFlowRoot),
     );
+    this.destinationRegistry = new PlaybackDestinationRegistry([
+      this.navidromeDestination,
+      this.plexDestination,
+    ]);
     this._ensureInFlight = null;
     this._refreshInFlight = new Map();
     this.updateConfig(triggerEnsureOnInit);
@@ -48,10 +53,7 @@ export class WeeklyFlowPlaylistManager {
 
   updateConfig(triggerEnsurePlaylists = true) {
     const settings = dbOps.getSettings();
-    const navidromeConfig = settings.integrations?.navidrome || {};
-    this.navidromeDestination.updateConfig(navidromeConfig);
-
-    this.plexDestination.updateConfig(settings.integrations?.plex || {});
+    this.destinationRegistry.updateConfig(settings.integrations);
 
     if (triggerEnsurePlaylists) {
       this.ensurePlaylists().catch((err) =>
@@ -106,11 +108,11 @@ export class WeeklyFlowPlaylistManager {
     const flow = flowPlaylistConfig.getFlow(playlistType);
     if (flow) {
       if (!flow.enabled) return null;
-      return this._publishNavidromePlaylist(flow, "Flow");
+      return this._publishPlaylist(flow, "Flow");
     }
     const sharedPlaylist = flowPlaylistConfig.getSharedPlaylist(playlistType);
     if (!sharedPlaylist) return null;
-    return this._publishNavidromePlaylist(sharedPlaylist, "Playlist");
+    return this._publishPlaylist(sharedPlaylist, "Playlist");
   }
 
   scheduleScanLibrary(force = false) {
@@ -147,92 +149,52 @@ export class WeeklyFlowPlaylistManager {
     });
   }
 
-  async _publishNavidromePlaylist(entity, artworkKind) {
+  async _publishPlaylist(entity, artworkKind) {
     const snapshot = await this._createPlaybackSnapshot(entity);
-    const result = await this.navidromeDestination.publishPlaylist(snapshot);
-    if (!result.ok) throw new Error(result.error.message);
-    const playlistName = this.navidromeDestination.getPlaylistName(snapshot);
-    await this._ensureFlowArtwork(entity.id, playlistName, artworkKind);
-    return result;
+    const results = await this.destinationRegistry.run("publishPlaylist", snapshot);
+    if (
+      results.some(
+        (result) => result.destination === this.navidromeDestination.name && result.ok,
+      )
+    ) {
+      const playlistName = this.navidromeDestination.getPlaylistName(snapshot);
+      await this._ensureFlowArtwork(entity.id, playlistName, artworkKind);
+    }
+    return results;
   }
 
   async _ensurePlaylistsInternal() {
     const flows = flowPlaylistConfig.getFlows();
     const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
-    const syncEntity = async (entityId, run) => {
-      try {
-        await run();
-      } catch (err) {
-        console.warn(
-          `[WeeklyFlowPlaylistManager] Navidrome sync failed for ${entityId}:`,
-          err?.message,
-        );
-      }
-    };
-    try {
-      const ensured = await this.navidromeDestination.ensureLibrary();
-      if (!ensured.ok) throw new Error(ensured.error.message);
-    } catch (err) {
-      console.warn("[WeeklyFlowPlaylistManager] Navidrome library setup failed:", err?.message);
-    }
+    await this.destinationRegistry.run("ensureLibrary");
     for (const flow of flows) {
-      await syncEntity(flow.id, async () => {
-        if (flow.enabled) {
-          await this._publishNavidromePlaylist(flow, "Flow");
-          return;
-        }
-        const deleted = await this.navidromeDestination.deletePlaylist(
+      if (flow.enabled) {
+        await this._publishPlaylist(flow, "Flow");
+      } else {
+        const results = await this.destinationRegistry.run(
+          "deletePlaylist",
           createPlaybackPlaylistIdentity({
             entityId: flow.id,
             ownerUserId: flow.ownerUserId ?? null,
           }),
         );
-        if (!deleted.ok) throw new Error(deleted.error.message);
-        const playlistName = this.navidromeDestination.getPlaylistName({
-          entityId: flow.id,
-          ownerUserId: flow.ownerUserId ?? null,
-          displayName: flow.name,
-        });
-        await this._ensureFlowArtwork(flow.id, playlistName, "Flow");
-      });
+        if (
+          results.some(
+            (result) => result.destination === this.navidromeDestination.name && result.ok,
+          )
+        ) {
+          const playlistName = this.navidromeDestination.getPlaylistName({
+            entityId: flow.id,
+            ownerUserId: flow.ownerUserId ?? null,
+            displayName: flow.name,
+          });
+          await this._ensureFlowArtwork(flow.id, playlistName, "Flow");
+        }
+      }
     }
     for (const playlist of sharedPlaylists) {
-      await syncEntity(playlist.id, () => this._publishNavidromePlaylist(playlist, "Playlist"));
+      await this._publishPlaylist(playlist, "Playlist");
     }
-
-    if (this.plexDestination.isConfigured()) {
-      try {
-        await this._syncPlexPlaylists(flows, sharedPlaylists);
-      } catch (err) {
-        console.warn("[WeeklyFlowPlaylistManager] Plex playlist sync failed:", err?.message);
-      }
-    }
-  }
-
-  async _syncPlexPlaylists(flows, sharedPlaylists) {
-    if (!this.plexDestination.isConfigured()) return;
-    const ensured = await this.plexDestination.ensureLibrary();
-    if (!ensured.ok) throw new Error(ensured.error.message);
-    const sync = async (entity, enabled = true) => {
-      try {
-        const result = enabled
-          ? await this.plexDestination.publishPlaylist(await this._createPlaybackSnapshot(entity))
-          : await this.plexDestination.deletePlaylist(
-              createPlaybackPlaylistIdentity({
-                entityId: entity.id,
-                ownerUserId: entity.ownerUserId ?? null,
-              }),
-            );
-        if (!result.ok) throw new Error(result.error.message);
-      } catch (error) {
-        console.warn(
-          `[WeeklyFlowPlaylistManager] Plex sync failed for ${entity.id}:`,
-          error?.message,
-        );
-      }
-    };
-    for (const flow of flows) await sync(flow, flow.enabled);
-    for (const playlist of sharedPlaylists) await sync(playlist);
   }
 
   async _activePlaybackSnapshots() {
@@ -281,13 +243,7 @@ export class WeeklyFlowPlaylistManager {
   }
 
   async scanLibrary() {
-    const results = [];
-    if (this.navidromeDestination.isConfigured()) {
-      results.push(await this.navidromeDestination.requestScan());
-    }
-    if (this.plexDestination.isConfigured()) {
-      results.push(await this.plexDestination.requestScan());
-    }
+    const results = await this.destinationRegistry.run("requestScan");
     return results.length ? results : null;
   }
 

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-`WeeklyFlowPlaylistManager` creates path-first playlist snapshots. It calls the Navidrome and Plex destinations directly. Navidrome writes track paths to M3U files. Plex resolves track paths to Plex track IDs and stores Plex playlist pointers. Both destinations publish the same Aurral playlists, but their configuration and identity rules are different.
+`WeeklyFlowPlaylistManager` creates path-first playlist snapshots. A settings-driven registry sends each snapshot to every configured playback destination. Navidrome writes track paths to M3U files. Plex resolves track paths to Plex track IDs and stores Plex playlist pointers. Both destinations publish the same Aurral playlists, but their configuration and identity rules are different.
 
 ## Decision
 
@@ -40,7 +40,7 @@ The Navidrome adapter writes snapshot paths to M3U files after it applies Navidr
 
 The Plex adapter resolves snapshot paths to Plex rating keys. It keeps section IDs, user tokens, playlist pointers, owner-specific titles, library setup, and scans inside the adapter.
 
-This decision does not change current Navidrome or Plex behavior. Both playback flows now use this seam. A later roadmap issue will replace the direct adapter calls with settings-driven orchestration.
+This decision does not change current Navidrome or Plex behavior. Both playback flows use this seam through an in-process registry. The registry checks saved settings, runs every configured destination, and records one destination failure without blocking another destination.
 
 ## Deliberate non-goals
 


### PR DESCRIPTION
## Summary

- add a fixed in-process registry for the existing Navidrome and Plex playback destinations
- drive adapter configuration from saved integration settings and fan out publish, delete, library setup, and scan operations to every configured destination
- identify and isolate structured or thrown destination failures without adding plugin registration or changing adapter-owned authentication and playback behavior
- route flow and shared-playlist deletion through the registry before adapter-specific stale Plex pointer cleanup

## Validation

- `npm run lint`
- `npm test` (537 passed)
- `npm run test:integration` (30 passed)
- `npm run build`
- `(cd docs && npm ci && npm run build)`
- local image build and `/api/health` check
- exact `ghcr.io/lklynet/aurral:pr-590` image for `c2970675187fce025533a7176487bfb0abe1fd68` at `sha256:6f0146a0c7828bf17f7b800905c28432d374aca78f679d5dc3d08710f06b3039`
- live one-track Navidrome and Plex publish, scan, isolated Plex outage, isolated Navidrome outage, recovery, rename, and delete journeys passed
- login page, static asset, health, unauthenticated `/api/auth/me`, and authenticated `/api/auth/me` checks passed
- candidate logs contained no uncaught exceptions, unhandled rejections, authentication errors, or worker failures
- disposable playlist, M3U, Plex media, jobs, track file, backup, and candidate container removed; shared Plex and Navidrome services are running

The persistent Plex server used its existing disposable test-stack identity. Its fresh claim variable remains empty, so a reset server requires a new disposable claim.

Refs #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback playlists can now be published, updated, deleted, and scanned across all configured destinations.
  * Added support for independently processing multiple playback destinations.
* **Bug Fixes**
  * Failures in one playback destination no longer prevent successful destinations from completing.
  * Deleting weekly flows and shared playlists now also removes their associated playback playlists.
* **Documentation**
  * Updated playback architecture documentation to reflect multi-destination processing and independent failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->