### PR TITLE
feat(playback): sync Navidrome playlists through API

### DIFF
--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { NavidromeClient } from "../backend/services/navidrome.js";
+
+const jsonResponse = (value) => new Response(JSON.stringify(value), {
+  headers: { "content-type": "application/json" },
+});
+
+test("creates a distinct playlist without looking up matching display names", async () => {
+  const originalFetch = globalThis.fetch;
+  const urls = [];
+  globalThis.fetch = async (url) => {
+    urls.push(new URL(url));
+    return jsonResponse({
+      "subsonic-response": { status: "ok", playlist: { id: "new-id", name: "Same Name" } },
+    });
+  };
+
+  let playlist;
+  try {
+    playlist = await new NavidromeClient("http://navidrome.test", "user", "password")
+      .createPlaylist("Same Name", ["song-1"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(playlist.id, "new-id");
+  assert.equal(urls.length, 1);
+  assert.equal(urls[0].pathname, "/rest/createPlaylist");
+});
+
+test("replaces playlist entries with repeated Subsonic parameters", async () => {
+  const originalFetch = globalThis.fetch;
+  const urls = [];
+  globalThis.fetch = async (url) => {
+    urls.push(new URL(url));
+    if (urls.length === 1) {
+      return jsonResponse({
+        "subsonic-response": {
+          status: "ok",
+          playlist: { entry: [{ id: "old-1" }, { id: "old-2" }] },
+        },
+      });
+    }
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .updatePlaylist("playlist-1", { name: "Renamed", songIds: ["song-1", "song-2"] });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(urls[1].searchParams.getAll("songIndexToRemove"), ["0", "1"]);
+  assert.deepEqual(urls[1].searchParams.getAll("songIdToAdd"), ["song-1", "song-2"]);
+  assert.equal(urls[1].searchParams.get("name"), "Renamed");
+});
+
+test("prefers the exact path and metadata when duplicate songs match", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => jsonResponse({
+    "subsonic-response": {
+      status: "ok",
+      searchResult3: {
+        song: [
+          { id: "other", title: "Song", artist: "Artist", album: "Other", path: "Song.flac" },
+          {
+            id: "match",
+            title: "Song",
+            artist: "Artist",
+            album: "Album",
+            path: "Artist/Album/Song.flac",
+            duration: 240,
+          },
+        ],
+      },
+    },
+  });
+
+  let song;
+  try {
+    song = await new NavidromeClient("http://navidrome.test", "user", "password")
+      .findSong("Song", "Artist", {
+        album: "Album",
+        durationMs: 240000,
+        path: "/music/Artist/Album/Song.flac",
+      });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(song.id, "match");
+});

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -30,6 +30,26 @@ test("creates a distinct playlist without looking up matching display names", as
   assert.equal(urls[0].pathname, "/rest/createPlaylist");
 });
 
+test("preserves Subsonic error codes for missing native IDs", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => jsonResponse({
+    "subsonic-response": {
+      status: "failed",
+      error: { code: 70, message: "Playlist not found" },
+    },
+  });
+
+  try {
+    await assert.rejects(
+      new NavidromeClient("http://navidrome.test", "user", "password")
+        .getPlaylist("missing"),
+      (error) => error.code === 70,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("replaces playlist entries with repeated Subsonic parameters", async () => {
   const originalFetch = globalThis.fetch;
   const urls = [];

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -16,6 +16,7 @@ const [
   { flowPlaylistConfig },
   { syncM3uPathMappings },
   { createPlaybackPlaylistIdentity, createPlaybackPlaylistSnapshot },
+  { navidromePlaylistPointerStore },
   { NavidromePlaybackDestination },
 ] = await setupIsolatedBackend(
   "navidrome-playback-destination",
@@ -24,13 +25,15 @@ const [
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/playlistM3uPaths.js",
   "backend/services/playback/playbackDestination.js",
+  "backend/services/navidrome/navidromePlaylistPointerStore.js",
   "backend/services/playback/navidromePlaybackDestination.js",
 );
 
 const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
-function createClient({ configured = true, playlists = [] } = {}) {
-  const calls = { deleted: [], ensured: [], scans: 0 };
+function createClient({ configured = true, playlists = [], songs = {} } = {}) {
+  const currentPlaylists = playlists.map((playlist) => ({ ...playlist }));
+  const calls = { created: [], deleted: [], ensured: [], scans: 0, updated: [] };
   return {
     calls,
     isConfigured: () => configured,
@@ -39,10 +42,26 @@ function createClient({ configured = true, playlists = [] } = {}) {
       calls.ensured.push(libraryPath);
     },
     async getPlaylists() {
-      return playlists;
+      return currentPlaylists;
+    },
+    async findSong(title) {
+      return songs[title] || null;
+    },
+    async createPlaylist(name, songIds) {
+      calls.created.push({ name, songIds });
+      const playlist = { id: "created", name };
+      currentPlaylists.push(playlist);
+      return playlist;
+    },
+    async updatePlaylist(id, payload) {
+      calls.updated.push({ id, ...payload });
+      const playlist = currentPlaylists.find((candidate) => candidate.id === id);
+      if (playlist) playlist.name = payload.name;
     },
     async deletePlaylist(id) {
       calls.deleted.push(id);
+      const index = currentPlaylists.findIndex((playlist) => playlist.id === id);
+      if (index >= 0) currentPlaylists.splice(index, 1);
     },
     async scanLibrary() {
       calls.scans += 1;
@@ -99,6 +118,181 @@ test("publishes mapped M3U files and ensures the Navidrome library", async () =>
   );
 });
 
+test("publishes resolved tracks through the Subsonic API and stores the playlist ID", async () => {
+  const owner = userOps.createUser("casey", "hash", "user");
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "API Mix",
+    ownerUserId: owner.id,
+  });
+  const client = createClient({
+    songs: {
+      First: { id: "song-1" },
+      Second: { id: "song-2" },
+    },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+
+  assert.deepEqual(
+    await destination.publishPlaylist(
+      createPlaybackPlaylistSnapshot({
+        entityId: playlist.id,
+        ownerUserId: owner.id,
+        displayName: playlist.name,
+        tracks: [
+          { path: "/music/first.flac", title: "First", artist: "Artist" },
+          { path: "/music/second.flac", title: "Second", artist: "Artist" },
+        ],
+      }),
+    ),
+    { ok: true },
+  );
+
+  assert.deepEqual(client.calls.created, [
+    { name: "casey - API Mix", songIds: ["song-1", "song-2"] },
+  ]);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, String(owner.id)).playlistId,
+    "created",
+  );
+  await assert.rejects(
+    fs.access(path.join(destination.libraryRoot, "casey - API Mix.m3u")),
+  );
+});
+
+test("creates an empty API playlist without waiting for a scan", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Empty" });
+  const client = createClient();
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+
+  assert.deepEqual(
+    await destination.publishPlaylist(
+      createPlaybackPlaylistSnapshot({
+        entityId: playlist.id,
+        displayName: playlist.name,
+        tracks: [],
+      }),
+    ),
+    { ok: true },
+  );
+  assert.deepEqual(client.calls.created, [{ name: "Empty", songIds: [] }]);
+});
+
+test("adopts an imported M3U playlist and keeps its ID across rename and delete", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Imported" });
+  const client = createClient({
+    playlists: [{ id: "imported-id", name: "Imported" }],
+    songs: { Song: { id: "song-1" } },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, "Imported.m3u"), "legacy");
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: "Imported",
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: "Renamed",
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+  assert.deepEqual(client.calls.updated, [
+    { id: "imported-id", name: "Imported", songIds: ["song-1"] },
+    { id: "imported-id", name: "Renamed", songIds: ["song-1"] },
+  ]);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "imported-id",
+  );
+
+  await destination.deletePlaylist(
+    createPlaybackPlaylistIdentity({ entityId: playlist.id }),
+  );
+  assert.deepEqual(client.calls.deleted, ["imported-id"]);
+  assert.equal(navidromePlaylistPointerStore.getPointer(playlist.id, "global"), null);
+});
+
+test("does not adopt a same-name playlist claimed by another Aurral entity", async () => {
+  const second = flowPlaylistConfig.createSharedPlaylist({ name: "Same Name" });
+  const client = createClient({
+    playlists: [{ id: "claimed-id", name: "Same Name" }],
+    songs: { Song: { id: "song-1" } },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer("other-entity", "global", {
+    playlistId: "claimed-id",
+    title: second.name,
+  });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, "Same Name.m3u"), "migration");
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: second.id,
+      displayName: second.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.updated, []);
+  assert.deepEqual(client.calls.created, [{ name: "Same Name", songIds: ["song-1"] }]);
+});
+
+test("converts the M3U fallback after Navidrome indexes a missing song", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Catch-up" });
+  const songs = {};
+  const client = createClient({ songs });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: playlist.id,
+    displayName: playlist.name,
+    tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+  });
+
+  await destination.publishPlaylist(snapshot);
+  await assert.doesNotReject(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
+  songs.Song = { id: "indexed-song" };
+  destination._scheduleCatchup([0]);
+  while (destination._catchupRunning) await new Promise((resolve) => setTimeout(resolve, 1));
+
+  assert.deepEqual(client.calls.created, [
+    { name: "Catch-up", songIds: ["indexed-song"] },
+  ]);
+  await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
+});
+
+test("keeps the stored playlist ID when Navidrome is unavailable", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Offline" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  client.getPlaylists = async () => {
+    throw new Error("offline");
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "saved-id",
+    title: playlist.name,
+  });
+
+  const result = await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "saved-id",
+  );
+});
+
 test("deletes the current playlist but preserves its artwork", async () => {
   const flow = flowPlaylistConfig.createFlow({ name: "Quiet Night" });
   const client = createClient({ playlists: [{ id: "current", name: "Quiet Night" }] });
@@ -121,13 +315,40 @@ test("deletes the current playlist but preserves its artwork", async () => {
   assert.deepEqual(client.calls.deleted, ["current"]);
 });
 
-test("publishing removes legacy files and Navidrome playlists", async () => {
+test("cleans local files when deleting a stored playlist during an outage", async () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Offline Delete" });
+  const client = createClient({ playlists: [{ id: "saved-id", name: flow.name }] });
+  client.deletePlaylist = async () => {
+    throw new Error("offline");
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(flow.id, "global", {
+    playlistId: "saved-id",
+    title: flow.name,
+  });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, `${flow.name}.m3u`), "playlist");
+
+  const result = await destination.deletePlaylist(
+    createPlaybackPlaylistIdentity({ entityId: flow.id }),
+  );
+
+  assert.equal(result.ok, false);
+  await assert.rejects(fs.access(path.join(destination.libraryRoot, `${flow.name}.m3u`)));
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(flow.id, "global").playlistId,
+    "saved-id",
+  );
+});
+
+test("publishing adopts one legacy playlist and removes the other legacy copies", async () => {
   const flow = flowPlaylistConfig.createFlow({ name: "Road Trip" });
   const client = createClient({
     playlists: [
       { id: "bracketed", name: "[A] Road Trip" },
       { id: "prefixed", name: "Aurral Road Trip" },
     ],
+    songs: { Song: { id: "song-1" } },
   });
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
   await fs.mkdir(destination.libraryRoot, { recursive: true });
@@ -141,7 +362,7 @@ test("publishing removes legacy files and Navidrome playlists", async () => {
       createPlaybackPlaylistSnapshot({
         entityId: flow.id,
         displayName: flow.name,
-        tracks: [],
+        tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
       }),
     ),
     { ok: true },
@@ -151,7 +372,10 @@ test("publishing removes legacy files and Navidrome playlists", async () => {
     await assert.rejects(fs.access(path.join(destination.libraryRoot, `${name}.m3u`)));
     await assert.rejects(fs.access(path.join(destination.libraryRoot, `${name}.webp`)));
   }
-  assert.deepEqual(client.calls.deleted.sort(), ["bracketed", "prefixed"]);
+  assert.deepEqual(client.calls.updated, [
+    { id: "bracketed", name: "Road Trip", songIds: ["song-1"] },
+  ]);
+  assert.deepEqual(client.calls.deleted, ["prefixed"]);
 });
 
 test("requests configured scans and treats an unconfigured destination as a no-op", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -159,6 +159,43 @@ test("publishes resolved tracks through the Subsonic API and stores the playlist
   );
 });
 
+test("bounds concurrent Navidrome song lookups and preserves track order", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Large API Mix" });
+  const tracks = Array.from({ length: 6 }, (_, index) => ({
+    path: `/music/song-${index}.flac`,
+    title: `Song ${index}`,
+    artist: "Artist",
+  }));
+  const client = createClient({
+    songs: Object.fromEntries(tracks.map((track, index) => [track.title, { id: `song-${index}` }])),
+  });
+  const findSong = client.findSong.bind(client);
+  let active = 0;
+  let maxActive = 0;
+  client.findSong = async (...args) => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((resolve) => setImmediate(resolve));
+    const song = await findSong(...args);
+    active -= 1;
+    return song;
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+
+  assert.deepEqual(
+    await destination.publishPlaylist(
+      createPlaybackPlaylistSnapshot({
+        entityId: playlist.id,
+        displayName: playlist.name,
+        tracks,
+      }),
+    ),
+    { ok: true },
+  );
+  assert.equal(maxActive, 5);
+  assert.deepEqual(client.calls.created[0].songIds, tracks.map((_, index) => `song-${index}`));
+});
+
 test("creates an empty API playlist without waiting for a scan", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Empty" });
   const client = createClient();
@@ -478,6 +515,29 @@ test("cleans local files when deleting a stored playlist during an outage", asyn
   );
 
   assert.equal(result.ok, false);
+  await assert.rejects(fs.access(path.join(destination.libraryRoot, `${flow.name}.m3u`)));
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(flow.id, "global").playlistId,
+    "saved-id",
+  );
+});
+
+test("keeps a stored pointer while deleting local files when Navidrome is unconfigured", async () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Disabled Delete" });
+  const client = createClient({ configured: false });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(flow.id, "global", {
+    playlistId: "saved-id",
+    title: flow.name,
+  });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, `${flow.name}.m3u`), "playlist");
+
+  assert.deepEqual(
+    await destination.deletePlaylist(createPlaybackPlaylistIdentity({ entityId: flow.id })),
+    { ok: true },
+  );
+  assert.deepEqual(client.calls.deleted, []);
   await assert.rejects(fs.access(path.join(destination.libraryRoot, `${flow.name}.m3u`)));
   assert.equal(
     navidromePlaylistPointerStore.getPointer(flow.id, "global").playlistId,

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -210,9 +210,7 @@ test("serializes concurrent publishes before creating a native playlist", async 
   await Promise.all(publishes);
 
   assert.equal(client.calls.created.length, 1);
-  assert.deepEqual(client.calls.updated, [
-    { id: "created", name: "Concurrent", songIds: ["song-1"] },
-  ]);
+  assert.deepEqual(client.calls.updated, []);
 });
 
 test("adopts an imported M3U playlist and keeps its ID across rename and delete", async () => {
@@ -347,6 +345,43 @@ test("updates a stored playlist ID without relying on the playlist list", async 
     { id: "saved-id", name: "Stored", songIds: ["song-1"] },
   ]);
   assert.deepEqual(client.calls.created, []);
+});
+
+test("retries a transient missing-ID response without replacing the playlist", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Transient" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  const updatePlaylist = client.updatePlaylist.bind(client);
+  let attempts = 0;
+  client.updatePlaylist = async (...args) => {
+    attempts += 1;
+    if (attempts === 1) {
+      const error = new Error("temporarily missing");
+      error.code = 70;
+      throw error;
+    }
+    return updatePlaylist(...args);
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "saved-id",
+    title: playlist.name,
+  });
+
+  const result = await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(attempts, 2);
+  assert.deepEqual(client.calls.created, []);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "saved-id",
+  );
 });
 
 test("recreates a stored playlist only when Navidrome reports it missing", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -325,10 +325,60 @@ test("converts the M3U fallback after Navidrome indexes a missing song", async (
   await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
 });
 
+test("updates a stored playlist ID without relying on the playlist list", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Stored" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "saved-id",
+    title: playlist.name,
+  });
+
+  const result = await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(client.calls.updated, [
+    { id: "saved-id", name: "Stored", songIds: ["song-1"] },
+  ]);
+  assert.deepEqual(client.calls.created, []);
+});
+
+test("recreates a stored playlist only when Navidrome reports it missing", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Missing" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  client.updatePlaylist = async () => {
+    const error = new Error("not found");
+    error.code = 70;
+    throw error;
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "missing-id",
+    title: playlist.name,
+  });
+
+  const result = await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(client.calls.created, [{ name: "Missing", songIds: ["song-1"] }]);
+});
+
 test("keeps the stored playlist ID when Navidrome is unavailable", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Offline" });
   const client = createClient({ songs: { Song: { id: "song-1" } } });
-  client.getPlaylists = async () => {
+  client.updatePlaylist = async () => {
     throw new Error("offline");
   };
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -177,6 +177,44 @@ test("creates an empty API playlist without waiting for a scan", async () => {
   assert.deepEqual(client.calls.created, [{ name: "Empty", songIds: [] }]);
 });
 
+test("serializes concurrent publishes before creating a native playlist", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Concurrent" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  const createPlaylist = client.createPlaylist.bind(client);
+  let createEntrants = 0;
+  let releaseCreate;
+  let signalCreate;
+  const createStarted = new Promise((resolve) => {
+    signalCreate = resolve;
+  });
+  client.createPlaylist = async (...args) => {
+    createEntrants += 1;
+    signalCreate();
+    await new Promise((resolve) => {
+      releaseCreate = resolve;
+    });
+    return createPlaylist(...args);
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: playlist.id,
+    displayName: playlist.name,
+    tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+  });
+
+  const publishes = [destination.publishPlaylist(snapshot), destination.publishPlaylist(snapshot)];
+  await createStarted;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(createEntrants, 1);
+  releaseCreate();
+  await Promise.all(publishes);
+
+  assert.equal(client.calls.created.length, 1);
+  assert.deepEqual(client.calls.updated, [
+    { id: "created", name: "Concurrent", songIds: ["song-1"] },
+  ]);
+});
+
 test("adopts an imported M3U playlist and keeps its ID across rename and delete", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Imported" });
   const client = createClient({
@@ -186,14 +224,35 @@ test("adopts an imported M3U playlist and keeps its ID across rename and delete"
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
   await fs.mkdir(destination.libraryRoot, { recursive: true });
   await fs.writeFile(path.join(destination.libraryRoot, "Imported.m3u"), "legacy");
+  const updatePlaylist = client.updatePlaylist.bind(client);
+  let releaseUpdate;
+  let signalUpdate;
+  const updateStarted = new Promise((resolve) => {
+    signalUpdate = resolve;
+  });
+  client.updatePlaylist = async (...args) => {
+    signalUpdate();
+    await new Promise((resolve) => {
+      releaseUpdate = resolve;
+    });
+    return updatePlaylist(...args);
+  };
 
-  await destination.publishPlaylist(
+  const migrating = destination.publishPlaylist(
     createPlaybackPlaylistSnapshot({
       entityId: playlist.id,
       displayName: "Imported",
       tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
     }),
   );
+  await updateStarted;
+  assert.equal(
+    await fs.readFile(path.join(destination.libraryRoot, "Imported.m3u"), "utf8"),
+    "legacy",
+  );
+  releaseUpdate();
+  await migrating;
+  client.updatePlaylist = updatePlaylist;
   await destination.publishPlaylist(
     createPlaybackPlaylistSnapshot({
       entityId: playlist.id,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Aurral is the Lidarr companion for self-hosted music discovery. Best-in-class re
 - **Playlists**: Run scheduled flows, adopt discover playlists like Release Radar, import spotify playlists, and convert flows to fixed tracklists.
 - **Activity**: Queue, review, and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, and Aurral playlist jobs.
 - **Integrations**: Lidarr, Last.fm, ListenBrainz, Koito, yt-dlp, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
-- **Playback**: Stream through Navidrome (M3U playlists) or Plex/Plexamp (API-synced playlists) from a dedicated download folder.
+- **Playback**: Stream through API-synced Navidrome or Plex/Plexamp playlists from a dedicated download folder.
 - **Multi-user**: Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, reverse-proxy SSO, and native OIDC.
 
 ## Screenshots

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -48,12 +48,15 @@ export class NavidromeClient {
     if (!this.isConfigured()) throw new Error("Navidrome not configured");
 
     try {
-      const response = await axios.get(`${this.url}/rest/${endpoint}`, {
-        params: {
-          ...this.getAuthParams(),
-          ...params,
-        },
-      });
+      const query = new URLSearchParams();
+      for (const [key, value] of Object.entries({ ...this.getAuthParams(), ...params })) {
+        if (Array.isArray(value)) {
+          for (const item of value) query.append(key, item);
+        } else if (value != null) {
+          query.set(key, value);
+        }
+      }
+      const response = await axios.get(`${this.url}/rest/${endpoint}?${query}`);
 
       if (response.data["subsonic-response"]?.status === "failed") {
         throw new Error(
@@ -72,7 +75,7 @@ export class NavidromeClient {
     return this.request("ping");
   }
 
-  async findSong(title, artist) {
+  async findSong(title, artist, track = {}) {
     const data = await this.request("search3", {
       query: `${artist} ${title}`,
       songCount: 5,
@@ -81,13 +84,27 @@ export class NavidromeClient {
     });
 
     const songs = data.searchResult3?.song || [];
-    const match = songs.find(
+    const matches = (Array.isArray(songs) ? songs : [songs]).filter(
       (s) =>
-        s.title.toLowerCase() === title.toLowerCase() &&
-        s.artist.toLowerCase() === artist.toLowerCase(),
+        String(s.title || "").toLowerCase() === title.toLowerCase() &&
+        String(s.artist || "").toLowerCase() === artist.toLowerCase(),
     );
-
-    return match || null;
+    const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
+    const fileName = normalizedPath.split("/").at(-1);
+    const album = String(track.album || "").toLowerCase();
+    const mbid = String(track.mbid || "").toLowerCase();
+    const duration = Number(track.durationMs) / 1000;
+    const score = (song) => {
+      const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
+      let value = 0;
+      if (mbid && String(song.musicBrainzId || "").toLowerCase() === mbid) value += 8;
+      if (songPath && normalizedPath.endsWith(songPath)) value += 4;
+      else if (fileName && songPath.split("/").at(-1) === fileName) value += 2;
+      if (album && String(song.album || "").toLowerCase() === album) value += 2;
+      if (Number.isFinite(duration) && Math.abs(Number(song.duration) - duration) <= 2) value += 1;
+      return value;
+    };
+    return matches.sort((a, b) => score(b) - score(a))[0] || null;
   }
 
   async searchSongsByArtist(artistName, limit = 5) {
@@ -119,42 +136,35 @@ export class NavidromeClient {
 
   async getPlaylists() {
     const data = await this.request("getPlaylists");
-    return data.playlists?.playlist || [];
+    const playlists = data.playlists?.playlist || [];
+    return Array.isArray(playlists) ? playlists : [playlists];
   }
 
-  async createPlaylist(name, songIds, replace = false) {
-    if (!songIds || songIds.length === 0) {
-      if (replace) {
-        const playlists = await this.getPlaylists();
-        const existing = playlists.find((p) => p.name === name);
-        if (existing) {
-          await this.deletePlaylist(existing.id);
-        }
-      }
-      return null;
-    }
+  async getPlaylist(id) {
+    const data = await this.request("getPlaylist", { id });
+    return data.playlist || null;
+  }
 
-    const playlists = await this.getPlaylists();
-    const existing = playlists.find((p) => p.name === name);
-
-    if (existing) {
-      if (replace) {
-        await this.deletePlaylist(existing.id);
-      } else {
-        const data = await this.request("updatePlaylist", {
-          playlistId: existing.id,
-          songIdToAdd: songIds,
-        });
-        return data.playlist || existing;
-      }
-    }
-
+  async createPlaylist(name, songIds) {
+    const ids = Array.isArray(songIds) ? songIds : [];
     const data = await this.request("createPlaylist", {
       name,
-      songId: songIds,
+      songId: ids,
     });
+    return data.playlist || null;
+  }
 
-    return data.playlist;
+  async updatePlaylist(playlistId, { name, songIds = [] } = {}) {
+    const playlist = await this.getPlaylist(playlistId);
+    const entries = playlist?.entry
+      ? Array.isArray(playlist.entry) ? playlist.entry : [playlist.entry]
+      : [];
+    await this.request("updatePlaylist", {
+      playlistId,
+      name,
+      songIndexToRemove: entries.map((_, index) => index),
+      songIdToAdd: songIds,
+    });
   }
 
   async deletePlaylist(id) {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -59,9 +59,10 @@ export class NavidromeClient {
       const response = await axios.get(`${this.url}/rest/${endpoint}?${query}`);
 
       if (response.data["subsonic-response"]?.status === "failed") {
-        throw new Error(
-          response.data["subsonic-response"].error?.message || "Navidrome request failed",
-        );
+        const responseError = response.data["subsonic-response"].error || {};
+        const error = new Error(responseError.message || "Navidrome request failed");
+        error.code = responseError.code;
+        throw error;
       }
 
       return response.data["subsonic-response"];

--- a/backend/services/navidrome/navidromePlaylistPointerStore.js
+++ b/backend/services/navidrome/navidromePlaylistPointerStore.js
@@ -1,0 +1,60 @@
+import { db, dbHelpers } from "../../config/db-sqlite.js";
+
+const SETTINGS_KEY = "navidromePlaylistPointers";
+const getSettingStmt = db.prepare("SELECT value FROM settings WHERE key = ?");
+const upsertSettingStmt = db.prepare(
+  "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+);
+
+const readStore = () => {
+  const parsed = dbHelpers.parseJSON(getSettingStmt.get(SETTINGS_KEY)?.value);
+  return parsed && typeof parsed === "object" ? parsed : {};
+};
+
+const writeStore = (store) => {
+  upsertSettingStmt.run(SETTINGS_KEY, dbHelpers.stringifyJSON(store));
+};
+
+const normalizePointer = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const playlistId = raw.playlistId != null ? String(raw.playlistId) : null;
+  if (!playlistId) return null;
+  return {
+    playlistId,
+    title: String(raw.title || ""),
+    updatedAt: Number(raw.updatedAt) || Date.now(),
+  };
+};
+
+export const navidromePlaylistPointerStore = {
+  getPointer(entityId, targetKey) {
+    return normalizePointer(readStore()[entityId]?.[targetKey] || null);
+  },
+
+  setPointer(entityId, targetKey, { playlistId, title }) {
+    const store = readStore();
+    if (!store[entityId]) store[entityId] = {};
+    store[entityId][targetKey] = {
+      playlistId: String(playlistId),
+      title: String(title || ""),
+      updatedAt: Date.now(),
+    };
+    writeStore(store);
+  },
+
+  deletePointer(entityId, targetKey) {
+    const store = readStore();
+    if (!store[entityId]?.[targetKey]) return false;
+    delete store[entityId][targetKey];
+    if (!Object.keys(store[entityId]).length) delete store[entityId];
+    writeStore(store);
+    return true;
+  },
+
+  hasPlaylistId(playlistId) {
+    const expected = String(playlistId);
+    return Object.values(readStore()).some((targets) =>
+      Object.values(targets || {}).some((raw) => normalizePointer(raw)?.playlistId === expected),
+    );
+  },
+};

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -48,6 +48,7 @@ export class NavidromePlaybackDestination {
     this._playlists = null;
     this._pendingSnapshots = new Map();
     this._catchupRunning = false;
+    this._publishInFlight = new Map();
   }
 
   updateConfig(config = {}) {
@@ -247,45 +248,44 @@ export class NavidromePlaybackDestination {
     }
   }
 
-  async publishPlaylist(value) {
-    try {
-      const snapshot = createPlaybackPlaylistSnapshot(value);
-      await fs.mkdir(this.libraryRoot, { recursive: true });
-      const { current, legacy } = this.getPlaylistNames(snapshot);
-      const playlistPath = path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`);
-      let hadPlaylistFile = false;
-      for (const name of [current, ...legacy]) {
-        try {
-          await fs.access(path.join(this.libraryRoot, `${this._sanitize(name)}.m3u`));
-          hadPlaylistFile = true;
-          break;
-        } catch {}
-      }
-      const jobsByPath = this._jobsByPath(snapshot.entityId);
-      const content = buildM3uContent(snapshot.tracks, (track) => {
-        const localPath = path.resolve(track.path);
-        return resolveM3uTrackPath(jobsByPath.get(localPath), localPath, getM3uPathMode());
-      });
+  async _publishPlaylist(snapshot) {
+    await fs.mkdir(this.libraryRoot, { recursive: true });
+    const { current, legacy } = this.getPlaylistNames(snapshot);
+    const playlistPath = path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`);
+    let hadPlaylistFile = false;
+    for (const name of [current, ...legacy]) {
+      try {
+        await fs.access(path.join(this.libraryRoot, `${this._sanitize(name)}.m3u`));
+        hadPlaylistFile = true;
+        break;
+      } catch {}
+    }
+    const jobsByPath = this._jobsByPath(snapshot.entityId);
+    const content = buildM3uContent(snapshot.tracks, (track) => {
+      const localPath = path.resolve(track.path);
+      return resolveM3uTrackPath(jobsByPath.get(localPath), localPath, getM3uPathMode());
+    });
+    if (
+      typeof this.client?.createPlaylist !== "function"
+      || typeof this.client?.updatePlaylist !== "function"
+      || (snapshot.tracks.length && typeof this.client?.findSong !== "function")
+    ) {
       await fs.writeFile(playlistPath, content, "utf8");
-      if (
-        typeof this.client?.createPlaylist !== "function"
-        || typeof this.client?.updatePlaylist !== "function"
-        || (snapshot.tracks.length && typeof this.client?.findSong !== "function")
-      ) return playbackOperationSuccess();
+      return playbackOperationSuccess();
+    }
+    const targetKey = this._targetKey(snapshot.ownerUserId);
+    try {
       const songs = await Promise.all(
         snapshot.tracks.map((track) =>
           this.client.findSong(track.title, track.artist, track),
         ),
       );
       if (songs.some((song) => !song?.id)) {
-        this._pendingSnapshots.set(
-          `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`,
-          snapshot,
-        );
+        await fs.writeFile(playlistPath, content, "utf8");
+        this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
         return playbackOperationSuccess();
       }
 
-      const targetKey = this._targetKey(snapshot.ownerUserId);
       const playlists = await this._fetchPlaylists();
       const pointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
       let playlist = pointer
@@ -311,16 +311,34 @@ export class NavidromePlaybackDestination {
         playlistId: playlist.id,
         title: current,
       });
-      this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);
-      this._playlists = null;
-      await this._deleteNativePlaylists(legacy);
-      await this._deleteFiles([current], PLAYLIST_FILE_EXTENSIONS);
-      await this._deleteFiles(legacy, [
-        ...PLAYLIST_FILE_EXTENSIONS,
-        ...ARTWORK_FILE_EXTENSIONS,
-        ARTWORK_SUPPRESS_SUFFIX,
-      ]);
-      return playbackOperationSuccess();
+    } catch (error) {
+      await fs.writeFile(playlistPath, content, "utf8");
+      throw error;
+    }
+    this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);
+    this._playlists = null;
+    await this._deleteNativePlaylists(legacy);
+    await this._deleteFiles([current], PLAYLIST_FILE_EXTENSIONS);
+    await this._deleteFiles(legacy, [
+      ...PLAYLIST_FILE_EXTENSIONS,
+      ...ARTWORK_FILE_EXTENSIONS,
+      ARTWORK_SUPPRESS_SUFFIX,
+    ]);
+    return playbackOperationSuccess();
+  }
+
+  async publishPlaylist(value) {
+    try {
+      const snapshot = createPlaybackPlaylistSnapshot(value);
+      const key = `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`;
+      const previous = this._publishInFlight.get(key) || Promise.resolve();
+      const operation = previous.catch(() => {}).then(() => this._publishPlaylist(snapshot));
+      this._publishInFlight.set(key, operation);
+      try {
+        return await operation;
+      } finally {
+        if (this._publishInFlight.get(key) === operation) this._publishInFlight.delete(key);
+      }
     } catch (error) {
       return playbackOperationFailure({
         code: "PLAYLIST_PUBLISH_FAILED",

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -297,7 +297,7 @@ export class NavidromePlaybackDestination {
       const pointer = storedPointer;
       let playlist = null;
       if (pointer) {
-        for (const delayMs of [0, 250, 1000, 2000]) {
+        for (const delayMs of [0, 250, 1000, 2000, 4000]) {
           if (delayMs) await wait(delayMs);
           try {
             await this.client.updatePlaylist(pointer.playlistId, {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -297,7 +297,7 @@ export class NavidromePlaybackDestination {
       const pointer = storedPointer;
       let playlist = null;
       if (pointer) {
-        for (const delayMs of [0, 250, 1000, 2000, 4000]) {
+        for (const delayMs of [0, 250, 1000, 2000]) {
           if (delayMs) await wait(delayMs);
           try {
             await this.client.updatePlaylist(pointer.playlistId, {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as wait } from "node:timers/promises";
 import { userOps } from "../../db/helpers/index.js";
 import { NavidromeClient } from "../navidrome.js";
+import { navidromePlaylistPointerStore } from "../navidrome/navidromePlaylistPointerStore.js";
 import { getM3uPathMode, resolveM3uTrackPath } from "../playlistM3uPaths.js";
 import {
   PLAYLIST_LIBRARY_DIR,
@@ -44,6 +46,8 @@ export class NavidromePlaybackDestination {
     this.client = client;
     this._configKey = "";
     this._playlists = null;
+    this._pendingSnapshots = new Map();
+    this._catchupRunning = false;
   }
 
   updateConfig(config = {}) {
@@ -55,6 +59,7 @@ export class NavidromePlaybackDestination {
     if (key === this._configKey) return;
     this._configKey = key;
     this._playlists = null;
+    this._pendingSnapshots.clear();
     this.client = config.url && config.username && config.password
       ? new NavidromeClient(config.url, config.username, config.password)
       : null;
@@ -83,6 +88,10 @@ export class NavidromePlaybackDestination {
     return this.getPlaylistNames(playlist).current;
   }
 
+  _targetKey(ownerUserId) {
+    return String(ownerUserId ?? "global");
+  }
+
   _getEntity(entityId) {
     return flowPlaylistConfig.getFlow(entityId) || flowPlaylistConfig.getSharedPlaylist(entityId);
   }
@@ -101,12 +110,17 @@ export class NavidromePlaybackDestination {
     if (!this.isConfigured()) return [];
     if (!force && this._playlists) return this._playlists;
     try {
-      const playlists = await this.client.getPlaylists();
-      this._playlists = Array.isArray(playlists) ? playlists : playlists ? [playlists] : [];
+      await this._fetchPlaylists();
     } catch (error) {
       console.warn("[NavidromePlaybackDestination] getPlaylists failed:", error?.message);
       this._playlists = [];
     }
+    return this._playlists;
+  }
+
+  async _fetchPlaylists() {
+    const playlists = await this.client.getPlaylists();
+    this._playlists = Array.isArray(playlists) ? playlists : playlists ? [playlists] : [];
     return this._playlists;
   }
 
@@ -238,17 +252,69 @@ export class NavidromePlaybackDestination {
       const snapshot = createPlaybackPlaylistSnapshot(value);
       await fs.mkdir(this.libraryRoot, { recursive: true });
       const { current, legacy } = this.getPlaylistNames(snapshot);
+      const playlistPath = path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`);
+      let hadPlaylistFile = false;
+      for (const name of [current, ...legacy]) {
+        try {
+          await fs.access(path.join(this.libraryRoot, `${this._sanitize(name)}.m3u`));
+          hadPlaylistFile = true;
+          break;
+        } catch {}
+      }
       const jobsByPath = this._jobsByPath(snapshot.entityId);
       const content = buildM3uContent(snapshot.tracks, (track) => {
         const localPath = path.resolve(track.path);
         return resolveM3uTrackPath(jobsByPath.get(localPath), localPath, getM3uPathMode());
       });
-      await fs.writeFile(
-        path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`),
-        content,
-        "utf8",
+      await fs.writeFile(playlistPath, content, "utf8");
+      if (
+        typeof this.client?.createPlaylist !== "function"
+        || typeof this.client?.updatePlaylist !== "function"
+        || (snapshot.tracks.length && typeof this.client?.findSong !== "function")
+      ) return playbackOperationSuccess();
+      const songs = await Promise.all(
+        snapshot.tracks.map((track) =>
+          this.client.findSong(track.title, track.artist, track),
+        ),
       );
+      if (songs.some((song) => !song?.id)) {
+        this._pendingSnapshots.set(
+          `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`,
+          snapshot,
+        );
+        return playbackOperationSuccess();
+      }
+
+      const targetKey = this._targetKey(snapshot.ownerUserId);
+      const playlists = await this._fetchPlaylists();
+      const pointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
+      let playlist = pointer
+        ? playlists.find((candidate) => String(candidate.id) === pointer.playlistId)
+        : null;
+      if (!playlist && pointer) {
+        navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
+      }
+      if (!playlist && hadPlaylistFile) {
+        playlist = playlists.find((candidate) =>
+          (candidate.name === current || legacy.includes(candidate.name))
+          && !navidromePlaylistPointerStore.hasPlaylistId(candidate.id),
+        );
+      }
+      const songIds = songs.map((song) => song.id);
+      if (playlist) {
+        await this.client.updatePlaylist(playlist.id, { name: current, songIds });
+      } else {
+        playlist = await this.client.createPlaylist(current, songIds);
+      }
+      if (!playlist?.id) throw new Error("Navidrome did not return a playlist ID");
+      navidromePlaylistPointerStore.setPointer(snapshot.entityId, targetKey, {
+        playlistId: playlist.id,
+        title: current,
+      });
+      this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);
+      this._playlists = null;
       await this._deleteNativePlaylists(legacy);
+      await this._deleteFiles([current], PLAYLIST_FILE_EXTENSIONS);
       await this._deleteFiles(legacy, [
         ...PLAYLIST_FILE_EXTENSIONS,
         ...ARTWORK_FILE_EXTENSIONS,
@@ -269,6 +335,21 @@ export class NavidromePlaybackDestination {
       const identity = createPlaybackPlaylistIdentity(value);
       const names = this._getNamesForIdentity(identity);
       if (!names) return playbackOperationSuccess();
+      const targetKey = this._targetKey(identity.ownerUserId);
+      const pointer = navidromePlaylistPointerStore.getPointer(identity.entityId, targetKey);
+      let pointerError = null;
+      if (pointer && this.isConfigured()) {
+        try {
+          await this.client.deletePlaylist(pointer.playlistId);
+        } catch (error) {
+          pointerError = error;
+        }
+      }
+      if (!pointerError) {
+        navidromePlaylistPointerStore.deletePointer(identity.entityId, targetKey);
+      }
+      this._pendingSnapshots.delete(`${identity.entityId}:${targetKey}`);
+      this._playlists = null;
       await this._deleteNativePlaylists([names.current, ...names.legacy]);
       await this._deleteFiles([names.current], PLAYLIST_FILE_EXTENSIONS);
       await this._deleteFiles(names.legacy, [
@@ -276,6 +357,7 @@ export class NavidromePlaybackDestination {
         ...ARTWORK_FILE_EXTENSIONS,
         ARTWORK_SUPPRESS_SUFFIX,
       ]);
+      if (pointerError) throw pointerError;
       return playbackOperationSuccess();
     } catch (error) {
       return playbackOperationFailure({
@@ -290,6 +372,7 @@ export class NavidromePlaybackDestination {
     if (!this.isConfigured()) return playbackOperationSuccess();
     try {
       await this.client.scanLibrary();
+      this._scheduleCatchup();
       return playbackOperationSuccess();
     } catch (error) {
       return playbackOperationFailure({
@@ -298,5 +381,26 @@ export class NavidromePlaybackDestination {
         retryable: true,
       });
     }
+  }
+
+  _scheduleCatchup(delaysMs = [30000, 90000, 180000]) {
+    if (this._catchupRunning || !this._pendingSnapshots.size) return;
+    this._catchupRunning = true;
+    const run = async () => {
+      try {
+        for (const delayMs of delaysMs) {
+          await wait(delayMs, undefined, { ref: false });
+          if (!this.isConfigured() || !this._pendingSnapshots.size) break;
+          for (const snapshot of [...this._pendingSnapshots.values()]) {
+            await this.publishPlaylist(snapshot);
+          }
+        }
+      } catch (error) {
+        console.warn("[NavidromePlaybackDestination] Navidrome catch-up failed:", error?.message);
+      } finally {
+        this._catchupRunning = false;
+      }
+    };
+    run();
   }
 }

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -286,25 +286,32 @@ export class NavidromePlaybackDestination {
         return playbackOperationSuccess();
       }
 
-      const playlists = await this._fetchPlaylists();
       const pointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
-      let playlist = pointer
-        ? playlists.find((candidate) => String(candidate.id) === pointer.playlistId)
-        : null;
-      if (!playlist && pointer) {
-        navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
+      let playlist = null;
+      if (pointer) {
+        try {
+          await this.client.updatePlaylist(pointer.playlistId, {
+            name: current,
+            songIds: songs.map((song) => song.id),
+          });
+          playlist = { id: pointer.playlistId };
+        } catch (error) {
+          if (Number(error?.code) !== 70) throw error;
+          navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
+        }
       }
-      if (!playlist && hadPlaylistFile) {
-        playlist = playlists.find((candidate) =>
+      if (!playlist) {
+        const playlists = await this._fetchPlaylists();
+        if (hadPlaylistFile) playlist = playlists.find((candidate) =>
           (candidate.name === current || legacy.includes(candidate.name))
           && !navidromePlaylistPointerStore.hasPlaylistId(candidate.id),
         );
-      }
-      const songIds = songs.map((song) => song.id);
-      if (playlist) {
-        await this.client.updatePlaylist(playlist.id, { name: current, songIds });
-      } else {
-        playlist = await this.client.createPlaylist(current, songIds);
+        const songIds = songs.map((song) => song.id);
+        if (playlist) {
+          await this.client.updatePlaylist(playlist.id, { name: current, songIds });
+        } else {
+          playlist = await this.client.createPlaylist(current, songIds);
+        }
       }
       if (!playlist?.id) throw new Error("Navidrome did not return a playlist ID");
       navidromePlaylistPointerStore.setPointer(snapshot.entityId, targetKey, {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -49,6 +49,7 @@ export class NavidromePlaybackDestination {
     this._pendingSnapshots = new Map();
     this._catchupRunning = false;
     this._publishInFlight = new Map();
+    this._syncHashes = new Map();
   }
 
   updateConfig(config = {}) {
@@ -61,6 +62,7 @@ export class NavidromePlaybackDestination {
     this._configKey = key;
     this._playlists = null;
     this._pendingSnapshots.clear();
+    this._syncHashes.clear();
     this.client = config.url && config.username && config.password
       ? new NavidromeClient(config.url, config.username, config.password)
       : null;
@@ -251,6 +253,13 @@ export class NavidromePlaybackDestination {
   async _publishPlaylist(snapshot) {
     await fs.mkdir(this.libraryRoot, { recursive: true });
     const { current, legacy } = this.getPlaylistNames(snapshot);
+    const targetKey = this._targetKey(snapshot.ownerUserId);
+    const syncKey = `${snapshot.entityId}:${targetKey}`;
+    const syncHash = JSON.stringify(snapshot);
+    const storedPointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
+    if (storedPointer && this._syncHashes.get(syncKey) === syncHash) {
+      return playbackOperationSuccess();
+    }
     const playlistPath = path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`);
     let hadPlaylistFile = false;
     for (const name of [current, ...legacy]) {
@@ -273,7 +282,6 @@ export class NavidromePlaybackDestination {
       await fs.writeFile(playlistPath, content, "utf8");
       return playbackOperationSuccess();
     }
-    const targetKey = this._targetKey(snapshot.ownerUserId);
     try {
       const songs = await Promise.all(
         snapshot.tracks.map((track) =>
@@ -286,17 +294,23 @@ export class NavidromePlaybackDestination {
         return playbackOperationSuccess();
       }
 
-      const pointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
+      const pointer = storedPointer;
       let playlist = null;
       if (pointer) {
-        try {
-          await this.client.updatePlaylist(pointer.playlistId, {
-            name: current,
-            songIds: songs.map((song) => song.id),
-          });
-          playlist = { id: pointer.playlistId };
-        } catch (error) {
-          if (Number(error?.code) !== 70) throw error;
+        for (const delayMs of [0, 250, 1000, 2000]) {
+          if (delayMs) await wait(delayMs);
+          try {
+            await this.client.updatePlaylist(pointer.playlistId, {
+              name: current,
+              songIds: songs.map((song) => song.id),
+            });
+            playlist = { id: pointer.playlistId };
+            break;
+          } catch (error) {
+            if (Number(error?.code) !== 70) throw error;
+          }
+        }
+        if (!playlist) {
           navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
         }
       }
@@ -331,6 +345,7 @@ export class NavidromePlaybackDestination {
       ...ARTWORK_FILE_EXTENSIONS,
       ARTWORK_SUPPRESS_SUFFIX,
     ]);
+    this._syncHashes.set(syncKey, syncHash);
     return playbackOperationSuccess();
   }
 
@@ -374,6 +389,7 @@ export class NavidromePlaybackDestination {
         navidromePlaylistPointerStore.deletePointer(identity.entityId, targetKey);
       }
       this._pendingSnapshots.delete(`${identity.entityId}:${targetKey}`);
+      this._syncHashes.delete(`${identity.entityId}:${targetKey}`);
       this._playlists = null;
       await this._deleteNativePlaylists([names.current, ...names.legacy]);
       await this._deleteFiles([names.current], PLAYLIST_FILE_EXTENSIONS);

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -22,6 +22,7 @@ import {
 const ARTWORK_FILE_EXTENSIONS = [".webp", ".jpg", ".png"];
 const ARTWORK_SUPPRESS_SUFFIX = ".no-artwork";
 const PLAYLIST_FILE_EXTENSIONS = [".m3u", ".nsp"];
+const SONG_LOOKUP_BATCH_SIZE = 5;
 
 function buildM3uContent(tracks, resolveTrackPath) {
   const lines = ["#EXTM3U"];
@@ -283,11 +284,13 @@ export class NavidromePlaybackDestination {
       return playbackOperationSuccess();
     }
     try {
-      const songs = await Promise.all(
-        snapshot.tracks.map((track) =>
-          this.client.findSong(track.title, track.artist, track),
-        ),
-      );
+      const songs = [];
+      for (let index = 0; index < snapshot.tracks.length; index += SONG_LOOKUP_BATCH_SIZE) {
+        const batch = snapshot.tracks.slice(index, index + SONG_LOOKUP_BATCH_SIZE);
+        songs.push(...await Promise.all(
+          batch.map((track) => this.client.findSong(track.title, track.artist, track)),
+        ));
+      }
       if (songs.some((song) => !song?.id)) {
         await fs.writeFile(playlistPath, content, "utf8");
         this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
@@ -378,14 +381,16 @@ export class NavidromePlaybackDestination {
       const targetKey = this._targetKey(identity.ownerUserId);
       const pointer = navidromePlaylistPointerStore.getPointer(identity.entityId, targetKey);
       let pointerError = null;
+      let pointerResolved = !pointer;
       if (pointer && this.isConfigured()) {
         try {
           await this.client.deletePlaylist(pointer.playlistId);
+          pointerResolved = true;
         } catch (error) {
           pointerError = error;
         }
       }
-      if (!pointerError) {
+      if (pointerResolved) {
         navidromePlaylistPointerStore.deletePointer(identity.entityId, targetKey);
       }
       this._pendingSnapshots.delete(`${identity.entityId}:${targetKey}`);

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-`WeeklyFlowPlaylistManager` creates path-first playlist snapshots. A settings-driven registry sends each snapshot to every configured playback destination. Navidrome writes track paths to M3U files. Plex resolves track paths to Plex track IDs and stores Plex playlist pointers. Both destinations publish the same Aurral playlists, but their configuration and identity rules are different.
+`WeeklyFlowPlaylistManager` creates path-first playlist snapshots. A settings-driven registry sends each snapshot to every configured playback destination. Navidrome and Plex resolve snapshot tracks to their own song IDs and store playlist pointers. Both destinations publish the same Aurral playlists, but their configuration and identity rules are different.
 
 ## Decision
 
@@ -36,16 +36,15 @@ Destination adapters own their names, authentication, configuration, vendor IDs,
 
 ## Compatibility
 
-The Navidrome adapter writes snapshot paths to M3U files after it applies Navidrome path mappings. It owns Navidrome file naming, legacy cleanup, library setup, and scans.
+The Navidrome adapter resolves snapshot paths and metadata to Subsonic song IDs. It stores a Navidrome playlist ID for each Aurral entity and owner. It temporarily writes an M3U file when Navidrome has not indexed all tracks. A post-scan catch-up replaces that file with an API-managed playlist. The adapter owns Navidrome naming, migration cleanup, library setup, and scans.
 
 The Plex adapter resolves snapshot paths to Plex rating keys. It keeps section IDs, user tokens, playlist pointers, owner-specific titles, library setup, and scans inside the adapter.
 
-This decision does not change current Navidrome or Plex behavior. Both playback flows use this seam through an in-process registry. The registry checks saved settings, runs every configured destination, and records one destination failure without blocking another destination.
+The registry and playback contract remain unchanged. Navidrome's Subsonic API behavior stays inside its adapter, and Plex retains its existing behavior. The registry checks saved settings, runs every configured destination, and records one destination failure without blocking another destination.
 
 ## Deliberate non-goals
 
 - Do not add a generic integration host.
 - Do not add plugin loading or uploaded code.
-- Do not migrate Navidrome from M3U files to the Subsonic API.
 - Do not make Settings forms part of this contract.
-- Do not move current destination behavior in this issue.
+- Do not move vendor behavior out of destination adapters.

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -18,8 +18,8 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | Variable | Purpose |
 | -------- | ------- |
 | `PATH_MAPPINGS` | Translate paths for mixed Windows and Docker setups. Use the format `remote\|local`. Separate multiple mappings with `;`. To limit a mapping to one source, use `source\|remote\|local`. Aurral applies these mappings at runtime. Edit them under **Settings > Download Clients > Remote Path Mappings**. |
-| `M3U_PATH_MODE` | `local` (default, Aurral paths in `.m3u` files) or `remote` (paths Navidrome can open). |
-| `M3U_PATH_MAPPINGS` | Translate Navidrome playlist paths. Use the format `Aurral path\|Navidrome path`. Separate multiple mappings with `;`. Aurral applies these mappings at runtime. The UI does not show them. |
+| `M3U_PATH_MODE` | `local` (default, Aurral paths in temporary fallback files) or `remote` (paths Navidrome can open). |
+| `M3U_PATH_MAPPINGS` | Translate paths in temporary Navidrome fallback files. Use the format `Aurral path\|Navidrome path`. Separate multiple mappings with `;`. Aurral applies these mappings at runtime. The UI does not show them. |
 
 ## Authentication
 

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -72,15 +72,17 @@ Lidarr keeps each artist's own folder when you change or rename a root folder, s
 
 Flows or shared playlists can appear in Navidrome, but the tracks do not play.
 
-The path problem is common when Aurral runs in Docker and Navidrome runs on Windows.
+First, wait for Navidrome to finish its scan. Aurral creates the API playlist after Navidrome indexes the tracks.
+
+If Aurral keeps a temporary M3U fallback file, a path problem is common when Aurral runs in Docker and Navidrome runs on Windows.
 
 - Make sure that **Test library access** passes in Lidarr settings.
 - Enable **Use Navidrome paths in M3U files** and add a Navidrome path mapping in **Settings > Playback > Navidrome**.
 - Alternatively, set `M3U_PATH_MODE=remote` and `M3U_PATH_MAPPINGS` in the Compose file.
 - Recreate the container.
-- Refresh the playlists to rewrite the `.m3u` files.
+- Refresh the playlists to rewrite the fallback files.
 - Run or save a flow. You can also edit and save a shared playlist.
-- Open a generated `.m3u` under `aurral-weekly-flow`. Make sure that track lines use paths Navidrome can open.
+- If a generated `.m3u` remains under `aurral-weekly-flow`, make sure that its track lines use paths Navidrome can open.
 
 Leave **Use Navidrome paths in M3U files** off when Navidrome runs in Docker with the same mounts as Aurral.
 

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -222,7 +222,7 @@ For a native Windows service, the remote path can be `N:\ServerFolders\Music`. M
 
 ### Navidrome sees a different path
 
-This is a separate mapping. It changes paths in generated `.m3u` files; it does not help Aurral read Lidarr or download-client paths.
+This is a separate mapping. It changes paths in temporary M3U fallback files; it does not help Aurral read Lidarr or download-client paths.
 
 1. Open **Settings > Playback > Navidrome**.
 2. Enable **Use Navidrome paths in M3U files**.
@@ -260,10 +260,10 @@ The same rule applies when one service runs on Windows:
 
 1. Mount the Windows media folder into Aurral.
 2. Add a **Remote Path Mapping** from the Windows path reported by Lidarr or the download client to the Aurral container path.
-3. If Navidrome also runs on Windows, add a separate Navidrome M3U mapping so generated playlists contain Windows paths.
+3. If Navidrome also runs on Windows, add a separate Navidrome M3U mapping so temporary fallback files contain Windows paths.
 4. If Plex sees a different path, set **Plex Aurral Library path** to the Plex path.
 
-Do not use one mapping for all three jobs. A Lidarr mapping, a Navidrome M3U mapping, and the Plex library path solve different path translations.
+Do not use one mapping for all three jobs. A Lidarr mapping, a Navidrome fallback mapping, and the Plex library path solve different path translations.
 
 ## Common incorrect layouts
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -37,7 +37,7 @@ See [Library access fails on a folder that is not your root folder](/admin/troub
 
 In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports. If that path differs from the path inside Aurral, add a mapping under **Settings > Download Clients > Remote Path Mappings** with **Source** set to **Lidarr**.
 
-This mapping only helps Aurral read Lidarr files. It does not change paths in Navidrome `.m3u` files. Configure Navidrome paths under **Settings > Playback > Navidrome**. See [Path mismatches](/getting-started/storage/#when-paths-cannot-match).
+This mapping only helps Aurral read Lidarr files. It does not change paths in temporary Navidrome M3U fallback files. Configure Navidrome paths under **Settings > Playback > Navidrome**. See [Path mismatches](/getting-started/storage/#when-paths-cannot-match).
 
 ## Safety
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -3,7 +3,7 @@ title: Navidrome
 description: Connect Navidrome to play Aurral downloads and generated playlists.
 ---
 
-Navidrome is optional. Aurral connects to Navidrome through its API and writes playlist files to the Aurral download tree. Navidrome must also be able to read that tree on disk.
+Navidrome is optional. Aurral creates and updates Navidrome playlists through the Subsonic API. Navidrome must also be able to read and scan the Aurral download tree.
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
@@ -50,9 +50,9 @@ Add `/data/music` as a normal Navidrome music library if it is not already prese
 Use matching container paths when possible. A different path affects two things:
 
 - the path Navidrome uses for its music library;
-- the paths written into Aurral's `.m3u` files.
+- the paths in temporary M3U fallback files.
 
-The **Use Navidrome paths in M3U files** setting only changes the second item. It does not mount a folder and it does not make an incorrect Navidrome library path valid.
+The **Use Navidrome paths in M3U files** setting only changes the fallback files. Aurral uses a fallback while Navidrome waits to index a new track. The setting does not mount a folder and it does not make an incorrect Navidrome library path valid.
 
 If Aurral uses `/data/downloads/aurral` and Navidrome uses `/music/aurral` for the same host folder:
 
@@ -67,19 +67,21 @@ If Aurral uses `/data/downloads/aurral` and Navidrome uses `/music/aurral` for t
    | Aurral Path | `/data/downloads/aurral` |
    | Navidrome Path | `/music/aurral` |
 
-6. After the settings save automatically, refresh the affected playlist. Run the flow again, or edit and save a shared playlist, to rewrite its `.m3u` file.
+6. After the settings save automatically, refresh the affected playlist. Run the flow again, or edit and save a shared playlist.
 
 For a native Windows Navidrome installation, use the Windows path as **Navidrome Path**, for example `N:/ServerFolders/Music/Aurral`. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) if Aurral cannot read paths reported by Lidarr or a download client.
 
-## Generated playlists and scans
+## API playlists and scans
 
-Aurral stores generated `.m3u` files under:
+Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
+
+If a new track is not indexed, Aurral temporarily writes an `.m3u` file under:
 
 ```text
 /data/downloads/aurral/aurral-weekly-flow/_playlists/
 ```
 
-Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
+After a scan, Aurral resolves the song IDs, updates the API playlist, and removes the fallback file. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
 - confirm that a track exists under `aurral-weekly-flow`;
 - confirm that the Navidrome library path points to that folder;

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -38,7 +38,7 @@ Aurral registers the library at `<plex-visible-downloads>/aurral-weekly-flow`. T
 
 You do not need to create this library manually in Plex. The library can be empty until a flow finishes downloading tracks. Plex can take several minutes to scan the files.
 
-Navidrome M3U playlists are in `aurral-weekly-flow/_playlists/`. Plex does not use these files.
+Navidrome can temporarily write M3U fallback files in `aurral-weekly-flow/_playlists/`. Plex does not use these files.
 
 ## Plex compared with Navidrome
 
@@ -46,9 +46,9 @@ You can run both at the same time. They use the same download tree but different
 
 |                   | Navidrome                                              | Plex                                               |
 | ----------------- | ------------------------------------------------------ | -------------------------------------------------- |
-| Playlist format   | `.m3u` files on disk                                   | Regular Plex playlists through the API                     |
-| Library setup     | Scan folders and read M3U                              | Aurral creates an **Aurral** music library through the API |
-| Path mismatch fix | **Use Navidrome paths in M3U files** / `M3U_PATH_MODE` | **Plex Aurral Library path** (optional)            |
+| Playlist format   | Regular playlists through the Subsonic API             | Regular Plex playlists through the API                     |
+| Library setup     | Aurral creates a library and requests scans             | Aurral creates an **Aurral** music library through the API |
+| Path mismatch fix | M3U path setting for temporary fallback files          | **Plex Aurral Library path** (optional)                     |
 | Playlist names    | Bare flow or playlist name                             | Bare flow or playlist name                         |
 
 Navidrome's M3U path settings do not affect Plex.

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -165,7 +165,7 @@ Aurral treats a top-level array of track objects as one playlist.
 - If an imported playlist name conflicts with an existing playlist, Aurral renames it automatically.
 - Imported playlists queue their own downloads and do not affect any flow configuration.
 - When existing file reuse succeeds, Aurral immediately marks the imported track as complete.
-- Aurral keeps the imported track order in the playlist view and in the `.m3u` file after reuse and downloads finish.
+- Aurral keeps the imported track order in the playlist view and in the Navidrome playlist after reuse and downloads finish.
 
 ## Download retries and failure behavior
 
@@ -199,4 +199,4 @@ Use the reported path to add a mapping under **Settings > Download Clients > Rem
 
 If Navidrome uses a different path for reused Lidarr files, enable **Use Navidrome paths in M3U files**.
 
-Add a Navidrome path mapping so `.m3u` files use paths that Navidrome can open. See [Navidrome](/integrations/navidrome/#different-navidrome-paths).
+Add a Navidrome path mapping so temporary fallback files use paths that Navidrome can open. See [Navidrome](/integrations/navidrome/#different-navidrome-paths).

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -40,7 +40,7 @@ Generated playlists go under your Downloads Folder path. Set this path in **Sett
 /data/downloads/aurral/aurral-weekly-flow/<playlist-id>/
 ```
 
-Navidrome can scan that tree and play `.m3u` playlists. Plex can index the track folders and create playlists for Plexamp.
+Navidrome scans that tree, then Aurral creates playlists through the Subsonic API. Plex can index the track folders and create playlists for Plexamp.
 
 See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/) for playback setup.
 


### PR DESCRIPTION
## Summary

- manage Navidrome playlists through the Subsonic API inside the existing playback adapter
- resolve path-first snapshots to Navidrome song IDs and persist playlist IDs by Aurral entity and owner
- keep temporary M3U fallback/migration behavior until Navidrome indexes new tracks
- preserve Plex behavior and destination failure isolation

## Linked issues

Fixes #519

## Validation

- [x] CI passes
- [x] Tested using the `ghcr.io/lklynet/aurral:pr-591` preview image
- [x] Upgrade, migration, and rollback notes are updated where applicable

Current preview image:

- commit: `4027878f6ad7f3d3b71cecce98414b087a49bc31`
- digest: `sha256:27fd92013d90aabb9abc4693e0e684418e18552d00563823ddf77e9fde7f8e73`
- app version: `pr.591+4027878`
- runtime image ID: `sha256:044a054e47b57f4ff33cc5827d6e35264d6af439e76e0a536ff0e8b0dd78a288`

Automated checks:

- lint
- 554 unit tests
- 30 integration tests
- frontend build
- docs build
- production container build and smoke test

Live checks:

- M3U migration adopted the imported Navidrome playlist ID without a duplicate
- ordered one-track content survived rename and candidate restart with the same Navidrome ID
- Plex created one one-track playlist and preserved its rating key across rename and restart
- Navidrome outage/recovery preserved Plex operation and recovered the same Navidrome ID
- Plex outage/recovery preserved Navidrome operation and recovered the same Plex rating key
- delete removed both native playlists, stored pointers, the task job, fallback files, and local task data
- health, static assets, login, authenticated session, and both connection tests passed

The full live journey was completed before the review-only follow-up. Commit `4027878f` adds bounded song lookups and retains stored pointers during unconfigured deletion. It passed 17 focused adapter tests, full CI, and exact-image health, static, auth, and connection smoke checks.

## Test plan

- Affected area(s): Navidrome playback, playlist migration, destination outage isolation, docs
- Automated coverage: Navidrome client request encoding/song matching plus adapter create, update, rename, delete, migration, catch-up, collision, bounded lookup, and outage cases; full unit and integration suites
- Manual result: preview runtime passed M3U-to-API conversion, stable-ID rename/restart/delete, Plex/Navidrome outage recovery, health, static assets, login, and authenticated session

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change