### PR TITLE
fix(playback): preserve Navidrome playlist during rename

### DIFF
--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -305,6 +305,46 @@ test("adopts an imported M3U playlist and keeps its ID across rename and delete"
   assert.equal(navidromePlaylistPointerStore.getPointer(playlist.id, "global"), null);
 });
 
+test("keeps a stored playlist during rename cleanup until tracks resolve", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed" });
+  const client = createClient({
+    playlists: [{ id: "imported-id", name: "Legacy Rename Fixture" }],
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "imported-id",
+    title: "Legacy Rename Fixture",
+  });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(destination.libraryRoot, "Legacy Rename Fixture.m3u"),
+    "legacy",
+  );
+
+  await destination.ensureLibrary();
+  assert.deepEqual(client.calls.deleted, []);
+  await assert.rejects(
+    fs.access(path.join(destination.libraryRoot, "Legacy Rename Fixture.m3u")),
+  );
+
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: playlist.id,
+    displayName: playlist.name,
+    tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+  });
+  await destination.publishPlaylist(snapshot);
+  client.findSong = async () => ({ id: "song-1" });
+  await destination.publishPlaylist(snapshot);
+
+  assert.deepEqual(client.calls.updated, [
+    { id: "imported-id", name: "Renamed", songIds: ["song-1"] },
+  ]);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "imported-id",
+  );
+});
+
 test("does not adopt a same-name playlist claimed by another Aurral entity", async () => {
   const second = flowPlaylistConfig.createSharedPlaylist({ name: "Same Name" });
   const client = createClient({

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -116,7 +116,7 @@ export class NavidromePlaybackDestination {
     const playlists = await this._loadPlaylists();
     for (const name of [...new Set((names || []).filter(Boolean))]) {
       const playlist = playlists.find((candidate) => candidate.name === name);
-      if (!playlist) continue;
+      if (!playlist || navidromePlaylistPointerStore.hasPlaylistId(playlist.id)) continue;
       try {
         await this.client.deletePlaylist(playlist.id);
         this._playlists = this._playlists.filter((candidate) => candidate.id !== playlist.id);


### PR DESCRIPTION
## Summary

Prevent rename cleanup from deleting Navidrome playlists already tracked by Aurral, preserving their IDs for subsequent updates.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): playback, Navidrome integration
- Automated coverage: Added coverage verifying stored playlists survive rename cleanup and retain their Navidrome ID.
- Manual steps and expected result: Rename a playlist with an existing Navidrome destination and publish it; the existing Navidrome playlist should be updated rather than deleted and recreated.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pointer-managed Navidrome playlists from being deleted during library cleanup.
  * Preserved existing remote playlists when local playlist names are changed.
  * Ensured renamed playlists update correctly after unresolved tracks finish processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->