### PR TITLE
feat(library): add canonical library foundation

### DIFF
--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -21,6 +21,12 @@ const RESET_TABLES = [
   "musicbrainz_artist_mbid_cache",
   "artist_overrides",
   "lidarr_artist_id_map",
+  "library_media_files",
+  "library_album_tracks",
+  "library_tracks",
+  "library_albums",
+  "library_artists",
+  "library_scan_runs",
   "settings",
 ];
 

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -1,0 +1,174 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import { getLibrarySnapshot } from "../../backend/services/libraryMediaStore.js";
+import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
+import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
+
+const metadata = {
+  common: {
+    albumartist: "Aurral Fixture",
+    artist: "Aurral Fixture",
+    album: "Playback Roadmap",
+    title: "First Step",
+    track: { no: 1, of: 4 },
+    disk: { no: 1, of: 1 },
+    musicbrainz_albumartistid: "11111111-1111-4111-8111-111111111111",
+    musicbrainz_releasegroupid: "22222222-2222-4222-8222-222222222222",
+    musicbrainz_recordingid: "33333333-3333-4333-8333-333333333333",
+  },
+  format: {
+    duration: 123.4,
+    codec: "FLAC",
+    sampleRate: 44100,
+    bitsPerSample: 16,
+  },
+};
+
+async function createAudioFile(root, relativePath) {
+  const filePath = path.join(root, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, "fixture");
+  return filePath;
+}
+
+test("scanMusicRoot indexes tagged media and ignores Flow output", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-scan-"));
+  try {
+    const filePath = await createAudioFile(root, "Aurral Fixture/Playback Roadmap/01 First Step.flac");
+    await createAudioFile(root, "aurral-weekly-flow/flow/ignored.flac");
+
+    const result = await scanMusicRoot({
+      rootPath: root,
+      source: `test-aurral-${process.pid}`,
+      metadataReader: async () => metadata,
+    });
+    const snapshot = getLibrarySnapshot();
+    const files = snapshot.files.filter((file) => file.source === `test-aurral-${process.pid}`);
+
+    assert.equal(result.filesSeen, 1);
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(files.length, 1);
+    assert.equal(files[0].path, filePath);
+    assert.equal(snapshot.artists.some((artist) => artist.name === "Aurral Fixture"), true);
+    assert.equal(snapshot.albums.some((album) => album.title === "Playback Roadmap"), true);
+    assert.equal(snapshot.tracks.some((track) => track.title === "First Step"), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a successful rescan marks removed files unavailable without removing media records", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-reconcile-"));
+  const source = `test-reconcile-${process.pid}`;
+  try {
+    const filePath = await createAudioFile(root, "Artist/Album/01 Track.mp3");
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => metadata,
+    });
+    await rm(filePath);
+
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => metadata,
+    });
+    const snapshot = getLibrarySnapshot();
+    const file = snapshot.files.find((entry) => entry.path === filePath);
+
+    assert.equal(file?.available, 0);
+    assert.equal(snapshot.tracks.some((track) => track.title === "First Step"), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a partial rescan preserves the last known-good file availability", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-partial-"));
+  const source = `test-partial-${process.pid}`;
+  try {
+    await createAudioFile(root, "Artist/Album/01 Track.flac");
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => metadata,
+    });
+
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => {
+        throw new Error("metadata unavailable");
+      },
+    });
+    const file = getLibrarySnapshot().files.find((entry) => entry.source === source);
+
+    assert.equal(file?.available, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("indexLidarrLibrary imports logical media and readable track files", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-index-"));
+  const source = `lidarr-${process.pid}`;
+  try {
+    const filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
+    const client = {
+      isConfigured: () => true,
+      request: async () => [
+        {
+          id: 7,
+          artistName: "Artist",
+          foreignArtistId: "44444444-4444-4444-8444-444444444444",
+          path: path.join(root, "Artist"),
+        },
+      ],
+      getAllAlbums: async () => [
+        {
+          id: 8,
+          artistId: 7,
+          title: "Album",
+          foreignAlbumId: "55555555-5555-4555-8555-555555555555",
+          path: path.join(root, "Artist", "Album"),
+        },
+      ],
+      getAllTracks: async () => [
+        {
+          id: 9,
+          albumId: 8,
+          title: "Track",
+          trackNumber: 1,
+          foreignRecordingId: "66666666-6666-4666-8666-666666666666",
+          trackFileId: 10,
+        },
+      ],
+      getAllTrackFiles: async () => [
+        { id: 10, path: filePath, trackIds: [9], mediaInfo: { audioFormat: "FLAC" } },
+      ],
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    const result = await indexLidarrLibrary({ client });
+    const snapshot = getLibrarySnapshot();
+    const file = snapshot.files.find((entry) => entry.path === filePath);
+
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(file?.source, "lidarr");
+    assert.equal(snapshot.artists.some((artist) => artist.name === "Artist"), true);
+    assert.equal(snapshot.albums.some((album) => album.title === "Album"), true);
+    assert.equal(snapshot.tracks.some((track) => track.title === "Track"), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source IN (?, ?)").run(
+      source,
+      `test-aurral-${process.pid}`,
+    );
+  }
+});

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -139,7 +139,7 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
           path: path.join(root, "Artist", "Album"),
         },
       ],
-      getAllTracks: async () => [
+      getTracksByAlbumId: async () => [
         {
           id: 9,
           albumId: 8,
@@ -149,7 +149,7 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
           trackFileId: 10,
         },
       ],
-      getAllTrackFiles: async () => [
+      getTrackFilesByAlbumId: async () => [
         { id: 10, path: filePath, trackIds: [9], mediaInfo: { audioFormat: "FLAC" } },
       ],
       getRootFolders: async () => [{ path: root }],

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -117,9 +117,9 @@ test("a partial rescan preserves the last known-good file availability", async (
 
 test("indexLidarrLibrary imports logical media and readable track files", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-index-"));
-  const source = `lidarr-${process.pid}`;
+  let filePath;
   try {
-    const filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
+    filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
     const client = {
       isConfigured: () => true,
       request: async () => [
@@ -166,9 +166,52 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
     assert.equal(snapshot.tracks.some((track) => track.title === "Track"), true);
   } finally {
     await rm(root, { recursive: true, force: true });
-    db.prepare("DELETE FROM library_media_files WHERE source IN (?, ?)").run(
-      source,
-      `test-aurral-${process.pid}`,
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
+test("a partial Lidarr rescan preserves existing file availability", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-partial-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
+    const client = {
+      isConfigured: () => true,
+      request: async () => [{ id: 17, artistName: "Artist", foreignArtistId: "77777777-7777-4777-8777-777777777777" }],
+      getAllAlbums: async () => [{
+        id: 18,
+        artistId: 17,
+        title: "Album",
+        foreignAlbumId: "88888888-8888-4888-8888-888888888888",
+        path: path.join(root, "Artist", "Album"),
+      }],
+      getTracksByAlbumId: async () => [{
+        id: 19,
+        albumId: 18,
+        title: "Track",
+        trackNumber: 1,
+        foreignRecordingId: "99999999-9999-4999-8999-999999999999",
+        trackFileId: 20,
+      }],
+      getTrackFilesByAlbumId: async () => [{ id: 20, path: filePath, trackIds: [19] }],
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    await indexLidarrLibrary({ client });
+    await rm(filePath);
+    const result = await indexLidarrLibrary({ client });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.equal(result.filesFailed, 1);
+    assert.equal(file?.available, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
     );
   }
 });

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -9,6 +9,10 @@ import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
 import { getCanonicalLibrary } from "../../backend/services/libraryQueryService.js";
 import { toPublicLibrary } from "../../backend/routes/library/handlers/canonical.js";
+import {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+} from "../../backend/services/libraryMediaStore.js";
 
 const metadata = {
   common: {
@@ -34,14 +38,10 @@ async function createAudioFile(root, relativePath) {
 
 test("getCanonicalLibrary merges sources and preserves normalized hierarchy", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-query-"));
-  const lidarrRoot = await mkdtemp(path.join(tmpdir(), "aurral-library-query-lidarr-"));
   const source = `query-aurral-${process.pid}`;
+  let filePath;
   try {
-    const filePath = await createAudioFile(root, "Query Fixture/Canonical Reads/01 One Source, Two Files.flac");
-    const lidarrFilePath = await createAudioFile(
-      lidarrRoot,
-      "Query Fixture/Canonical Reads/01 One Source, Two Files.flac",
-    );
+    filePath = await createAudioFile(root, "Query Fixture/Canonical Reads/01 One Source, Two Files.flac");
     await scanMusicRoot({ rootPath: root, source, metadataReader: async () => metadata });
 
     await indexLidarrLibrary({
@@ -53,7 +53,7 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
           artistId: 7,
           title: "Canonical Reads",
           foreignAlbumId: metadata.common.musicbrainz_releasegroupid,
-          path: path.join(lidarrRoot, "Query Fixture", "Canonical Reads"),
+          path: path.join(root, "Query Fixture", "Canonical Reads"),
         }],
         getTracksByAlbumId: async () => [{
           id: 9,
@@ -63,8 +63,8 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
           foreignRecordingId: metadata.common.musicbrainz_recordingid,
           trackFileId: 10,
         }],
-        getTrackFilesByAlbumId: async () => [{ id: 10, path: lidarrFilePath, trackIds: [9] }],
-        getRootFolders: async () => [{ path: lidarrRoot }],
+        getTrackFilesByAlbumId: async () => [{ id: 10, path: filePath, trackIds: [9] }],
+        getRootFolders: async () => [{ path: root }],
       },
     });
 
@@ -82,15 +82,46 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
     assert.equal(lidarr.tracks.length, 1);
     assert.deepEqual(lidarr.tracks[0].sources, ["lidarr"]);
 
-    db.prepare("UPDATE library_media_files SET available = 0 WHERE path = ?").run(lidarrFilePath);
+    db.prepare("UPDATE library_media_files SET available = 0 WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
     const available = getCanonicalLibrary({ availableOnly: true });
     assert.equal(available.tracks.length, 1);
     assert.deepEqual(available.tracks[0].sources, [source]);
     assert.equal(available.tracks[0].files.length, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
-    await rm(lidarrRoot, { recursive: true, force: true });
-    db.prepare("DELETE FROM library_media_files WHERE source IN (?, ?)").run(source, "lidarr");
+    db.prepare("DELETE FROM library_media_files WHERE source IN (?, ?) AND path = ?").run(
+      source,
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
+test("getCanonicalLibrary deduplicates a file shared by multiple album relationships", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-query-duplicate-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
+    await scanMusicRoot({ rootPath: root, source: "aurral", metadataReader: async () => metadata });
+    const first = getCanonicalLibrary({ source: "aurral" });
+    const track = first.tracks.find((entry) => entry.files.some((file) => file.path === filePath));
+    const album = first.albums.find((entry) => entry.trackIds.includes(track.id));
+    const duplicateAlbum = upsertLibraryAlbum({
+      identityKey: `duplicate-album:${process.pid}`,
+      artistId: album.artistId,
+      title: "Duplicate Relationship",
+    });
+    linkLibraryAlbumTrack({ albumId: duplicateAlbum.id, trackId: track.id, trackNumber: 1 });
+
+    const result = getCanonicalLibrary({ source: "aurral" });
+    const resultTrack = result.tracks.find((entry) => entry.files.some((file) => file.path === filePath));
+    assert.equal(resultTrack.files.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run("aurral", filePath);
   }
 });
 

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -103,6 +103,7 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
 test("getCanonicalLibrary deduplicates a file shared by multiple album relationships", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-query-duplicate-"));
   let filePath;
+  let duplicateAlbumId;
   try {
     filePath = await createAudioFile(root, "Artist/Album/01 Track.flac");
     await scanMusicRoot({ rootPath: root, source: "aurral", metadataReader: async () => metadata });
@@ -114,6 +115,7 @@ test("getCanonicalLibrary deduplicates a file shared by multiple album relations
       artistId: album.artistId,
       title: "Duplicate Relationship",
     });
+    duplicateAlbumId = duplicateAlbum.id;
     linkLibraryAlbumTrack({ albumId: duplicateAlbum.id, trackId: track.id, trackNumber: 1 });
 
     const result = getCanonicalLibrary({ source: "aurral" });
@@ -121,6 +123,10 @@ test("getCanonicalLibrary deduplicates a file shared by multiple album relations
     assert.equal(resultTrack.files.length, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
+    if (duplicateAlbumId) {
+      db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(duplicateAlbumId);
+      db.prepare("DELETE FROM library_albums WHERE id = ?").run(duplicateAlbumId);
+    }
     db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run("aurral", filePath);
   }
 });

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -55,7 +55,7 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
           foreignAlbumId: metadata.common.musicbrainz_releasegroupid,
           path: path.join(lidarrRoot, "Query Fixture", "Canonical Reads"),
         }],
-        getAllTracks: async () => [{
+        getTracksByAlbumId: async () => [{
           id: 9,
           albumId: 8,
           title: "One Source, Two Files",
@@ -63,7 +63,7 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
           foreignRecordingId: metadata.common.musicbrainz_recordingid,
           trackFileId: 10,
         }],
-        getAllTrackFiles: async () => [{ id: 10, path: lidarrFilePath, trackIds: [9] }],
+        getTrackFilesByAlbumId: async () => [{ id: 10, path: lidarrFilePath, trackIds: [9] }],
         getRootFolders: async () => [{ path: lidarrRoot }],
       },
     });

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
+import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
+import { getCanonicalLibrary } from "../../backend/services/libraryQueryService.js";
+import { toPublicLibrary } from "../../backend/routes/library/handlers/canonical.js";
+
+const metadata = {
+  common: {
+    albumartist: "Query Fixture",
+    artist: "Query Fixture",
+    album: "Canonical Reads",
+    title: "One Source, Two Files",
+    track: { no: 1 },
+    disk: { no: 1 },
+    musicbrainz_albumartistid: "11111111-1111-4111-8111-111111111111",
+    musicbrainz_releasegroupid: "22222222-2222-4222-8222-222222222222",
+    musicbrainz_recordingid: "33333333-3333-4333-8333-333333333333",
+  },
+  format: { duration: 123.4, codec: "FLAC" },
+};
+
+async function createAudioFile(root, relativePath) {
+  const filePath = path.join(root, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, "fixture");
+  return filePath;
+}
+
+test("getCanonicalLibrary merges sources and preserves normalized hierarchy", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-query-"));
+  const lidarrRoot = await mkdtemp(path.join(tmpdir(), "aurral-library-query-lidarr-"));
+  const source = `query-aurral-${process.pid}`;
+  try {
+    const filePath = await createAudioFile(root, "Query Fixture/Canonical Reads/01 One Source, Two Files.flac");
+    const lidarrFilePath = await createAudioFile(
+      lidarrRoot,
+      "Query Fixture/Canonical Reads/01 One Source, Two Files.flac",
+    );
+    await scanMusicRoot({ rootPath: root, source, metadataReader: async () => metadata });
+
+    await indexLidarrLibrary({
+      client: {
+        isConfigured: () => true,
+        request: async () => [{ id: 7, artistName: "Query Fixture", foreignArtistId: metadata.common.musicbrainz_albumartistid }],
+        getAllAlbums: async () => [{
+          id: 8,
+          artistId: 7,
+          title: "Canonical Reads",
+          foreignAlbumId: metadata.common.musicbrainz_releasegroupid,
+          path: path.join(lidarrRoot, "Query Fixture", "Canonical Reads"),
+        }],
+        getAllTracks: async () => [{
+          id: 9,
+          albumId: 8,
+          title: "One Source, Two Files",
+          trackNumber: 1,
+          foreignRecordingId: metadata.common.musicbrainz_recordingid,
+          trackFileId: 10,
+        }],
+        getAllTrackFiles: async () => [{ id: 10, path: lidarrFilePath, trackIds: [9] }],
+        getRootFolders: async () => [{ path: lidarrRoot }],
+      },
+    });
+
+    const all = getCanonicalLibrary();
+    assert.equal(all.artists.length, 1);
+    assert.equal(all.albums.length, 1);
+    assert.equal(all.tracks.length, 1);
+    assert.deepEqual(all.tracks[0].sources, ["lidarr", source]);
+    assert.equal(all.tracks[0].files.length, 2);
+    assert.equal(all.albums[0].trackIds[0], all.tracks[0].id);
+    assert.equal(all.artists[0].albumIds[0], all.albums[0].id);
+    assert.equal(all.tracks[0].available, true);
+
+    const lidarr = getCanonicalLibrary({ source: "lidarr" });
+    assert.equal(lidarr.tracks.length, 1);
+    assert.deepEqual(lidarr.tracks[0].sources, ["lidarr"]);
+
+    db.prepare("UPDATE library_media_files SET available = 0 WHERE path = ?").run(lidarrFilePath);
+    const available = getCanonicalLibrary({ availableOnly: true });
+    assert.equal(available.tracks.length, 1);
+    assert.deepEqual(available.tracks[0].sources, [source]);
+    assert.equal(available.tracks[0].files.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(lidarrRoot, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source IN (?, ?)").run(source, "lidarr");
+  }
+});
+
+test("getCanonicalLibrary rejects unknown source filters", () => {
+  assert.throws(() => getCanonicalLibrary({ source: "plex" }), /Unsupported library source/);
+});
+
+test("canonical library responses do not expose filesystem paths", () => {
+  const response = toPublicLibrary({
+    artists: [],
+    albums: [],
+    tracks: [{ id: 1, files: [{ id: 2, path: "/music/private.flac", source: "aurral" }] }],
+  });
+
+  assert.deepEqual(response.tracks[0].files, [{ id: 2, source: "aurral" }]);
+});

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -146,8 +146,96 @@ db.exec(`
     updated_at INTEGER NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS library_artists (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identity_key TEXT NOT NULL UNIQUE,
+    mbid TEXT,
+    name TEXT NOT NULL,
+    sort_name TEXT,
+    metadata_json TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS library_albums (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identity_key TEXT NOT NULL UNIQUE,
+    mbid TEXT,
+    release_group_mbid TEXT,
+    artist_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    album_artist TEXT,
+    release_date TEXT,
+    metadata_json TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (artist_id) REFERENCES library_artists(id) ON DELETE CASCADE
+  );
+
+  CREATE TABLE IF NOT EXISTS library_tracks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identity_key TEXT NOT NULL UNIQUE,
+    mbid TEXT,
+    title TEXT NOT NULL,
+    artist_name TEXT,
+    metadata_json TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS library_album_tracks (
+    album_id INTEGER NOT NULL,
+    track_id INTEGER NOT NULL,
+    disc_number INTEGER NOT NULL DEFAULT 1,
+    track_number INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (album_id, track_id, disc_number, track_number),
+    FOREIGN KEY (album_id) REFERENCES library_albums(id) ON DELETE CASCADE,
+    FOREIGN KEY (track_id) REFERENCES library_tracks(id) ON DELETE CASCADE
+  );
+
+  CREATE TABLE IF NOT EXISTS library_media_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    path TEXT NOT NULL UNIQUE,
+    format TEXT,
+    size INTEGER NOT NULL DEFAULT 0,
+    mtime_ms INTEGER,
+    duration_ms INTEGER,
+    quality_json TEXT,
+    available INTEGER NOT NULL DEFAULT 1,
+    last_seen_scan_id INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (track_id) REFERENCES library_tracks(id) ON DELETE CASCADE
+  );
+
+  CREATE TABLE IF NOT EXISTS library_scan_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    root_path TEXT,
+    status TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    error TEXT,
+    files_seen INTEGER NOT NULL DEFAULT 0,
+    files_indexed INTEGER NOT NULL DEFAULT 0,
+    files_failed INTEGER NOT NULL DEFAULT 0
+  );
+
   CREATE INDEX IF NOT EXISTS idx_lidarr_artist_id_map_foreign_id
     ON lidarr_artist_id_map (lidarr_foreign_artist_id);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_artist_id
+    ON library_albums (artist_id);
+  CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
+    ON library_album_tracks (track_id);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_track_id
+    ON library_media_files (track_id);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_source_available
+    ON library_media_files (source, available);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_scan_id
+    ON library_media_files (last_seen_scan_id);
 
   CREATE TABLE IF NOT EXISTS aurral_history (
     id TEXT PRIMARY KEY,

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -198,7 +198,7 @@ db.exec(`
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     track_id INTEGER NOT NULL,
     source TEXT NOT NULL,
-    path TEXT NOT NULL UNIQUE,
+    path TEXT NOT NULL,
     format TEXT,
     size INTEGER NOT NULL DEFAULT 0,
     mtime_ms INTEGER,
@@ -208,6 +208,7 @@ db.exec(`
     last_seen_scan_id INTEGER,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
+    UNIQUE (source, path),
     FOREIGN KEY (track_id) REFERENCES library_tracks(id) ON DELETE CASCADE
   );
 
@@ -328,6 +329,61 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_honker_task_runs_queue_started ON honker_task_runs(queue, started_at DESC);
   CREATE INDEX IF NOT EXISTS idx_honker_task_runs_job ON honker_task_runs(job_id, queue);
 `);
+
+function hasUniqueIndex(columns) {
+  return db.prepare("PRAGMA index_list(library_media_files)").all().some((index) => {
+    if (!index.unique) return false;
+    const indexName = String(index.name).replaceAll('"', '""');
+    const indexColumns = db
+      .prepare(`PRAGMA index_info("${indexName}")`)
+      .all()
+      .map((column) => column.name);
+    return JSON.stringify(indexColumns) === JSON.stringify(columns);
+  });
+}
+
+if (hasUniqueIndex(["path"])) {
+  db.transaction(() => {
+    db.exec(`
+      CREATE TABLE library_media_files_v3 (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        track_id INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        path TEXT NOT NULL,
+        format TEXT,
+        size INTEGER NOT NULL DEFAULT 0,
+        mtime_ms INTEGER,
+        duration_ms INTEGER,
+        quality_json TEXT,
+        available INTEGER NOT NULL DEFAULT 1,
+        last_seen_scan_id INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE (source, path),
+        FOREIGN KEY (track_id) REFERENCES library_tracks(id) ON DELETE CASCADE
+      );
+
+      INSERT INTO library_media_files_v3
+        (id, track_id, source, path, format, size, mtime_ms, duration_ms, quality_json,
+         available, last_seen_scan_id, created_at, updated_at)
+      SELECT id, track_id, source, path, format, size, mtime_ms, duration_ms, quality_json,
+        available, last_seen_scan_id, created_at, updated_at
+      FROM library_media_files;
+
+      DROP TABLE library_media_files;
+      ALTER TABLE library_media_files_v3 RENAME TO library_media_files;
+    `);
+  })();
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_library_media_files_track_id
+      ON library_media_files (track_id);
+    CREATE INDEX IF NOT EXISTS idx_library_media_files_source_available
+      ON library_media_files (source, available);
+    CREATE INDEX IF NOT EXISTS idx_library_media_files_scan_id
+      ON library_media_files (last_seen_scan_id);
+  `);
+}
 
 const duplicateLidarrArtistIds = db
   .prepare(

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,0 +1,35 @@
+import { noCache } from "../../../middleware/cache.js";
+import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
+
+function toPublicLibrary(library) {
+  return {
+    artists: library.artists,
+    albums: library.albums,
+    tracks: library.tracks.map((track) => ({
+      ...track,
+      files: track.files.map(({ path: _path, ...file }) => file),
+    })),
+  };
+}
+
+export function registerCanonical(router) {
+  router.get("/canonical", noCache, (req, res) => {
+    try {
+      const library = getCanonicalLibrary({
+        source: req.query.source,
+        availableOnly: req.query.availableOnly === "true",
+      });
+      return res.json(toPublicLibrary(library));
+    } catch (error) {
+      if (error.message.startsWith("Unsupported library source:")) {
+        return res.status(400).json({ error: error.message });
+      }
+      return res.status(500).json({
+        error: "Failed to query canonical library",
+        message: error.message,
+      });
+    }
+  });
+}
+
+export { toPublicLibrary };

--- a/backend/routes/library/index.js
+++ b/backend/routes/library/index.js
@@ -4,9 +4,11 @@ import { registerAlbums } from "./handlers/albums.js";
 import { registerTracks } from "./handlers/tracks.js";
 import { registerDownloads } from "./handlers/downloads.js";
 import { registerMisc } from "./handlers/misc.js";
+import { registerCanonical } from "./handlers/canonical.js";
 import mountRoutes from "../shared/mountRoutes.js";
 
 export default mountRoutes([
+  registerCanonical,
   registerStream,
   registerArtists,
   registerAlbums,

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -97,6 +97,12 @@ export const SCHEDULED_SYSTEM_TASKS = [
     payload: { kind: "playlist-mbid-enrichment-sweep", reason: "schedule" },
     maxAttempts: 4,
   },
+  {
+    name: "library-index-refresh",
+    queue: "system-task",
+    schedule: "@every 15m",
+    payload: { kind: "library-index-refresh" },
+  },
 ];
 
 const PIPELINE_PHASE_PRIORITY = {
@@ -374,6 +380,7 @@ export function enqueueHonkerStartupTasks() {
   );
   enqueueSystemTaskJob({ kind: "discovery-bootstrap" }, { delaySeconds: 15, priority: 5 });
   enqueueSystemTaskJob({ kind: "inbox-refresh" }, { delaySeconds: 20, priority: -5 });
+  enqueueSystemTaskJob({ kind: "library-index-refresh" }, { delaySeconds: 8, priority: 0 });
   enqueuePlaylistMbidEnrichmentJob(
     {
       kind: "playlist-mbid-enrichment-sweep",

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -1,0 +1,210 @@
+import fs from "fs/promises";
+import path from "path";
+import { parseFile } from "music-metadata";
+import {
+  buildFallbackIdentityKey,
+  buildIdentityKey,
+  linkLibraryAlbumTrack,
+  markUnseenFilesUnavailable,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+  withLibraryScan,
+} from "./libraryMediaStore.js";
+
+const AUDIO_EXTENSIONS = new Set([
+  ".aac",
+  ".aiff",
+  ".ape",
+  ".flac",
+  ".m4a",
+  ".mp3",
+  ".oga",
+  ".ogg",
+  ".opus",
+  ".wav",
+  ".wv",
+]);
+
+const EXCLUDED_DIRECTORIES = new Set([
+  ".git",
+  "_fallback",
+  "_playlists",
+  "_staging",
+  "aurral-weekly-flow",
+]);
+
+const text = (value) => String(value || "").trim();
+
+const first = (value) => (Array.isArray(value) ? value[0] : value);
+
+const numberPart = (value, fallback = 0) => {
+  const number = Number(value?.no ?? value);
+  return Number.isFinite(number) ? Math.max(0, Math.trunc(number)) : fallback;
+};
+
+const normalizeMbid = (value) => text(first(value)) || null;
+
+const normalizeMetadata = (metadata) => metadata?.common || {};
+
+function readPathFallback(filePath, rootPath) {
+  const relative = path.relative(rootPath, filePath);
+  const segments = relative.split(path.sep).filter(Boolean);
+  const fileName = path.basename(filePath, path.extname(filePath));
+  return {
+    artistName: text(segments.at(-3)) || "Unknown Artist",
+    albumName: text(segments.at(-2)) || "Unknown Album",
+    title: text(fileName.replace(/^\d+(?:[. _-]+|$)/, "")) || fileName,
+    trackNumber: Number.parseInt(fileName.match(/^\d+/)?.[0] || "0", 10) || 0,
+    discNumber: 1,
+  };
+}
+
+function buildMetadataRecord(metadata, filePath, rootPath) {
+  const common = normalizeMetadata(metadata);
+  const fallback = readPathFallback(filePath, rootPath);
+  const artistName = text(common.albumartist || common.artist) || fallback.artistName;
+  const albumName = text(common.album) || fallback.albumName;
+  const title = text(common.title) || fallback.title;
+  const trackNumber = numberPart(common.track, fallback.trackNumber);
+  const discNumber = numberPart(common.disk, fallback.discNumber) || 1;
+  const artistMbid = normalizeMbid(common.musicbrainz_albumartistid || common.musicbrainz_artistid);
+  const albumMbid = normalizeMbid(common.musicbrainz_albumid);
+  const releaseGroupMbid = normalizeMbid(common.musicbrainz_releasegroupid);
+  const trackMbid = normalizeMbid(
+    common.musicbrainz_recordingid || common.musicbrainz_trackid,
+  );
+  const artistKey =
+    (artistMbid && buildIdentityKey("mbid", artistMbid)) ||
+    buildFallbackIdentityKey("artist", artistName);
+  const albumKey =
+    (releaseGroupMbid && buildIdentityKey("release-group", releaseGroupMbid)) ||
+    (albumMbid && buildIdentityKey("album", albumMbid)) ||
+    buildFallbackIdentityKey("album", artistKey, albumName);
+  const trackKey =
+    (trackMbid && buildIdentityKey("recording", trackMbid)) ||
+    buildFallbackIdentityKey("track", albumKey, discNumber, trackNumber, title);
+
+  return {
+    artistKey,
+    artistMbid,
+    artistName,
+    albumKey,
+    albumMbid,
+    releaseGroupMbid,
+    albumName,
+    trackKey,
+    trackMbid,
+    title,
+    trackNumber,
+    discNumber,
+    albumArtist: text(common.albumartist) || artistName,
+    releaseDate: text(common.releasedate || common.date) || null,
+    artistMetadata: { tags: common },
+    albumMetadata: { tags: common },
+    trackMetadata: { tags: common },
+    durationMs: Number.isFinite(Number(metadata?.format?.duration))
+      ? Math.round(Number(metadata.format.duration) * 1000)
+      : null,
+    quality: {
+      format: text(metadata?.format?.codec) || null,
+      bitrate: Number.isFinite(Number(metadata?.format?.bitrate))
+        ? Math.round(Number(metadata.format.bitrate))
+        : null,
+      sampleRate: Number.isFinite(Number(metadata?.format?.sampleRate))
+        ? Number(metadata.format.sampleRate)
+        : null,
+      bitsPerSample: Number.isFinite(Number(metadata?.format?.bitsPerSample))
+        ? Number(metadata.format.bitsPerSample)
+        : null,
+    },
+  };
+}
+
+async function* walkAudioFiles(rootPath) {
+  const entries = await fs.readdir(rootPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRECTORIES.has(entry.name) || entry.name.startsWith(".")) continue;
+      yield* walkAudioFiles(path.join(rootPath, entry.name));
+      continue;
+    }
+    if (entry.isFile() && AUDIO_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      yield path.join(rootPath, entry.name);
+    }
+  }
+}
+
+export async function scanMusicRoot({
+  rootPath,
+  source = "aurral",
+  metadataReader = parseFile,
+} = {}) {
+  const resolvedRoot = path.resolve(String(rootPath || ""));
+  await fs.mkdir(resolvedRoot, { recursive: true });
+  const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  const scanResult = await withLibraryScan(source, resolvedRoot, (scanId) => {
+    const run = async () => {
+      for await (const filePath of walkAudioFiles(resolvedRoot)) {
+        result.filesSeen += 1;
+        try {
+          const [metadata, stat] = await Promise.all([
+            metadataReader(filePath, { skipCovers: true }),
+            fs.stat(filePath),
+          ]);
+          const record = buildMetadataRecord(metadata, filePath, resolvedRoot);
+          const artist = upsertLibraryArtist({
+            identityKey: record.artistKey,
+            mbid: record.artistMbid,
+            name: record.artistName,
+            metadata: record.artistMetadata,
+          });
+          const album = upsertLibraryAlbum({
+            identityKey: record.albumKey,
+            mbid: record.albumMbid,
+            releaseGroupMbid: record.releaseGroupMbid,
+            artistId: artist.id,
+            title: record.albumName,
+            albumArtist: record.albumArtist,
+            releaseDate: record.releaseDate,
+            metadata: record.albumMetadata,
+          });
+          const track = upsertLibraryTrack({
+            identityKey: record.trackKey,
+            mbid: record.trackMbid,
+            title: record.title,
+            artistName: record.artistName,
+            metadata: record.trackMetadata,
+          });
+          linkLibraryAlbumTrack({
+            albumId: album.id,
+            trackId: track.id,
+            discNumber: record.discNumber,
+            trackNumber: record.trackNumber,
+          });
+          upsertLibraryMediaFile({
+            trackId: track.id,
+            source,
+            path: filePath,
+            format: path.extname(filePath).slice(1).toLowerCase(),
+            size: stat.size,
+            mtimeMs: stat.mtimeMs,
+            durationMs: record.durationMs,
+            quality: record.quality,
+            scanId,
+          });
+          result.filesIndexed += 1;
+        } catch {
+          result.filesFailed += 1;
+        }
+      }
+      if (result.filesFailed === 0) markUnseenFilesUnavailable(scanId, source);
+      return result;
+    };
+    return run();
+  });
+  return scanResult;
+}
+
+export { buildMetadataRecord, readPathFallback, AUDIO_EXTENSIONS };

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -1,0 +1,20 @@
+import { resolvePlaylistRoot } from "./playlistPaths.js";
+import { scanMusicRoot } from "./libraryFileScanner.js";
+import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
+
+export async function scanConfiguredLibrary({ musicRoot = resolvePlaylistRoot(), lidarrClient } = {}) {
+  const local = await scanMusicRoot({ rootPath: musicRoot, source: "aurral" });
+  let lidarr = { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  try {
+    lidarr = await indexLidarrLibrary({ client: lidarrClient });
+  } catch (error) {
+    lidarr = {
+      skipped: false,
+      error: error.message,
+      filesSeen: 0,
+      filesIndexed: 0,
+      filesFailed: 0,
+    };
+  }
+  return { local, lidarr };
+}

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -1,0 +1,175 @@
+import fs from "fs/promises";
+import path from "path";
+import {
+  buildFallbackIdentityKey,
+  buildIdentityKey,
+  linkLibraryAlbumTrack,
+  markUnseenFilesUnavailable,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+  withLibraryScan,
+} from "./libraryMediaStore.js";
+import { getPathMappings, resolveLocalPath } from "./pathMappings.js";
+
+const text = (value) => String(value || "").trim();
+
+const isUuid = (value) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    text(value),
+  );
+
+function buildFileIndex(files) {
+  const index = new Map();
+  for (const file of Array.isArray(files) ? files : []) {
+    if (file?.id != null) index.set(`file:${file.id}`, file);
+    for (const trackId of Array.isArray(file?.trackIds) ? file.trackIds : []) {
+      index.set(`track:${trackId}`, file);
+    }
+  }
+  return index;
+}
+
+function resolveTrackFile(track, fileIndex, album) {
+  const file =
+    fileIndex.get(`file:${track?.trackFileId}`) ||
+    fileIndex.get(`track:${track?.id}`) ||
+    track?.trackFile ||
+    track?.file ||
+    null;
+  const externalPath =
+    track?.path ||
+    file?.path ||
+    (file?.relativePath && album?.path ? path.join(album.path, file.relativePath) : null);
+  if (!externalPath) return null;
+  return {
+    externalPath,
+    localPath: resolveLocalPath(externalPath, getPathMappings("lidarr")),
+    file,
+  };
+}
+
+async function readFileStats(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile() ? stat : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function indexLidarrLibrary({ client } = {}) {
+  if (!client || typeof client.isConfigured !== "function" || !client.isConfigured()) {
+    return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  }
+
+  const [artists, albums, tracks, files, rootFolders] = await Promise.all([
+    client.request("/artist", "GET", null, false, { forceRefresh: true }),
+    client.getAllAlbums({ forceRefresh: true }),
+    client.getAllTracks(),
+    client.getAllTrackFiles(),
+    client.getRootFolders(),
+  ]);
+  const artistById = new Map((Array.isArray(artists) ? artists : []).map((item) => [String(item.id), item]));
+  const tracksByAlbumId = new Map();
+  for (const track of Array.isArray(tracks) ? tracks : []) {
+    const key = String(track?.albumId || "");
+    if (!key) continue;
+    const list = tracksByAlbumId.get(key) || [];
+    list.push(track);
+    tracksByAlbumId.set(key, list);
+  }
+  const fileIndex = buildFileIndex(files);
+  const rootPath = (Array.isArray(rootFolders) ? rootFolders : [])
+    .map((folder) => text(folder?.path))
+    .filter(Boolean)
+    .join(";") || null;
+  const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+
+  return withLibraryScan("lidarr", rootPath, async (scanId) => {
+    for (const album of Array.isArray(albums) ? albums : []) {
+      const artist = artistById.get(String(album?.artistId));
+      if (!artist || !album?.id) continue;
+      const artistProviderId = text(artist.foreignArtistId);
+      const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
+      const artistKey =
+        (artistProviderId &&
+          buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
+        buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
+      const artistRecord = upsertLibraryArtist({
+        identityKey: artistKey,
+        mbid: isUuid(artistProviderId) ? artistProviderId : null,
+        name: artistName,
+        sortName: artist.sortName || null,
+        metadata: artist,
+      });
+      const albumProviderId = text(album.foreignAlbumId);
+      const albumKey =
+        (albumProviderId &&
+          buildIdentityKey(
+            isUuid(albumProviderId) ? "release-group" : "lidarr-album",
+            albumProviderId,
+          )) ||
+        buildFallbackIdentityKey("lidarr-album", album.id, album.title);
+      const albumRecord = upsertLibraryAlbum({
+        identityKey: albumKey,
+        mbid: isUuid(albumProviderId) ? albumProviderId : null,
+        releaseGroupMbid: isUuid(albumProviderId) ? albumProviderId : null,
+        artistId: artistRecord.id,
+        title: text(album.title) || "Unknown Album",
+        albumArtist: artistName,
+        releaseDate: album.releaseDate || null,
+        metadata: album,
+      });
+
+      for (const track of tracksByAlbumId.get(String(album.id)) || []) {
+        const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);
+        const trackKey =
+          (trackProviderId &&
+            buildIdentityKey(isUuid(trackProviderId) ? "recording" : "lidarr-track", trackProviderId)) ||
+          buildFallbackIdentityKey("lidarr-track", albumRecord.id, track.id, track.title);
+        const trackRecord = upsertLibraryTrack({
+          identityKey: trackKey,
+          mbid: isUuid(trackProviderId) ? trackProviderId : null,
+          title: text(track.title || track.trackTitle) || "Unknown Track",
+          artistName,
+          metadata: track,
+        });
+        const trackNumber = Number(track.trackNumber || track.absoluteTrackNumber) || 0;
+        linkLibraryAlbumTrack({
+          albumId: albumRecord.id,
+          trackId: trackRecord.id,
+          discNumber: Number(track.mediumNumber || track.discNumber) || 1,
+          trackNumber,
+        });
+
+        const resolvedFile = resolveTrackFile(track, fileIndex, album);
+        if (!resolvedFile) continue;
+        result.filesSeen += 1;
+        const stat = await readFileStats(resolvedFile.localPath);
+        if (!stat) {
+          result.filesFailed += 1;
+          continue;
+        }
+        upsertLibraryMediaFile({
+          trackId: trackRecord.id,
+          source: "lidarr",
+          path: resolvedFile.localPath,
+          format: path.extname(resolvedFile.localPath).slice(1).toLowerCase(),
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+          durationMs: track.duration || resolvedFile.file?.duration || null,
+          quality: resolvedFile.file?.mediaInfo || track.mediaInfo || null,
+          available: true,
+          scanId,
+        });
+        result.filesIndexed += 1;
+      }
+    }
+    markUnseenFilesUnavailable(scanId, "lidarr");
+    return result;
+  });
+}
+
+export { buildFileIndex, resolveTrackFile };

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -176,7 +176,9 @@ export async function indexLidarrLibrary({ client } = {}) {
         result.filesIndexed += 1;
       }
     }
-    markUnseenFilesUnavailable(scanId, "lidarr");
+    if (result.filesFailed === 0) {
+      markUnseenFilesUnavailable(scanId, "lidarr");
+    }
     return result;
   });
 }

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -12,6 +12,7 @@ import {
   withLibraryScan,
 } from "./libraryMediaStore.js";
 import { getPathMappings, resolveLocalPath } from "./pathMappings.js";
+import { mapWithConcurrency } from "./discovery/helpers.js";
 
 const text = (value) => String(value || "").trim();
 
@@ -64,23 +65,31 @@ export async function indexLidarrLibrary({ client } = {}) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
 
-  const [artists, albums, tracks, files, rootFolders] = await Promise.all([
+  const [artists, albums, rootFolders] = await Promise.all([
     client.request("/artist", "GET", null, false, { forceRefresh: true }),
     client.getAllAlbums({ forceRefresh: true }),
-    client.getAllTracks(),
-    client.getAllTrackFiles(),
     client.getRootFolders(),
   ]);
   const artistById = new Map((Array.isArray(artists) ? artists : []).map((item) => [String(item.id), item]));
+  const albumTrackData = await mapWithConcurrency(albums, 4, async (album) => {
+    if (!album?.id) return { albumId: null, tracks: [], files: [] };
+    const [tracks, files] = await Promise.all([
+      client.getTracksByAlbumId(album.id),
+      client.getTrackFilesByAlbumId(album.id),
+    ]);
+    return {
+      albumId: String(album.id),
+      tracks: Array.isArray(tracks) ? tracks : [],
+      files: Array.isArray(files) ? files : [],
+    };
+  });
   const tracksByAlbumId = new Map();
-  for (const track of Array.isArray(tracks) ? tracks : []) {
-    const key = String(track?.albumId || "");
-    if (!key) continue;
-    const list = tracksByAlbumId.get(key) || [];
-    list.push(track);
-    tracksByAlbumId.set(key, list);
+  const allFiles = [];
+  for (const albumData of albumTrackData) {
+    if (albumData.albumId) tracksByAlbumId.set(albumData.albumId, albumData.tracks);
+    allFiles.push(...albumData.files);
   }
-  const fileIndex = buildFileIndex(files);
+  const fileIndex = buildFileIndex(allFiles);
   const rootPath = (Array.isArray(rootFolders) ? rootFolders : [])
     .map((folder) => text(folder?.path))
     .filter(Boolean)

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -174,7 +174,7 @@ export function upsertLibraryMediaFile({
     `INSERT INTO library_media_files
       (track_id, source, path, format, size, mtime_ms, duration_ms, quality_json, available, last_seen_scan_id, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(path) DO UPDATE SET
+     ON CONFLICT(source, path) DO UPDATE SET
        track_id = excluded.track_id,
        source = excluded.source,
        format = excluded.format,

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -1,0 +1,232 @@
+import { db, dbHelpers } from "../config/db-sqlite.js";
+
+const now = () => Date.now();
+
+const stringify = (value) => dbHelpers.stringifyJSON(value) || null;
+
+const normalizeText = (value) => String(value || "").trim();
+
+const normalizeKeyPart = (value) =>
+  normalizeText(value)
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+export function buildIdentityKey(prefix, value) {
+  const normalized = normalizeText(value);
+  if (!normalized) return null;
+  return `${prefix}:${normalized}`;
+}
+
+export function buildFallbackIdentityKey(...parts) {
+  const normalized = parts.map(normalizeKeyPart).filter(Boolean);
+  return normalized.length ? `name:${normalized.join(":")}` : null;
+}
+
+export function beginLibraryScan({ source, rootPath = null } = {}) {
+  const startedAt = now();
+  const result = db
+    .prepare(
+      `INSERT INTO library_scan_runs (source, root_path, status, started_at)
+       VALUES (?, ?, 'running', ?)`,
+    )
+    .run(normalizeText(source), rootPath ? normalizeText(rootPath) : null, startedAt);
+  return Number(result.lastInsertRowid);
+}
+
+export function finishLibraryScan(scanId, {
+  status = "complete",
+  error = null,
+  filesSeen = 0,
+  filesIndexed = 0,
+  filesFailed = 0,
+} = {}) {
+  db.prepare(
+    `UPDATE library_scan_runs
+     SET status = ?, completed_at = ?, error = ?, files_seen = ?, files_indexed = ?, files_failed = ?
+     WHERE id = ?`,
+  ).run(
+    status,
+    now(),
+    error ? String(error) : null,
+    Number(filesSeen) || 0,
+    Number(filesIndexed) || 0,
+    Number(filesFailed) || 0,
+    scanId,
+  );
+}
+
+export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName = null, metadata = null }) {
+  const timestamp = now();
+  const key = normalizeText(identityKey);
+  const artistName = normalizeText(name);
+  if (!key || !artistName) throw new Error("Library artist identityKey and name are required");
+  db.prepare(
+    `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(identity_key) DO UPDATE SET
+       mbid = COALESCE(excluded.mbid, library_artists.mbid),
+       name = excluded.name,
+       sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
+       metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
+       updated_at = excluded.updated_at`,
+  ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+  return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+}
+
+export function upsertLibraryAlbum({
+  identityKey,
+  mbid = null,
+  releaseGroupMbid = null,
+  artistId,
+  title,
+  albumArtist = null,
+  releaseDate = null,
+  metadata = null,
+}) {
+  const timestamp = now();
+  const key = normalizeText(identityKey);
+  const albumTitle = normalizeText(title);
+  if (!key || !Number.isSafeInteger(Number(artistId)) || !albumTitle) {
+    throw new Error("Library album identityKey, artistId, and title are required");
+  }
+  db.prepare(
+    `INSERT INTO library_albums
+      (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(identity_key) DO UPDATE SET
+       mbid = COALESCE(excluded.mbid, library_albums.mbid),
+       release_group_mbid = COALESCE(excluded.release_group_mbid, library_albums.release_group_mbid),
+       artist_id = excluded.artist_id,
+       title = excluded.title,
+       album_artist = COALESCE(excluded.album_artist, library_albums.album_artist),
+       release_date = COALESCE(excluded.release_date, library_albums.release_date),
+       metadata_json = COALESCE(excluded.metadata_json, library_albums.metadata_json),
+       updated_at = excluded.updated_at`,
+  ).run(
+    key,
+    mbid || null,
+    releaseGroupMbid || null,
+    Number(artistId),
+    albumTitle,
+    albumArtist || null,
+    releaseDate || null,
+    stringify(metadata),
+    timestamp,
+    timestamp,
+  );
+  return db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+}
+
+export function upsertLibraryTrack({
+  identityKey,
+  mbid = null,
+  title,
+  artistName = null,
+  metadata = null,
+}) {
+  const timestamp = now();
+  const key = normalizeText(identityKey);
+  const trackTitle = normalizeText(title);
+  if (!key || !trackTitle) throw new Error("Library track identityKey and title are required");
+  db.prepare(
+    `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(identity_key) DO UPDATE SET
+       mbid = COALESCE(excluded.mbid, library_tracks.mbid),
+       title = excluded.title,
+       artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
+       metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
+       updated_at = excluded.updated_at`,
+  ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+  return db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+}
+
+export function linkLibraryAlbumTrack({ albumId, trackId, discNumber = 1, trackNumber = 0 }) {
+  db.prepare(
+    `INSERT OR IGNORE INTO library_album_tracks
+      (album_id, track_id, disc_number, track_number, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+}
+
+export function upsertLibraryMediaFile({
+  trackId,
+  source,
+  path,
+  format = null,
+  size = 0,
+  mtimeMs = null,
+  durationMs = null,
+  quality = null,
+  available = true,
+  scanId,
+}) {
+  const filePath = normalizeText(path);
+  const fileSource = normalizeText(source);
+  if (!Number.isSafeInteger(Number(trackId)) || !fileSource || !filePath) {
+    throw new Error("Library media file trackId, source, and path are required");
+  }
+  const timestamp = now();
+  db.prepare(
+    `INSERT INTO library_media_files
+      (track_id, source, path, format, size, mtime_ms, duration_ms, quality_json, available, last_seen_scan_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       track_id = excluded.track_id,
+       source = excluded.source,
+       format = excluded.format,
+       size = excluded.size,
+       mtime_ms = excluded.mtime_ms,
+       duration_ms = excluded.duration_ms,
+       quality_json = COALESCE(excluded.quality_json, library_media_files.quality_json),
+       available = excluded.available,
+       last_seen_scan_id = excluded.last_seen_scan_id,
+       updated_at = excluded.updated_at`,
+  ).run(
+    Number(trackId),
+    fileSource,
+    filePath,
+    format || null,
+    Number(size) || 0,
+    Number.isFinite(Number(mtimeMs)) ? Number(mtimeMs) : null,
+    Number.isFinite(Number(durationMs)) ? Number(durationMs) : null,
+    stringify(quality),
+    available === true ? 1 : 0,
+    Number(scanId),
+    timestamp,
+    timestamp,
+  );
+}
+
+export function markUnseenFilesUnavailable(scanId, source) {
+  db.prepare(
+    `UPDATE library_media_files
+     SET available = 0, updated_at = ?
+     WHERE source = ? AND (last_seen_scan_id IS NULL OR last_seen_scan_id != ?)`,
+  ).run(now(), normalizeText(source), Number(scanId));
+}
+
+export async function withLibraryScan(source, rootPath, run) {
+  const scanId = beginLibraryScan({ source, rootPath });
+  try {
+    const result = await run(scanId);
+    finishLibraryScan(scanId, { ...result, status: "complete" });
+    return { scanId, ...result, status: "complete" };
+  } catch (error) {
+    finishLibraryScan(scanId, { status: "failed", error: error.message });
+    throw error;
+  }
+}
+
+export function getLibrarySnapshot() {
+  return {
+    artists: db.prepare("SELECT * FROM library_artists ORDER BY name").all(),
+    albums: db.prepare("SELECT * FROM library_albums ORDER BY title").all(),
+    tracks: db.prepare("SELECT * FROM library_tracks ORDER BY title").all(),
+    albumTracks: db.prepare("SELECT * FROM library_album_tracks").all(),
+    files: db.prepare("SELECT * FROM library_media_files ORDER BY path").all(),
+  };
+}

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -148,7 +148,9 @@ export function getCanonicalLibrary({ source = null, availableOnly = false } = {
       quality: parseJson(row.media_quality_json),
       available: Boolean(row.media_available),
     };
-    track.files.push(file);
+    if (!track.files.some((entry) => entry.id === file.id)) {
+      track.files.push(file);
+    }
     if (file.available) {
       artist.available = true;
       album.available = true;

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1,0 +1,173 @@
+import { db, dbHelpers } from "../config/db-sqlite.js";
+
+const SOURCES = new Set(["aurral", "lidarr"]);
+
+const parseJson = (value) => {
+  if (!value) return null;
+  try {
+    return dbHelpers.parseJSON(value);
+  } catch {
+    return null;
+  }
+};
+
+function normalizeSource(source) {
+  const value = String(source || "").trim().toLowerCase();
+  if (!value || value === "all") return null;
+  if (!SOURCES.has(value)) throw new Error(`Unsupported library source: ${value}`);
+  return value;
+}
+
+function createEntity(map, id, value) {
+  if (!map.has(id)) map.set(id, value);
+  return map.get(id);
+}
+
+export function getCanonicalLibrary({ source = null, availableOnly = false } = {}) {
+  const sourceFilter = normalizeSource(source);
+  const conditions = [];
+  const parameters = [];
+
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+
+  const rows = db
+    .prepare(
+      `SELECT
+        artist.id AS artist_id,
+        artist.identity_key AS artist_identity_key,
+        artist.mbid AS artist_mbid,
+        artist.name AS artist_name,
+        artist.sort_name AS artist_sort_name,
+        artist.metadata_json AS artist_metadata_json,
+        album.id AS album_id,
+        album.identity_key AS album_identity_key,
+        album.mbid AS album_mbid,
+        album.release_group_mbid AS album_release_group_mbid,
+        album.title AS album_title,
+        album.album_artist AS album_artist,
+        album.release_date AS album_release_date,
+        album.metadata_json AS album_metadata_json,
+        track.id AS track_id,
+        track.identity_key AS track_identity_key,
+        track.mbid AS track_mbid,
+        track.title AS track_title,
+        track.artist_name AS track_artist_name,
+        track.metadata_json AS track_metadata_json,
+        album_track.disc_number,
+        album_track.track_number,
+        media.id AS media_id,
+        media.source AS media_source,
+        media.path AS media_path,
+        media.format AS media_format,
+        media.size AS media_size,
+        media.mtime_ms AS media_mtime_ms,
+        media.duration_ms AS media_duration_ms,
+        media.quality_json AS media_quality_json,
+        media.available AS media_available
+      FROM library_media_files AS media
+      JOIN library_tracks AS track ON track.id = media.track_id
+      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+      JOIN library_albums AS album ON album.id = album_track.album_id
+      JOIN library_artists AS artist ON artist.id = album.artist_id
+      ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
+      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
+        album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
+        track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+    )
+    .all(...parameters);
+
+  const artists = new Map();
+  const albums = new Map();
+  const tracks = new Map();
+
+  for (const row of rows) {
+    const artist = createEntity(artists, row.artist_id, {
+      id: row.artist_id,
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata: parseJson(row.artist_metadata_json),
+      albumIds: [],
+      sources: [],
+      available: false,
+    });
+    const album = createEntity(albums, row.album_id, {
+      id: row.album_id,
+      identityKey: row.album_identity_key,
+      mbid: row.album_mbid,
+      releaseGroupMbid: row.album_release_group_mbid,
+      artistId: row.artist_id,
+      title: row.album_title,
+      albumArtist: row.album_artist,
+      releaseDate: row.album_release_date,
+      metadata: parseJson(row.album_metadata_json),
+      trackIds: [],
+      sources: [],
+      available: false,
+    });
+    const track = createEntity(tracks, row.track_id, {
+      id: row.track_id,
+      identityKey: row.track_identity_key,
+      mbid: row.track_mbid,
+      title: row.track_title,
+      artistName: row.track_artist_name,
+      metadata: parseJson(row.track_metadata_json),
+      albums: [],
+      files: [],
+      sources: [],
+      available: false,
+    });
+
+    if (!artist.albumIds.includes(album.id)) artist.albumIds.push(album.id);
+    if (!album.trackIds.includes(track.id)) album.trackIds.push(track.id);
+    if (!track.albums.some((entry) => entry.albumId === album.id)) {
+      track.albums.push({
+        albumId: album.id,
+        discNumber: row.disc_number,
+        trackNumber: row.track_number,
+      });
+    }
+
+    if (!artist.sources.includes(row.media_source)) artist.sources.push(row.media_source);
+    if (!album.sources.includes(row.media_source)) album.sources.push(row.media_source);
+    if (!track.sources.includes(row.media_source)) track.sources.push(row.media_source);
+
+    const file = {
+      id: row.media_id,
+      source: row.media_source,
+      path: row.media_path,
+      format: row.media_format,
+      size: row.media_size,
+      mtimeMs: row.media_mtime_ms,
+      durationMs: row.media_duration_ms,
+      quality: parseJson(row.media_quality_json),
+      available: Boolean(row.media_available),
+    };
+    track.files.push(file);
+    if (file.available) {
+      artist.available = true;
+      album.available = true;
+      track.available = true;
+    }
+  }
+
+  for (const entity of [...artists.values(), ...albums.values(), ...tracks.values()]) {
+    entity.sources.sort();
+  }
+  for (const track of tracks.values()) {
+    track.files.sort((left, right) => left.path.localeCompare(right.path));
+  }
+
+  return {
+    artists: [...artists.values()],
+    albums: [...albums.values()],
+    tracks: [...tracks.values()],
+  };
+}
+
+export { normalizeSource };

--- a/backend/services/libraryScanWorker.js
+++ b/backend/services/libraryScanWorker.js
@@ -59,6 +59,9 @@ const {
     return true;
   },
   processJob: async () => {
+    const { lidarrClient } = await import("./lidarrClient.js");
+    const { scanConfiguredLibrary } = await import("./libraryIndexService.js");
+    await scanConfiguredLibrary({ lidarrClient });
     const { playlistManager } = await import("./weeklyFlow/weeklyFlowPlaylistManager.js");
     await playlistManager.scanLibrary();
   },

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -49,6 +49,11 @@ async function processSystemTask(payload = {}) {
       await runDueImportSourceSyncs();
       return;
     }
+    case "library-index-refresh": {
+      const { scheduleLibraryScan } = await import("./libraryScanWorker.js");
+      scheduleLibraryScan();
+      return;
+    }
     case "weekly-flow-startup-check": {
       const { startWorkerIfPending } = await import("./weeklyFlow/weeklyFlowScheduler.js");
       await startWorkerIfPending();

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -116,7 +116,7 @@ export class WeeklyFlowPlaylistManager {
   }
 
   scheduleScanLibrary(force = false) {
-    return scheduleLibraryScan(force);
+    return scheduleLibraryScan({ force });
   }
 
   async _ensureFlowArtwork(playlistType, playlistName, artworkKind) {


### PR DESCRIPTION
## Problem
Aurral still has no application-owned read index for its canonical music files, so future library, playback, and Subsonic work would continue depending on provider-shaped reads.

## Solution
This adds an additive canonical media foundation:

- persist artists, albums, tracks, relationships, media files, and scan runs
- scan the configured Aurral root and reconcile stale or partial file state
- index Lidarr-owned files through its existing filtered adapter calls
- expose source-aware canonical hierarchy queries at `/api/library/canonical`
- keep existing Library reads, acquisition behavior, Lidarr integration, and UI unchanged

## Verification
- `npm test` — 574 passing
- `npm run lint:backend`
- focused media-index and media-query tests
- local synthetic four-track fixture indexed successfully
- authenticated canonical API read verified without exposing filesystem paths
- candidate startup and health check verified
- live Lidarr indexing verified without unfiltered API errors

## Limitations
This is the additive shadow path only. The existing Library UI has not been cut over, and no production files are migrated or moved by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a canonical music library API with source and availability filters.
  - Added automatic scanning and indexing of local music files and Lidarr libraries.
  - Added artist, album, track, metadata, quality, duration, and availability details.
  - Added library refreshes every 15 minutes.
  - Public library responses no longer expose filesystem paths.

- **Bug Fixes**
  - Failed metadata reads no longer incorrectly mark existing media unavailable.
  - Removed files remain in the library and are accurately marked unavailable.
  - Successful scan results remain available when part of an indexing operation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->