### PR TITLE
refactor(library): add canonical read path for library handlers

### DIFF
--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildCanonicalLibraryReadModel,
+  findCanonicalAlbumsForArtist,
+  findCanonicalArtist,
+  findCanonicalTracksForAlbum,
+} from "../../backend/services/canonicalLibraryReadAdapter.js";
+
+const library = {
+  artists: [
+    {
+      id: 1,
+      identityKey: "mbid:artist-1",
+      mbid: "artist-1",
+      name: "Root Artist",
+      sortName: "Root Artist",
+      albumIds: [2],
+      sources: ["lidarr"],
+      available: true,
+    },
+  ],
+  albums: [
+    {
+      id: 2,
+      identityKey: "release-group:album-1",
+      mbid: "album-1",
+      releaseGroupMbid: "album-1",
+      artistId: 1,
+      title: "Root Album",
+      albumArtist: "Root Artist",
+      releaseDate: "2026-01-01",
+      trackIds: [3],
+      sources: ["lidarr"],
+      available: true,
+    },
+  ],
+  tracks: [
+    {
+      id: 3,
+      mbid: "track-1",
+      title: "Root Track",
+      albums: [{ albumId: 2, trackNumber: 1 }],
+      files: [
+        {
+          id: 4,
+          source: "lidarr",
+          path: "/music/Root Artist/Root Album/01 Root Track.flac",
+          size: 123,
+          quality: { format: "FLAC" },
+          available: true,
+        },
+      ],
+      sources: ["lidarr"],
+      available: true,
+    },
+  ],
+};
+
+test("canonical read model maps the existing root to Library-shaped records", () => {
+  const result = buildCanonicalLibraryReadModel(library);
+
+  assert.equal(findCanonicalArtist(result.artists, "artist-1")?.artistName, "Root Artist");
+  assert.deepEqual(findCanonicalAlbumsForArtist(result.albums, "artist-1").map((album) => album.id), [2]);
+  assert.deepEqual(findCanonicalTracksForAlbum(result.tracks, 2).map((track) => track.trackName), [
+    "Root Track",
+  ]);
+  assert.equal(result.albums[0].statistics.sizeOnDisk, 123);
+  assert.equal(result.artists[0].statistics.sizeOnDisk, 123);
+  assert.equal(result.tracks[0].path, "/music/Root Artist/Root Album/01 Root Track.flac");
+});
+
+test("canonical read model keeps flow-like records out when the index excludes them", () => {
+  const result = buildCanonicalLibraryReadModel({
+    artists: [],
+    albums: [],
+    tracks: [],
+  });
+
+  assert.deepEqual(result, { artists: [], albums: [], tracks: [] });
+});

--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -63,6 +63,7 @@ test("canonical read model maps the existing root to Library-shaped records", ()
 
   assert.equal(findCanonicalArtist(result.artists, "artist-1")?.artistName, "Root Artist");
   assert.deepEqual(findCanonicalAlbumsForArtist(result.albums, "artist-1").map((album) => album.id), [2]);
+  assert.deepEqual(findCanonicalAlbumsForArtist(result.albums, 2), []);
   assert.deepEqual(findCanonicalTracksForAlbum(result.tracks, 2).map((track) => track.trackName), [
     "Root Track",
   ]);

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -8,6 +8,10 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
+import {
+  findCanonicalAlbumsForArtist,
+  getCanonicalLibraryReadModel,
+} from "../../../services/canonicalLibraryReadAdapter.js";
 
 export function registerAlbums(router) {
   router.get("/albums", cacheMiddleware(5), async (req, res) => {
@@ -15,6 +19,11 @@ export function registerAlbums(router) {
       const { artistId } = req.query;
       if (!artistId) {
         return res.status(400).json({ error: "artistId parameter is required" });
+      }
+
+      if (req.query.readPath === "canonical") {
+        const { albums } = getCanonicalLibraryReadModel({ source: req.query.source || "lidarr" });
+        return res.json(findCanonicalAlbumsForArtist(albums, artistId));
       }
 
       const albums = await libraryManager.getAlbums(artistId);

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -6,9 +6,19 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
+import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
+      if (req.query.readPath === "canonical") {
+        const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "lidarr" });
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
+        const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+        return res.json(artists.slice(offset, offset + limit).map((artist) => ({
+          ...artist,
+          added: artist.addedAt,
+        })));
+      }
       const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
       const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
       const artists = await libraryManager.getAllArtists();

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -94,12 +94,16 @@ export function registerTracks(router) {
         const { albums, tracks } = getCanonicalLibraryReadModel({
           source: req.query.source || "lidarr",
         });
-        const reference = albumId || releaseGroupMbid;
-        const album = albums.find((candidate) =>
-          [candidate.id, candidate.mbid, candidate.foreignAlbumId].some(
-            (value) => String(value ?? "") === String(reference),
-          ),
-        );
+        const album = [albumId, releaseGroupMbid]
+          .filter(Boolean)
+          .map((reference) =>
+            albums.find((candidate) =>
+              [candidate.id, candidate.mbid, candidate.foreignAlbumId].some(
+                (value) => String(value ?? "") === String(reference),
+              ),
+            ),
+          )
+          .find(Boolean);
         const canonicalTracks = album
           ? findCanonicalTracksForAlbum(tracks, album.id).map(({ path: _path, ...track }) => ({
               ...track,

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -8,6 +8,10 @@ import fs from "fs";
 import fsp from "fs/promises";
 import path from "path";
 import { logger } from "../../../services/logger.js";
+import {
+  findCanonicalTracksForAlbum,
+  getCanonicalLibraryReadModel,
+} from "../../../services/canonicalLibraryReadAdapter.js";
 
 const AUDIO_CONTENT_TYPES = {
   ".mp3": "audio/mpeg",
@@ -85,6 +89,26 @@ export function registerTracks(router) {
   router.get("/tracks", cacheMiddleware(120), async (req, res) => {
     try {
       const { albumId, releaseGroupMbid } = req.query;
+
+      if (req.query.readPath === "canonical") {
+        const { albums, tracks } = getCanonicalLibraryReadModel({
+          source: req.query.source || "lidarr",
+        });
+        const reference = albumId || releaseGroupMbid;
+        const album = albums.find((candidate) =>
+          [candidate.id, candidate.mbid, candidate.foreignAlbumId].some(
+            (value) => String(value ?? "") === String(reference),
+          ),
+        );
+        const canonicalTracks = album
+          ? findCanonicalTracksForAlbum(tracks, album.id).map(({ path: _path, ...track }) => ({
+              ...track,
+              streamPath: null,
+              streamFormat: null,
+            }))
+          : [];
+        return res.json(canonicalTracks);
+      }
 
       let tracks = [];
 

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -120,11 +120,13 @@ export function findCanonicalArtist(artists, reference) {
 }
 
 export function findCanonicalAlbumsForArtist(albums, reference) {
+  const normalizedReference = String(reference ?? "").trim();
+  if (!normalizedReference) return [];
+
   return albums.filter(
     (album) =>
-      recordMatches(album, reference) ||
       [album.artistId, album.artistMbid].some(
-        (candidate) => String(candidate ?? "").trim() === String(reference ?? "").trim(),
+        (candidate) => String(candidate ?? "").trim() === normalizedReference,
       ),
   );
 }

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -1,0 +1,134 @@
+import { getCanonicalLibrary } from "./libraryQueryService.js";
+
+const firstAvailableFile = (track) =>
+  (track.files || []).find((file) => file.available) || track.files?.[0] || null;
+
+const recordMatches = (record, reference) => {
+  const value = String(reference ?? "").trim();
+  if (!value) return false;
+  return [record.id, record.mbid, record.identityKey].some(
+    (candidate) => String(candidate ?? "").trim() === value,
+  );
+};
+
+const buildArtist = (artist, albums) => {
+  const artistAlbums = albums.filter((album) => album.artistId === artist.id);
+  const trackCount = artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
+  const sizeOnDisk = artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
+  return {
+    id: artist.id,
+    mbid: artist.mbid,
+    foreignArtistId: artist.mbid || artist.identityKey,
+    artistName: artist.name,
+    name: artist.name,
+    sortName: artist.sortName,
+    addedAt: null,
+    monitored: false,
+    statistics: {
+      albumCount: artistAlbums.length,
+      trackCount,
+      sizeOnDisk,
+    },
+    sources: artist.sources,
+    available: artist.available,
+  };
+};
+
+const buildAlbum = (album, artists, tracks) => {
+  const artist = artists.find((candidate) => candidate.id === album.artistId);
+  const albumTracks = album.trackIds
+    .map((trackId) => tracks.find((track) => track.id === trackId))
+    .filter(Boolean);
+  const sizeOnDisk = albumTracks.reduce((total, track) => {
+    const file = firstAvailableFile(track);
+    return total + Number(file?.size || 0);
+  }, 0);
+  return {
+    id: album.id,
+    artistId: album.artistId,
+    artistMbid: artist?.mbid || null,
+    artistName: artist?.name || album.albumArtist,
+    mbid: album.mbid || album.releaseGroupMbid,
+    foreignAlbumId: album.mbid || album.releaseGroupMbid || album.identityKey,
+    albumName: album.title,
+    title: album.title,
+    releaseDate: album.releaseDate,
+    addedAt: null,
+    monitored: false,
+    statistics: {
+      trackCount: albumTracks.length,
+      sizeOnDisk,
+      percentOfTracks:
+        albumTracks.length > 0 && albumTracks.every((track) => track.available) ? 100 : 0,
+    },
+    trackIds: album.trackIds,
+    sources: album.sources,
+    available: album.available,
+  };
+};
+
+const buildTrack = (track, album) => {
+  const file = firstAvailableFile(track);
+  const relation = track.albums.find((entry) => entry.albumId === album.id);
+  return {
+    id: track.id,
+    albumId: album.id,
+    artistId: album.artistId,
+    mbid: track.mbid,
+    trackName: track.title,
+    title: track.title,
+    trackNumber: relation?.trackNumber || 0,
+    path: file?.path || null,
+    hasFile: Boolean(file?.available),
+    size: Number(file?.size || 0),
+    quality: file?.quality || null,
+    addedAt: null,
+    source: file?.source || null,
+    available: track.available,
+    sources: track.sources,
+  };
+};
+
+export function buildCanonicalLibraryReadModel(library) {
+  const artists = library.artists.map((artist) => ({ ...artist }));
+  const albums = library.albums.map((album) => ({
+    ...album,
+    trackIds: [...album.trackIds],
+  }));
+  const tracks = library.tracks.map((track) => ({
+    ...track,
+    albums: [...track.albums],
+    files: [...track.files],
+  }));
+  const readAlbums = albums.map((album) => buildAlbum(album, artists, tracks));
+  const readArtists = artists.map((artist) => buildArtist(artist, readAlbums));
+  const readTracks = readAlbums.flatMap((album) =>
+    album.trackIds
+      .map((trackId) => tracks.find((track) => track.id === trackId))
+      .filter(Boolean)
+      .map((track) => buildTrack(track, album)),
+  );
+  return { artists: readArtists, albums: readAlbums, tracks: readTracks };
+}
+
+export function getCanonicalLibraryReadModel({ source = "lidarr", availableOnly = true } = {}) {
+  return buildCanonicalLibraryReadModel(getCanonicalLibrary({ source, availableOnly }));
+}
+
+export function findCanonicalArtist(artists, reference) {
+  return artists.find((artist) => recordMatches(artist, reference)) || null;
+}
+
+export function findCanonicalAlbumsForArtist(albums, reference) {
+  return albums.filter(
+    (album) =>
+      recordMatches(album, reference) ||
+      [album.artistId, album.artistMbid].some(
+        (candidate) => String(candidate ?? "").trim() === String(reference ?? "").trim(),
+      ),
+  );
+}
+
+export function findCanonicalTracksForAlbum(tracks, reference) {
+  return tracks.filter((track) => String(track.albumId) === String(reference));
+}


### PR DESCRIPTION
## Summary

Adds an optional canonical read path for artist, album, and track library handlers, adapting canonical library records to the existing Library-shaped API responses.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): library API, persistence/read adapters, automated tests
- Automated coverage: Added tests for canonical artist, album, and track mapping and empty-index behavior.
- Manual steps and expected result: Exercise the library endpoints with `readPath=canonical` and confirm responses match the existing Library-shaped records.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional canonical library view for artists, albums, and tracks.
  - Artists support pagination and consistent added-date information.
  - Albums can be filtered by artist.
  - Tracks can be found using album identifiers and include consistent streaming fields.
  - Canonical library results include availability, file details, statistics, identifiers, and relationships.

- **Tests**
  - Added coverage for canonical artist, album, track, and file mapping, including empty-library results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->