### PR TITLE
Retry transient Navidrome rate limits

### DIFF
--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -30,6 +30,24 @@ test("creates a distinct playlist without looking up matching display names", as
   assert.equal(urls[0].pathname, "/rest/createPlaylist");
 });
 
+test("retries Navidrome rate limits", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) return new Response("", { status: 429, headers: { "retry-after": "0" } });
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password").ping();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(attempts, 2);
+});
+
 test("batches large playlist creation requests", async () => {
   const originalFetch = globalThis.fetch;
   const urls = [];

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -48,6 +48,23 @@ test("retries Navidrome rate limits", async () => {
   assert.equal(attempts, 2);
 });
 
+test("uses the fallback delay for invalid rate limit headers", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("", {
+    status: 429,
+    headers: { "retry-after": "-1" },
+  });
+
+  try {
+    await assert.rejects(
+      new NavidromeClient("http://navidrome.test", "user", "password").ping(),
+      /status code 429/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("batches large playlist creation requests", async () => {
   const originalFetch = globalThis.fetch;
   const urls = [];

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -5,6 +5,11 @@ const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PLAYLIST_LIBRARY_NAME = "Aurral Playlists";
 const LEGACY_LIBRARY_NAMES = new Set(["Aurral Weekly Flow"]);
 const PLAYLIST_SONG_BATCH_SIZE = 50;
+const NAVIDROME_RATE_LIMIT_RETRIES = 2;
+const NAVIDROME_RATE_LIMIT_DELAY_MS = 250;
+const NAVIDROME_RATE_LIMIT_MAX_DELAY_MS = 5_000;
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 function normalizeSearchText(value) {
   return String(value || "")
@@ -75,24 +80,35 @@ export class NavidromeClient {
     if (!this.isConfigured()) throw new Error("Navidrome not configured");
 
     try {
-      const query = new URLSearchParams();
-      for (const [key, value] of Object.entries({ ...this.getAuthParams(), ...params })) {
-        if (Array.isArray(value)) {
-          for (const item of value) query.append(key, item);
-        } else if (value != null) {
-          query.set(key, value);
+      for (let attempt = 0; ; attempt += 1) {
+        const query = new URLSearchParams();
+        for (const [key, value] of Object.entries({ ...this.getAuthParams(), ...params })) {
+          if (Array.isArray(value)) {
+            for (const item of value) query.append(key, item);
+          } else if (value != null) {
+            query.set(key, value);
+          }
+        }
+        try {
+          const response = await axios.get(`${this.url}/rest/${endpoint}?${query}`);
+
+          if (response.data["subsonic-response"]?.status === "failed") {
+            const responseError = response.data["subsonic-response"].error || {};
+            const error = new Error(responseError.message || "Navidrome request failed");
+            error.code = responseError.code;
+            throw error;
+          }
+
+          return response.data["subsonic-response"];
+        } catch (error) {
+          if (error?.response?.status !== 429 || attempt >= NAVIDROME_RATE_LIMIT_RETRIES) throw error;
+          const retryAfter = Number(error.response.headers?.["retry-after"]);
+          const delay = Number.isFinite(retryAfter)
+            ? Math.min(retryAfter * 1000, NAVIDROME_RATE_LIMIT_MAX_DELAY_MS)
+            : NAVIDROME_RATE_LIMIT_DELAY_MS;
+          await wait(Math.max(0, delay));
         }
       }
-      const response = await axios.get(`${this.url}/rest/${endpoint}?${query}`);
-
-      if (response.data["subsonic-response"]?.status === "failed") {
-        const responseError = response.data["subsonic-response"].error || {};
-        const error = new Error(responseError.message || "Navidrome request failed");
-        error.code = responseError.code;
-        throw error;
-      }
-
-      return response.data["subsonic-response"];
     } catch (error) {
       console.error(`Navidrome Error [${endpoint}]:`, error.message);
       throw error;

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -102,8 +102,9 @@ export class NavidromeClient {
           return response.data["subsonic-response"];
         } catch (error) {
           if (error?.response?.status !== 429 || attempt >= NAVIDROME_RATE_LIMIT_RETRIES) throw error;
-          const retryAfter = Number(error.response.headers?.["retry-after"]);
-          const delay = Number.isFinite(retryAfter)
+          const retryAfterHeader = error.response.headers?.["retry-after"]?.trim();
+          const retryAfter = Number(retryAfterHeader);
+          const delay = retryAfterHeader && Number.isFinite(retryAfter) && retryAfter >= 0
             ? Math.min(retryAfter * 1000, NAVIDROME_RATE_LIMIT_MAX_DELAY_MS)
             : NAVIDROME_RATE_LIMIT_DELAY_MS;
           await wait(Math.max(0, delay));


### PR DESCRIPTION
Navidrome rate limiting caused Aurral playlist-library setup to fail immediately with HTTP 429.

The Navidrome client now retries 429 responses twice, honors a bounded Retry-After delay, and preserves the existing failure behavior after retries are exhausted. A focused regression test covers recovery after a rate limit.

Verification:
- node --test --import ./.tests/setup-env.js .tests/navidrome-client.test.js
- npm run lint:backend
- git diff --check

Known limitation: this reduces transient failures but cannot overcome a sustained Navidrome rate limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Navidrome rate-limit responses.
  - Requests receiving a 429 response are now retried automatically, respecting the server’s retry delay when available.
  - Added a fallback delay when no valid retry timing is provided.
  - Requests continue to fail normally after the retry limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->