### PR TITLE
chore: ignore local generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 # Private maintainer instructions
 /.maintainer/
 /AGENTS.md
+/.agents/


### PR DESCRIPTION
## Problem

Fresh development worktrees create local generated files that shouldn't appear in the public repository.

## Change

Ignore the generated worktree instruction and local setup directory alongside the existing local environment and runtime paths.

## Verification

- Checked the staged diff for whitespace errors.
- Verified the fleet worktree setup passes its ignore preflight with this rule.

No application behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository exclusions to prevent agent-related files from being included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->