### PR TITLE
fix(library): remove filesystem paths from canonical responses

### DIFF
--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -137,10 +137,17 @@ test("getCanonicalLibrary rejects unknown source filters", () => {
 
 test("canonical library responses do not expose filesystem paths", () => {
   const response = toPublicLibrary({
-    artists: [],
-    albums: [],
-    tracks: [{ id: 1, files: [{ id: 2, path: "/music/private.flac", source: "aurral" }] }],
+    artists: [{ metadata: { path: "/music/private", tags: { genre: "rock" } } }],
+    albums: [{ metadata: { rootFolderPath: "/music/private" } }],
+    tracks: [{
+      id: 1,
+      metadata: { nested: { filePath: "/music/private.flac" } },
+      files: [{ id: 2, path: "/music/private.flac", source: "aurral" }],
+    }],
   });
 
+  assert.deepEqual(response.artists[0].metadata, { tags: { genre: "rock" } });
+  assert.deepEqual(response.albums[0].metadata, {});
+  assert.deepEqual(response.tracks[0].metadata, { nested: {} });
   assert.deepEqual(response.tracks[0].files, [{ id: 2, source: "aurral" }]);
 });

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,15 +1,24 @@
 import { noCache } from "../../../middleware/cache.js";
 import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 
+const isFilesystemPathKey = (key) => key.toLowerCase().endsWith("path");
+
+function stripFilesystemPaths(value) {
+  if (Array.isArray(value)) return value.map(stripFilesystemPaths);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !isFilesystemPathKey(key))
+      .map(([key, entry]) => [key, stripFilesystemPaths(entry)]),
+  );
+}
+
 function toPublicLibrary(library) {
-  return {
+  return stripFilesystemPaths({
     artists: library.artists,
     albums: library.albums,
-    tracks: library.tracks.map((track) => ({
-      ...track,
-      files: track.files.map(({ path: _path, ...file }) => file),
-    })),
-  };
+    tracks: library.tracks,
+  });
 }
 
 export function registerCanonical(router) {


### PR DESCRIPTION
## Summary

Remove filesystem path fields from canonical library responses, including nested metadata, to prevent private paths from being exposed to clients.

## Linked issues

None.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): library API responses
- Automated coverage: Extended canonical library response tests to cover filesystem paths in artist, album, and track metadata, plus track file paths.
- Manual steps and expected result: Request a canonical library response and verify that no fields ending in `path` remain, while non-path metadata is preserved.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved library data privacy by removing filesystem path information from artists, albums, tracks, and nested metadata.
  - Preserved non-path metadata while ensuring entries containing only path information are returned empty.
  - Applied consistent sanitization across nested objects and arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->