### PR TITLE
fix(lidarr): use the v1 API path

### DIFF
--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -22,6 +22,47 @@ test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   assert.equal(artists[0].artistName, "Test");
 });
 
+test("testConnection preserves Lidarr HTTP diagnostics", async (t) => {
+  let status = 401;
+  const server = http.createServer((_request, response) => {
+    response.writeHead(status, {
+      "content-type": "application/json",
+      "x-test-header": String(status),
+    });
+    response.end(JSON.stringify({ message: `failure-${status}` }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+
+  let result = await client.testConnection(true);
+  assert.equal(result.statusCode, 401);
+  assert.match(result.details, /failure-401/);
+  assert.equal(result.responseHeaders["x-test-header"], "401");
+
+  status = 500;
+  result = await client.testConnection(true);
+  assert.equal(result.statusCode, 500);
+  assert.match(result.details, /failure-500/);
+  assert.equal(result.responseHeaders["x-test-header"], "500");
+
+  client._httpAgent.destroy();
+  client._httpsAgent.destroy();
+  client._httpsInsecureAgent.destroy();
+});
+
 test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
   const requests = [];
   const server = http.createServer((request, response) => {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -606,34 +606,44 @@ export class LidarrClient {
               responseTextLower.includes("connect") ||
               responseTextLower.includes("econnrefused"));
           if (isLidarrSkyhookRefused) {
-            throw new Error(
+            const userError = new Error(
               "Lidarr cannot reach api.lidarr.audio from its container. Check Lidarr outbound internet/DNS or proxy settings.",
             );
+            userError.response = raw.response;
+            throw userError;
           }
           if (status === 400) {
-            throw new Error(
+            const userError = new Error(
               `Lidarr API returned 400 Bad Request: ${errorMsg}${
                 errorDetails ? `\n\nFull Response: ${errorDetails}` : ""
               }`,
             );
+            userError.response = raw.response;
+            throw userError;
           }
           if (status === 401) {
-            throw new Error(`Lidarr API authentication failed. Check your API key.`);
+            const userError = new Error(`Lidarr API authentication failed. Check your API key.`);
+            userError.response = raw.response;
+            throw userError;
           }
           if (status === 404) {
             const isAlbumEndpoint = endpoint.includes("/album/");
             if (isAlbumEndpoint) {
               return null;
             }
-            throw new Error(
+            const userError = new Error(
               `Lidarr endpoint not found: ${endpoint}. Check if Lidarr is running and the API version is correct.`,
             );
+            userError.response = raw.response;
+            throw userError;
           }
-          throw new Error(
+          const userError = new Error(
             `Lidarr API error: ${status} - ${
               responseData?.message || responseData?.error || statusText || "Unknown error"
             }`,
           );
+          userError.response = raw.response;
+          throw userError;
         } else if (error.request) {
           console.error("Lidarr API request failed - no response:", msg);
           throw new Error(
@@ -656,78 +666,37 @@ export class LidarrClient {
       return { connected: false, error: "Lidarr not configured" };
     }
 
-    const apiPaths = ["/api/v1", "/api"];
+    this.apiPath = "/api/v1";
 
-    for (const apiPath of apiPaths) {
-      this.apiPath = apiPath;
+    try {
+      const status = await this.request("/system/status", "GET", null, skipConfigUpdate, {
+        bypassCircuit: true,
+      });
+      return {
+        connected: true,
+        version: status.version || "unknown",
+        instanceName: status.instanceName || "Lidarr",
+        apiPath: this.apiPath,
+      };
+    } catch (error) {
+      const errorMessage = error.message || "Unknown error";
+      const errorDetails = error.response?.data
+        ? typeof error.response.data === "string"
+          ? error.response.data
+          : JSON.stringify(error.response.data, null, 2)
+        : "";
 
-      try {
-        try {
-          const rootFolders = await this.request("/rootFolder", "GET", null, skipConfigUpdate, {
-            bypassCircuit: true,
-          });
-          return {
-            connected: true,
-            version: "connected",
-            instanceName: "Lidarr",
-            rootFoldersCount: Array.isArray(rootFolders) ? rootFolders.length : 0,
-            apiPath: apiPath,
-          };
-        } catch (rootFolderError) {
-          if (rootFolderError.message.includes("404") || rootFolderError.message.includes("400")) {
-            try {
-              const status = await this.request("/system/status", "GET", null, skipConfigUpdate, {
-                bypassCircuit: true,
-              });
-              return {
-                connected: true,
-                version: status.version || "unknown",
-                instanceName: status.instanceName || "Lidarr",
-                apiPath: apiPath,
-              };
-            } catch (statusError) {
-              if (apiPath === "/api/v1" && apiPaths.length > 1) {
-                continue;
-              }
-              throw rootFolderError;
-            }
-          }
-          if (apiPath === "/api/v1" && apiPaths.length > 1) {
-            continue;
-          }
-          throw rootFolderError;
-        }
-      } catch (error) {
-        if (apiPath === apiPaths[apiPaths.length - 1]) {
-          const errorMessage = error.message || "Unknown error";
-          const errorDetails = error.response?.data
-            ? typeof error.response.data === "string"
-              ? error.response.data
-              : JSON.stringify(error.response.data, null, 2)
-            : "";
-
-          const fullUrl = `${this.config.url}${apiPath}/rootFolder`;
-
-          return {
-            connected: false,
-            error: errorMessage,
-            details: errorDetails,
-            url: this.config.url,
-            fullUrl: fullUrl,
-            statusCode: error.response?.status,
-            apiPath: apiPath,
-            responseHeaders: error.response?.headers,
-          };
-        }
-        continue;
-      }
+      return {
+        connected: false,
+        error: errorMessage,
+        details: errorDetails,
+        url: this.config.url,
+        fullUrl: `${this.config.url}${this.apiPath}/system/status`,
+        statusCode: error.response?.status,
+        apiPath: this.apiPath,
+        responseHeaders: error.response?.headers,
+      };
     }
-
-    return {
-      connected: false,
-      error: "Failed to connect with any API path",
-      url: this.config.url,
-    };
   }
 
   async getRootFolders() {


### PR DESCRIPTION
Lidarr has exposed its application API under `/api/v1` for years, but Aurral still fell back to `/api` after a connection probe. That caused healthy Lidarr instances to produce repeated 404s for `/api/artist`.

The connection test now probes `/api/v1/system/status`, reports Lidarr's version, and keeps the client on `/api/v1`.

Verification:
- Focused Lidarr tests pass (16 tests)
- Backend lint passes
- `git diff --check` passes

Known limitation: installations that do not expose Lidarr's `/api/v1` API will now need to update or correct their Lidarr/proxy configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection testing reliability by checking the service status directly.
  * Connection checks now provide clearer metadata when successful and more detailed information when they fail.
  * Removed unnecessary preliminary checks that could cause connection tests to fail or produce misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->