### PR TITLE
fix(library): sanitize canonical track reads

### DIFF
--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -82,6 +82,7 @@ test("canonical track reads remove nested filesystem paths", async () => {
     assert.equal("path" in body[0], false);
     assert.deepEqual(body[0].quality, { audioFormat: "FLAC", nested: {} });
     assert.equal(body[0].streamPath, null);
+    assert.equal(body[0].streamFormat, null);
   } finally {
     const track = db.prepare(
       "SELECT track_id AS trackId FROM library_media_files WHERE source = ? AND path = ?",

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import { registerTracks } from "../../backend/routes/library/handlers/tracks.js";
+import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
+
+test("canonical track reads remove nested filesystem paths", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-canonical-route-"));
+  const filePath = path.join(root, "Route Artist", "Route Album", "01 Route Track.flac");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, "fixture");
+
+  try {
+    await indexLidarrLibrary({
+      client: {
+        isConfigured: () => true,
+        request: async () => [{
+          id: 701,
+          artistName: "Route Artist",
+          foreignArtistId: "71111111-1111-4111-8111-111111111111",
+        }],
+        getAllAlbums: async () => [{
+          id: 702,
+          artistId: 701,
+          title: "Route Album",
+          foreignAlbumId: "72222222-2222-4222-8222-222222222222",
+          path: path.dirname(filePath),
+        }],
+        getTracksByAlbumId: async () => [{
+          id: 703,
+          albumId: 702,
+          title: "Route Track",
+          trackNumber: 1,
+          foreignRecordingId: "73333333-3333-4333-8333-333333333333",
+          trackFileId: 704,
+        }],
+        getTrackFilesByAlbumId: async () => [{
+          id: 704,
+          path: filePath,
+          trackIds: [703],
+          mediaInfo: {
+            audioFormat: "FLAC",
+            rootFolderPath: root,
+            nested: { filePath },
+          },
+        }],
+        getRootFolders: async () => [{ path: root }],
+      },
+    });
+
+    const routes = new Map();
+    registerTracks({
+      get(routePath, ...handlers) {
+        routes.set(routePath, handlers.at(-1));
+      },
+    });
+
+    let body;
+    await routes.get("/tracks")(
+      {
+        query: {
+          readPath: "canonical",
+          releaseGroupMbid: "72222222-2222-4222-8222-222222222222",
+        },
+      },
+      {
+        json(value) {
+          body = value;
+          return this;
+        },
+        status() {
+          return this;
+        },
+      },
+    );
+
+    assert.equal(body.length, 1);
+    assert.equal("path" in body[0], false);
+    assert.deepEqual(body[0].quality, { audioFormat: "FLAC", nested: {} });
+    assert.equal(body[0].streamPath, null);
+  } finally {
+    const track = db.prepare(
+      "SELECT track_id AS trackId FROM library_media_files WHERE source = ? AND path = ?",
+    ).get("lidarr", filePath);
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+    if (track) {
+      const link = db.prepare(
+        `SELECT album_track.album_id AS albumId, album.artist_id AS artistId
+         FROM library_album_tracks AS album_track
+         JOIN library_albums AS album ON album.id = album_track.album_id
+         WHERE album_track.track_id = ?`,
+      ).get(track.trackId);
+      db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(track.trackId);
+      db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.trackId);
+      if (link) {
+        db.prepare("DELETE FROM library_albums WHERE id = ?").run(link.albumId);
+        db.prepare("DELETE FROM library_artists WHERE id = ?").run(link.artistId);
+      }
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -8,6 +8,7 @@ import { db } from "../../backend/config/db-sqlite.js";
 import { getLibrarySnapshot } from "../../backend/services/libraryMediaStore.js";
 import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
+import { scanConfiguredLibrary } from "../../backend/services/libraryIndexService.js";
 
 const metadata = {
   common: {
@@ -36,19 +37,56 @@ async function createAudioFile(root, relativePath) {
   return filePath;
 }
 
+function deleteIndexedFile(source, filePath) {
+  const links = db.prepare(
+    `SELECT media.track_id AS trackId, album_track.album_id AS albumId, album.artist_id AS artistId
+     FROM library_media_files AS media
+     LEFT JOIN library_album_tracks AS album_track ON album_track.track_id = media.track_id
+     LEFT JOIN library_albums AS album ON album.id = album_track.album_id
+     WHERE media.source = ? AND media.path = ?`,
+  ).all(source, filePath);
+  db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(source, filePath);
+
+  for (const { trackId, albumId, artistId } of links) {
+    const remainingFiles = db.prepare(
+      "SELECT COUNT(*) AS count FROM library_media_files WHERE track_id = ?",
+    ).get(trackId).count;
+    if (remainingFiles === 0) {
+      db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(trackId);
+      db.prepare("DELETE FROM library_tracks WHERE id = ?").run(trackId);
+    }
+    if (albumId != null) {
+      db.prepare(
+        "DELETE FROM library_albums WHERE id = ? AND NOT EXISTS (SELECT 1 FROM library_album_tracks WHERE album_id = ?)",
+      ).run(albumId, albumId);
+    }
+    if (artistId != null) {
+      db.prepare(
+        "DELETE FROM library_artists WHERE id = ? AND NOT EXISTS (SELECT 1 FROM library_albums WHERE artist_id = ?)",
+      ).run(artistId, artistId);
+    }
+  }
+}
+
 test("scanMusicRoot indexes tagged media and ignores Flow output", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-scan-"));
+  const source = `test-aurral-${process.pid}`;
+  let filePath;
   try {
-    const filePath = await createAudioFile(root, "Aurral Fixture/Playback Roadmap/01 First Step.flac");
+    filePath = await createAudioFile(root, "Aurral Fixture/Playback Roadmap/01 First Step.flac");
     await createAudioFile(root, "aurral-weekly-flow/flow/ignored.flac");
+    await createAudioFile(root, "_playlists/ignored.flac");
+    await createAudioFile(root, "_staging/ignored.flac");
+    await createAudioFile(root, "_fallback/ignored.flac");
+    await createAudioFile(root, ".hidden/ignored.flac");
 
     const result = await scanMusicRoot({
       rootPath: root,
-      source: `test-aurral-${process.pid}`,
+      source,
       metadataReader: async () => metadata,
     });
     const snapshot = getLibrarySnapshot();
-    const files = snapshot.files.filter((file) => file.source === `test-aurral-${process.pid}`);
+    const files = snapshot.files.filter((file) => file.source === source);
 
     assert.equal(result.filesSeen, 1);
     assert.equal(result.filesIndexed, 1);
@@ -58,6 +96,41 @@ test("scanMusicRoot indexes tagged media and ignores Flow output", async () => {
     assert.equal(snapshot.albums.some((album) => album.title === "Playback Roadmap"), true);
     assert.equal(snapshot.tracks.some((track) => track.title === "First Step"), true);
   } finally {
+    if (filePath) deleteIndexedFile(source, filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("scanMusicRoot derives stable fallback records when tags are missing", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-fallback-"));
+  const source = `test-fallback-${process.pid}`;
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Fallback Artist/Fallback Album/02 Fallback Track.mp3");
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => ({ common: {}, format: {} }),
+    });
+    const indexed = db.prepare(
+      `SELECT artist.name AS artistName, album.title AS albumTitle,
+        track.title AS trackTitle, media.available
+       FROM library_media_files AS media
+       JOIN library_tracks AS track ON track.id = media.track_id
+       JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+       JOIN library_albums AS album ON album.id = album_track.album_id
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       WHERE media.source = ? AND media.path = ?`,
+    ).get(source, filePath);
+
+    assert.deepEqual(indexed, {
+      artistName: "Fallback Artist",
+      albumTitle: "Fallback Album",
+      trackTitle: "Fallback Track",
+      available: 1,
+    });
+  } finally {
+    if (filePath) deleteIndexedFile(source, filePath);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -213,5 +286,59 @@ test("a partial Lidarr rescan preserves existing file availability", async () =>
       "lidarr",
       filePath,
     );
+  }
+});
+
+test("a Lidarr outage leaves the last indexed library available", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-outage-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Outage Artist/Outage Album/01 Outage Track.flac");
+    await indexLidarrLibrary({
+      client: {
+        isConfigured: () => true,
+        request: async () => [{
+          id: 27,
+          artistName: "Outage Artist",
+          foreignArtistId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        }],
+        getAllAlbums: async () => [{
+          id: 28,
+          artistId: 27,
+          title: "Outage Album",
+          foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          path: path.dirname(filePath),
+        }],
+        getTracksByAlbumId: async () => [{
+          id: 29,
+          albumId: 28,
+          title: "Outage Track",
+          trackNumber: 1,
+          foreignRecordingId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          trackFileId: 30,
+        }],
+        getTrackFilesByAlbumId: async () => [{ id: 30, path: filePath, trackIds: [29] }],
+        getRootFolders: async () => [{ path: root }],
+      },
+    });
+
+    const result = await scanConfiguredLibrary({
+      musicRoot: path.join(root, "empty-aurral-root"),
+      lidarrClient: {
+        isConfigured: () => true,
+        request: async () => {
+          throw new Error("Lidarr unavailable");
+        },
+        getAllAlbums: async () => [],
+        getRootFolders: async () => [],
+      },
+    });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.equal(result.lidarr.error, "Lidarr unavailable");
+    assert.equal(file?.available, 1);
+  } finally {
+    if (filePath) deleteIndexedFile("lidarr", filePath);
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -3,7 +3,7 @@ import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 
 const isFilesystemPathKey = (key) => key.toLowerCase().endsWith("path");
 
-function stripFilesystemPaths(value) {
+export function stripFilesystemPaths(value) {
   if (Array.isArray(value)) return value.map(stripFilesystemPaths);
   if (!value || typeof value !== "object") return value;
   return Object.fromEntries(

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -12,6 +12,7 @@ import {
   findCanonicalTracksForAlbum,
   getCanonicalLibraryReadModel,
 } from "../../../services/canonicalLibraryReadAdapter.js";
+import { stripFilesystemPaths } from "./canonical.js";
 
 const AUDIO_CONTENT_TYPES = {
   ".mp3": "audio/mpeg",
@@ -105,8 +106,8 @@ export function registerTracks(router) {
           )
           .find(Boolean);
         const canonicalTracks = album
-          ? findCanonicalTracksForAlbum(tracks, album.id).map(({ path: _path, ...track }) => ({
-              ...track,
+          ? findCanonicalTracksForAlbum(tracks, album.id).map((track) => ({
+              ...stripFilesystemPaths(track),
               streamPath: null,
               streamFormat: null,
             }))


### PR DESCRIPTION
Canonical `/library/tracks?readPath=canonical` responses removed only the top-level `path` field. Nested Lidarr media metadata could still expose host or container filesystem paths.

This change reuses the recursive sanitizer from the canonical snapshot handler before adding the API stream placeholders. It also adds coverage for the read prerequisites this phase depends on: excluded working directories, metadata fallback behavior, and preserving the last indexed library during a Lidarr outage.

Verification:
- `node --test --test-concurrency=1 .tests/library/canonical-read-routes.test.js .tests/library/media-index.test.js` (8 passed)
- Full test suite (581 passed)
- Backend lint passed
- `git diff --check` passed

Known limitation: `streamPath` remains `null` until the authenticated Aurral streaming endpoint is implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved track responses by removing filesystem path information, including paths nested in metadata.
  * Streaming path fields now consistently return `null` when unavailable.
  * Library scans continue showing previously indexed files when external metadata services are unavailable.
  * Added fallback metadata from file paths when standard metadata cannot be retrieved.

* **Tests**
  * Expanded coverage for secure track responses, library scanning, fallback metadata, and service outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->