### PR TITLE
feat(settings): make playback adapter settings declarative

### DIFF
--- a/.tests/playback/playback-destination-settings.test.js
+++ b/.tests/playback/playback-destination-settings.test.js
@@ -16,6 +16,8 @@ test("playback adapters expose declarative connection settings without credentia
   );
   assert.equal(settings.plex.customUi, "plex");
   assert.equal(settings.plex.fields.find((field) => field.key === "token").hidden, true);
+  assert.deepEqual(settings.navidrome.validation.required, ["url", "username", "password"]);
+  assert.equal(settings.navidrome.fields.find((field) => field.key === "password").required, true);
   for (const field of [...settings.navidrome.fields, ...settings.plex.fields]) {
     assert.equal("value" in field, false);
     assert.equal("default" in field, false);

--- a/.tests/playback/playback-destination-settings.test.js
+++ b/.tests/playback/playback-destination-settings.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getPlaybackDestinationSettings } from "../../backend/services/playback/playbackDestinationSettings.js";
+
+test("playback adapters expose declarative connection settings without credentials", () => {
+  const settings = getPlaybackDestinationSettings();
+
+  assert.deepEqual(Object.keys(settings), ["navidrome", "plex"]);
+  assert.deepEqual(
+    settings.navidrome.fields.map(({ key, type, secret }) => ({ key, type, secret })),
+    [
+      { key: "url", type: "url", secret: undefined },
+      { key: "username", type: "text", secret: undefined },
+      { key: "password", type: "password", secret: true },
+    ],
+  );
+  assert.equal(settings.plex.customUi, "plex");
+  assert.equal(settings.plex.fields.find((field) => field.key === "token").hidden, true);
+  for (const field of [...settings.navidrome.fields, ...settings.plex.fields]) {
+    assert.equal("value" in field, false);
+    assert.equal("default" in field, false);
+  }
+});

--- a/backend/routes/settings/handlers/playback.js
+++ b/backend/routes/settings/handlers/playback.js
@@ -1,0 +1,22 @@
+import {
+  getPlaybackDestinationSettings,
+  testPlaybackDestination,
+} from "../../../services/playback/playbackDestinationSettings.js";
+
+export function registerPlayback(router) {
+  router.get("/playback", (_req, res) => {
+    res.json({ destinations: getPlaybackDestinationSettings() });
+  });
+
+  router.post("/playback/:key/test", async (req, res) => {
+    try {
+      const result = await testPlaybackDestination(req.params.key, req.body || {});
+      if (!result.ok) {
+        return res.status(400).json({ error: result.error.message, ...result.error });
+      }
+      return res.json({ success: true });
+    } catch (error) {
+      return res.status(400).json({ error: "Connection failed", message: error.message });
+    }
+  });
+}

--- a/backend/routes/settings/index.js
+++ b/backend/routes/settings/index.js
@@ -5,6 +5,7 @@ import { registerPlex } from "./handlers/plex.js";
 import { registerDownloadClients } from "./handlers/downloadClients.js";
 import { registerTasks } from "./handlers/tasks.js";
 import { registerStorageHealth } from "./handlers/storageHealth.js";
+import { registerPlayback } from "./handlers/playback.js";
 import mountRoutes from "../shared/mountRoutes.js";
 
 export default mountRoutes([
@@ -14,4 +15,5 @@ export default mountRoutes([
   registerDownloadClients,
   registerTasks,
   registerStorageHealth,
+  registerPlayback,
 ], [requireAuth, requireAdmin]);

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -28,10 +28,10 @@ export const navidromeSettings = Object.freeze({
   fields: Object.freeze([
     Object.freeze({ key: "url", label: "Server URL", type: "url", required: true }),
     Object.freeze({ key: "username", label: "Username", type: "text", required: true }),
-    Object.freeze({ key: "password", label: "Password", type: "password", secret: true }),
+    Object.freeze({ key: "password", label: "Password", type: "password", required: true, secret: true }),
   ]),
   defaults: Object.freeze({ url: "", username: "", password: "" }),
-  validation: Object.freeze({ required: ["url", "username"], url: ["url"] }),
+  validation: Object.freeze({ required: ["url", "username", "password"], url: ["url"] }),
   testConnection: true,
 });
 

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -21,6 +21,20 @@ const ARTWORK_SUPPRESS_SUFFIX = ".no-artwork";
 const PLAYLIST_FILE_EXTENSIONS = [".m3u", ".nsp"];
 const SONG_LOOKUP_BATCH_SIZE = 5;
 
+export const navidromeSettings = Object.freeze({
+  key: "navidrome",
+  label: "Navidrome",
+  subtitle: "Subsonic",
+  fields: Object.freeze([
+    Object.freeze({ key: "url", label: "Server URL", type: "url", required: true }),
+    Object.freeze({ key: "username", label: "Username", type: "text", required: true }),
+    Object.freeze({ key: "password", label: "Password", type: "password", secret: true }),
+  ]),
+  defaults: Object.freeze({ url: "", username: "", password: "" }),
+  validation: Object.freeze({ required: ["url", "username"], url: ["url"] }),
+  testConnection: true,
+});
+
 function buildM3uContent(tracks) {
   const lines = ["#EXTM3U"];
   for (const track of tracks) {

--- a/backend/services/playback/playbackDestinationSettings.js
+++ b/backend/services/playback/playbackDestinationSettings.js
@@ -1,0 +1,23 @@
+import { navidromeSettings, NavidromePlaybackDestination } from "./navidromePlaybackDestination.js";
+import { plexSettings, PlexPlaybackDestination } from "./plexPlaybackDestination.js";
+
+const definitions = Object.freeze({
+  navidrome: navidromeSettings,
+  plex: plexSettings,
+});
+
+const factories = {
+  navidrome: () => new NavidromePlaybackDestination(),
+  plex: () => new PlexPlaybackDestination(),
+};
+
+export function getPlaybackDestinationSettings() {
+  return structuredClone(definitions);
+}
+
+export async function testPlaybackDestination(key, config) {
+  const destination = factories[key]?.();
+  if (!destination) throw new Error(`Unknown playback destination: ${key}`);
+  destination.updateConfig(config);
+  return destination.testConnection();
+}

--- a/backend/services/playback/plexPlaybackDestination.js
+++ b/backend/services/playback/plexPlaybackDestination.js
@@ -20,6 +20,20 @@ import {
 
 const SYNC_SKIPPED = Symbol("plex-sync-skipped");
 
+export const plexSettings = Object.freeze({
+  key: "plex",
+  label: "Plex",
+  subtitle: "Plexamp",
+  customUi: "plex",
+  fields: Object.freeze([
+    Object.freeze({ key: "url", label: "Server URL", type: "url", required: true }),
+    Object.freeze({ key: "token", label: "Account token", type: "password", secret: true, hidden: true }),
+  ]),
+  defaults: Object.freeze({ url: "", token: "" }),
+  validation: Object.freeze({ required: ["url"], url: ["url"] }),
+  testConnection: true,
+});
+
 export class PlexPlaybackDestination {
   constructor(weeklyFlowRoot = resolvePlaylistRoot(), { client = null } = {}) {
     this.key = "plex";

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -155,6 +155,7 @@ function SettingsPage() {
         return (
           <SettingsPlaybackTab
             settings={data.settings}
+            playbackSettings={data.playbackSettings}
             updateSettings={data.updateSettings}
             hasUnsavedChanges={data.hasUnsavedChanges}
             saving={data.saving}

--- a/frontend/src/pages/Settings/components/SettingsAdapterFields.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAdapterFields.jsx
@@ -1,0 +1,16 @@
+import { SettingsInput } from "./SettingsField";
+import { SettingsModalField } from "./SettingsModalLayout";
+
+export function SettingsAdapterFields({ definition, settings, onChange }) {
+  return (definition?.fields || []).filter((field) => !field.hidden).map((field) => (
+    <SettingsModalField key={field.key} label={field.label}>
+      <SettingsInput
+        type={field.type || "text"}
+        required={field.required === true}
+        autoComplete={field.secret ? "new-password" : "off"}
+        value={settings?.[field.key] || ""}
+        onChange={(event) => onChange({ [field.key]: event.target.value })}
+      />
+    </SettingsModalField>
+  ));
+}

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -254,8 +254,8 @@ export function SettingsPlaybackSection({
   };
 
   const handleTestNavidrome = async () => {
-    if (!navidrome.url || !navidrome.username) {
-      showError("Enter Navidrome URL and username first");
+    if (!navidrome.url || !navidrome.username || !navidrome.password) {
+      showError("Enter Navidrome URL, username, and password first");
       return;
     }
     setTestingNavidrome(true);
@@ -338,7 +338,7 @@ export function SettingsPlaybackSection({
               type="button"
               className="btn btn-secondary"
               onClick={handleTestNavidrome}
-              disabled={testingNavidrome || !navidrome.url || !navidrome.username}
+              disabled={testingNavidrome || !navidrome.url || !navidrome.username || !navidrome.password}
             >
               <RefreshCw className={`artist-icon-sm${testingNavidrome ? " animate-spin" : ""}`} />
               {testingNavidrome ? "Testing…" : "Test connection"}

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -5,8 +5,7 @@ import {
   getPlexResources,
   getPlexLibraries,
   checkPlexLibraryAccess,
-  testPlexConnection,
-  testNavidromeConnection,
+  testPlaybackConnection,
   syncPlexNow,
 } from "../../../utils/api/endpoints/settings.js";
 import { getConfiguredStatus } from "../utils/integrationStatus";
@@ -19,6 +18,7 @@ import {
 } from "lucide-react";
 import DownloadFolderPickerModal from "../../../components/DownloadFolderPickerModal";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
+import { SettingsAdapterFields } from "./SettingsAdapterFields";
 import { IntegrationCard, SettingsIntegrationModal } from "./SettingsIntegrationCards";
 import {
   SettingsArrCardGrid,
@@ -36,6 +36,7 @@ import {
 } from "../utils/plexConnections";
 export function SettingsPlaybackSection({
   settings,
+  playbackSettings,
   updateSettings,
   hasUnsavedChanges,
   handleSaveSettings,
@@ -235,7 +236,7 @@ export function SettingsPlaybackSection({
     }
     setTestingPlex(true);
     try {
-      const result = await testPlexConnection(plex.url, plex.token);
+      const result = await testPlaybackConnection("plex", plex);
       if (result.success) {
         showSuccess(`Plex connection successful!${result.version ? ` (v${result.version})` : ""}`);
         if (result.machineIdentifier) {
@@ -262,7 +263,7 @@ export function SettingsPlaybackSection({
       if (handleSaveSettings) {
         await handleSaveSettings();
       }
-      await testNavidromeConnection(navidrome.url, navidrome.username, navidrome.password || "");
+      await testPlaybackConnection("navidrome", navidrome);
       showSuccess("Navidrome connection OK");
     } catch (err) {
       const errorMsg = err.response?.data?.message || err.response?.data?.error || err.message;
@@ -345,31 +346,11 @@ export function SettingsPlaybackSection({
           }
         >
           <SettingsModalSection title="Connection">
-            <SettingsModalField label="Server URL">
-              <SettingsInput
-                type="url"
-                placeholder="https://music.example.com"
-                autoComplete="off"
-                value={navidrome.url || ""}
-                onChange={(event) => updateNavidrome({ url: event.target.value })}
-              />
-            </SettingsModalField>
-            <SettingsModalField label="Username">
-              <SettingsInput
-                type="text"
-                autoComplete="off"
-                value={navidrome.username || ""}
-                onChange={(event) => updateNavidrome({ username: event.target.value })}
-              />
-            </SettingsModalField>
-            <SettingsModalField label="Password">
-              <SettingsInput
-                type="password"
-                autoComplete="off"
-                value={navidrome.password || ""}
-                onChange={(event) => updateNavidrome({ password: event.target.value })}
-              />
-            </SettingsModalField>
+            <SettingsAdapterFields
+              definition={playbackSettings?.navidrome}
+              settings={navidrome}
+              onChange={updateNavidrome}
+            />
           </SettingsModalSection>
         </SettingsIntegrationModal>
       )}
@@ -429,6 +410,11 @@ export function SettingsPlaybackSection({
           </SettingsModalSection>
 
           <SettingsModalSection title="Connection">
+            <SettingsAdapterFields
+              definition={playbackSettings?.plex}
+              settings={plex}
+              onChange={updatePlex}
+            />
             {plex.token && (
               <SettingsModalField label="Plex server">
                 <SettingsSelect
@@ -452,18 +438,6 @@ export function SettingsPlaybackSection({
                 </SettingsSelect>
               </SettingsModalField>
             )}
-            <SettingsModalField
-              label="Server URL"
-              hint="Auto-filled when you select a server, or enter it manually."
-            >
-              <SettingsInput
-                type="url"
-                placeholder="http://localhost:32400"
-                autoComplete="off"
-                value={plex.url || ""}
-                onChange={(event) => updatePlex({ url: event.target.value })}
-              />
-            </SettingsModalField>
           </SettingsModalSection>
 
           <SettingsModalSection title="Aurral Library Path">

--- a/frontend/src/pages/Settings/components/SettingsPlaybackTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackTab.jsx
@@ -9,6 +9,7 @@ const PLAYLIST_ARTWORK_STYLE_OPTIONS = [
 
 export function SettingsPlaybackTab({
   settings,
+  playbackSettings,
   updateSettings,
   hasUnsavedChanges,
   handleSaveSettings,
@@ -23,6 +24,7 @@ export function SettingsPlaybackTab({
       <form onSubmit={handleSaveSettings} className="arr-form" autoComplete="off">
         <SettingsPlaybackSection
           settings={settings}
+          playbackSettings={playbackSettings}
           updateSettings={updateSettings}
           hasUnsavedChanges={hasUnsavedChanges}
           handleSaveSettings={handleSaveSettings}

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -3,6 +3,7 @@ import api from "../../../utils/api/core.js";
 import { checkHealth } from "../../../utils/api/endpoints/auth.js";
 import {
   getAppSettings,
+  getPlaybackSettings,
   updateAppSettings,
   getLidarrRootFolders,
   getLidarrProfiles,
@@ -184,6 +185,7 @@ const defaultSettings = {
 const AUTOSAVE_DELAY_MS = 450;
 
 export function useSettingsData(showSuccess, showError, showInfo) {
+  const [playbackSettings, setPlaybackSettings] = useState(null);
   const [health, setHealth] = useState(null);
   const [settings, setSettingsState] = useState(defaultSettings);
   const [originalSettings, setOriginalSettings] = useState(null);
@@ -281,7 +283,12 @@ export function useSettingsData(showSuccess, showError, showInfo) {
     comparisonEnabledRef.current = false;
     if (settingsActivationTimerRef.current) clearTimeout(settingsActivationTimerRef.current);
     try {
-      const [, savedSettings] = await Promise.all([refreshHealth(), getAppSettings()]);
+      const [, savedSettings, playback] = await Promise.all([
+        refreshHealth(),
+        getAppSettings(),
+        getPlaybackSettings(),
+      ]);
+      setPlaybackSettings(playback?.destinations || null);
       const updatedSettings = normalizeSettings(savedSettings);
       const savedSnapshot = structuredClone(updatedSettings);
       settingsRef.current = updatedSettings;
@@ -608,6 +615,7 @@ export function useSettingsData(showSuccess, showError, showInfo) {
   return {
     health,
     settings,
+    playbackSettings,
     updateSettings,
     originalSettings,
     hasUnsavedChanges,

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -283,11 +283,11 @@ export function useSettingsData(showSuccess, showError, showInfo) {
     comparisonEnabledRef.current = false;
     if (settingsActivationTimerRef.current) clearTimeout(settingsActivationTimerRef.current);
     try {
-      const [, savedSettings, playback] = await Promise.all([
-        refreshHealth(),
-        getAppSettings(),
-        getPlaybackSettings(),
-      ]);
+      const [, savedSettings] = await Promise.all([refreshHealth(), getAppSettings()]);
+      let playback = null;
+      try {
+        playback = await getPlaybackSettings();
+      } catch {}
       setPlaybackSettings(playback?.destinations || null);
       const updatedSettings = normalizeSettings(savedSettings);
       const savedSnapshot = structuredClone(updatedSettings);

--- a/frontend/src/utils/api/endpoints/settings.js
+++ b/frontend/src/utils/api/endpoints/settings.js
@@ -30,6 +30,9 @@ export const checkPlexLibraryAccess = (sectionId) =>
   getData(`/settings/plex/libraries/${encodeURIComponent(sectionId)}/access-check`);
 
 export const getAppSettings = () => getData("/settings");
+export const getPlaybackSettings = () => getData("/settings/playback");
+export const testPlaybackConnection = (key, config) =>
+  postData(`/settings/playback/${encodeURIComponent(key)}/test`, config);
 
 export const updateAppSettings = (settings) => postData("/settings", settings);
 


### PR DESCRIPTION
Playback connection forms were hardcoded in core Settings, making each new playback destination require destination-specific UI and API wiring.

This adds adapter-owned declarative metadata for Navidrome and Plex, a generic authenticated schema/test API, and generic rendering for ordinary connection fields. Plex PIN/OAuth, library, and sync flows remain first-party custom UI.

Verification:
- npm run lint
- focused playback and Settings tests (10 passed)
- npm run build
- git diff --check

Known limitation: full live playback E2E was not rerun for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added playback destination settings for Navidrome and Plex.
  * Configure connection details through the Settings page with required-field and URL validation.
  * Test playback connections directly from settings with clear success or error feedback.
  * Plex account tokens are securely handled and hidden from the interface.
  * Playback fields and options load dynamically for a consistent settings experience.
  * Navidrome connection testing indicates when a password is required.

* **Tests**
  * Added coverage for destination ordering, field metadata, validation, and credential protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->