### PR TITLE
feat(subsonic): serve canonical library media

### DIFF
--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+  startServerProcess,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }] =
+  await setupIsolatedBackend(
+    "subsonic-canonical",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/middleware/passwordHash.js",
+    "backend/services/libraryLidarrIndexer.js",
+    "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
+    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  );
+
+let aurral;
+let fixtureRoot;
+let fixturePath;
+
+function subsonicUrl(method, params = {}) {
+  const query = new URLSearchParams({
+    u: "alice",
+    p: "password123",
+    v: "1.16.1",
+    c: "canonical-test",
+    f: "json",
+    ...params,
+  });
+  return `http://127.0.0.1:${aurral.port}/rest/${method}.view?${query}`;
+}
+
+async function request(method, params = {}, options = {}) {
+  const response = await fetch(subsonicUrl(method, params), options);
+  const contentType = response.headers.get("content-type") || "";
+  return {
+    response,
+    contentType,
+    body: await response.text(),
+  };
+}
+
+function responseJson(result) {
+  return JSON.parse(result.body)["subsonic-response"];
+}
+
+test.before(async () => {
+  resetDatabase(db);
+  dbOps.updateSettings({ integrations: {}, onboardingComplete: true });
+  userOps.createUser("alice", hashPassword("password123"), "admin");
+
+  fixtureRoot = await mkdtemp(path.join(isolatedState.baseDir, "media-"));
+  fixturePath = path.join(fixtureRoot, "Canonical Artist", "Canonical Album", "01 Canonical Song.flac");
+  await mkdir(path.dirname(fixturePath), { recursive: true });
+  await writeFile(fixturePath, "0123456789");
+  await indexLidarrLibrary({
+    client: {
+      isConfigured: () => true,
+      request: async () => [{
+        id: 1,
+        artistName: "Canonical Artist",
+        sortName: "Canonical Artist",
+        foreignArtistId: "11111111-1111-4111-8111-111111111111",
+      }],
+      getAllAlbums: async () => [{
+        id: 2,
+        artistId: 1,
+        title: "Canonical Album",
+        foreignAlbumId: "22222222-2222-4222-8222-222222222222",
+      }],
+      getTracksByAlbumId: async () => [{
+        id: 3,
+        albumId: 2,
+        title: "Canonical Song",
+        trackNumber: 1,
+        duration: 10,
+        foreignRecordingId: "33333333-3333-4333-8333-333333333333",
+        trackFileId: 4,
+      }],
+      getTrackFilesByAlbumId: async () => [{
+        id: 4,
+        path: fixturePath,
+        trackIds: [3],
+        duration: 10,
+        mediaInfo: { audioFormat: "FLAC" },
+      }],
+      getRootFolders: async () => [{ path: fixtureRoot }],
+    },
+  });
+
+  const flow = flowPlaylistConfig.createFlow({ name: "Canonical Flow", size: 1 });
+  const jobId = downloadTracker.addJob({
+    artistName: "Flow Artist",
+    albumName: "Flow Album",
+    trackName: "Flow Song",
+    durationMs: 1000,
+  }, flow.id);
+  downloadTracker.setDone(jobId, fixturePath);
+  aurral = await startServerProcess();
+});
+
+test.after(async () => {
+  await aurral?.stop();
+  await rm(fixtureRoot, { recursive: true, force: true });
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("browses canonical artists, albums, and songs with stable protocol IDs", async () => {
+  const artistsResult = responseJson(await request("getArtists"));
+  const artist = artistsResult.artists.index[0].artist[0];
+  assert.match(artist.id, /^artist:/);
+  const artistsXml = await request("getArtists", { f: "xml" });
+  assert.match(artistsXml.body, /<artists><index name="C"><artist id="artist:/);
+
+  const albumResult = responseJson(await request("getArtist", { id: artist.id }));
+  const album = albumResult.artist.album[0];
+  assert.match(album.id, /^album:/);
+
+  const songResult = responseJson(await request("getAlbum", { id: album.id }));
+  const song = songResult.album.song[0];
+  assert.match(song.id, /^song:/);
+  assert.equal(responseJson(await request("getSong", { id: song.id })).song.title, "Canonical Song");
+});
+
+test("searches canonical records and exposes flow entries as playlist items", async () => {
+  const search = responseJson(await request("search3", { query: "Canonical" }));
+  assert.equal(search.searchResult3.artist[0].name, "Canonical Artist");
+  assert.equal(search.searchResult3.song[0].title, "Canonical Song");
+
+  const playlists = responseJson(await request("getPlaylists"));
+  const flow = playlists.playlists.playlist.find((entry) => entry.name === "Canonical Flow");
+  assert.ok(flow);
+  const playlist = responseJson(await request("getPlaylist", { id: flow.id }));
+  assert.equal(playlist.playlist.entry[0].title, "Flow Song");
+});
+
+test("streams canonical files with full and range responses", async () => {
+  const artist = responseJson(await request("getArtists")).artists.index[0].artist[0];
+  const album = responseJson(await request("getArtist", { id: artist.id })).artist.album[0];
+  const song = responseJson(await request("getAlbum", { id: album.id })).album.song[0];
+
+  const full = await request("stream", { id: song.id });
+  assert.equal(full.response.status, 200);
+  assert.equal(full.body, "0123456789");
+  assert.equal(full.response.headers.get("accept-ranges"), "bytes");
+
+  const range = await request("stream", { id: song.id }, { headers: { Range: "bytes=3-5" } });
+  assert.equal(range.response.status, 206);
+  assert.equal(range.body, "345");
+  assert.equal(range.response.headers.get("content-range"), "bytes 3-5/10");
+
+  const suffix = await request("stream", { id: song.id }, { headers: { Range: "bytes=-3" } });
+  assert.equal(suffix.response.status, 206);
+  assert.equal(suffix.body, "789");
+});
+
+test("returns missing files and stale IDs without exposing filesystem paths", async () => {
+  const artist = responseJson(await request("getArtists")).artists.index[0].artist[0];
+  const album = responseJson(await request("getArtist", { id: artist.id })).artist.album[0];
+  const song = responseJson(await request("getAlbum", { id: album.id })).album.song[0];
+  await rm(fixturePath);
+
+  const missing = await request("stream", { id: song.id });
+  assert.equal(missing.response.status, 404);
+
+  const stale = await request("getSong", { id: "song:missing-identity" });
+  assert.equal(responseJson(stale).error.code, 70);
+  assert.equal(stale.body.includes(fixturePath), false);
+});
+
+test("keeps canonical protocol IDs and flow entries after restart", async () => {
+  const before = responseJson(await request("getArtists")).artists.index[0].artist[0].id;
+  await aurral.stop();
+  aurral = await startServerProcess();
+  const after = responseJson(await request("getArtists")).artists.index[0].artist[0].id;
+  assert.equal(after, before);
+  assert.equal(responseJson(await request("getPlaylists")).playlists.playlist[0].name, "Canonical Flow");
+});
+
+test("returns the canonical artwork redirect contract", async () => {
+  const artist = responseJson(await request("getArtists")).artists.index[0].artist[0];
+  dbOps.setImage("11111111-1111-4111-8111-111111111111", "https://example.com/cover.jpg");
+  const result = await request("getCoverArt", { id: artist.id }, { redirect: "manual" });
+  assert.equal(result.response.status, 302);
+  assert.match(result.response.headers.get("location"), /image-proxy/);
+});

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -116,8 +116,14 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   const artistsResult = responseJson(await request("getArtists"));
   const artist = artistsResult.artists.index[0].artist[0];
   assert.match(artist.id, /^artist:/);
+  assert.equal(artistsResult.artists.ignoredArticles, "The El La Los Las Le Les");
   const artistsXml = await request("getArtists", { f: "xml" });
-  assert.match(artistsXml.body, /<artists><index name="C"><artist id="artist:/);
+  assert.match(artistsXml.body, /<artists[^>]*><index name="C"><artist id="artist:/);
+
+  const license = responseJson(await request("getLicense"));
+  assert.equal(license.license.valid, true);
+  const indexes = responseJson(await request("getIndexes"));
+  assert.equal(typeof indexes.indexes.lastModified, "number");
 
   const albumResult = responseJson(await request("getArtist", { id: artist.id }));
   const album = albumResult.artist.album[0];
@@ -159,6 +165,17 @@ test("streams canonical files with full and range responses", async () => {
   const suffix = await request("stream", { id: song.id }, { headers: { Range: "bytes=-3" } });
   assert.equal(suffix.response.status, 206);
   assert.equal(suffix.body, "789");
+
+  const invalid = await request("stream", { id: song.id }, { headers: { Range: "not-a-range" } });
+  assert.equal(invalid.response.status, 200);
+  assert.equal(invalid.body, "0123456789");
+
+  const unsatisfiable = await request(
+    "stream",
+    { id: song.id },
+    { headers: { Range: "bytes=99-" } },
+  );
+  assert.equal(unsatisfiable.response.status, 416);
 });
 
 test("returns missing files and stale IDs without exposing filesystem paths", async () => {

--- a/.tests/subsonic/subsonic.int.test.js
+++ b/.tests/subsonic/subsonic.int.test.js
@@ -89,10 +89,10 @@ test("returns protocol errors for unsupported authentication and requests", asyn
   const token = await request("ping", { p: "", t: "token", s: "salt", f: "json" });
   assert.equal(token.json.error.code, 41);
 
-  const unsupported = await request("getArtists", { f: "json" });
+  const unsupported = await request("getVideos", { f: "json" });
   assert.deepEqual(unsupported.json.error, {
     code: 0,
-    message: "Unsupported request: getartists",
+    message: "Unsupported request: getvideos",
   });
 
   const unsupportedFormat = await request("ping", { f: "jsonp" });

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -4,7 +4,6 @@ import { noCache } from "../../../middleware/cache.js";
 import { verifyTokenAuth } from "../../../middleware/auth.js";
 import { getAlbumTracksByAlbumMbid } from "../../../services/providers/brainzmashProvider.js";
 import { enrichTracksWithDeezerPreviews } from "../../../services/apiClients/index.js";
-import fs from "fs";
 import fsp from "fs/promises";
 import path from "path";
 import { logger } from "../../../services/logger.js";
@@ -13,15 +12,7 @@ import {
   getCanonicalLibraryReadModel,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 import { stripFilesystemPaths } from "./canonical.js";
-
-const AUDIO_CONTENT_TYPES = {
-  ".mp3": "audio/mpeg",
-  ".m4a": "audio/mp4",
-  ".aac": "audio/aac",
-  ".flac": "audio/flac",
-  ".ogg": "audio/ogg",
-  ".wav": "audio/wav",
-};
+import { streamAudioFile } from "../../../services/audioFileStream.js";
 
 const canReadAudioFile = async (filePath) => {
   if (!filePath) return false;
@@ -31,47 +22,6 @@ const canReadAudioFile = async (filePath) => {
   } catch {
     return false;
   }
-};
-
-const streamAudioFile = async (req, res, filePath) => {
-  let stat;
-  try {
-    stat = await fsp.stat(filePath);
-    if (!stat.isFile()) {
-      return res.status(404).json({ error: "Track file missing" });
-    }
-  } catch {
-    return res.status(404).json({ error: "Track file missing" });
-  }
-
-  const ext = path.extname(filePath).toLowerCase();
-  res.setHeader("Content-Type", AUDIO_CONTENT_TYPES[ext] || "application/octet-stream");
-  res.setHeader("Accept-Ranges", "bytes");
-
-  const range = req.headers.range;
-  if (!range) {
-    res.setHeader("Content-Length", stat.size);
-    fs.createReadStream(filePath).pipe(res);
-    return;
-  }
-
-  const match = /bytes=(\d*)-(\d*)/.exec(range);
-  if (!match) {
-    res.status(416).end();
-    return;
-  }
-  const rawStart = match[1] ? Number(match[1]) : 0;
-  const rawEnd = match[2] ? Number(match[2]) : stat.size - 1;
-  const start = Number.isFinite(rawStart) ? rawStart : 0;
-  const end = Number.isFinite(rawEnd) ? rawEnd : stat.size - 1;
-  if (start < 0 || end < start || end >= stat.size) {
-    res.status(416).end();
-    return;
-  }
-  res.status(206);
-  res.setHeader("Content-Range", `bytes ${start}-${end}/${stat.size}`);
-  res.setHeader("Content-Length", end - start + 1);
-  fs.createReadStream(filePath, { start, end }).pipe(res);
 };
 
 export function registerTracks(router) {
@@ -233,7 +183,9 @@ export function registerTracks(router) {
       if (!track?.hasFile || !track.path) {
         return res.status(404).json({ error: "Track file missing" });
       }
-      return streamAudioFile(req, res, track.path);
+      if (!(await streamAudioFile(req, res, track.path))) {
+        if (!res.headersSent) return res.status(404).json({ error: "Track file missing" });
+      }
     } catch (error) {
       if (!res.headersSent) {
         res.status(500).json({

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -2,6 +2,19 @@ import express from "express";
 
 import { APP_NAME, APP_VERSION } from "../config/constants.js";
 import { resolveUser } from "../middleware/auth.js";
+import { streamAudioFile } from "../services/audioFileStream.js";
+import {
+  getAlbum,
+  getArtist,
+  getFlowPlaylist,
+  getFlowPlaylists,
+  getMusicDirectory,
+  getSong,
+  listArtists,
+  resolveArtworkUrl,
+  resolveStreamPath,
+  searchLibrary,
+} from "../services/subsonicLibraryService.js";
 
 const SUBSONIC_VERSION = "1.16.1";
 const SUBSONIC_NAMESPACE = "http://subsonic.org/restapi";
@@ -41,25 +54,49 @@ function responseAttributes(status) {
   };
 }
 
-function renderXml({ status, error }) {
+function renderXmlElement(name, value) {
+  if (Array.isArray(value)) return value.map((entry) => renderXmlElement(name, entry)).join("");
+  if (value == null) return "";
+  if (typeof value !== "object") {
+    return `<${name}>${escapeXml(value)}</${name}>`;
+  }
+
+  const attributes = [];
+  const children = [];
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry == null || entry === undefined) continue;
+    if (typeof entry === "object") children.push(renderXmlElement(key, entry));
+    else attributes.push(`${key}="${escapeXml(entry)}"`);
+  }
+  const opening = `<${name}${attributes.length ? ` ${attributes.join(" ")}` : ""}>`;
+  return children.length ? `${opening}${children.join("")}</${name}>` : opening.slice(0, -1) + "/>";
+}
+
+function renderXml({ status, data = {}, error }) {
   const attributes = Object.entries(responseAttributes(status))
     .map(([key, value]) => `${key}="${escapeXml(value)}"`)
     .join(" ");
-  const errorElement = error
+  const body = error
     ? `<error code="${error.code}" message="${escapeXml(error.message)}"/>`
-    : "";
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<subsonic-response xmlns="${SUBSONIC_NAMESPACE}" ${attributes}>${errorElement}</subsonic-response>`;
+    : Object.entries(data)
+        .map(([key, value]) => renderXmlElement(key, value))
+        .join("");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<subsonic-response xmlns="${SUBSONIC_NAMESPACE}" ${attributes}>${body}</subsonic-response>`;
 }
 
-function sendResponse(res, format, status = "ok", error = null) {
+function sendResponse(res, format, status = "ok", error = null, data = {}) {
   const payload = {
     "subsonic-response": {
       ...responseAttributes(status),
-      ...(error ? { error } : {}),
+      ...(error ? { error } : data),
     },
   };
   res.type(format === "json" ? "application/json" : "application/xml");
-  return res.send(format === "json" ? JSON.stringify(payload) : renderXml({ status, error }));
+  return res.send(
+    format === "json"
+      ? JSON.stringify(payload)
+      : renderXml({ status, data, error }),
+  );
 }
 
 function sendError(res, format, code, message) {
@@ -101,7 +138,22 @@ function validateRequest(req, format) {
   return { format, password, token, salt };
 }
 
-function handleSubsonicRequest(req, res) {
+const groupArtists = (artists) => {
+  const groups = new Map();
+  for (const artist of artists) {
+    const name = String(artist.name || "#");
+    const key = name.slice(0, 1).toUpperCase();
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(artist);
+  }
+  return [...groups.entries()].map(([name, artist]) => ({ name, artist }));
+};
+
+function handleBinaryError(res, message = "Requested media was not found") {
+  return res.status(404).set("Content-Type", "text/plain; charset=utf-8").send(message);
+}
+
+async function handleSubsonicRequest(req, res) {
   const validation = validateRequest(req, requestedFormat(req));
   if (validation.error) return sendError(res, validation.format, ...validation.error);
 
@@ -116,11 +168,73 @@ function handleSubsonicRequest(req, res) {
   req.user = user;
 
   const method = String(req.params.method || "").replace(/\.view$/i, "").toLowerCase();
-  if (method !== "ping") return sendError(res, format, 0, `Unsupported request: ${method}`);
-  return sendResponse(res, format);
+  if (method === "ping") return sendResponse(res, format);
+  if (method === "getmusicfolders") {
+    return sendResponse(res, format, "ok", null, {
+      musicFolders: { musicFolder: [{ id: "root", name: APP_NAME }] },
+    });
+  }
+  if (method === "getartists" || method === "getindexes") {
+    const indexes = groupArtists(listArtists());
+    return sendResponse(res, format, "ok", null, {
+      [method === "getartists" ? "artists" : "indexes"]: { index: indexes },
+    });
+  }
+  if (method === "getartist") {
+    const artist = getArtist(getParameter(req, "id"));
+    return artist
+      ? sendResponse(res, format, "ok", null, { artist })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "getalbum") {
+    const album = getAlbum(getParameter(req, "id"));
+    return album
+      ? sendResponse(res, format, "ok", null, { album })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "getsong") {
+    const song = getSong(getParameter(req, "id"), user);
+    return song
+      ? sendResponse(res, format, "ok", null, { song })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "getmusicdirectory") {
+    const directory = getMusicDirectory(getParameter(req, "id"));
+    return directory
+      ? sendResponse(res, format, "ok", null, { directory })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "search3" || method === "search2") {
+    const query = getParameter(req, "query");
+    if (!query) return sendError(res, format, 10, "Required parameter is missing: query");
+    return sendResponse(res, format, "ok", null, {
+      [method === "search3" ? "searchResult3" : "searchResult2"]: searchLibrary(query, req.query),
+    });
+  }
+  if (method === "getplaylists") {
+    return sendResponse(res, format, "ok", null, { playlists: { playlist: getFlowPlaylists(user) } });
+  }
+  if (method === "getplaylist") {
+    const playlist = getFlowPlaylist(getParameter(req, "id"), user);
+    return playlist
+      ? sendResponse(res, format, "ok", null, { playlist })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "stream" || method === "download") {
+    const filePath = resolveStreamPath(getParameter(req, "id"), user);
+    if (!filePath) return handleBinaryError(res, "Track file missing");
+    const streamed = await streamAudioFile(req, res, filePath);
+    return streamed || res.headersSent ? undefined : handleBinaryError(res, "Track file missing");
+  }
+  if (method === "getcoverart") {
+    const artworkUrl = await resolveArtworkUrl(getParameter(req, "id"));
+    return artworkUrl ? res.redirect(302, artworkUrl) : handleBinaryError(res, "Cover art not found");
+  }
+  return sendError(res, format, 0, `Unsupported request: ${method}`);
 }
 
 router.all("/:method", handleSubsonicRequest);
 router.use((_req, res) => sendError(res, "xml", 0, "Unsupported request"));
 
+export { groupArtists, renderXmlElement };
 export default router;

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -169,6 +169,9 @@ async function handleSubsonicRequest(req, res) {
 
   const method = String(req.params.method || "").replace(/\.view$/i, "").toLowerCase();
   if (method === "ping") return sendResponse(res, format);
+  if (method === "getlicense") {
+    return sendResponse(res, format, "ok", null, { license: { valid: true } });
+  }
   if (method === "getmusicfolders") {
     return sendResponse(res, format, "ok", null, {
       musicFolders: { musicFolder: [{ id: "root", name: APP_NAME }] },
@@ -177,7 +180,11 @@ async function handleSubsonicRequest(req, res) {
   if (method === "getartists" || method === "getindexes") {
     const indexes = groupArtists(listArtists());
     return sendResponse(res, format, "ok", null, {
-      [method === "getartists" ? "artists" : "indexes"]: { index: indexes },
+      [method === "getartists" ? "artists" : "indexes"]: {
+        ignoredArticles: "The El La Los Las Le Les",
+        ...(method === "getindexes" ? { lastModified: Date.now() } : {}),
+        index: indexes,
+      },
     });
   }
   if (method === "getartist") {

--- a/backend/services/audioFileStream.js
+++ b/backend/services/audioFileStream.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 
 export const AUDIO_CONTENT_TYPES = {
   ".mp3": "audio/mpeg",
@@ -12,21 +13,42 @@ export const AUDIO_CONTENT_TYPES = {
 };
 
 function parseRangeHeader(value, size) {
-  const match = /^bytes=(\d*)-(\d*)$/.exec(String(value || "").trim());
-  if (!match || size <= 0) return null;
+  const match = /^([a-z][a-z0-9+.-]*)=(.*)$/i.exec(String(value || "").trim());
+  if (!match || match[1].toLowerCase() !== "bytes" || match[2].includes(",")) return null;
 
-  const hasStart = match[1] !== "";
-  const hasEnd = match[2] !== "";
+  const rangeMatch = /^(\d*)-(\d*)$/.exec(match[2]);
+  if (!rangeMatch) return null;
+
+  const hasStart = rangeMatch[1] !== "";
+  const hasEnd = rangeMatch[2] !== "";
   if (!hasStart && !hasEnd) return null;
+  if (size <= 0) return { unsatisfiable: true };
 
-  let start = hasStart ? Number(match[1]) : Math.max(size - Number(match[2]), 0);
-  let end = hasStart && hasEnd ? Number(match[2]) : size - 1;
-  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return null;
-  if (hasStart && !hasEnd) end = size - 1;
-  if (!hasStart && Number(match[2]) <= 0) return null;
-  if (end >= size) end = size - 1;
-  if (start < 0 || start >= size || end < start) return null;
+  const sizeValue = BigInt(size);
+  const startValue = hasStart ? BigInt(rangeMatch[1]) : null;
+  const endValue = hasEnd ? BigInt(rangeMatch[2]) : null;
+  if (!hasStart && endValue === 0n) return { unsatisfiable: true };
+
+  if (!hasStart) {
+    return {
+      start: endValue >= sizeValue ? 0 : Number(sizeValue - endValue),
+      end: size - 1,
+    };
+  }
+
+  if (startValue >= sizeValue) return { unsatisfiable: true };
+  const start = Number(startValue);
+  const end = !hasEnd || endValue >= sizeValue ? size - 1 : Number(endValue);
+  if (end < start) return { unsatisfiable: true };
   return { start, end };
+}
+
+async function pipeToResponse(filePath, res, options) {
+  try {
+    await pipeline(fs.createReadStream(filePath, options), res);
+  } catch {
+    if (!res.destroyed) res.destroy();
+  }
 }
 
 export async function streamAudioFile(req, res, filePath) {
@@ -46,12 +68,17 @@ export async function streamAudioFile(req, res, filePath) {
 
   if (!req.headers.range) {
     res.setHeader("Content-Length", stat.size);
-    fs.createReadStream(filePath).pipe(res);
+    await pipeToResponse(filePath, res);
     return true;
   }
 
   const range = parseRangeHeader(req.headers.range, stat.size);
   if (!range) {
+    res.setHeader("Content-Length", stat.size);
+    await pipeToResponse(filePath, res);
+    return true;
+  }
+  if (range.unsatisfiable) {
     res.status(416).setHeader("Content-Range", `bytes */${stat.size}`).end();
     return false;
   }
@@ -59,7 +86,7 @@ export async function streamAudioFile(req, res, filePath) {
   res.status(206);
   res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
   res.setHeader("Content-Length", range.end - range.start + 1);
-  fs.createReadStream(filePath, range).pipe(res);
+  await pipeToResponse(filePath, res, range);
   return true;
 }
 

--- a/backend/services/audioFileStream.js
+++ b/backend/services/audioFileStream.js
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+export const AUDIO_CONTENT_TYPES = {
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
+  ".flac": "audio/flac",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+};
+
+function parseRangeHeader(value, size) {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(String(value || "").trim());
+  if (!match || size <= 0) return null;
+
+  const hasStart = match[1] !== "";
+  const hasEnd = match[2] !== "";
+  if (!hasStart && !hasEnd) return null;
+
+  let start = hasStart ? Number(match[1]) : Math.max(size - Number(match[2]), 0);
+  let end = hasStart && hasEnd ? Number(match[2]) : size - 1;
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return null;
+  if (hasStart && !hasEnd) end = size - 1;
+  if (!hasStart && Number(match[2]) <= 0) return null;
+  if (end >= size) end = size - 1;
+  if (start < 0 || start >= size || end < start) return null;
+  return { start, end };
+}
+
+export async function streamAudioFile(req, res, filePath) {
+  let stat;
+  try {
+    stat = await fsp.stat(filePath);
+    if (!stat.isFile()) return false;
+  } catch {
+    return false;
+  }
+
+  res.setHeader(
+    "Content-Type",
+    AUDIO_CONTENT_TYPES[path.extname(filePath).toLowerCase()] || "application/octet-stream",
+  );
+  res.setHeader("Accept-Ranges", "bytes");
+
+  if (!req.headers.range) {
+    res.setHeader("Content-Length", stat.size);
+    fs.createReadStream(filePath).pipe(res);
+    return true;
+  }
+
+  const range = parseRangeHeader(req.headers.range, stat.size);
+  if (!range) {
+    res.status(416).setHeader("Content-Range", `bytes */${stat.size}`).end();
+    return false;
+  }
+
+  res.status(206);
+  res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
+  res.setHeader("Content-Length", range.end - range.start + 1);
+  fs.createReadStream(filePath, range).pipe(res);
+  return true;
+}
+
+export { parseRangeHeader };

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -47,19 +47,21 @@ const visibleFlows = (user) =>
 
 const findAlbumForTrack = (library, track) => {
   const relation = track?.albums?.[0];
-  return library.albums.find((album) => album.id === relation?.albumId) || null;
+  return library.albumsById.get(relation?.albumId) || null;
 };
 
 const findArtistForAlbum = (library, album) =>
-  library.artists.find((artist) => artist.id === album?.artistId) || null;
+  library.artistsById.get(album?.artistId) || null;
 
 const albumTracks = (library, album) =>
   (album?.trackIds || [])
-    .map((trackId) => library.tracks.find((track) => track.id === trackId))
+    .map((trackId) => library.tracksById.get(trackId))
     .filter(Boolean);
 
 const artistAlbums = (library, artist) =>
-  library.albums.filter((album) => album.artistId === artist?.id);
+  (artist?.albumIds || [])
+    .map((albumId) => library.albumsById.get(albumId))
+    .filter(Boolean);
 
 const coverArtForAlbum = (album) => idFor("album", album.identityKey);
 
@@ -67,6 +69,7 @@ const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   const artist = findArtistForAlbum(library, album);
   const file = firstFile(track);
   const genres = track.metadata?.common?.genre || track.metadata?.genre;
+  const relation = track.albums?.find((entry) => entry.albumId === album?.id);
   return {
     id: idFor("song", track.identityKey),
     parent: album ? idFor("album", album.identityKey) : null,
@@ -76,11 +79,8 @@ const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
     artist: artist?.name || track.artistName || null,
     albumId: album ? idFor("album", album.identityKey) : null,
     artistId: artist ? idFor("artist", artist.identityKey) : null,
-    track: album
-      ? album.trackIds
-          .map((trackId) => library.tracks.find((entry) => entry.id === trackId))
-          .findIndex((entry) => entry?.id === track.id) + 1
-      : 0,
+    track: Number(relation?.trackNumber) || 0,
+    discNumber: Number(relation?.discNumber) || null,
     year: year(album?.releaseDate),
     genre: (Array.isArray(genres) ? genres[0] : genres) || null,
     coverArt: album ? coverArtForAlbum(album) : null,
@@ -91,20 +91,29 @@ const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   };
 };
 
-const toAlbum = (library, album) => {
+const albumData = (library, album) => {
   const artist = findArtistForAlbum(library, album);
   const tracks = albumTracks(library, album);
   return {
-    id: idFor("album", album.identityKey),
-    name: album.title,
-    artist: artist?.name || album.albumArtist || null,
-    artistId: artist ? idFor("artist", artist.identityKey) : null,
-    coverArt: coverArtForAlbum(album),
-    songCount: tracks.length,
-    duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
-    year: year(album.releaseDate),
-    song: tracks.map((track) => toSong(library, track, album)),
+    tracks,
+    value: {
+      id: idFor("album", album.identityKey),
+      name: album.title,
+      artist: artist?.name || album.albumArtist || null,
+      artistId: artist ? idFor("artist", artist.identityKey) : null,
+      coverArt: coverArtForAlbum(album),
+      songCount: tracks.length,
+      duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
+      year: year(album.releaseDate),
+    },
   };
+};
+
+const toAlbumSummary = (library, album) => albumData(library, album).value;
+
+const toAlbum = (library, album) => {
+  const { tracks, value } = albumData(library, album);
+  return { ...value, song: tracks.map((track) => toSong(library, track, album)) };
 };
 
 const toArtist = (library, artist) => {
@@ -114,10 +123,7 @@ const toArtist = (library, artist) => {
     name: artist.name,
     coverArt: idFor("artist", artist.identityKey),
     albumCount: albums.length,
-    album: albums.map((album) => ({
-      ...toAlbum(library, album),
-      song: undefined,
-    })),
+    album: albums.map((album) => toAlbumSummary(library, album)),
   };
 };
 
@@ -129,19 +135,28 @@ const toArtistSummary = (artist) => ({
 });
 
 function readLibrary() {
-  return getCanonicalLibrary({ availableOnly: false });
+  const library = getCanonicalLibrary({ availableOnly: false });
+  return {
+    ...library,
+    artistsById: new Map(library.artists.map((artist) => [artist.id, artist])),
+    albumsById: new Map(library.albums.map((album) => [album.id, album])),
+    tracksById: new Map(library.tracks.map((track) => [track.id, track])),
+    artistsByIdentity: new Map(library.artists.map((artist) => [artist.identityKey, artist])),
+    albumsByIdentity: new Map(library.albums.map((album) => [album.identityKey, album])),
+    tracksByIdentity: new Map(library.tracks.map((track) => [track.identityKey, track])),
+  };
 }
 
 function findCanonical(library, parsed) {
   if (!parsed) return null;
   if (parsed.kind === "artist") {
-    return library.artists.find((artist) => artist.identityKey === parsed.key) || null;
+    return library.artistsByIdentity.get(parsed.key) || null;
   }
   if (parsed.kind === "album") {
-    return library.albums.find((album) => album.identityKey === parsed.key) || null;
+    return library.albumsByIdentity.get(parsed.key) || null;
   }
   if (parsed.kind === "song") {
-    return library.tracks.find((track) => track.identityKey === parsed.key) || null;
+    return library.tracksByIdentity.get(parsed.key) || null;
   }
   return null;
 }
@@ -247,17 +262,16 @@ export function getMusicDirectory(value) {
 export function searchLibrary(query, options = {}) {
   const needle = String(query || "").trim().toLocaleLowerCase();
   const library = readLibrary();
-  const artists = library.artists
-    .filter((artist) => artist.name.toLocaleLowerCase().includes(needle))
-    .map(toArtistSummary);
+  const artists = library.artists.filter((artist) =>
+    artist.name.toLocaleLowerCase().includes(needle),
+  );
   const albums = library.albums
     .filter((album) => {
       const artist = findArtistForAlbum(library, album);
       return [album.title, album.albumArtist, artist?.name].some((value) =>
         String(value || "").toLocaleLowerCase().includes(needle),
       );
-    })
-    .map((album) => ({ ...toAlbum(library, album), song: undefined }));
+    });
   const songs = library.tracks
     .filter((track) => {
       const album = findAlbumForTrack(library, track);
@@ -265,13 +279,18 @@ export function searchLibrary(query, options = {}) {
       return [track.title, track.artistName, album?.title, artist?.name].some((value) =>
         String(value || "").toLocaleLowerCase().includes(needle),
       );
-    })
-    .map((track) => toSong(library, track));
+    });
   const page = (items, count, offset) => items.slice(offset, offset + count);
   return {
-    artist: page(artists, normalizeLimit(options.artistCount), normalizeOffset(options.artistOffset)),
-    album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)),
-    song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)),
+    artist: page(artists, normalizeLimit(options.artistCount), normalizeOffset(options.artistOffset)).map(
+      toArtistSummary,
+    ),
+    album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)).map(
+      (album) => toAlbumSummary(library, album),
+    ),
+    song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)).map(
+      (track) => toSong(library, track),
+    ),
   };
 }
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -1,0 +1,356 @@
+import { dbOps } from "../db/helpers/index.js";
+import { getCanonicalLibrary } from "./libraryQueryService.js";
+import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
+import { getArtistImage } from "./imageService.js";
+import { buildImageProxyUrl } from "./imageProxyService.js";
+import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
+import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
+import { hasPermission } from "../middleware/auth.js";
+
+const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
+
+const parseId = (value) => {
+  const match = /^(artist|album|song|flow|flow-song):(.+)$/.exec(String(value || ""));
+  if (!match) return null;
+  try {
+    return { kind: match[1], key: decodeURIComponent(match[2]) };
+  } catch {
+    return null;
+  }
+};
+
+const firstFile = (track) =>
+  (track?.files || []).find((file) => file.available) || (track?.files || [])[0] || null;
+
+const seconds = (durationMs) => {
+  const value = Number(durationMs);
+  return Number.isFinite(value) && value > 0 ? Math.round(value / 1000) : 0;
+};
+
+const year = (value) => {
+  const match = /^(\d{4})/.exec(String(value || ""));
+  return match ? Number(match[1]) : null;
+};
+
+const normalizeLimit = (value, fallback = 20) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? Math.min(Math.max(parsed, 0), 500) : fallback;
+};
+
+const normalizeOffset = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? Math.max(parsed, 0) : 0;
+};
+
+const visibleFlows = (user) =>
+  user && hasPermission(user, "accessFlow") ? flowPlaylistConfig.getFlowsForUser(user) : [];
+
+const findAlbumForTrack = (library, track) => {
+  const relation = track?.albums?.[0];
+  return library.albums.find((album) => album.id === relation?.albumId) || null;
+};
+
+const findArtistForAlbum = (library, album) =>
+  library.artists.find((artist) => artist.id === album?.artistId) || null;
+
+const albumTracks = (library, album) =>
+  (album?.trackIds || [])
+    .map((trackId) => library.tracks.find((track) => track.id === trackId))
+    .filter(Boolean);
+
+const artistAlbums = (library, artist) =>
+  library.albums.filter((album) => album.artistId === artist?.id);
+
+const coverArtForAlbum = (album) => idFor("album", album.identityKey);
+
+const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
+  const artist = findArtistForAlbum(library, album);
+  const file = firstFile(track);
+  const genres = track.metadata?.common?.genre || track.metadata?.genre;
+  return {
+    id: idFor("song", track.identityKey),
+    parent: album ? idFor("album", album.identityKey) : null,
+    isDir: false,
+    title: track.title,
+    album: album?.title || null,
+    artist: artist?.name || track.artistName || null,
+    albumId: album ? idFor("album", album.identityKey) : null,
+    artistId: artist ? idFor("artist", artist.identityKey) : null,
+    track: album
+      ? album.trackIds
+          .map((trackId) => library.tracks.find((entry) => entry.id === trackId))
+          .findIndex((entry) => entry?.id === track.id) + 1
+      : 0,
+    year: year(album?.releaseDate),
+    genre: (Array.isArray(genres) ? genres[0] : genres) || null,
+    coverArt: album ? coverArtForAlbum(album) : null,
+    duration: seconds(file?.durationMs),
+    size: Number(file?.size || 0),
+    suffix: file?.format || null,
+    type: "music",
+  };
+};
+
+const toAlbum = (library, album) => {
+  const artist = findArtistForAlbum(library, album);
+  const tracks = albumTracks(library, album);
+  return {
+    id: idFor("album", album.identityKey),
+    name: album.title,
+    artist: artist?.name || album.albumArtist || null,
+    artistId: artist ? idFor("artist", artist.identityKey) : null,
+    coverArt: coverArtForAlbum(album),
+    songCount: tracks.length,
+    duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
+    year: year(album.releaseDate),
+    song: tracks.map((track) => toSong(library, track, album)),
+  };
+};
+
+const toArtist = (library, artist) => {
+  const albums = artistAlbums(library, artist);
+  return {
+    id: idFor("artist", artist.identityKey),
+    name: artist.name,
+    coverArt: idFor("artist", artist.identityKey),
+    albumCount: albums.length,
+    album: albums.map((album) => ({
+      ...toAlbum(library, album),
+      song: undefined,
+    })),
+  };
+};
+
+const toArtistSummary = (artist) => ({
+  id: idFor("artist", artist.identityKey),
+  name: artist.name,
+  coverArt: idFor("artist", artist.identityKey),
+  albumCount: artist.albumIds.length,
+});
+
+function readLibrary() {
+  return getCanonicalLibrary({ availableOnly: false });
+}
+
+function findCanonical(library, parsed) {
+  if (!parsed) return null;
+  if (parsed.kind === "artist") {
+    return library.artists.find((artist) => artist.identityKey === parsed.key) || null;
+  }
+  if (parsed.kind === "album") {
+    return library.albums.find((album) => album.identityKey === parsed.key) || null;
+  }
+  if (parsed.kind === "song") {
+    return library.tracks.find((track) => track.identityKey === parsed.key) || null;
+  }
+  return null;
+}
+
+function flowFromId(user, value) {
+  const parsed = parseId(value);
+  if (!parsed || parsed.kind !== "flow") return null;
+  const flow = flowPlaylistConfig.getFlow(parsed.key);
+  return flow && visibleFlows(user).some((entry) => entry.id === flow.id) ? flow : null;
+}
+
+function toFlowSong(flow, job) {
+  return {
+    id: idFor("flow-song", `${flow.id}:${job.id}`),
+    parent: idFor("flow", flow.id),
+    isDir: false,
+    title: job.trackName,
+    album: job.albumName,
+    artist: job.artistName,
+    track: job.trackNumber || 0,
+    year: job.releaseYear ? Number(job.releaseYear) : null,
+    duration: seconds(job.durationMs),
+    type: "music",
+  };
+}
+
+function flowJobFromId(user, value) {
+  const parsed = parseId(value);
+  if (!parsed || parsed.kind !== "flow-song") return null;
+  const separator = parsed.key.indexOf(":");
+  if (separator < 1) return null;
+  const flow = flowFromId(user, idFor("flow", parsed.key.slice(0, separator)));
+  if (!flow) return null;
+  const job = downloadTracker.getJob(parsed.key.slice(separator + 1));
+  return job?.playlistType === flow.id && job.status === "done" && job.finalPath
+    ? { flow, job }
+    : null;
+}
+
+const flowJobs = (flow) =>
+  downloadTracker
+    .getByPlaylistType(flow.id)
+    .filter((job) => job.status === "done" && job.finalPath);
+
+export function listArtists() {
+  const library = readLibrary();
+  const artists = [...library.artists].sort((left, right) =>
+    String(left.sortName || left.name).localeCompare(String(right.sortName || right.name)),
+  );
+  return artists.map(toArtistSummary);
+}
+
+export function getArtist(value) {
+  const library = readLibrary();
+  const parsed = parseId(value);
+  const artist = parsed?.kind === "artist" ? findCanonical(library, parsed) : null;
+  return artist?.identityKey ? toArtist(library, artist) : null;
+}
+
+export function getAlbum(value) {
+  const library = readLibrary();
+  const parsed = parseId(value);
+  const album = parsed?.kind === "album" ? findCanonical(library, parsed) : null;
+  return album?.identityKey ? toAlbum(library, album) : null;
+}
+
+export function getSong(value, user) {
+  const flowEntry = flowJobFromId(user, value);
+  if (flowEntry) return toFlowSong(flowEntry.flow, flowEntry.job);
+
+  const library = readLibrary();
+  const parsed = parseId(value);
+  const track = parsed?.kind === "song" ? findCanonical(library, parsed) : null;
+  return track?.identityKey ? toSong(library, track) : null;
+}
+
+export function getMusicDirectory(value) {
+  if (value === "root") {
+    return {
+      id: "root",
+      name: "Aurral",
+      child: listArtists().map((artist) => ({
+        id: artist.id,
+        parent: "root",
+        isDir: true,
+        title: artist.name,
+        artist: artist.name,
+      })),
+    };
+  }
+  const parsed = parseId(value);
+  if (parsed?.kind === "artist") {
+    const artist = getArtist(value);
+    return artist ? { id: artist.id, name: artist.name, child: artist.album || [] } : null;
+  }
+  if (parsed?.kind === "album") {
+    const album = getAlbum(value);
+    return album ? { id: album.id, name: album.name, child: album.song || [] } : null;
+  }
+  return null;
+}
+
+export function searchLibrary(query, options = {}) {
+  const needle = String(query || "").trim().toLocaleLowerCase();
+  const library = readLibrary();
+  const artists = library.artists
+    .filter((artist) => artist.name.toLocaleLowerCase().includes(needle))
+    .map(toArtistSummary);
+  const albums = library.albums
+    .filter((album) => {
+      const artist = findArtistForAlbum(library, album);
+      return [album.title, album.albumArtist, artist?.name].some((value) =>
+        String(value || "").toLocaleLowerCase().includes(needle),
+      );
+    })
+    .map((album) => ({ ...toAlbum(library, album), song: undefined }));
+  const songs = library.tracks
+    .filter((track) => {
+      const album = findAlbumForTrack(library, track);
+      const artist = findArtistForAlbum(library, album);
+      return [track.title, track.artistName, album?.title, artist?.name].some((value) =>
+        String(value || "").toLocaleLowerCase().includes(needle),
+      );
+    })
+    .map((track) => toSong(library, track));
+  const page = (items, count, offset) => items.slice(offset, offset + count);
+  return {
+    artist: page(artists, normalizeLimit(options.artistCount), normalizeOffset(options.artistOffset)),
+    album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)),
+    song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)),
+  };
+}
+
+export function getFlowPlaylists(user) {
+  return visibleFlows(user).map((flow) => {
+    const jobs = flowJobs(flow);
+    return {
+      id: idFor("flow", flow.id),
+      name: flow.name,
+      owner: user.username,
+      songCount: jobs.length,
+      duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
+      created: new Date(flow.createdAt || Date.now()).toISOString(),
+      changed: new Date(flow.lastRunAt || flow.createdAt || Date.now()).toISOString(),
+      comment: flow.description || null,
+    };
+  });
+}
+
+export function getFlowPlaylist(value, user) {
+  const flow = flowFromId(user, value);
+  if (!flow) return null;
+  const jobs = flowJobs(flow);
+  return {
+    id: idFor("flow", flow.id),
+    name: flow.name,
+    owner: user.username,
+    songCount: jobs.length,
+    duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
+    entry: jobs.map((job) => toFlowSong(flow, job)),
+  };
+}
+
+export function resolveStreamPath(value, user) {
+  const flowEntry = flowJobFromId(user, value);
+  if (flowEntry) {
+    return flowEntry.job.status === "done" && flowEntry.job.finalPath
+      ? flowEntry.job.finalPath
+      : null;
+  }
+
+  const library = readLibrary();
+  const track = findCanonical(library, parseId(value));
+  const file = firstFile(track);
+  return file?.available && file.path ? file.path : null;
+}
+
+const cachedArtworkUrl = (key) => {
+  const cached = dbOps.getImage(key);
+  if (!cached?.imageUrl || cached.imageUrl === "NOT_FOUND") return null;
+  return buildImageProxyUrl(cached.imageUrl);
+};
+
+export async function resolveArtworkUrl(value) {
+  const library = readLibrary();
+  const parsed = parseId(value);
+  const entity = findCanonical(library, parsed);
+  if (!entity) return null;
+
+  if (parsed.kind === "artist") {
+    const cached = cachedArtworkUrl(entity.mbid || entity.identityKey);
+    if (cached) return cached;
+    if (!entity.mbid) return null;
+    const result = await getArtistImage(entity.mbid, { artistName: entity.name });
+    return result?.url ? buildImageProxyUrl(result.url) : null;
+  }
+
+  const album = parsed.kind === "album" ? entity : findAlbumForTrack(library, entity);
+  if (!album) return null;
+  const cacheId = album.releaseGroupMbid || album.mbid;
+  const cached = cacheId ? cachedArtworkUrl(`rg:${cacheId}`) : null;
+  if (cached) return cached;
+  if (!cacheId) return null;
+  const artist = findArtistForAlbum(library, album);
+  const result = await fetchReleaseGroupCoverUrl(cacheId, {
+    artistName: artist?.name || album.albumArtist || "",
+    albumTitle: album.title,
+  });
+  return result?.imageUrl ? buildImageProxyUrl(result.imageUrl) : null;
+}
+
+export { idFor, parseId };

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -7,7 +7,7 @@ Navidrome is optional. Aurral creates and updates Navidrome playlists through th
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
-Aurral also exposes an authenticated Subsonic handshake at `/rest/ping.view`. It supports XML and JSON responses and identifies the running server version. Browsing, artwork, streaming, playlists, and transcoding are not available through this endpoint yet. Navidrome remains the playback server.
+Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, and direct streaming with byte ranges. Completed flow entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
 
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
 


### PR DESCRIPTION
Canonical library records are now indexed, but Subsonic clients can only complete the authenticated handshake. They need a read-only browse, search, artwork, and playback surface that stays independent from provider-shaped services.

This adds Subsonic browse and search projections over the canonical library, stable identity-based protocol IDs, artwork delegation through the existing image proxy, direct streaming with full and byte-range responses, and read-only flow entries through `getPlaylists` and `getPlaylist`. The route owns protocol envelopes and authentication; the library service owns canonical reads and state resolution. The shared stream helper also corrects range handling for the existing library file route.

## Linked issues

- AURRALOWNE-16: Serve canonical browse, artwork, and streams through Subsonic

## Test plan

Affected surfaces: Subsonic route/protocol handling, canonical library read adapter, shared audio streaming, flow read projections, integration tests, and Navidrome documentation.

Automated verification:
- `node --test --import ./.tests/setup-env.js --test-concurrency=1 .tests/subsonic/*.int.test.js` — 10 passed
- `npm run lint:backend -- --no-warn-ignored` — passed
- `npm run docs:build` — passed
- `node --check` on changed backend modules — passed
- `git diff --check` — passed

Coverage includes JSON/XML envelopes, `getLicense`, canonical browse/search, stable IDs, full/bounded/suffix/invalid/unsatisfiable ranges, missing files, stale IDs, restart persistence, artwork, and flow entries.

Manual verification can use the generated preview image:
`docker pull ghcr.io/lklynet/aurral:pr-611`

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

This intentionally adds no playlist mutation, transcoding, canonical writes, root migration, standalone acquisition, Navidrome removal, or Lidarr ownership changes. Token authentication remains the existing unsupported protocol path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated Subsonic-compatible browsing, search, read-only playlists, artwork, downloads, and audio streaming.
  * Added XML and JSON responses with byte-range playback support.
  * Added handling for missing files, invalid IDs, unsupported requests, and unavailable content.
  * Added persistent library and playlist access across server restarts.

* **Documentation**
  * Updated Navidrome integration guidance with supported capabilities and limitations.

* **Tests**
  * Added comprehensive integration coverage for browsing, search, playback, errors, persistence, playlists, and artwork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->