### PR TITLE
fix(playback): preserve pending Navidrome migrations

### DIFF
--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -31,7 +31,7 @@ const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
 function createClient({ configured = true, playlists = [], songs = {} } = {}) {
   const currentPlaylists = playlists.map((playlist) => ({ ...playlist }));
-  const calls = { created: [], deleted: [], ensured: [], scans: 0, updated: [] };
+  const calls = { created: [], deleted: [], ensured: [], renamed: [], scans: 0, updated: [] };
   return {
     calls,
     isConfigured: () => configured,
@@ -55,6 +55,11 @@ function createClient({ configured = true, playlists = [], songs = {} } = {}) {
       calls.updated.push({ id, ...payload });
       const playlist = currentPlaylists.find((candidate) => candidate.id === id);
       if (playlist) playlist.name = payload.name;
+    },
+    async renamePlaylist(id, name) {
+      calls.renamed.push({ id, name });
+      const playlist = currentPlaylists.find((candidate) => candidate.id === id);
+      if (playlist) playlist.name = name;
     },
     async deletePlaylist(id) {
       calls.deleted.push(id);
@@ -323,7 +328,7 @@ test("keeps a stored playlist during rename cleanup until tracks resolve", async
 
   await destination.ensureLibrary();
   assert.deepEqual(client.calls.deleted, []);
-  await assert.rejects(
+  await assert.doesNotReject(
     fs.access(path.join(destination.libraryRoot, "Legacy Rename Fixture.m3u")),
   );
 
@@ -343,6 +348,112 @@ test("keeps a stored playlist during rename cleanup until tracks resolve", async
     navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
     "imported-id",
   );
+});
+
+test("keeps an unclaimed imported playlist during rename cleanup until tracks resolve", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed without pointer" });
+  const client = createClient({
+    playlists: [{ id: "unclaimed-id", name: "Legacy Unclaimed Fixture" }],
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  const legacyPath = path.join(destination.libraryRoot, "Legacy Unclaimed Fixture.m3u");
+  await fs.writeFile(legacyPath, "#EXTM3U\n/music/song.flac\n");
+
+  await destination.ensureLibrary();
+  assert.deepEqual(client.calls.deleted, []);
+  await assert.doesNotReject(fs.access(legacyPath));
+
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: playlist.id,
+    displayName: playlist.name,
+    tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+  });
+  await destination.publishPlaylist(snapshot);
+  client.findSong = async () => ({ id: "song-1" });
+  await destination.publishPlaylist(snapshot);
+
+  assert.deepEqual(client.calls.updated, [
+    { id: "unclaimed-id", name: "Renamed without pointer", songIds: ["song-1"] },
+  ]);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "unclaimed-id",
+  );
+});
+
+test("renames an imported playlist before unresolved tracks are ready", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed immediately" });
+  const client = createClient({
+    playlists: [{ id: "rename-first-id", name: "Legacy Rename First" }],
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(destination.libraryRoot, "Legacy Rename First.m3u"),
+    "#EXTM3U\n/music/song.flac\n",
+  );
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.renamed, [
+    { id: "rename-first-id", name: "Renamed immediately" },
+  ]);
+  assert.deepEqual(client.calls.updated, []);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "rename-first-id",
+  );
+});
+
+test("preserves imported files when Navidrome names require sanitizing", async () => {
+  flowPlaylistConfig.createSharedPlaylist({ name: "Current" });
+  const client = createClient({
+    playlists: [{ id: "sanitized-id", name: "Legacy: Name" }],
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  const legacyPath = path.join(destination.libraryRoot, "Legacy_ Name.m3u");
+  await fs.writeFile(legacyPath, "legacy");
+
+  await destination.ensureLibrary();
+
+  assert.deepEqual(client.calls.deleted, []);
+  await assert.doesNotReject(fs.access(legacyPath));
+});
+
+test("does not adopt an imported playlist from a colliding track basename", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Collision target" });
+  const client = createClient({
+    playlists: [{ id: "unrelated-id", name: "Legacy Collision" }],
+    songs: { Song: { id: "song-1" } },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(destination.libraryRoot, "Legacy Collision.m3u"),
+    "#EXTM3U\n/music/other/intro.flac\n",
+  );
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/expected/intro.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.renamed, []);
+  assert.deepEqual(client.calls.created, [
+    { name: "Collision target", songIds: ["song-1"] },
+  ]);
+  assert.deepEqual(client.calls.deleted, []);
 });
 
 test("does not adopt a same-name playlist claimed by another Aurral entity", async () => {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -168,6 +168,10 @@ export class NavidromeClient {
     });
   }
 
+  async renamePlaylist(playlistId, name) {
+    return this.request("updatePlaylist", { playlistId, name });
+  }
+
   async deletePlaylist(id) {
     return this.request("deletePlaylist", { id });
   }

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -180,7 +180,9 @@ export class NavidromePlaybackDestination {
       ) continue;
       if (expected.has(file)) continue;
       if (PLAYLIST_FILE_EXTENSIONS.includes(extension)) {
-        await this._deleteNativePlaylists([path.basename(file, extension)]);
+        const name = path.basename(file, extension);
+        const playlists = await this._loadPlaylists();
+        if (playlists.some((playlist) => this._sanitize(playlist.name) === name)) continue;
       }
       try {
         await fs.unlink(path.join(this.libraryRoot, file));
@@ -233,17 +235,53 @@ export class NavidromePlaybackDestination {
     const targetKey = this._targetKey(snapshot.ownerUserId);
     const syncKey = `${snapshot.entityId}:${targetKey}`;
     const syncHash = JSON.stringify(snapshot);
-    const storedPointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
-    if (storedPointer && this._syncHashes.get(syncKey) === syncHash) {
+    let pointer = navidromePlaylistPointerStore.getPointer(snapshot.entityId, targetKey);
+    if (pointer && this._syncHashes.get(syncKey) === syncHash) {
       return playbackOperationSuccess();
     }
-    let hadPlaylistFile = false;
-    for (const name of [current, ...legacy]) {
-      try {
-        await fs.access(path.join(this.libraryRoot, `${this._sanitize(name)}.m3u`));
-        hadPlaylistFile = true;
-        break;
-      } catch {}
+    const files = await fs.readdir(this.libraryRoot).catch(() => []);
+    const normalizeTrackPath = (value) => path
+      .normalize(String(value || "").replace(/\\/g, "/"))
+      .toLowerCase();
+    const trackPaths = new Set(
+      snapshot.tracks.map((track) => normalizeTrackPath(track.path)),
+    );
+    const importedPlaylistNames = [];
+    for (const file of files) {
+      if (!PLAYLIST_FILE_EXTENSIONS.includes(path.extname(file).toLowerCase())) continue;
+      const name = path.basename(file, path.extname(file));
+      if ([current, ...legacy].includes(name)) {
+        importedPlaylistNames.push(name);
+        continue;
+      }
+      const content = await fs.readFile(path.join(this.libraryRoot, file), "utf8").catch(() => "");
+      const matchesTrack = content
+        .split(/\r?\n/)
+        .filter((line) => line && !line.startsWith("#"))
+        .some((line) => trackPaths.has(normalizeTrackPath(line)));
+      if (matchesTrack) importedPlaylistNames.push(name);
+    }
+    let importedPlaylistName = null;
+    if (!pointer && importedPlaylistNames.length) {
+      const playlists = await this._loadPlaylists();
+      const importedPlaylist = playlists.find(
+        (playlist) => importedPlaylistNames.includes(playlist.name)
+          && !navidromePlaylistPointerStore.hasPlaylistId(playlist.id),
+      );
+      if (importedPlaylist) {
+        importedPlaylistName = importedPlaylist.name;
+        pointer = { playlistId: importedPlaylist.id, title: importedPlaylist.name };
+        navidromePlaylistPointerStore.setPointer(snapshot.entityId, targetKey, pointer);
+      }
+    }
+    if (
+      pointer?.title
+      && pointer.title !== current
+      && typeof this.client.renamePlaylist === "function"
+    ) {
+      await this.client.renamePlaylist(pointer.playlistId, current);
+      pointer = { ...pointer, title: current };
+      navidromePlaylistPointerStore.setPointer(snapshot.entityId, targetKey, pointer);
     }
     const songs = [];
     for (let index = 0; index < snapshot.tracks.length; index += SONG_LOOKUP_BATCH_SIZE) {
@@ -257,7 +295,6 @@ export class NavidromePlaybackDestination {
       return playbackOperationSuccess();
     }
 
-    const pointer = storedPointer;
     let playlist = null;
     if (pointer) {
       for (const delayMs of [0, 250, 1000, 2000]) {
@@ -279,8 +316,8 @@ export class NavidromePlaybackDestination {
     }
     if (!playlist) {
       const playlists = await this._fetchPlaylists();
-      if (hadPlaylistFile) playlist = playlists.find((candidate) =>
-        (candidate.name === current || legacy.includes(candidate.name))
+      if (importedPlaylistNames.length) playlist = playlists.find((candidate) =>
+        importedPlaylistNames.includes(candidate.name)
         && !navidromePlaylistPointerStore.hasPlaylistId(candidate.id),
       );
       const songIds = songs.map((song) => song.id);
@@ -297,8 +334,9 @@ export class NavidromePlaybackDestination {
     });
     this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);
     this._playlists = null;
-    await this._deleteNativePlaylists(legacy);
-    await this._deleteFiles([current], PLAYLIST_FILE_EXTENSIONS);
+    const cleanupNames = [current, ...legacy, importedPlaylistName, pointer?.title];
+    await this._deleteNativePlaylists([...legacy, importedPlaylistName, pointer?.title]);
+    await this._deleteFiles(cleanupNames, PLAYLIST_FILE_EXTENSIONS);
     await this._deleteFiles(legacy, [
       ...PLAYLIST_FILE_EXTENSIONS,
       ...ARTWORK_FILE_EXTENSIONS,


### PR DESCRIPTION
## What changed

- Preserve an imported Navidrome playlist and its M3U fallback while track resolution is pending.
- Adopt and persist the existing native playlist ID before content lookup completes.
- Rename the native playlist immediately through the Subsonic API.
- Remove the fallback only after the API playlist is synchronized.
- Add regression coverage for pointerless imported playlists and unresolved-track renames.

## Root cause

Startup stale-file cleanup deleted the old native playlist before a renamed playlist had a stored pointer. The subsequent publish waited for unresolved song matches, leaving no playlist visible.

## Validation

- 24 focused Navidrome client/playback tests passed.
- npm run lint passed.
- git diff --check passed.

The already-deleted personal playlists are not part of the test scope; this PR prevents the migration failure for future deployments.