### PR TITLE
fix(playback): require complete imported playlist matches

### DIFF
--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -30,6 +30,34 @@ test("creates a distinct playlist without looking up matching display names", as
   assert.equal(urls[0].pathname, "/rest/createPlaylist");
 });
 
+test("batches large playlist creation requests", async () => {
+  const originalFetch = globalThis.fetch;
+  const urls = [];
+  globalThis.fetch = async (url) => {
+    urls.push(new URL(url));
+    return jsonResponse({
+      "subsonic-response": {
+        status: "ok",
+        playlist: urls.length === 1 ? { id: "new-id", name: "Large" } : undefined,
+      },
+    });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .createPlaylist("Large", Array.from({ length: 401 }, (_, index) => `song-${index}`));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(urls.length, 9);
+  assert.equal(urls[0].pathname, "/rest/createPlaylist");
+  assert.equal(urls[0].searchParams.getAll("songId").length, 50);
+  assert.equal(urls[1].pathname, "/rest/updatePlaylist");
+  assert.equal(urls[1].searchParams.getAll("songIdToAdd").length, 50);
+  assert.ok(urls.every((url) => url.toString().length < 8192));
+});
+
 test("preserves Subsonic error codes for missing native IDs", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => jsonResponse({
@@ -76,6 +104,39 @@ test("replaces playlist entries with repeated Subsonic parameters", async () => 
   assert.deepEqual(urls[1].searchParams.getAll("songIndexToRemove"), ["0", "1"]);
   assert.deepEqual(urls[1].searchParams.getAll("songIdToAdd"), ["song-1", "song-2"]);
   assert.equal(urls[1].searchParams.get("name"), "Renamed");
+});
+
+test("batches large playlist replacement requests", async () => {
+  const originalFetch = globalThis.fetch;
+  const urls = [];
+  globalThis.fetch = async (url) => {
+    urls.push(new URL(url));
+    if (urls.length === 1) {
+      return jsonResponse({
+        "subsonic-response": {
+          status: "ok",
+          playlist: { entry: [{ id: "old-1" }] },
+        },
+      });
+    }
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .updatePlaylist("playlist-1", {
+        name: "Large",
+        songIds: Array.from({ length: 101 }, (_, index) => `song-${index}`),
+      });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(urls.length, 4);
+  assert.equal(urls[1].searchParams.getAll("songIdToAdd").length, 50);
+  assert.equal(urls[2].searchParams.getAll("songIdToAdd").length, 50);
+  assert.equal(urls[3].searchParams.getAll("songIdToAdd").length, 1);
+  assert.ok(urls.every((url) => url.toString().length < 8192));
 });
 
 test("prefers the exact path and metadata when duplicate songs match", async () => {

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -200,7 +200,9 @@ test("matches metadata variants and falls back to title search", async () => {
 
   let song;
   try {
-    song = await new NavidromeClient("http://navidrome.test", "user", "password")
+    const client = new NavidromeClient("http://navidrome.test", "user", "password");
+    client._getIndexedSongs = async () => [];
+    song = await client
       .findSong("Slide", "The Goo Goo Dolls", {
         album: "Dizzy Up the Girl",
         path: "/music/Goo Goo Dolls/Dizzy Up the Girl/Slide.flac",

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -181,7 +181,7 @@ test("matches metadata variants and falls back to title search", async () => {
   globalThis.fetch = async (url) => {
     const request = new URL(url);
     queries.push(request.searchParams.get("query"));
-    const songs = queries.length === 1
+    const songs = queries.filter(Boolean).length === 1
       ? []
       : [{
         id: "variant",
@@ -210,7 +210,26 @@ test("matches metadata variants and falls back to title search", async () => {
   }
 
   assert.equal(song.id, "variant");
-  assert.deepEqual(queries, ["The Goo Goo Dolls Slide", "Slide"]);
+  assert.deepEqual(queries.filter(Boolean), ["The Goo Goo Dolls Slide", "Slide"]);
+});
+
+test("uses an indexed path before metadata matching", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._getIndexedSongs = async () => [{
+    id: "path-match",
+    path: "Artist/Album/track.flac",
+    title: "Different tag",
+    artist: "Different artist",
+  }];
+  client.request = async () => {
+    throw new Error("metadata search should not run");
+  };
+
+  const song = await client.findSong("Wanted title", "Wanted artist", {
+    path: "/data/music/Artist/Album/track.flac",
+  });
+
+  assert.equal(song.id, "path-match");
 });
 
 test("uploads playlist artwork through the native API", async () => {
@@ -238,4 +257,25 @@ test("uploads playlist artwork through the native API", async () => {
   assert.equal(new URL(requests[0].url).pathname, "/api/playlist/playlist-1/image");
   assert.equal(requests[0].options.headers["X-ND-Authorization"], "Bearer token");
   assert.equal(requests[0].options.body.get("image").name, "cover.webp");
+});
+
+test("deletes playlist artwork through the native API", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return new Response(null, { status: 204 });
+  };
+
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._nativeLogin = async () => "token";
+  try {
+    await client.deletePlaylistArtwork("playlist-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(new URL(requests[0].url).pathname, "/api/playlist/playlist-1/image");
+  assert.equal(requests[0].options.method, "DELETE");
+  assert.equal(requests[0].options.headers["X-ND-Authorization"], "Bearer token");
 });

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -174,3 +174,68 @@ test("prefers the exact path and metadata when duplicate songs match", async () 
 
   assert.equal(song.id, "match");
 });
+
+test("matches metadata variants and falls back to title search", async () => {
+  const originalFetch = globalThis.fetch;
+  const queries = [];
+  globalThis.fetch = async (url) => {
+    const request = new URL(url);
+    queries.push(request.searchParams.get("query"));
+    const songs = queries.length === 1
+      ? []
+      : [{
+        id: "variant",
+        title: "Slide",
+        artist: "Goo Goo Dolls",
+        album: "Dizzy Up the Girl",
+        path: "Goo Goo Dolls/Dizzy Up the Girl/Slide.flac",
+      }];
+    return jsonResponse({
+      "subsonic-response": {
+        status: "ok",
+        searchResult3: { song: songs },
+      },
+    });
+  };
+
+  let song;
+  try {
+    song = await new NavidromeClient("http://navidrome.test", "user", "password")
+      .findSong("Slide", "The Goo Goo Dolls", {
+        album: "Dizzy Up the Girl",
+        path: "/music/Goo Goo Dolls/Dizzy Up the Girl/Slide.flac",
+      });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(song.id, "variant");
+  assert.deepEqual(queries, ["The Goo Goo Dolls Slide", "Slide"]);
+});
+
+test("uploads playlist artwork through the native API", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return new Response(null, { status: 204 });
+  };
+
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._nativeLogin = async () => "token";
+  try {
+    await client.uploadPlaylistArtwork(
+      "playlist-1",
+      Buffer.from("image"),
+      "cover.webp",
+      "image/webp",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requests.length, 1);
+  assert.equal(new URL(requests[0].url).pathname, "/api/playlist/playlist-1/image");
+  assert.equal(requests[0].options.headers["X-ND-Authorization"], "Bearer token");
+  assert.equal(requests[0].options.body.get("image").name, "cover.webp");
+});

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -42,6 +42,9 @@ function createClient({ configured = true, playlists = [], songs = {} } = {}) {
     async getPlaylists() {
       return currentPlaylists;
     },
+    async getPlaylist(id) {
+      return currentPlaylists.find((playlist) => playlist.id === id) || null;
+    },
     async findSong(title) {
       return songs[title] || null;
     },
@@ -308,6 +311,72 @@ test("adopts an imported M3U playlist and keeps its ID across rename and delete"
   );
   assert.deepEqual(client.calls.deleted, ["imported-id"]);
   assert.equal(navidromePlaylistPointerStore.getPointer(playlist.id, "global"), null);
+});
+
+test("adopts an imported API playlist from its source comment", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Comment Recovery" });
+  const client = createClient({
+    playlists: [{
+      id: "comment-id",
+      name: "Imported Legacy Name",
+      comment: "Auto-imported from 'Comment Recovery.m3u'",
+    }],
+    songs: { Song: { id: "song-1" } },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.renamed, [
+    { id: "comment-id", name: "Comment Recovery" },
+  ]);
+  assert.deepEqual(client.calls.created, []);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
+    "comment-id",
+  );
+});
+
+test("replaces a pointer whose imported source belongs to another entity", async () => {
+  const original = flowPlaylistConfig.createSharedPlaylist({ name: "Original" });
+  const wrong = flowPlaylistConfig.createSharedPlaylist({ name: "Wrong Target" });
+  const client = createClient({
+    playlists: [{
+      id: "foreign-id",
+      name: "Wrong Target",
+      comment: "Auto-imported from 'Original.m3u'",
+    }],
+    songs: { Song: { id: "song-1" } },
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(wrong.id, "global", {
+    playlistId: "foreign-id",
+    title: wrong.name,
+  });
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: wrong.id,
+      displayName: wrong.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.created, [
+    { name: "Wrong Target", songIds: ["song-1"] },
+  ]);
+  assert.deepEqual(client.calls.renamed, []);
+  assert.equal(
+    navidromePlaylistPointerStore.getPointer(wrong.id, "global").playlistId,
+    "created",
+  );
+  assert.equal(navidromePlaylistPointerStore.getPointer(original.id, "global"), null);
 });
 
 test("keeps a stored playlist during rename cleanup until tracks resolve", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -31,7 +31,15 @@ const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
 function createClient({ configured = true, playlists = [], songs = {} } = {}) {
   const currentPlaylists = playlists.map((playlist) => ({ ...playlist }));
-  const calls = { created: [], deleted: [], ensured: [], renamed: [], scans: 0, updated: [] };
+  const calls = {
+    artwork: [],
+    created: [],
+    deleted: [],
+    ensured: [],
+    renamed: [],
+    scans: 0,
+    updated: [],
+  };
   return {
     calls,
     isConfigured: () => configured,
@@ -58,6 +66,9 @@ function createClient({ configured = true, playlists = [], songs = {} } = {}) {
       calls.updated.push({ id, ...payload });
       const playlist = currentPlaylists.find((candidate) => candidate.id === id);
       if (playlist) playlist.name = payload.name;
+    },
+    async uploadPlaylistArtwork(id, data, filename, contentType) {
+      calls.artwork.push({ id, size: data.length, filename, contentType });
     },
     async renamePlaylist(id, name) {
       calls.renamed.push({ id, name });
@@ -155,6 +166,29 @@ test("publishes resolved tracks through the Subsonic API and stores the playlist
   await assert.rejects(
     fs.access(path.join(destination.libraryRoot, "casey - API Mix.m3u")),
   );
+});
+
+test("uploads generated artwork for API playlists", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Art Mix" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, "Art Mix.webp"), "image");
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.artwork, [{
+    id: "created",
+    size: 5,
+    filename: "Art Mix.webp",
+    contentType: "image/webp",
+  }]);
 });
 
 test("bounds concurrent Navidrome song lookups and preserves track order", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -87,7 +87,7 @@ test.after(async () => {
 test("ensures the Navidrome library without creating an M3U playlist", async () => {
   const owner = userOps.createUser("jody", "hash", "user");
   const flow = flowPlaylistConfig.createFlow({ name: "Morning Mix", ownerUserId: owner.id });
-  const client = createClient();
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
 
   assert.deepEqual(await destination.ensureLibrary(), { ok: true });
@@ -210,6 +210,26 @@ test("creates an empty API playlist without waiting for a scan", async () => {
     { ok: true },
   );
   assert.deepEqual(client.calls.created, [{ name: "Empty", songIds: [] }]);
+});
+
+test("keeps an M3U fallback when no songs are indexed", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Unindexed" });
+  const client = createClient();
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.created, []);
+  assert.equal(
+    await fs.readFile(path.join(destination.libraryRoot, "Unindexed.m3u"), "utf8"),
+    "#EXTM3U\n#EXTINF:0,Artist - Song\n/music/song.flac\n",
+  );
 });
 
 test("serializes concurrent publishes before creating a native playlist", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -551,25 +551,31 @@ test("does not adopt a same-name playlist claimed by another Aurral entity", asy
   assert.deepEqual(client.calls.created, [{ name: "Same Name", songIds: ["song-1"] }]);
 });
 
-test("creates the API playlist after Navidrome indexes a missing song", async () => {
+test("publishes resolved songs and catches up when Navidrome indexes the rest", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Catch-up" });
-  const songs = {};
+  const songs = { Ready: { id: "ready-song" } };
   const client = createClient({ songs });
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
   const snapshot = createPlaybackPlaylistSnapshot({
     entityId: playlist.id,
     displayName: playlist.name,
-    tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    tracks: [
+      { path: "/music/ready.flac", title: "Ready", artist: "Artist" },
+      { path: "/music/missing.flac", title: "Missing", artist: "Artist" },
+    ],
   });
 
   await destination.publishPlaylist(snapshot);
   await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
-  songs.Song = { id: "indexed-song" };
+  assert.deepEqual(client.calls.created, [
+    { name: "Catch-up", songIds: ["ready-song"] },
+  ]);
+  songs.Missing = { id: "missing-song" };
   destination._scheduleCatchup([0]);
   while (destination._catchupRunning) await new Promise((resolve) => setTimeout(resolve, 1));
 
-  assert.deepEqual(client.calls.created, [
-    { name: "Catch-up", songIds: ["indexed-song"] },
+  assert.deepEqual(client.calls.updated, [
+    { id: "created", name: "Catch-up", songIds: ["ready-song", "missing-song"] },
   ]);
   await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
 });

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -38,6 +38,7 @@ function createClient({ configured = true, playlists = [], songs = {} } = {}) {
     ensured: [],
     renamed: [],
     scans: 0,
+    artworkDeleted: [],
     updated: [],
   };
   return {
@@ -69,6 +70,9 @@ function createClient({ configured = true, playlists = [], songs = {} } = {}) {
     },
     async uploadPlaylistArtwork(id, data, filename, contentType) {
       calls.artwork.push({ id, size: data.length, filename, contentType });
+    },
+    async deletePlaylistArtwork(id) {
+      calls.artworkDeleted.push(id);
     },
     async renamePlaylist(id, name) {
       calls.renamed.push({ id, name });
@@ -189,6 +193,32 @@ test("uploads generated artwork for API playlists", async () => {
     filename: "Art Mix.webp",
     contentType: "image/webp",
   }]);
+});
+
+test("syncs and clears artwork for an existing API playlist", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Artwork Sync" });
+  const client = createClient({ songs: { Song: { id: "song-1" } } });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, "Artwork Sync.webp"), "image");
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(
+    await destination.syncPlaylistArtwork({ entityId: playlist.id }),
+    { ok: true },
+  );
+  assert.deepEqual(client.calls.artwork.map(({ id }) => id), ["created", "created"]);
+  assert.deepEqual(
+    await destination.clearPlaylistArtwork({ entityId: playlist.id }),
+    { ok: true },
+  );
+  assert.deepEqual(client.calls.artworkDeleted, ["created"]);
 });
 
 test("bounds concurrent Navidrome song lookups and preserves track order", async () => {

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -438,7 +438,7 @@ test("does not adopt an imported playlist from a colliding track basename", asyn
   await fs.mkdir(destination.libraryRoot, { recursive: true });
   await fs.writeFile(
     path.join(destination.libraryRoot, "Legacy Collision.m3u"),
-    "#EXTM3U\n/music/other/intro.flac\n",
+    "#EXTM3U\n/music/expected/intro.flac\n/music/other/intro.flac\n",
   );
 
   await destination.publishPlaylist(

--- a/.tests/weekly-flow/playlist-artwork.test.js
+++ b/.tests/weekly-flow/playlist-artwork.test.js
@@ -36,6 +36,7 @@ test.after(async () => {
 
 function makeManager() {
   const manager = new WeeklyFlowPlaylistManager(process.env.WEEKLY_FLOW_FOLDER);
+  manager.__artworkUploads = [];
   manager.navidromeDestination.client = {
     isConfigured: () => true,
     async ensureWeeklyFlowLibrary() {},
@@ -50,6 +51,12 @@ function makeManager() {
     },
     async updatePlaylist() {},
     async deletePlaylist() {},
+    async uploadPlaylistArtwork(id, data, filename) {
+      manager.__artworkUploads.push({ id, size: data.length, filename });
+    },
+    async deletePlaylistArtwork(id) {
+      manager.__artworkUploads.push({ id, deleted: true });
+    },
     async scanLibrary() {},
   };
   return manager;
@@ -184,4 +191,22 @@ test("does not regenerate artwork after explicit remove until generate", async (
 
   await manager.generateArtwork(flow.id);
   await assert.doesNotReject(() => fs.access(flowWebp));
+});
+
+test("syncs artwork changes to the existing Navidrome playlist", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Artwork API" });
+  const manager = makeManager();
+  await manager.ensurePlaylists();
+  manager.__artworkUploads.length = 0;
+
+  await manager.generateArtwork(playlist.id);
+  assert.equal(manager.__artworkUploads.length, 1);
+  assert.deepEqual(manager.__artworkUploads[0], {
+    id: "Artwork API",
+    size: manager.__artworkUploads[0].size,
+    filename: "Artwork API.webp",
+  });
+
+  await manager.removeArtwork(playlist.id);
+  assert.deepEqual(manager.__artworkUploads.at(-1), { id: "Artwork API", deleted: true });
 });

--- a/backend/routes/weeklyFlow/handlers/artworkServe.js
+++ b/backend/routes/weeklyFlow/handlers/artworkServe.js
@@ -27,7 +27,7 @@ export function registerArtworkServe(router) {
     const { getArtworkContentTypeForExtension } =
       await import("../../../services/playlistArtworkGenerator.js");
     res.type(getArtworkContentTypeForExtension(artwork.extension));
-    res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+    res.set("Cache-Control", "private, no-cache, must-revalidate");
     res.sendFile(artwork.safePath);
   });
 }

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -48,6 +48,7 @@ export class NavidromeClient {
     this.url = url ? url.replace(/\/+$/, "") : null;
     this.user = user;
     this.password = password;
+    this._indexedSongsPromise = null;
   }
 
   isConfigured() {
@@ -103,6 +104,15 @@ export class NavidromeClient {
   }
 
   async findSong(title, artist, track = {}) {
+    const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
+    if (normalizedPath) {
+      const indexedSongs = await this._getIndexedSongs();
+      const pathMatch = indexedSongs.find((song) => {
+        const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
+        return songPath && normalizedPath.endsWith(songPath);
+      });
+      if (pathMatch) return pathMatch;
+    }
     const search = (query, songCount) => this.request("search3", {
       query,
       songCount,
@@ -124,7 +134,6 @@ export class NavidromeClient {
       songs = toList(data.searchResult3?.song);
     }
     const candidates = songs;
-    const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
     const fileName = normalizedPath.split("/").at(-1);
     const album = String(track.album || "").toLowerCase();
     const mbid = String(track.mbid || "").toLowerCase();
@@ -317,6 +326,15 @@ export class NavidromeClient {
     return response.data;
   }
 
+  async _getIndexedSongs() {
+    if (!this._indexedSongsPromise) {
+      this._indexedSongsPromise = this._nativeRequest("GET", "/api/song?_start=0&_end=100000")
+        .then((songs) => (Array.isArray(songs) ? songs : []))
+        .catch(() => []);
+    }
+    return this._indexedSongsPromise;
+  }
+
   async uploadPlaylistArtwork(playlistId, data, filename = "cover.webp", contentType = "image/webp") {
     const token = await this._nativeLogin();
     const form = new FormData();
@@ -331,6 +349,20 @@ export class NavidromeClient {
     );
     if (!response.ok) {
       throw new Error(`Playlist artwork upload failed with status ${response.status}`);
+    }
+  }
+
+  async deletePlaylistArtwork(playlistId) {
+    const token = await this._nativeLogin();
+    const response = await fetch(
+      `${this.url}/api/playlist/${encodeURIComponent(playlistId)}/image`,
+      {
+        method: "DELETE",
+        headers: { "X-ND-Authorization": `Bearer ${token}` },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Playlist artwork deletion failed with status ${response.status}`);
     }
   }
 
@@ -349,6 +381,7 @@ export class NavidromeClient {
   async scanLibrary() {
     if (!this.isConfigured()) return null;
     try {
+      this._indexedSongsPromise = null;
       return await this.request("startScan");
     } catch (err) {
       console.warn("[Navidrome] scanLibrary failed:", err?.message);

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -4,6 +4,7 @@ import crypto from "crypto";
 const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PLAYLIST_LIBRARY_NAME = "Aurral Playlists";
 const LEGACY_LIBRARY_NAMES = new Set(["Aurral Weekly Flow"]);
+const PLAYLIST_SONG_BATCH_SIZE = 50;
 
 function normalizeLibraryPath(value) {
   return String(value || "")
@@ -150,9 +151,17 @@ export class NavidromeClient {
     const ids = Array.isArray(songIds) ? songIds : [];
     const data = await this.request("createPlaylist", {
       name,
-      songId: ids,
+      songId: ids.slice(0, PLAYLIST_SONG_BATCH_SIZE),
     });
-    return data.playlist || null;
+    const playlist = data.playlist || null;
+    if (!playlist?.id) return playlist;
+    for (let index = PLAYLIST_SONG_BATCH_SIZE; index < ids.length; index += PLAYLIST_SONG_BATCH_SIZE) {
+      await this.request("updatePlaylist", {
+        playlistId: playlist.id,
+        songIdToAdd: ids.slice(index, index + PLAYLIST_SONG_BATCH_SIZE),
+      });
+    }
+    return playlist;
   }
 
   async updatePlaylist(playlistId, { name, songIds = [] } = {}) {
@@ -160,12 +169,19 @@ export class NavidromeClient {
     const entries = playlist?.entry
       ? Array.isArray(playlist.entry) ? playlist.entry : [playlist.entry]
       : [];
+    const ids = Array.isArray(songIds) ? songIds : [];
     await this.request("updatePlaylist", {
       playlistId,
       name,
       songIndexToRemove: entries.map((_, index) => index),
-      songIdToAdd: songIds,
+      songIdToAdd: ids.slice(0, PLAYLIST_SONG_BATCH_SIZE),
     });
+    for (let index = PLAYLIST_SONG_BATCH_SIZE; index < ids.length; index += PLAYLIST_SONG_BATCH_SIZE) {
+      await this.request("updatePlaylist", {
+        playlistId,
+        songIdToAdd: ids.slice(index, index + PLAYLIST_SONG_BATCH_SIZE),
+      });
+    }
   }
 
   async renamePlaylist(playlistId, name) {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -107,9 +107,11 @@ export class NavidromeClient {
     const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
     if (normalizedPath) {
       const indexedSongs = await this._getIndexedSongs();
+      const matchesPathSuffix = (songPath) => songPath
+        && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`));
       const pathMatch = indexedSongs.find((song) => {
         const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
-        return songPath && normalizedPath.endsWith(songPath);
+        return matchesPathSuffix(songPath);
       });
       if (pathMatch) return pathMatch;
     }
@@ -152,7 +154,7 @@ export class NavidromeClient {
       );
       let value = 0;
       if (mbid && String(song.musicBrainzId || "").toLowerCase() === mbid) value += 8;
-      if (songPath && normalizedPath.endsWith(songPath)) value += 8;
+      if (songPath && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`))) value += 8;
       else if (fileName && songPath.split("/").at(-1) === fileName) value += 4;
       if (wantedTitles.has(normalizeSearchText(song.title))) value += 10;
       else if ([...wantedTitles].some((form) => candidateTitles.has(form))) value += 7;
@@ -330,7 +332,10 @@ export class NavidromeClient {
     if (!this._indexedSongsPromise) {
       this._indexedSongsPromise = this._nativeRequest("GET", "/api/song?_start=0&_end=100000")
         .then((songs) => (Array.isArray(songs) ? songs : []))
-        .catch(() => []);
+        .catch(() => {
+          this._indexedSongsPromise = null;
+          return [];
+        });
     }
     return this._indexedSongsPromise;
   }

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -6,6 +6,31 @@ const PLAYLIST_LIBRARY_NAME = "Aurral Playlists";
 const LEGACY_LIBRARY_NAMES = new Set(["Aurral Weekly Flow"]);
 const PLAYLIST_SONG_BATCH_SIZE = 50;
 
+function normalizeSearchText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function titleForms(value) {
+  const normalized = normalizeSearchText(value);
+  const base = normalized.split(/\s+-\s+|\s+\(/, 1)[0].trim();
+  return new Set([normalized, base].filter(Boolean));
+}
+
+function artistForms(value) {
+  const normalized = normalizeSearchText(value);
+  return new Set([normalized, normalized.replace(/^the\s+/, "")].filter(Boolean));
+}
+
+function stripTrackPrefix(value) {
+  return String(value || "").replace(/^\s*\d{1,3}(?:[-_. ]+\d{1,3})?\s*[-_. ]+/, "");
+}
+
 function normalizeLibraryPath(value) {
   return String(value || "")
     .trim()
@@ -78,35 +103,64 @@ export class NavidromeClient {
   }
 
   async findSong(title, artist, track = {}) {
-    const data = await this.request("search3", {
-      query: `${artist} ${title}`,
-      songCount: 5,
+    const search = (query, songCount) => this.request("search3", {
+      query,
+      songCount,
       artistCount: 0,
       albumCount: 0,
     });
-
-    const songs = data.searchResult3?.song || [];
-    const matches = (Array.isArray(songs) ? songs : [songs]).filter(
-      (s) =>
-        String(s.title || "").toLowerCase() === title.toLowerCase() &&
-        String(s.artist || "").toLowerCase() === artist.toLowerCase(),
-    );
+    const toList = (value) => {
+      if (!value) return [];
+      return Array.isArray(value) ? value : [value];
+    };
+    let data = await search(`${artist} ${title}`, 5);
+    let songs = toList(data.searchResult3?.song);
+    if (!songs.length) {
+      data = await search(title, 25);
+      songs = toList(data.searchResult3?.song);
+    }
+    if (!songs.length) {
+      data = await search(artist, 25);
+      songs = toList(data.searchResult3?.song);
+    }
+    const candidates = songs;
     const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
     const fileName = normalizedPath.split("/").at(-1);
     const album = String(track.album || "").toLowerCase();
     const mbid = String(track.mbid || "").toLowerCase();
     const duration = Number(track.durationMs) / 1000;
+    const wantedTitles = titleForms(title);
+    const wantedArtists = artistForms(artist);
+    const wantedAlbum = normalizeSearchText(album);
+    const wantedFileStem = normalizeSearchText(stripTrackPrefix(fileName?.replace(/\.[^.]+$/, "")));
     const score = (song) => {
       const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
+      const candidateTitles = titleForms(song.title);
+      const candidateArtists = artistForms(song.artist);
+      const candidateAlbum = normalizeSearchText(song.album);
+      const candidateFileStem = normalizeSearchText(
+        stripTrackPrefix(songPath.split("/").at(-1)?.replace(/\.[^.]+$/, "")),
+      );
       let value = 0;
       if (mbid && String(song.musicBrainzId || "").toLowerCase() === mbid) value += 8;
-      if (songPath && normalizedPath.endsWith(songPath)) value += 4;
-      else if (fileName && songPath.split("/").at(-1) === fileName) value += 2;
-      if (album && String(song.album || "").toLowerCase() === album) value += 2;
+      if (songPath && normalizedPath.endsWith(songPath)) value += 8;
+      else if (fileName && songPath.split("/").at(-1) === fileName) value += 4;
+      if (wantedTitles.has(normalizeSearchText(song.title))) value += 10;
+      else if ([...wantedTitles].some((form) => candidateTitles.has(form))) value += 7;
+      if ([...wantedArtists].some((form) => candidateArtists.has(form))) value += 6;
+      if (wantedAlbum && candidateAlbum === wantedAlbum) value += 3;
+      if (wantedFileStem && candidateFileStem && (
+        wantedFileStem === candidateFileStem
+        || wantedFileStem.startsWith(candidateFileStem)
+        || candidateFileStem.startsWith(wantedFileStem)
+      )) value += 6;
       if (Number.isFinite(duration) && Math.abs(Number(song.duration) - duration) <= 2) value += 1;
       return value;
     };
-    return matches.sort((a, b) => score(b) - score(a))[0] || null;
+    return candidates
+      .map((song) => ({ song, score: score(song) }))
+      .filter(({ score: value }) => value >= 13)
+      .sort((a, b) => b.score - a.score)[0]?.song || null;
   }
 
   async searchSongsByArtist(artistName, limit = 5) {
@@ -261,6 +315,23 @@ export class NavidromeClient {
     const newToken = response.headers["x-nd-authorization"];
     if (newToken) token = newToken;
     return response.data;
+  }
+
+  async uploadPlaylistArtwork(playlistId, data, filename = "cover.webp", contentType = "image/webp") {
+    const token = await this._nativeLogin();
+    const form = new FormData();
+    form.append("image", new Blob([data], { type: contentType }), filename);
+    const response = await fetch(
+      `${this.url}/api/playlist/${encodeURIComponent(playlistId)}/image`,
+      {
+        method: "POST",
+        headers: { "X-ND-Authorization": `Bearer ${token}` },
+        body: form,
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Playlist artwork upload failed with status ${response.status}`);
+    }
   }
 
   async getLibraries() {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -205,6 +205,48 @@ export class NavidromePlaybackDestination {
     }
   }
 
+  async syncPlaylistArtwork({ entityId, ownerUserId = null } = {}) {
+    try {
+      if (!this.isConfigured()) return playbackOperationSuccess();
+      const entity = this._getEntity(entityId);
+      const targetKey = this._targetKey(ownerUserId);
+      const pointer = navidromePlaylistPointerStore.getPointer(entityId, targetKey);
+      if (!entity || !pointer) return playbackOperationSuccess();
+      await this._uploadPlaylistArtwork({
+        entityId,
+        ownerUserId,
+        displayName: entity.name,
+      }, pointer.playlistId);
+      return playbackOperationSuccess();
+    } catch (error) {
+      return playbackOperationFailure({
+        code: "PLAYLIST_ARTWORK_SYNC_FAILED",
+        message: error?.message || "Could not sync Navidrome playlist artwork",
+        retryable: true,
+      });
+    }
+  }
+
+  async clearPlaylistArtwork({ entityId, ownerUserId = null } = {}) {
+    try {
+      if (!this.isConfigured() || typeof this.client?.deletePlaylistArtwork !== "function") {
+        return playbackOperationSuccess();
+      }
+      const pointer = navidromePlaylistPointerStore.getPointer(
+        entityId,
+        this._targetKey(ownerUserId),
+      );
+      if (pointer) await this.client.deletePlaylistArtwork(pointer.playlistId);
+      return playbackOperationSuccess();
+    } catch (error) {
+      return playbackOperationFailure({
+        code: "PLAYLIST_ARTWORK_CLEAR_FAILED",
+        message: error?.message || "Could not clear Navidrome playlist artwork",
+        retryable: true,
+      });
+    }
+  }
+
   _expectedFiles() {
     const expected = new Set();
     const addArtwork = (name) => {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -94,6 +94,31 @@ export class NavidromePlaybackDestination {
     });
   }
 
+  _getImportedSourceName(comment) {
+    const match = String(comment || "").match(/Auto-imported from ['"]([^'"]+)['"]/i);
+    if (!match) return null;
+    return this._sanitize(path.basename(match[1], path.extname(match[1])));
+  }
+
+  _isActiveNameForOtherEntity(entityId, name) {
+    const expected = this._sanitize(name);
+    const entities = [
+      ...flowPlaylistConfig.getFlows(),
+      ...flowPlaylistConfig.getSharedPlaylists(),
+    ];
+    return entities.some((entity) => {
+      if (entity.id === entityId) return false;
+      const names = this.getPlaylistNames({
+        entityId: entity.id,
+        ownerUserId: entity.ownerUserId,
+        displayName: entity.name,
+      });
+      return [names.current, ...names.legacy].some(
+        (candidate) => this._sanitize(candidate) === expected,
+      );
+    });
+  }
+
   async _loadPlaylists(force = false) {
     if (!this.isConfigured()) return [];
     if (!force && this._playlists) return this._playlists;
@@ -239,6 +264,14 @@ export class NavidromePlaybackDestination {
     if (pointer && this._syncHashes.get(syncKey) === syncHash) {
       return playbackOperationSuccess();
     }
+    if (pointer && typeof this.client.getPlaylist === "function") {
+      const nativePlaylist = await this.client.getPlaylist(pointer.playlistId).catch(() => null);
+      const importedSourceName = this._getImportedSourceName(nativePlaylist?.comment);
+      if (importedSourceName && this._isActiveNameForOtherEntity(snapshot.entityId, importedSourceName)) {
+        navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
+        pointer = null;
+      }
+    }
     const files = await fs.readdir(this.libraryRoot).catch(() => []);
     const normalizeTrackPath = (value) => path
       .normalize(String(value || "").replace(/\\/g, "/"))
@@ -264,10 +297,16 @@ export class NavidromePlaybackDestination {
       if (matchesTrackSet) importedPlaylistNames.push(name);
     }
     let importedPlaylistName = null;
-    if (!pointer && importedPlaylistNames.length) {
+    if (!pointer) {
       const playlists = await this._loadPlaylists();
       const importedPlaylist = playlists.find(
-        (playlist) => importedPlaylistNames.includes(playlist.name)
+        (playlist) => (
+          importedPlaylistNames.includes(playlist.name)
+          || this._getImportedSourceName(playlist.comment) === this._sanitize(current)
+          || legacy.some(
+            (name) => this._getImportedSourceName(playlist.comment) === this._sanitize(name),
+          )
+        )
           && !navidromePlaylistPointerStore.hasPlaylistId(playlist.id),
       );
       if (importedPlaylist) {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -21,6 +21,19 @@ const ARTWORK_SUPPRESS_SUFFIX = ".no-artwork";
 const PLAYLIST_FILE_EXTENSIONS = [".m3u", ".nsp"];
 const SONG_LOOKUP_BATCH_SIZE = 5;
 
+function buildM3uContent(tracks) {
+  const lines = ["#EXTM3U"];
+  for (const track of tracks) {
+    const duration = Math.max(0, Math.round(Number(track.durationMs) / 1000 || 0));
+    const label = track.artist && track.title
+      ? `${track.artist} - ${track.title}`
+      : track.title || track.artist || "";
+    lines.push(`#EXTINF:${duration},${label}`);
+    lines.push(String(track.path || "").replace(/\\/g, "/"));
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 export class NavidromePlaybackDestination {
   constructor(weeklyFlowRoot = resolvePlaylistRoot(), { client = null } = {}) {
     this.key = "navidrome";
@@ -333,6 +346,15 @@ export class NavidromePlaybackDestination {
     }
     const hasUnresolvedSongs = songs.some((song) => !song?.id);
     const songIds = songs.filter((song) => song?.id).map((song) => song.id);
+    if (snapshot.tracks.length && !songIds.length && !pointer) {
+      await fs.writeFile(
+        path.join(this.libraryRoot, `${this._sanitize(current)}.m3u`),
+        buildM3uContent(snapshot.tracks),
+        "utf8",
+      );
+      this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      return playbackOperationSuccess();
+    }
 
     let playlist = null;
     if (pointer) {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -255,11 +255,13 @@ export class NavidromePlaybackDestination {
         continue;
       }
       const content = await fs.readFile(path.join(this.libraryRoot, file), "utf8").catch(() => "");
-      const matchesTrack = content
+      const importedTrackPaths = new Set(content
         .split(/\r?\n/)
         .filter((line) => line && !line.startsWith("#"))
-        .some((line) => trackPaths.has(normalizeTrackPath(line)));
-      if (matchesTrack) importedPlaylistNames.push(name);
+        .map(normalizeTrackPath));
+      const matchesTrackSet = importedTrackPaths.size === trackPaths.size
+        && [...importedTrackPaths].every((trackPath) => trackPaths.has(trackPath));
+      if (matchesTrackSet) importedPlaylistNames.push(name);
     }
     let importedPlaylistName = null;
     if (!pointer && importedPlaylistNames.length) {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -178,6 +178,33 @@ export class NavidromePlaybackDestination {
     }
   }
 
+  async _uploadPlaylistArtwork(snapshot, playlistId) {
+    if (typeof this.client?.uploadPlaylistArtwork !== "function") return;
+    const { current } = this.getPlaylistNames(snapshot);
+    for (const extension of ARTWORK_FILE_EXTENSIONS) {
+      const artworkPath = path.join(this.libraryRoot, `${this._sanitize(current)}${extension}`);
+      const data = await fs.readFile(artworkPath).catch(() => null);
+      if (!data) continue;
+      const contentType = extension === ".png"
+        ? "image/png"
+        : extension === ".jpg" ? "image/jpeg" : "image/webp";
+      try {
+        await this.client.uploadPlaylistArtwork(
+          playlistId,
+          data,
+          path.basename(artworkPath),
+          contentType,
+        );
+      } catch (error) {
+        console.warn(
+          "[NavidromePlaybackDestination] Failed to upload playlist artwork:",
+          error?.message,
+        );
+      }
+      return;
+    }
+  }
+
   _expectedFiles() {
     const expected = new Set();
     const addArtwork = (name) => {
@@ -396,6 +423,7 @@ export class NavidromePlaybackDestination {
       playlistId: playlist.id,
       title: current,
     });
+    await this._uploadPlaylistArtwork(snapshot, playlist.id);
     if (hasUnresolvedSongs) {
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
       return playbackOperationSuccess();

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -331,25 +331,27 @@ export class NavidromePlaybackDestination {
         batch.map((track) => this.client.findSong(track.title, track.artist, track)),
       ));
     }
-    if (songs.some((song) => !song?.id)) {
-      this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
-      return playbackOperationSuccess();
-    }
+    const hasUnresolvedSongs = songs.some((song) => !song?.id);
+    const songIds = songs.filter((song) => song?.id).map((song) => song.id);
 
     let playlist = null;
     if (pointer) {
-      for (const delayMs of [0, 250, 1000, 2000]) {
-        if (delayMs) await wait(delayMs);
-        try {
-          await this.client.updatePlaylist(pointer.playlistId, {
-            name: current,
-            songIds: songs.map((song) => song.id),
-          });
-          playlist = { id: pointer.playlistId };
-          break;
-        } catch (error) {
-          if (Number(error?.code) !== 70) throw error;
+      if (songIds.length) {
+        for (const delayMs of [0, 250, 1000, 2000]) {
+          if (delayMs) await wait(delayMs);
+          try {
+            await this.client.updatePlaylist(pointer.playlistId, {
+              name: current,
+              songIds,
+            });
+            playlist = { id: pointer.playlistId };
+            break;
+          } catch (error) {
+            if (Number(error?.code) !== 70) throw error;
+          }
         }
+      } else {
+        playlist = { id: pointer.playlistId };
       }
       if (!playlist) {
         navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);
@@ -361,7 +363,6 @@ export class NavidromePlaybackDestination {
         importedPlaylistNames.includes(candidate.name)
         && !navidromePlaylistPointerStore.hasPlaylistId(candidate.id),
       );
-      const songIds = songs.map((song) => song.id);
       if (playlist) {
         await this.client.updatePlaylist(playlist.id, { name: current, songIds });
       } else {
@@ -373,6 +374,10 @@ export class NavidromePlaybackDestination {
       playlistId: playlist.id,
       title: current,
     });
+    if (hasUnresolvedSongs) {
+      this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      return playbackOperationSuccess();
+    }
     this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);
     this._playlists = null;
     const cleanupNames = [current, ...legacy, importedPlaylistName, pointer?.title];

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -374,7 +374,8 @@ export class NavidromePlaybackDestination {
         .split(/\r?\n/)
         .filter((line) => line && !line.startsWith("#"))
         .map(normalizeTrackPath));
-      const matchesTrackSet = importedTrackPaths.size === trackPaths.size
+      const matchesTrackSet = trackPaths.size > 0
+        && importedTrackPaths.size === trackPaths.size
         && [...importedTrackPaths].every((trackPath) => trackPaths.has(trackPath));
       if (matchesTrackSet) importedPlaylistNames.push(name);
     }

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -151,16 +151,9 @@ export class WeeklyFlowPlaylistManager {
 
   async _publishPlaylist(entity, artworkKind) {
     const snapshot = await this._createPlaybackSnapshot(entity);
-    const results = await this.destinationRegistry.run("publishPlaylist", snapshot);
-    if (
-      results.some(
-        (result) => result.destination === this.navidromeDestination.name && result.ok,
-      )
-    ) {
-      const playlistName = this.navidromeDestination.getPlaylistName(snapshot);
-      await this._ensureFlowArtwork(entity.id, playlistName, artworkKind);
-    }
-    return results;
+    const playlistName = this.navidromeDestination.getPlaylistName(snapshot);
+    await this._ensureFlowArtwork(entity.id, playlistName, artworkKind);
+    return this.destinationRegistry.run("publishPlaylist", snapshot);
   }
 
   async _ensurePlaylistsInternal() {

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -136,6 +136,24 @@ export class WeeklyFlowPlaylistManager {
     }
   }
 
+  async _syncNavidromeArtwork(playlistId, clear = false) {
+    const entity = flowPlaylistConfig.getFlow(playlistId)
+      || flowPlaylistConfig.getSharedPlaylist(playlistId);
+    if (!entity) return;
+    const operation = clear ? "clearPlaylistArtwork" : "syncPlaylistArtwork";
+    if (typeof this.navidromeDestination[operation] !== "function") return;
+    const result = await this.navidromeDestination[operation]({
+      entityId: entity.id,
+      ownerUserId: entity.ownerUserId ?? null,
+    });
+    if (!result.ok) {
+      console.warn(
+        `[WeeklyFlowPlaylistManager] Navidrome artwork ${clear ? "clear" : "sync"} failed:`,
+        result.error?.message,
+      );
+    }
+  }
+
   async _createPlaybackSnapshot(entity) {
     const tracks = await collectPlaybackPlaylistTracks(entity.id, {
       weeklyFlowRoot: this.weeklyFlowRoot,
@@ -388,6 +406,7 @@ export class WeeklyFlowPlaylistManager {
       await fs.unlink(legacyPng);
     } catch {}
     await this._setArtworkGenerationSuppressed(resolved.safeRoot, resolved.baseName, false);
+    await this._syncNavidromeArtwork(playlistId);
     return webpPath;
   }
 
@@ -406,6 +425,7 @@ export class WeeklyFlowPlaylistManager {
       } catch {}
     }
     await this._setArtworkGenerationSuppressed(resolved.safeRoot, resolved.baseName, true);
+    await this._syncNavidromeArtwork(playlistId, true);
     return removed;
   }
 
@@ -427,6 +447,7 @@ export class WeeklyFlowPlaylistManager {
       kind: artworkContext?.kind || this.getArtworkKindForPlaylistId(playlistId),
     });
     await this._setArtworkGenerationSuppressed(resolved.safeRoot, resolved.baseName, false);
+    await this._syncNavidromeArtwork(playlistId);
     return outputPath;
   }
 }

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -66,6 +66,8 @@ If a new track is not indexed, Aurral waits for the next scan catch-up instead o
 
 Aurral adopts a matching Navidrome playlist that was imported from an old M3U file. It keeps the native playlist ID, updates its ordered tracks through the API, and then removes the legacy file. It also removes obsolete duplicate names.
 
+If the old file is already gone, Aurral can recover the imported playlist from Navidrome's import comment during its next playlist publish. It also rejects an imported playlist whose comment belongs to a different Aurral playlist.
+
 If migration does not finish:
 
 1. Keep the existing Navidrome playlist and M3U file.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -49,13 +49,13 @@ Add `/data/music` as a normal Navidrome music library if it is not already prese
 
 Aurral uses the Subsonic API for playlists, so it does not have a Navidrome playlist path-mapping setting. The automatically managed **Aurral Playlists** library must use the same absolute path in Aurral and Navidrome. Mount the shared download tree at matching paths in both applications.
 
-Reused Lidarr tracks do not need matching path strings because Aurral resolves indexed songs by metadata. Navidrome still needs its own library for those files. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) only when Aurral cannot read a path reported by Lidarr or a download client.
+Reused Lidarr tracks do not need matching path strings because Aurral resolves indexed songs by metadata. For generated tracks, Aurral first uses the exact indexed Navidrome path to get the Navidrome song ID, then uses metadata search only when the path is not available. Navidrome still needs its own library for those files. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) only when Aurral cannot read a path reported by Lidarr or a download client.
 
 ## API playlists and scans
 
 Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
 
-Aurral also uploads its generated playlist artwork to API playlists. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
+Aurral also uploads its generated playlist artwork to API playlists and updates it when you change or regenerate artwork in Aurral. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
 
 If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -55,7 +55,7 @@ Reused Lidarr tracks do not need matching path strings because Aurral resolves i
 
 Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
 
-If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up instead of creating a file playlist. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
+If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
 - confirm that a track exists under `aurral-weekly-flow`;
 - confirm that the Navidrome library path points to that folder;

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -55,7 +55,7 @@ Reused Lidarr tracks do not need matching path strings because Aurral resolves i
 
 Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
 
-Aurral also uploads its generated playlist artwork to API playlists and updates it when you change or regenerate artwork in Aurral. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
+Aurral also uploads its generated playlist artwork to API playlists and updates it when you change or regenerate artwork in Aurral. Aurral revalidates its local artwork response after restart, so the image stays current in the Aurral UI. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
 
 If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -55,6 +55,8 @@ Reused Lidarr tracks do not need matching path strings because Aurral resolves i
 
 Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
 
+Aurral also uploads its generated playlist artwork to API playlists. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
+
 If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
 - confirm that a track exists under `aurral-weekly-flow`;

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -55,7 +55,7 @@ Reused Lidarr tracks do not need matching path strings because Aurral resolves i
 
 Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names are only display values, so a rename updates the same Navidrome playlist.
 
-If a new track is not indexed, Aurral waits for the next scan catch-up instead of creating a file playlist. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
+If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up instead of creating a file playlist. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
 - confirm that a track exists under `aurral-weekly-flow`;
 - confirm that the Navidrome library path points to that folder;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10327,7 +10327,7 @@ textarea {
 
 .flow-page__bulk-menu-anchor {
   position: absolute;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .flow-page__bulk-count {

--- a/frontend/src/utils/api/endpoints/playlists.js
+++ b/frontend/src/utils/api/endpoints/playlists.js
@@ -14,7 +14,7 @@ export const getFlowTrackStreamUrl = (jobId) =>
 export const getStagingStreamUrl = (jobId) =>
   buildAuthenticatedApiUrl(`/playlists/staging-stream/${encodeURIComponent(jobId)}`);
 
-export const getFlowArtworkUrl = (playlistId, version) =>
+export const getFlowArtworkUrl = (playlistId, version = "current") =>
   buildAuthenticatedApiUrl(
     `/playlists/artwork/${encodeURIComponent(playlistId)}`,
     { v: version },


### PR DESCRIPTION
## What changed

- Require an imported M3U/N​​SP path set to exactly match the active Aurral snapshot before adopting its native Navidrome playlist ID.
- Keep sanitized-name cleanup behavior aligned with playlist filename generation.
- Add regression coverage for overlapping playlists and duplicate basenames.

## Root cause

The previous fix treated one shared track path as proof that an imported playlist belonged to the active entity. That allowed Melancholic’s 25-song native playlist to be adopted and renamed as Boner Jams.

## Validation

- 26 focused Navidrome client/playback tests passed.
- npm run lint passed.
- git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Navidrome playlists now support artwork upload, synchronization, and removal.
  - Large playlists are created and updated reliably in batches.
  - Temporarily publishes M3U playlists when tracks are not yet indexed, then catches up automatically.
  - Improves track matching across metadata variations and imported playlists.

- **Bug Fixes**
  - Prevents playlists from being incorrectly reused across entities.
  - Adds safer recovery and handling for partially resolved tracks.

- **Documentation**
  - Expanded Navidrome integration guidance for artwork, matching, imports, and scan catch-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->