### PR TITLE
feat(settings): add sidebar environment art toggle

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -27,13 +27,20 @@ import {
 } from "../utils/discoverRecentNavigation";
 import { useStorageHealth } from "../hooks/useStorageHealth";
 import SidebarStageBackdrop, {
+  getSidebarStageBackdropEnabled,
   resolveSidebarStageBackdropVariant,
+  SIDEBAR_STAGE_BACKDROP_EVENT,
 } from "./SidebarStageBackdrop";
 
 function Sidebar({ mode, width = 208, settingsMode = false }) {
-  const stageBackdropVariant = resolveSidebarStageBackdropVariant();
   const location = useLocation();
   const { user, bootstrap } = useAuth();
+  const [showStageBackdrop, setShowStageBackdrop] = useState(() =>
+    getSidebarStageBackdropEnabled(user?.id),
+  );
+  const stageBackdropVariant = showStageBackdrop
+    ? resolveSidebarStageBackdropVariant()
+    : null;
   const hasFlowAccess = user?.role === "admin" || !!user?.permissions?.accessFlow;
   const canAccessSettings = user?.role === "admin" || !!user?.permissions?.accessSettings;
   const { hasReview: hasReviewAlert } = useFlowWorkerActivity({
@@ -52,6 +59,17 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
     clearRecentPages,
     isDiscoverSectionActive,
   } = useDiscoverRecent();
+
+  useEffect(() => {
+    setShowStageBackdrop(getSidebarStageBackdropEnabled(user?.id));
+    const onPreferenceChange = (event) => {
+      if (event.detail?.userId === user?.id) {
+        setShowStageBackdrop(getSidebarStageBackdropEnabled(user?.id));
+      }
+    };
+    window.addEventListener(SIDEBAR_STAGE_BACKDROP_EVENT, onPreferenceChange);
+    return () => window.removeEventListener(SIDEBAR_STAGE_BACKDROP_EVENT, onPreferenceChange);
+  }, [user?.id]);
 
   const isIcons = mode === "icons" && isDesktop;
   const currentDiscoverPath = `${location.pathname}${location.search}`;

--- a/frontend/src/components/SidebarStageBackdrop.jsx
+++ b/frontend/src/components/SidebarStageBackdrop.jsx
@@ -1,6 +1,26 @@
 import { useId } from "react";
 
 const STAGE_BACKDROP_VIEW_BOX = "0 0 8192 96";
+const SIDEBAR_STAGE_BACKDROP_EVENT = "aurral:sidebar-stage-backdrop";
+
+const getSidebarStageBackdropStorageKey = (userId) =>
+  `sidebar-stage-backdrop:${userId ?? "anonymous"}`;
+
+export function getSidebarStageBackdropEnabled(userId) {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem(getSidebarStageBackdropStorageKey(userId)) !== "false";
+}
+
+export function setSidebarStageBackdropEnabled(userId, enabled) {
+  if (typeof window === "undefined") return enabled;
+  window.localStorage.setItem(getSidebarStageBackdropStorageKey(userId), String(enabled));
+  window.dispatchEvent(
+    new CustomEvent(SIDEBAR_STAGE_BACKDROP_EVENT, { detail: { userId } }),
+  );
+  return enabled;
+}
+
+export { SIDEBAR_STAGE_BACKDROP_EVENT };
 
 const NIGHTLY_STARS = [
   { cx: 14, cy: 10, r: 0.6, opacity: 0.85 },

--- a/frontend/src/components/SidebarStageBackdrop.jsx
+++ b/frontend/src/components/SidebarStageBackdrop.jsx
@@ -8,12 +8,20 @@ const getSidebarStageBackdropStorageKey = (userId) =>
 
 export function getSidebarStageBackdropEnabled(userId) {
   if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(getSidebarStageBackdropStorageKey(userId)) !== "false";
+  try {
+    return window.localStorage.getItem(getSidebarStageBackdropStorageKey(userId)) !== "false";
+  } catch {
+    return true;
+  }
 }
 
 export function setSidebarStageBackdropEnabled(userId, enabled) {
   if (typeof window === "undefined") return enabled;
-  window.localStorage.setItem(getSidebarStageBackdropStorageKey(userId), String(enabled));
+  try {
+    window.localStorage.setItem(getSidebarStageBackdropStorageKey(userId), String(enabled));
+  } catch {
+    return enabled;
+  }
   window.dispatchEvent(
     new CustomEvent(SIDEBAR_STAGE_BACKDROP_EVENT, { detail: { userId } }),
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1745,7 +1745,7 @@ textarea {
   padding-left: 2.75rem;
   padding-right: 1rem;
   color: var(--aurral-text-muted);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   pointer-events: none;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11351,14 +11351,14 @@ textarea {
 }
 
 .profile-settings__section {
-  padding: 1rem 0 1.5rem;
+  padding: 2rem 0 2.25rem;
   border: 0;
   border-radius: 0;
   background: transparent;
 }
 
 .profile-settings__section:first-child {
-  padding-top: 0;
+  padding-top: 0.5rem;
 }
 
 .profile-settings__section + .profile-settings__section {
@@ -11370,7 +11370,7 @@ textarea {
 }
 
 .profile-settings__section .settings-page__section-intro {
-  margin-bottom: 0.5rem;
+  margin-bottom: 1.25rem;
 }
 
 .profile-settings__section .settings-page__callout {
@@ -11385,6 +11385,21 @@ textarea {
 .profile-settings__section .settings-page__inline-row > .btn {
   justify-self: start;
   width: max-content;
+}
+
+.profile-settings__section--action {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 2.5rem;
+}
+
+.profile-settings__section--action .settings-page__section-intro {
+  margin-bottom: 0;
+}
+
+.profile-settings__action {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .profile-page--settings .arr-input,
@@ -11403,33 +11418,40 @@ textarea {
 }
 
 .profile-settings__fields {
-  gap: 0.75rem;
+  gap: 2rem;
 }
 
 .profile-settings__field {
   display: grid;
-  grid-template-columns: minmax(10rem, 0.8fr) minmax(0, 1.2fr);
-  align-items: start;
-  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 20rem);
+  grid-template-areas:
+    "title control"
+    "description control";
+  align-items: center;
+  column-gap: 2.5rem;
+  row-gap: 0.25rem;
 }
 
 .profile-settings__label {
-  padding-top: 0.5rem;
+  grid-area: title;
   color: var(--aurral-text);
-  font-size: 0.8125rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   line-height: 1.35;
 }
 
 .profile-settings__field > .arr-input,
 .profile-settings__field > .arr-select,
-.profile-settings__field > .settings-page__hint {
-  grid-column: 2;
+.profile-settings__field > .pill-toggle {
+  grid-area: control;
   min-width: 0;
 }
 
 .profile-settings__field > .settings-page__hint {
-  margin-top: -0.5rem;
+  grid-area: description;
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
 }
 
 @media (max-width: 48rem) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1745,7 +1745,7 @@ textarea {
   padding-left: 2.75rem;
   padding-right: 1rem;
   color: var(--aurral-text-muted);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   pointer-events: none;
 }
 
@@ -11373,15 +11373,6 @@ textarea {
   margin-bottom: 1.25rem;
 }
 
-.profile-settings__section .settings-page__section-title {
-  font-size: 1.125rem;
-}
-
-.profile-settings__section .settings-page__section-note {
-  font-size: 0.9375rem;
-  line-height: 1.5;
-}
-
 .profile-settings__section .settings-page__callout {
   margin: 0;
   padding: 0.625rem 0;
@@ -11444,7 +11435,7 @@ textarea {
 .profile-settings__label {
   grid-area: title;
   color: var(--aurral-text);
-  font-size: 1rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   line-height: 1.35;
 }
@@ -11459,7 +11450,7 @@ textarea {
 .profile-settings__field > .settings-page__hint {
   grid-area: description;
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   line-height: 1.45;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11316,7 +11316,7 @@ textarea {
   width: min(100%, 55rem);
   margin-inline: auto;
   color: var(--aurral-text-muted);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   line-height: 1.5;
 }
 
@@ -11371,6 +11371,15 @@ textarea {
 
 .profile-settings__section .settings-page__section-intro {
   margin-bottom: 1.25rem;
+}
+
+.profile-settings__section .settings-page__section-title {
+  font-size: 1.125rem;
+}
+
+.profile-settings__section .settings-page__section-note {
+  font-size: 0.9375rem;
+  line-height: 1.5;
 }
 
 .profile-settings__section .settings-page__callout {
@@ -11435,7 +11444,7 @@ textarea {
 .profile-settings__label {
   grid-area: title;
   color: var(--aurral-text);
-  font-size: 0.9375rem;
+  font-size: 1rem;
   font-weight: 600;
   line-height: 1.35;
 }
@@ -11450,7 +11459,7 @@ textarea {
 .profile-settings__field > .settings-page__hint {
   grid-area: description;
   margin: 0;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1.45;
 }
 

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,14 +1,23 @@
+import { useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAccountSettings } from "./Settings/hooks/useAccountSettings";
 import { SettingsAccountTab } from "./Settings/components/SettingsAccountTab";
+import {
+  getSidebarStageBackdropEnabled,
+  resolveSidebarStageBackdropVariant,
+  setSidebarStageBackdropEnabled,
+} from "../components/SidebarStageBackdrop";
 import "./Settings/settingsArr.css";
 
 function ProfilePage() {
   useDocumentTitle("Profile");
   const { showSuccess, showError } = useToast();
   const { user: authUser } = useAuth();
+  const [showSidebarArt, setShowSidebarArt] = useState(() =>
+    getSidebarStageBackdropEnabled(authUser?.id),
+  );
   const account = useAccountSettings(authUser, showError);
 
   return (
@@ -43,6 +52,11 @@ function ProfilePage() {
         handleSave={account.handleSave}
         showSuccess={showSuccess}
         showError={showError}
+        showSidebarArt={!!resolveSidebarStageBackdropVariant()}
+        sidebarArtEnabled={showSidebarArt}
+        setSidebarArtEnabled={(enabled) =>
+          setShowSidebarArt(setSidebarStageBackdropEnabled(authUser?.id, enabled))
+        }
       />
     </div>
   );

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
@@ -18,6 +18,9 @@ function ProfilePage() {
   const [showSidebarArt, setShowSidebarArt] = useState(() =>
     getSidebarStageBackdropEnabled(authUser?.id),
   );
+  useEffect(() => {
+    setShowSidebarArt(getSidebarStageBackdropEnabled(authUser?.id));
+  }, [authUser?.id]);
   const account = useAccountSettings(authUser, showError);
 
   return (

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -156,6 +156,9 @@ export function SettingsAccountTab({
                 <option value="listenbrainz">ListenBrainz</option>
                 <option value="koito">Koito</option>
               </SettingsSelect>
+              <p className="settings-page__hint">
+                Select the service that supplies your listening history for personalized discovery.
+              </p>
             </div>
             {listenHistoryProvider === "koito" ? (
               <div className="profile-settings__field">
@@ -241,6 +244,9 @@ export function SettingsAccountTab({
                   </option>
                 ))}
               </SettingsSelect>
+              <p className="settings-page__hint">
+                Choose where one-click artist adds should be stored by default.
+              </p>
             </div>
 
             <div className="profile-settings__field">
@@ -259,6 +265,9 @@ export function SettingsAccountTab({
                   </option>
                 ))}
               </SettingsSelect>
+              <p className="settings-page__hint">
+                Choose the Lidarr quality profile for one-click artist adds.
+              </p>
             </div>
           </fieldset>
 
@@ -273,7 +282,7 @@ export function SettingsAccountTab({
           )}
         </div>
 
-        <div className="settings-page__section profile-settings__section">
+        <div className="settings-page__section profile-settings__section profile-settings__section--action">
           <div className="settings-page__section-intro">
             <h3 className="settings-page__section-title">Discovery Tastes</h3>
             <p className="settings-page__section-note">
@@ -281,15 +290,17 @@ export function SettingsAccountTab({
               Manage hard exclusions on the <Link to="/blocklist" className="settings-page__link">Blocked Artists</Link> page.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={handleResetDiscoveryTastes}
-            disabled={resettingTastes}
-            className="btn btn-secondary btn-sm"
-          >
-            <RotateCcw className={`artist-icon-xs${resettingTastes ? " animate-spin" : ""}`} />
-            {resettingTastes ? "Resetting…" : "Reset Discovery Tastes"}
-          </button>
+          <div className="profile-settings__action">
+            <button
+              type="button"
+              onClick={handleResetDiscoveryTastes}
+              disabled={resettingTastes}
+              className="btn btn-secondary btn-sm"
+            >
+              <RotateCcw className={`artist-icon-xs${resettingTastes ? " animate-spin" : ""}`} />
+              {resettingTastes ? "Resetting…" : "Reset Discovery Tastes"}
+            </button>
+          </div>
         </div>
       </form>
     </div>

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -5,6 +5,7 @@ import {
   setThemePreference,
 } from "../../../utils/theme.js";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
+import PillToggle from "../../../components/PillToggle";
 import { PlexSelfLinkSection } from "./PlexSelfLinkSection";
 
 import { Link } from "react-router-dom";
@@ -29,6 +30,9 @@ export function SettingsAccountTab({
   showSuccess,
   showError,
   profileVariant = false,
+  showSidebarArt = false,
+  sidebarArtEnabled = true,
+  setSidebarArtEnabled,
 }) {
   const [resettingTastes, setResettingTastes] = useState(false);
   const [theme, setTheme] = useState(getThemePreference);
@@ -107,6 +111,22 @@ export function SettingsAccountTab({
                 System follows the appearance setting of your device.
               </p>
             </div>
+            {profileVariant && showSidebarArt ? (
+              <div className="profile-settings__field">
+                <label className="profile-settings__label" htmlFor="profile-sidebar-art">
+                  Environment art
+                </label>
+                <PillToggle
+                  id="profile-sidebar-art"
+                  checked={sidebarArtEnabled}
+                  onChange={(event) => setSidebarArtEnabled(event.target.checked)}
+                  aria-label="Show sidebar environment art"
+                />
+                <p className="settings-page__hint">
+                  Show the nightly or preview environment art in the sidebar.
+                </p>
+              </div>
+            ) : null}
           </fieldset>
         </div>
 


### PR DESCRIPTION
Nightly and preview users who do not want the sidebar environment art currently have no way to hide it.

The profile Appearance section now includes a user-scoped toggle for the art, and the sidebar updates immediately when the preference changes. The toggle is shown only when the current release channel provides environment art.

Verification: `npm run lint` and `npm run build` pass. Browser verification was unavailable because no preview automation host was attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account setting to show or hide sidebar environment artwork.
  * Sidebar artwork preferences are saved per account and applied across the app.
  * Changes take effect immediately when the preference is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->