### PR TITLE
feat(subsonic): add authenticated handshake contract

### DIFF
--- a/.tests/subsonic/subsonic.int.test.js
+++ b/.tests/subsonic/subsonic.int.test.js
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+  startServerProcess,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }] =
+  await setupIsolatedBackend(
+    "subsonic-contract",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/middleware/passwordHash.js",
+  );
+
+let aurral;
+
+function subsonicUrl(method, params = {}) {
+  const query = new URLSearchParams({
+    u: "alice",
+    p: "password123",
+    v: "1.16.1",
+    c: "contract-test",
+    ...params,
+  });
+  return `http://127.0.0.1:${aurral.port}/rest/${method}.view?${query}`;
+}
+
+async function request(method, params) {
+  const response = await fetch(subsonicUrl(method, params));
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  return {
+    response,
+    contentType,
+    body,
+    json: contentType.includes("json") ? JSON.parse(body)["subsonic-response"] : null,
+  };
+}
+
+test.before(async () => {
+  resetDatabase(db);
+  dbOps.updateSettings({ integrations: {}, onboardingComplete: true });
+  userOps.createUser("alice", hashPassword("password123"), "user");
+  aurral = await startServerProcess();
+});
+
+test.after(async () => {
+  await aurral?.stop();
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("authenticates an Aurral user and returns JSON or XML envelopes", async () => {
+  const json = await request("ping", { f: "json" });
+  assert.equal(json.response.status, 200);
+  assert.equal(json.json.status, "ok");
+  assert.equal(json.json.version, "1.16.1");
+  assert.equal(json.json.type, "Aurral");
+  assert.equal(typeof json.json.serverVersion, "string");
+  assert.equal(Object.hasOwn(json.json, "error"), false);
+
+  const encoded = await request("ping", {
+    p: `enc:${Buffer.from("password123").toString("hex")}`,
+    f: "json",
+  });
+  assert.equal(encoded.json.status, "ok");
+
+  const xml = await request("ping");
+  assert.equal(xml.response.status, 200);
+  assert.match(xml.contentType, /application\/xml/);
+  assert.match(xml.body, /<subsonic-response[^>]+status="ok"/);
+  assert.match(xml.body, /xmlns="http:\/\/subsonic\.org\/restapi"/);
+});
+
+test("returns the Subsonic invalid-credentials error", async () => {
+  const result = await request("ping", { p: "wrong-password", f: "json" });
+  assert.equal(result.response.status, 200);
+  assert.deepEqual(result.json.error, {
+    code: 40,
+    message: "Wrong username or password",
+  });
+  assert.equal(result.json.status, "failed");
+});
+
+test("returns protocol errors for unsupported authentication and requests", async () => {
+  const token = await request("ping", { p: "", t: "token", s: "salt", f: "json" });
+  assert.equal(token.json.error.code, 41);
+
+  const unsupported = await request("getArtists", { f: "json" });
+  assert.deepEqual(unsupported.json.error, {
+    code: 0,
+    message: "Unsupported request: getartists",
+  });
+
+  const unsupportedFormat = await request("ping", { f: "jsonp" });
+  assert.match(unsupportedFormat.contentType, /application\/xml/);
+  assert.match(unsupportedFormat.body, /code="0"/);
+});
+
+test("keeps the Subsonic contract after a process restart", async () => {
+  await aurral.stop();
+  aurral = await startServerProcess();
+  const result = await request("ping", { f: "json" });
+  assert.equal(result.json.status, "ok");
+});

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -517,7 +517,7 @@ function migrateLegacyAdmin() {
   }
 }
 
-function resolveUser(username, password) {
+export function resolveUser(username, password) {
   if (userOps.countUsers() === 0) {
     migrateLegacyAdmin();
     if (userOps.countUsers() === 0) return null;

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -1,0 +1,126 @@
+import express from "express";
+
+import { APP_NAME, APP_VERSION } from "../config/constants.js";
+import { resolveUser } from "../middleware/auth.js";
+
+const SUBSONIC_VERSION = "1.16.1";
+const SUBSONIC_NAMESPACE = "http://subsonic.org/restapi";
+const router = express.Router();
+
+const getParameter = (req, name) => {
+  const value = req.query?.[name];
+  return String(Array.isArray(value) ? value[0] || "" : value || "");
+};
+
+const escapeXml = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)(?:\.\d+)?$/.exec(value);
+  return match ? { major: Number(match[1]), minor: Number(match[2]) } : null;
+}
+
+function decodePassword(value) {
+  if (!value.startsWith("enc:")) return value;
+  const encoded = value.slice(4);
+  if (!/^(?:[a-f\d]{2})+$/i.test(encoded)) return null;
+  return Buffer.from(encoded, "hex").toString("utf8");
+}
+
+function responseAttributes(status) {
+  return {
+    status,
+    version: SUBSONIC_VERSION,
+    type: APP_NAME,
+    serverVersion: APP_VERSION,
+  };
+}
+
+function renderXml({ status, error }) {
+  const attributes = Object.entries(responseAttributes(status))
+    .map(([key, value]) => `${key}="${escapeXml(value)}"`)
+    .join(" ");
+  const errorElement = error
+    ? `<error code="${error.code}" message="${escapeXml(error.message)}"/>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<subsonic-response xmlns="${SUBSONIC_NAMESPACE}" ${attributes}>${errorElement}</subsonic-response>`;
+}
+
+function sendResponse(res, format, status = "ok", error = null) {
+  const payload = {
+    "subsonic-response": {
+      ...responseAttributes(status),
+      ...(error ? { error } : {}),
+    },
+  };
+  res.type(format === "json" ? "application/json" : "application/xml");
+  return res.send(format === "json" ? JSON.stringify(payload) : renderXml({ status, error }));
+}
+
+function sendError(res, format, code, message) {
+  return sendResponse(res, format, "failed", { code, message });
+}
+
+function requestedFormat(req) {
+  const format = getParameter(req, "f").toLowerCase() || "xml";
+  return format === "xml" || format === "json" ? format : null;
+}
+
+function validateRequest(req, format) {
+  if (!format) return { format: "xml", error: [0, "Unsupported response format. Use xml or json."] };
+
+  for (const parameter of ["u", "v", "c"]) {
+    if (!getParameter(req, parameter)) {
+      return { format, error: [10, `Required parameter is missing: ${parameter}`] };
+    }
+  }
+
+  const password = getParameter(req, "p");
+  const token = getParameter(req, "t");
+  const salt = getParameter(req, "s");
+  if (!password && !(token && salt)) {
+    return { format, error: [10, "Required parameter is missing: p or t/s"] };
+  }
+
+  const version = parseVersion(getParameter(req, "v"));
+  if (!version) {
+    return { format, error: [20, "Incompatible Subsonic REST protocol version. Client must upgrade."] };
+  }
+  if (version.major > 1 || (version.major === 1 && version.minor > 16)) {
+    return { format, error: [30, "Incompatible Subsonic REST protocol version. Server must upgrade."] };
+  }
+  if (version.major < 1) {
+    return { format, error: [20, "Incompatible Subsonic REST protocol version. Client must upgrade."] };
+  }
+
+  return { format, password, token, salt };
+}
+
+function handleSubsonicRequest(req, res) {
+  const validation = validateRequest(req, requestedFormat(req));
+  if (validation.error) return sendError(res, validation.format, ...validation.error);
+
+  const { format, password, token, salt } = validation;
+  if (token && salt && !password) {
+    return sendError(res, format, 41, "Token authentication is not supported.");
+  }
+
+  const decodedPassword = decodePassword(password);
+  const user = decodedPassword == null ? null : resolveUser(getParameter(req, "u"), decodedPassword);
+  if (!user) return sendError(res, format, 40, "Wrong username or password");
+  req.user = user;
+
+  const method = String(req.params.method || "").replace(/\.view$/i, "").toLowerCase();
+  if (method !== "ping") return sendError(res, format, 0, `Unsupported request: ${method}`);
+  return sendResponse(res, format);
+}
+
+router.all("/:method", handleSubsonicRequest);
+router.use((_req, res) => sendError(res, "xml", 0, "Unsupported request"));
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -38,6 +38,7 @@ import imageProxyRouter from "./routes/imageProxy.js";
 import lidarrFeedRouter from "./routes/lidarrFeed.js";
 import inboxRouter from "./routes/inbox.js";
 import newsRouter from "./routes/news.js";
+import subsonicRouter from "./routes/subsonic.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -196,6 +197,7 @@ app.use("/api/weekly-flow", (req, res) => {
 });
 app.use("/api/auth", authRouter);
 app.use("/api/image-proxy", imageProxyRouter);
+app.use("/rest", subsonicRouter);
 
 app.get("/sso/callback", async (req, res) => {
   try {

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -7,6 +7,8 @@ Navidrome is optional. Aurral creates and updates Navidrome playlists through th
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
+Aurral also exposes an authenticated Subsonic handshake at `/rest/ping.view`. It supports XML and JSON responses and identifies the running server version. Browsing, artwork, streaming, playlists, and transcoding are not available through this endpoint yet. Navidrome remains the playback server.
+
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
 
 ```yaml


### PR DESCRIPTION
Subsonic clients need an authenticated handshake before Aurral can serve media. This adds the smallest server contract without starting the media endpoint work.

The server now exposes `/rest/ping.view` with Aurral-user authentication, server identity, JSON/XML envelopes, version checks, and compatible protocol errors. Protocol handling stays at the route boundary; no canonical library service or media endpoint is called yet.

## Linked issues

- AURRALOWNE-15: Define Aurral's Subsonic server contract

## Test plan

- `node --test --import ./.tests/setup-env.js --test-concurrency=1 .tests/subsonic/subsonic.int.test.js` — 4 passed
- `npm test` — 581 passed
- `npm run lint` and `npm run lint:backend` — passed
- `git diff --check` and `node --check backend/routes/subsonic.js` — passed
- Manual coverage includes authenticated JSON and XML `ping`, invalid credentials, unsupported requests and formats, and process restart persistence.

## Release impact

Adds the authenticated `/rest/ping.view` handshake. It adds no migration and does not change Navidrome, Lidarr ownership, or media behavior. Browsing, artwork, streaming, playlists, and transcoding remain out of scope.

Known limitation: `t/s` token authentication returns protocol error 41 because Aurral stores one-way password hashes and does not retain reversible password material.