### PR TITLE
test: remove obsolete fallback regression cases

### DIFF
--- a/.tests/discovery/single-pass-refresh.test.js
+++ b/.tests/discovery/single-pass-refresh.test.js
@@ -158,24 +158,3 @@ test("single-pass refresh: db discovery cache stores enriched quality after sing
   ]);
 });
 
-test("single-pass refresh: db discovery cache stores initial quality for backwards compatibility reads", async () => {
-  const { db } = await importFromRepo("backend/config/db-sqlite.js");
-  const { dbOps } = await importFromRepo("backend/db/helpers/index.js");
-  resetDatabase(db);
-
-  dbOps.updateDiscoveryCache({
-    recommendations: [{ id: "artist-2", name: "Initial Quality Artist" }],
-    recommendationQuality: "initial",
-    isEnriching: true,
-    discoveryRunId: "run-initial",
-    enrichmentStartedAt: "2026-06-22T00:00:00.000Z",
-    enrichmentProgressMessage: "Improving recommendations",
-  });
-
-  const cache = dbOps.getDiscoveryCache();
-  assert.equal(cache.recommendationQuality, "initial");
-  assert.equal(cache.isEnriching, true);
-  assert.equal(cache.discoveryRunId, "run-initial");
-  assert.equal(cache.enrichmentProgressMessage, "Improving recommendations");
-});
-

--- a/.tests/weekly-flow/weekly-flow-startup-retry.test.js
+++ b/.tests/weekly-flow/weekly-flow-startup-retry.test.js
@@ -90,20 +90,3 @@ test("startup resumes pending work", async () => {
   assert.equal(starts, 1);
   assert.equal(downloadTracker.getJob(pendingId)?.status, "pending");
 });
-
-test("legacy retry jobs leave failed tracks terminal", async () => {
-  const playlist = flowPlaylistConfig.createSharedPlaylist({
-    name: "Legacy retry",
-    tracks: [{ artistName: "Missing", trackName: "Leave Failed" }],
-  });
-  const failedId = downloadTracker.addJob(
-    { artistName: "Missing", trackName: "Leave Failed" },
-    playlist.id,
-  );
-  downloadTracker.setFailed(failedId, "not found");
-
-  const changed = await weeklyFlowWorker.retryIncompletePlaylist(playlist.id);
-
-  assert.equal(changed, 0);
-  assert.equal(downloadTracker.getJob(failedId)?.status, "failed");
-});


### PR DESCRIPTION
The test suite contained regression cases for behavior that is no longer produced by Aurral: the removed two-phase discovery cache state and a duplicate failed-track retry assertion.

This removes those two tests and leaves provider integration code unchanged until its behavior is supported by current provider source or documentation.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/discovery/single-pass-refresh.test.js .tests/weekly-flow/weekly-flow-startup-retry.test.js`
- `git diff --check`

Known limitation: this PR does not change undocumented provider fallback code; that requires separate, provider-specific evidence and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed obsolete compatibility coverage for legacy discovery cache entries.
  * Removed legacy retry-job coverage for terminal failed tracks.
  * Existing single-pass cache and current retry behavior tests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->