### PR TITLE
feat(playback): make Navidrome an optional destination

### DIFF
--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -10,6 +10,7 @@ const repoRoot = join(__dirname, "..", "..");
 
 const RESET_TABLES = [
   "sessions",
+  "subsonic_stars",
   "honker_task_runs",
   "slskd_transfer_history",
   "playlist_download_jobs",

--- a/.tests/image-proxy-cache.test.js
+++ b/.tests/image-proxy-cache.test.js
@@ -200,3 +200,42 @@ test("image proxy cache prunes oldest entries over the size cap", async () => {
     await fs.rm(dataDir, { recursive: true, force: true });
   }
 });
+
+test("image proxy keeps library artwork outside the FIFO cap", async () => {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-image-library-cap-"));
+  const previousDataDir = process.env.AURRAL_DATA_DIR;
+  const previousMaxBytes = process.env.AURRAL_IMAGE_PROXY_MAX_BYTES;
+  const originalFetch = global.fetch;
+  process.env.AURRAL_DATA_DIR = dataDir;
+  process.env.AURRAL_IMAGE_PROXY_MAX_BYTES = String(200 * 1024);
+  try {
+    const sharp = (await import("sharp")).default;
+    const { warmImageProxy } = await import(
+      `../backend/services/imageProxyService.js?library-cap-test=${Date.now()}`
+    );
+    const noise = Buffer.alloc(512 * 512 * 3);
+    for (let i = 0; i < noise.length; i += 1) {
+      noise[i] = (i * 37 + (i % 251) * 13) % 256;
+    }
+
+    global.fetch = async () =>
+      new Response(
+        await sharp(noise, { raw: { width: 512, height: 512, channels: 3 } }).png().toBuffer(),
+        { headers: { "content-type": "image/png" } },
+      );
+    const libraryImage = await warmImageProxy("https://images.example/library.png", "library");
+
+    for (let i = 0; i < 6; i += 1) {
+      await warmImageProxy(`https://images.example/fifo-${i}.png`);
+    }
+
+    assert.equal(await fs.access(libraryImage.imagePath).then(() => true, () => false), true);
+  } finally {
+    global.fetch = originalFetch;
+    if (previousDataDir === undefined) delete process.env.AURRAL_DATA_DIR;
+    else process.env.AURRAL_DATA_DIR = previousDataDir;
+    if (previousMaxBytes === undefined) delete process.env.AURRAL_IMAGE_PROXY_MAX_BYTES;
+    else process.env.AURRAL_IMAGE_PROXY_MAX_BYTES = previousMaxBytes;
+    await fs.rm(dataDir, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -81,8 +81,8 @@ test("canonical track reads remove nested filesystem paths", async () => {
     assert.equal(body.length, 1);
     assert.equal("path" in body[0], false);
     assert.deepEqual(body[0].quality, { audioFormat: "FLAC", nested: {} });
-    assert.equal(body[0].streamPath, null);
-    assert.equal(body[0].streamFormat, null);
+    assert.match(body[0].streamPath, /\/library\/canonical-stream\/\d+$/);
+    assert.equal(body[0].streamFormat, "flac");
   } finally {
     const track = db.prepare(
       "SELECT track_id AS trackId FROM library_media_files WHERE source = ? AND path = ?",

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -342,3 +342,38 @@ test("a Lidarr outage leaves the last indexed library available", async () => {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("an empty Lidarr response leaves the last indexed library available", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-empty-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Empty Artist/Empty Album/01 Empty Track.flac");
+    const indexedClient = {
+      isConfigured: () => true,
+      request: async () => [{ id: 37, artistName: "Empty Artist", foreignArtistId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd" }],
+      getAllAlbums: async () => [{ id: 38, artistId: 37, title: "Empty Album", foreignAlbumId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee" }],
+      getTracksByAlbumId: async () => [{ id: 39, albumId: 38, title: "Empty Track", trackNumber: 1, foreignRecordingId: "ffffffff-ffff-4fff-8fff-ffffffffffff", trackFileId: 40 }],
+      getTrackFilesByAlbumId: async () => [{ id: 40, path: filePath, trackIds: [39] }],
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    await indexLidarrLibrary({ client: indexedClient });
+    const result = await indexLidarrLibrary({
+      client: {
+        isConfigured: () => true,
+        request: async () => [{ id: 37, artistName: "Empty Artist", foreignArtistId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd" }],
+        getAllAlbums: async () => [{ id: 38, artistId: 37, title: "Empty Album", foreignAlbumId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee" }],
+        getTracksByAlbumId: async () => [],
+        getTrackFilesByAlbumId: async () => [],
+        getRootFolders: async () => [{ path: root }],
+      },
+    });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.equal(result.filesIndexed, 0);
+    assert.equal(file?.available, 1);
+  } finally {
+    if (filePath) deleteIndexedFile("lidarr", filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -69,6 +69,7 @@ test("getCanonicalLibrary merges sources and preserves normalized hierarchy", as
     });
 
     const all = getCanonicalLibrary();
+    assert.strictEqual(getCanonicalLibrary(), all);
     assert.equal(all.artists.length, 1);
     assert.equal(all.albums.length, 1);
     assert.equal(all.tracks.length, 1);

--- a/.tests/library/storage-health.test.js
+++ b/.tests/library/storage-health.test.js
@@ -179,6 +179,50 @@ test("runStorageHealthCheck skips optional integrations when unset", async () =>
   assert.match(nativePlayback?.steps[0]?.fix || "", /index refresh/i);
 });
 
+test("native playback passes when any available file is readable", async () => {
+  const {
+    linkLibraryAlbumTrack,
+    upsertLibraryAlbum,
+    upsertLibraryArtist,
+    upsertLibraryMediaFile,
+    upsertLibraryTrack,
+  } = await importFromRepo("backend/services/libraryMediaStore.js");
+  const artist = upsertLibraryArtist({
+    identityKey: "storage-health:artist",
+    name: "Storage Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: "storage-health:album",
+    artistId: artist.id,
+    title: "Storage Album",
+    albumArtist: artist.name,
+  });
+  const track = upsertLibraryTrack({
+    identityKey: "storage-health:track",
+    title: "Storage Track",
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+  const readablePath = path.join(process.env.DOWNLOAD_FOLDER, "1-readable.flac");
+  await fs.writeFile(readablePath, "audio");
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    source: "lidarr",
+    path: path.join(process.env.DOWNLOAD_FOLDER, "0-stale.flac"),
+    available: true,
+  });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    source: "aurral",
+    path: readablePath,
+    available: true,
+  });
+
+  const result = await runStorageHealthCheck({ force: true });
+  const nativePlayback = result.sections.find((section) => section.id === "native-playback");
+  assert.equal(nativePlayback?.status, "pass");
+});
+
 test("runStorageHealthCheck passes shared volume when dedicated browse roots exist", async () => {
   const result = await runStorageHealthCheck();
   const volume = result.sections.find((section) => section.id === "volume");

--- a/.tests/library/storage-health.test.js
+++ b/.tests/library/storage-health.test.js
@@ -172,8 +172,11 @@ test("runStorageHealthCheck skips optional integrations when unset", async () =>
   const result = await runStorageHealthCheck();
   const slskd = result.sections.find((section) => section.id === "slskd");
   const navidrome = result.sections.find((section) => section.id === "navidrome");
+  const nativePlayback = result.sections.find((section) => section.id === "native-playback");
   assert.equal(slskd?.status, "skip");
   assert.equal(navidrome?.status, "skip");
+  assert.equal(nativePlayback?.status, "warn");
+  assert.match(nativePlayback?.steps[0]?.fix || "", /index refresh/i);
 });
 
 test("runStorageHealthCheck passes shared volume when dedicated browse roots exist", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -114,6 +114,7 @@ test.before(async () => {
   const jobId = downloadTracker.addJob({
     artistName: "Flow Artist",
     albumName: "Flow Album",
+    albumMbid: "flow-album-mbid",
     trackName: "Flow Song",
     durationMs: 1000,
   }, flow.id);
@@ -131,6 +132,7 @@ test.before(async () => {
   const sharedJobId = downloadTracker.addJob({
     artistName: "Flow Artist",
     albumName: "Flow Album",
+    albumMbid: "shared-album-mbid",
     trackName: "Flow Song",
     durationMs: 1000,
   }, sharedPlaylist.id);
@@ -176,6 +178,12 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.deepEqual(responseJson(await request("getGenres")).genres.genre, [
     { albumCount: 1, songCount: 1, value: "Rock" },
   ]);
+  const songsByGenre = responseJson(await request("getSongsByGenre", {
+    genre: "Rock",
+    count: 10,
+    offset: 0,
+  }));
+  assert.equal(songsByGenre.songsByGenre.song[0].title, "Canonical Song");
   assert.deepEqual(responseJson(await request("getStarred")).starred, {
     album: [],
     artist: [],

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -175,6 +175,16 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.equal(song.path, song.id);
   assert.deepEqual(song.artists, [{ id: artist.id, name: "Canonical Artist" }]);
 
+  assert.equal(responseJson(await request("star", { id: song.id })).status, "ok");
+  assert.equal(responseJson(await request("getStarred")).starred.song[0].id, song.id);
+  assert.equal(responseJson(await request("getStarred2")).starred2.song[0].id, song.id);
+  userOps.createUser("bob", hashPassword("bob-password"), "user");
+  assert.deepEqual(
+    responseJson(await request("getStarred", { u: "bob", p: "bob-password" })).starred,
+    { album: [], artist: [], song: [] },
+  );
+  assert.equal(responseJson(await request("unstar", { id: song.id })).status, "ok");
+
   const missingArtist = await request("getTopSongs", { artist: "   " });
   assert.equal(responseJson(missingArtist).error.code, 10);
 });

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -53,7 +54,11 @@ function responseJson(result) {
 
 test.before(async () => {
   resetDatabase(db);
-  dbOps.updateSettings({ integrations: {}, onboardingComplete: true });
+  dbOps.updateSettings({
+    integrations: { general: { authUser: "alice", authPassword: "password123" } },
+    security: { localNetworkBypass: { enabled: false } },
+    onboardingComplete: true,
+  });
   userOps.createUser("alice", hashPassword("password123"), "admin");
 
   fixtureRoot = await mkdtemp(path.join(isolatedState.baseDir, "media-"));
@@ -113,6 +118,11 @@ test.after(async () => {
 });
 
 test("browses canonical artists, albums, and songs with stable protocol IDs", async () => {
+  const user = responseJson(await request("getUser")).user;
+  assert.equal(user.username, "alice");
+  assert.equal(user.adminRole, true);
+  assert.equal(user.streamRole, true);
+
   const artistsResult = responseJson(await request("getArtists"));
   const artist = artistsResult.artists.index[0].artist[0];
   assert.match(artist.id, /^artist:/);
@@ -124,15 +134,35 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.equal(license.license.valid, true);
   const indexes = responseJson(await request("getIndexes"));
   assert.equal(typeof indexes.indexes.lastModified, "number");
+  const albumList = responseJson(await request("getAlbumList2", { type: "newest", size: 10 }));
+  assert.equal(albumList.albumList2.album[0].title, "Canonical Album");
+  assert.deepEqual(responseJson(await request("getGenres")).genres.genre, []);
+  assert.deepEqual(responseJson(await request("getStarred")).starred, {
+    album: [],
+    artist: [],
+    song: [],
+  });
 
   const albumResult = responseJson(await request("getArtist", { id: artist.id }));
   const album = albumResult.artist.album[0];
   assert.match(album.id, /^album:/);
+  assert.deepEqual(responseJson(await request("getArtistInfo", { id: artist.id })).artistInfo.similarArtist, []);
+  assert.equal(responseJson(await request("getTopSongs", { artist: "Canonical Artist" })).topSongs.song[0].title, "Canonical Song");
 
   const songResult = responseJson(await request("getAlbum", { id: album.id }));
   const song = songResult.album.song[0];
   assert.match(song.id, /^song:/);
   assert.equal(responseJson(await request("getSong", { id: song.id })).song.title, "Canonical Song");
+  assert.equal(song.contentType, "audio/flac");
+  assert.equal(song.path, song.id);
+  assert.deepEqual(song.artists, [{ id: artist.id, name: "Canonical Artist" }]);
+});
+
+test("accepts Subsonic token auth for the configured Aurral account", async () => {
+  const salt = "canonical-salt";
+  const token = createHash("md5").update(`password123${salt}`).digest("hex");
+  const result = responseJson(await request("getUser", { p: "", t: token, s: salt }));
+  assert.equal(result.user.username, "alice");
 });
 
 test("searches canonical records and exposes flow entries as playlist items", async () => {
@@ -145,6 +175,7 @@ test("searches canonical records and exposes flow entries as playlist items", as
   assert.ok(flow);
   const playlist = responseJson(await request("getPlaylist", { id: flow.id }));
   assert.equal(playlist.playlist.entry[0].title, "Flow Song");
+  assert.equal(playlist.playlist.public, false);
 });
 
 test("streams canonical files with full and range responses", async () => {
@@ -176,6 +207,38 @@ test("streams canonical files with full and range responses", async () => {
     { headers: { Range: "bytes=99-" } },
   );
   assert.equal(unsatisfiable.response.status, 416);
+});
+
+test("streams canonical files through the authenticated native route", async () => {
+  const login = await fetch(`http://127.0.0.1:${aurral.port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "alice", password: "password123" }),
+  });
+  const { token } = await login.json();
+  const headers = { Authorization: `Bearer ${token}` };
+  const canonical = await fetch(
+    `http://127.0.0.1:${aurral.port}/api/library/canonical?source=lidarr&availableOnly=true`,
+    { headers },
+  );
+  const library = await canonical.json();
+  const albumId = library.tracks[0].albums[0].albumId;
+  const tracks = await fetch(
+    `http://127.0.0.1:${aurral.port}/api/library/tracks?readPath=canonical&source=lidarr&albumId=${albumId}`,
+    { headers },
+  );
+  const track = (await tracks.json())[0];
+  const stream = await fetch(
+    `http://127.0.0.1:${aurral.port}/api${track.streamPath}`,
+    { headers },
+  );
+  assert.equal(stream.status, 200);
+  assert.equal(await stream.text(), "0123456789");
+
+  const unauthorized = await fetch(
+    `http://127.0.0.1:${aurral.port}/api${track.streamPath}`,
+  );
+  assert.equal(unauthorized.status, 401);
 });
 
 test("returns missing files and stale IDs without exposing filesystem paths", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -11,7 +11,7 @@ import {
   startServerProcess,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }] =
+const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }, { resolveArtworkUrl }, { warmImageProxy }] =
   await setupIsolatedBackend(
     "subsonic-canonical",
     "backend/config/db-sqlite.js",
@@ -20,6 +20,8 @@ const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidar
     "backend/services/libraryLidarrIndexer.js",
     "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
     "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+    "backend/services/subsonicLibraryService.js",
+    "backend/services/imageProxyService.js",
   );
 
 let aurral;
@@ -338,4 +340,56 @@ test("returns the canonical artwork redirect contract", async () => {
   const result = await request("getCoverArt", { id: artist.id }, { redirect: "manual" });
   assert.equal(result.response.status, 302);
   assert.match(result.response.headers.get("location"), /image-proxy/);
+  assert.equal(result.response.headers.get("cache-control"), "public, max-age=31536000, immutable");
+});
+
+test("resolves playlist release-group artwork without a canonical album row", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      ),
+      { headers: { "content-type": "image/png" } },
+    );
+  try {
+    const cached = await warmImageProxy("https://images.example/playlist.webp");
+    const releaseGroupId = "44444444-4444-4444-8444-444444444444";
+    dbOps.setImage(`rg:${releaseGroupId}`, cached.localUrl);
+
+    const artwork = await resolveArtworkUrl(
+      `album:${encodeURIComponent(`release-group:${releaseGroupId}`)}`,
+    );
+    const libraryArtwork = await warmImageProxy(cached.localUrl, "library");
+    assert.equal(artwork, libraryArtwork.localUrl);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("uses cached album artwork for artist artwork", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      ),
+      { headers: { "content-type": "image/png" } },
+    );
+  try {
+    const artist = db.prepare("SELECT mbid, identity_key FROM library_artists LIMIT 1").get();
+    const album = db.prepare("SELECT mbid, release_group_mbid FROM library_albums LIMIT 1").get();
+    const cacheId = album.release_group_mbid || album.mbid;
+    const cached = await warmImageProxy(`https://images.example/artist-album-${cacheId}.png`);
+    dbOps.deleteImage(artist.mbid);
+    dbOps.setImage(`rg:${cacheId}`, cached.localUrl);
+
+    const artwork = await resolveArtworkUrl(`artist:${encodeURIComponent(artist.identity_key)}`);
+    const libraryArtwork = await warmImageProxy(cached.localUrl, "library");
+    assert.equal(artwork, libraryArtwork.localUrl);
+  } finally {
+    global.fetch = originalFetch;
+  }
 });

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -156,6 +156,9 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.equal(song.contentType, "audio/flac");
   assert.equal(song.path, song.id);
   assert.deepEqual(song.artists, [{ id: artist.id, name: "Canonical Artist" }]);
+
+  const missingArtist = await request("getTopSongs", { artist: "   " });
+  assert.equal(responseJson(missingArtist).error.code, 10);
 });
 
 test("accepts Subsonic token auth for the configured Aurral account", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -25,6 +25,7 @@ const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidar
 let aurral;
 let fixtureRoot;
 let fixturePath;
+let sharedPlaylist;
 
 function subsonicUrl(method, params = {}) {
   const query = new URLSearchParams({
@@ -59,7 +60,7 @@ test.before(async () => {
     security: { localNetworkBypass: { enabled: false } },
     onboardingComplete: true,
   });
-  userOps.createUser("alice", hashPassword("password123"), "admin");
+  const alice = userOps.createUser("alice", hashPassword("password123"), "admin");
 
   fixtureRoot = await mkdtemp(path.join(isolatedState.baseDir, "media-"));
   fixturePath = path.join(fixtureRoot, "Canonical Artist", "Canonical Album", "01 Canonical Song.flac");
@@ -108,6 +109,23 @@ test.before(async () => {
     durationMs: 1000,
   }, flow.id);
   downloadTracker.setDone(jobId, fixturePath);
+  sharedPlaylist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Canonical Shared",
+    ownerUserId: alice.id,
+    tracks: [{
+      artistName: "Flow Artist",
+      trackName: "Flow Song",
+      albumName: "Flow Album",
+      durationMs: 1000,
+    }],
+  });
+  const sharedJobId = downloadTracker.addJob({
+    artistName: "Flow Artist",
+    albumName: "Flow Album",
+    trackName: "Flow Song",
+    durationMs: 1000,
+  }, sharedPlaylist.id);
+  downloadTracker.setDone(sharedJobId, fixturePath);
   aurral = await startServerProcess();
 });
 
@@ -179,6 +197,43 @@ test("searches canonical records and exposes flow entries as playlist items", as
   const playlist = responseJson(await request("getPlaylist", { id: flow.id }));
   assert.equal(playlist.playlist.entry[0].title, "Flow Song");
   assert.equal(playlist.playlist.public, false);
+});
+
+test("accepts Feishin's empty search request for the tracks view", async () => {
+  const search = responseJson(await request("search3", {
+    query: "",
+    artistCount: 20,
+    albumCount: 20,
+    songCount: 20,
+  }));
+  assert.equal(search.searchResult3.song[0].title, "Canonical Song");
+});
+
+test("exposes owned static playlists and keeps their entries playable", async () => {
+  const playlists = responseJson(await request("getPlaylists")).playlists.playlist;
+  const shared = playlists.find((entry) => entry.name === "Canonical Shared");
+  assert.ok(shared);
+  assert.equal(shared.songCount, 1);
+
+  const playlist = responseJson(await request("getPlaylist", { id: shared.id })).playlist;
+  assert.equal(playlist.entry[0].title, "Flow Song");
+  assert.match(playlist.entry[0].id, /^shared-song:/);
+
+  const song = responseJson(await request("getSong", { id: playlist.entry[0].id })).song;
+  assert.equal(song.title, "Flow Song");
+  const stream = await request("stream", { id: song.id });
+  assert.equal(stream.response.status, 200);
+  assert.equal(stream.body, "0123456789");
+});
+
+test("does not expose another user's static playlist", async () => {
+  userOps.createUser("bob", hashPassword("bob-password"), "user");
+  const result = responseJson(await request("getPlaylist", {
+    id: `shared:${encodeURIComponent(sharedPlaylist.id)}`,
+    u: "bob",
+    p: "bob-password",
+  }));
+  assert.deepEqual(result.error, { code: 70, message: "Requested data was not found" });
 });
 
 test("streams canonical files with full and range responses", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -39,6 +39,11 @@ function subsonicUrl(method, params = {}) {
     f: "json",
     ...params,
   });
+  for (const [key, value] of Object.entries(params)) {
+    if (!Array.isArray(value)) continue;
+    query.delete(key);
+    for (const entry of value) query.append(key, entry);
+  }
   return `http://127.0.0.1:${aurral.port}/rest/${method}.view?${query}`;
 }
 
@@ -193,15 +198,30 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.equal(song.path, song.id);
   assert.deepEqual(song.artists, [{ id: artist.id, name: "Canonical Artist" }]);
 
-  assert.equal(responseJson(await request("star", { id: song.id })).status, "ok");
-  assert.equal(responseJson(await request("getStarred")).starred.song[0].id, song.id);
+  assert.equal(
+    responseJson(await request("star", { id: [song.id, album.id], artistId: artist.id })).status,
+    "ok",
+  );
+  const starred = responseJson(await request("getStarred")).starred;
+  assert.equal(starred.song[0].id, song.id);
+  assert.equal(starred.album[0].id, album.id);
+  assert.equal(starred.artist[0].id, artist.id);
   assert.equal(responseJson(await request("getStarred2")).starred2.song[0].id, song.id);
   userOps.createUser("bob", hashPassword("bob-password"), "user");
   assert.deepEqual(
     responseJson(await request("getStarred", { u: "bob", p: "bob-password" })).starred,
     { album: [], artist: [], song: [] },
   );
-  assert.equal(responseJson(await request("unstar", { id: song.id })).status, "ok");
+  assert.equal(
+    responseJson(await request("unstar", { id: [song.id, album.id], artistId: artist.id })).status,
+    "ok",
+  );
+  assert.deepEqual(responseJson(await request("getStarred")).starred, { album: [], artist: [], song: [] });
+  assert.equal(
+    responseJson(await request("star", { id: [song.id, "song:missing"] })).error.code,
+    70,
+  );
+  assert.deepEqual(responseJson(await request("getStarred")).starred, { album: [], artist: [], song: [] });
 
   const missingArtist = await request("getTopSongs", { artist: "   " });
   assert.equal(responseJson(missingArtist).error.code, 10);

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -11,7 +11,7 @@ import {
   startServerProcess,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }, { resolveArtworkUrl }, { warmImageProxy }] =
+const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }, { resolveArtworkUrl }, { warmImageProxy }, { playlistManager }] =
   await setupIsolatedBackend(
     "subsonic-canonical",
     "backend/config/db-sqlite.js",
@@ -19,10 +19,11 @@ const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidar
     "backend/middleware/passwordHash.js",
     "backend/services/libraryLidarrIndexer.js",
     "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
-    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
-    "backend/services/subsonicLibraryService.js",
-    "backend/services/imageProxyService.js",
-  );
+  "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  "backend/services/subsonicLibraryService.js",
+  "backend/services/imageProxyService.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
+);
 
 let aurral;
 let fixtureRoot;
@@ -76,6 +77,7 @@ test.before(async () => {
         artistName: "Canonical Artist",
         sortName: "Canonical Artist",
         foreignArtistId: "11111111-1111-4111-8111-111111111111",
+        genres: ["Rock"],
       }],
       getAllAlbums: async () => [{
         id: 2,
@@ -128,6 +130,15 @@ test.before(async () => {
     durationMs: 1000,
   }, sharedPlaylist.id);
   downloadTracker.setDone(sharedJobId, fixturePath);
+  await mkdir(playlistManager.libraryRoot, { recursive: true });
+  await writeFile(
+    path.join(playlistManager.libraryRoot, `${playlistManager.getPlaylistName(flow.id)}.webp`),
+    "flow-artwork",
+  );
+  await writeFile(
+    path.join(playlistManager.libraryRoot, `${playlistManager.getPlaylistName(sharedPlaylist.id)}.webp`),
+    "shared-artwork",
+  );
   aurral = await startServerProcess();
 });
 
@@ -146,6 +157,7 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   const artistsResult = responseJson(await request("getArtists"));
   const artist = artistsResult.artists.index[0].artist[0];
   assert.match(artist.id, /^artist:/);
+  assert.equal(artist.genre, "Rock");
   assert.equal(artistsResult.artists.ignoredArticles, "The El La Los Las Le Les");
   const artistsXml = await request("getArtists", { f: "xml" });
   assert.match(artistsXml.body, /<artists[^>]*><index name="C"><artist id="artist:/);
@@ -156,7 +168,9 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.equal(typeof indexes.indexes.lastModified, "number");
   const albumList = responseJson(await request("getAlbumList2", { type: "newest", size: 10 }));
   assert.equal(albumList.albumList2.album[0].title, "Canonical Album");
-  assert.deepEqual(responseJson(await request("getGenres")).genres.genre, []);
+  assert.deepEqual(responseJson(await request("getGenres")).genres.genre, [
+    { albumCount: 1, songCount: 1, value: "Rock" },
+  ]);
   assert.deepEqual(responseJson(await request("getStarred")).starred, {
     album: [],
     artist: [],
@@ -166,6 +180,7 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   const albumResult = responseJson(await request("getArtist", { id: artist.id }));
   const album = albumResult.artist.album[0];
   assert.match(album.id, /^album:/);
+  assert.equal(album.genre, "Rock");
   assert.deepEqual(responseJson(await request("getArtistInfo", { id: artist.id })).artistInfo.similarArtist, []);
   assert.equal(responseJson(await request("getTopSongs", { artist: "Canonical Artist" })).topSongs.song[0].title, "Canonical Song");
 
@@ -174,6 +189,7 @@ test("browses canonical artists, albums, and songs with stable protocol IDs", as
   assert.match(song.id, /^song:/);
   assert.equal(responseJson(await request("getSong", { id: song.id })).song.title, "Canonical Song");
   assert.equal(song.contentType, "audio/flac");
+  assert.equal(song.genre, "Rock");
   assert.equal(song.path, song.id);
   assert.deepEqual(song.artists, [{ id: artist.id, name: "Canonical Artist" }]);
 
@@ -206,9 +222,14 @@ test("searches canonical records and exposes flow entries as playlist items", as
   const playlists = responseJson(await request("getPlaylists"));
   const flow = playlists.playlists.playlist.find((entry) => entry.name === "Canonical Flow");
   assert.ok(flow);
+  assert.equal(flow.coverArt, flow.id);
   const playlist = responseJson(await request("getPlaylist", { id: flow.id }));
   assert.equal(playlist.playlist.entry[0].title, "Flow Song");
   assert.equal(playlist.playlist.public, false);
+  assert.equal(playlist.playlist.coverArt, flow.coverArt);
+  const artwork = await request("getCoverArt", { id: flow.coverArt });
+  assert.equal(artwork.response.status, 200);
+  assert.equal(artwork.body, "flow-artwork");
 });
 
 test("accepts Feishin's empty search request for the tracks view", async () => {
@@ -226,10 +247,14 @@ test("exposes owned static playlists and keeps their entries playable", async ()
   const shared = playlists.find((entry) => entry.name === "Canonical Shared");
   assert.ok(shared);
   assert.equal(shared.songCount, 1);
+  assert.equal(shared.coverArt, shared.id);
 
   const playlist = responseJson(await request("getPlaylist", { id: shared.id })).playlist;
   assert.equal(playlist.entry[0].title, "Flow Song");
   assert.match(playlist.entry[0].id, /^shared-song:/);
+  const artwork = await request("getCoverArt", { id: shared.coverArt });
+  assert.equal(artwork.response.status, 200);
+  assert.equal(artwork.body, "shared-artwork");
 
   const song = responseJson(await request("getSong", { id: playlist.entry[0].id })).song;
   assert.equal(song.title, "Flow Song");

--- a/.tests/subsonic/subsonic-library.test.js
+++ b/.tests/subsonic/subsonic-library.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { getAlbumList, getTopSongs }, libraryStore] =
+  await setupIsolatedBackend(
+    "subsonic-library",
+    "backend/config/db-sqlite.js",
+    "backend/services/subsonicLibraryService.js",
+    "backend/services/libraryMediaStore.js",
+  );
+
+const {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} = libraryStore;
+
+function addAlbum({ artist, title, releaseDate, trackTitle }) {
+  const album = upsertLibraryAlbum({
+    identityKey: `test-album:${title}`,
+    artistId: artist.id,
+    title,
+    albumArtist: artist.name,
+    releaseDate,
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `test-track:${trackTitle}`,
+    title: trackTitle,
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    source: "lidarr",
+    path: `/test/${title}/${trackTitle}.flac`,
+    format: "flac",
+    available: true,
+  });
+}
+
+test.before(() => {
+  resetDatabase(db);
+  const artistA = upsertLibraryArtist({
+    identityKey: "test-artist:artist-a",
+    name: "Artist A",
+  });
+  const artistB = upsertLibraryArtist({
+    identityKey: "test-artist:artist-b",
+    name: "Artist B",
+  });
+  addAlbum({
+    artist: artistA,
+    title: "Old Album",
+    releaseDate: "2010-01-01",
+    trackTitle: "Old Song",
+  });
+  addAlbum({
+    artist: artistA,
+    title: "New Album",
+    releaseDate: "2024-01-01",
+    trackTitle: "New Song",
+  });
+  addAlbum({
+    artist: artistB,
+    title: "Artist A Collection",
+    releaseDate: "2022-01-01",
+    trackTitle: "Other Artist Song",
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("orders newest albums before applying pagination", () => {
+  assert.deepEqual(
+    getAlbumList({ type: "newest", size: 1 }).map((album) => album.title),
+    ["New Album"],
+  );
+  assert.deepEqual(
+    getAlbumList({ type: "newest", size: 1, offset: 1 }).map((album) => album.title),
+    ["Artist A Collection"],
+  );
+  assert.deepEqual(
+    getAlbumList({ type: "byYear", fromYear: 2024, toYear: 2010 }).map((album) => album.title),
+    ["New Album", "Artist A Collection", "Old Album"],
+  );
+});
+
+test("returns top songs only for the requested artist", () => {
+  const songs = getTopSongs("Artist A", { count: 10 });
+  assert.deepEqual(songs.map((song) => song.title), ["New Song", "Old Song"]);
+  assert.equal(songs.every((song) => song.artist === "Artist A"), true);
+});

--- a/.tests/subsonic/subsonic.int.test.js
+++ b/.tests/subsonic/subsonic.int.test.js
@@ -45,7 +45,7 @@ test.before(async () => {
   resetDatabase(db);
   dbOps.updateSettings({ integrations: {}, onboardingComplete: true });
   userOps.createUser("alice", hashPassword("password123"), "user");
-  aurral = await startServerProcess();
+  aurral = await startServerProcess({ extraEnv: { CORS_ORIGIN: "" } });
 });
 
 test.after(async () => {
@@ -73,6 +73,23 @@ test("authenticates an Aurral user and returns JSON or XML envelopes", async () 
   assert.match(xml.contentType, /application\/xml/);
   assert.match(xml.body, /<subsonic-response[^>]+status="ok"/);
   assert.match(xml.body, /xmlns="http:\/\/subsonic\.org\/restapi"/);
+});
+
+test("allows browser Subsonic clients without CORS configuration", async () => {
+  const response = await fetch(subsonicUrl("ping", { f: "json" }), {
+    headers: { Origin: "http://feishin.example" },
+  });
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+
+  const preflight = await fetch(subsonicUrl("ping", { f: "json" }), {
+    method: "OPTIONS",
+    headers: {
+      Origin: "http://feishin.example",
+      "Access-Control-Request-Method": "GET",
+    },
+  });
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get("access-control-allow-origin"), "*");
 });
 
 test("returns the Subsonic invalid-credentials error", async () => {

--- a/.tests/subsonic/subsonic.int.test.js
+++ b/.tests/subsonic/subsonic.int.test.js
@@ -92,6 +92,14 @@ test("allows browser Subsonic clients without CORS configuration", async () => {
   assert.equal(preflight.headers.get("access-control-allow-origin"), "*");
 });
 
+test("allows browser clients to read redirected artwork without CORS configuration", async () => {
+  const response = await fetch(`http://127.0.0.1:${aurral.port}/api/image-proxy/missing-cache-key.webp`, {
+    headers: { Origin: "http://feishin.example" },
+  });
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assert.equal(response.headers.get("cross-origin-resource-policy"), "cross-origin");
+});
+
 test("returns the Subsonic invalid-credentials error", async () => {
   const result = await request("ping", { p: "wrong-password", f: "json" });
   assert.equal(result.response.status, 200);

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -76,6 +76,15 @@ db.exec(`
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   );
 
+  CREATE TABLE IF NOT EXISTS subsonic_stars (
+    user_id INTEGER NOT NULL,
+    entity_kind TEXT NOT NULL,
+    entity_key TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (user_id, entity_kind, entity_key),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+
   CREATE TABLE IF NOT EXISTS playlist_download_jobs (
     id TEXT PRIMARY KEY,
     artist_name TEXT NOT NULL,
@@ -318,6 +327,8 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(token);
   CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
   CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
+  CREATE INDEX IF NOT EXISTS idx_subsonic_stars_user_created
+    ON subsonic_stars (user_id, created_at);
   CREATE INDEX IF NOT EXISTS idx_aurral_history_created_at ON aurral_history(created_at DESC);
   CREATE INDEX IF NOT EXISTS idx_inbox_items_user_state ON inbox_items(user_id, is_dismissed, is_read, created_at DESC);
   CREATE INDEX IF NOT EXISTS idx_inbox_items_expiry ON inbox_items(expires_at, created_at DESC);

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -540,6 +540,24 @@ export function resolveUser(username, password) {
   };
 }
 
+export function resolveSubsonicTokenUser(username, token, salt) {
+  if (!/^[a-f\d]{32}$/i.test(String(token || "")) || !String(salt || "")) return null;
+  if (
+    !safeCompare(
+      String(username || "").trim().toLowerCase(),
+      String(getAuthUser()).trim().toLowerCase(),
+    )
+  ) return null;
+
+  const matchedPassword = getAuthPassword().find((password) =>
+    safeCompare(
+      crypto.createHash("md5").update(`${password}${salt}`).digest("hex"),
+      token,
+    ),
+  );
+  return matchedPassword ? resolveUser(username, matchedPassword) : null;
+}
+
 function legacyAuth(username, password) {
   const authUser = getAuthUser();
   const passwords = getAuthPassword();
@@ -648,6 +666,7 @@ export const authMiddleware = (req, res, next) => {
     }
     if (
       /^\/api\/library\/stream\/[^/]+$/.test(req.path) ||
+      /^\/api\/library\/canonical-stream\/[^/]+$/i.test(req.path) ||
       /^\/api\/library\/file-stream\/[^/]+\/[^/]+$/i.test(req.path) ||
       /^\/api\/artists\/[a-f0-9-]{36}\/stream$/i.test(req.path) ||
       /^\/api\/weekly-flow\/stream\/[^/]+$/i.test(req.path) ||

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -10,6 +10,7 @@ import { logger } from "../../../services/logger.js";
 import {
   findCanonicalTracksForAlbum,
   getCanonicalLibraryReadModel,
+  resolveCanonicalTrackPath,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 import { stripFilesystemPaths } from "./canonical.js";
 import { streamAudioFile } from "../../../services/audioFileStream.js";
@@ -58,8 +59,9 @@ export function registerTracks(router) {
         const canonicalTracks = album
           ? findCanonicalTracksForAlbum(tracks, album.id).map((track) => ({
               ...stripFilesystemPaths(track),
-              streamPath: null,
-              streamFormat: null,
+              streamPath: track.hasFile
+                ? `/library/canonical-stream/${encodeURIComponent(track.id)}`
+                : null,
             }))
           : [];
         return res.json(canonicalTracks);
@@ -170,6 +172,25 @@ export function registerTracks(router) {
         message: error.message,
       });
     }
+  });
+
+  router.get("/canonical-stream/:trackId", noCache, async (req, res) => {
+    if (!verifyTokenAuth(req)) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const filePath = resolveCanonicalTrackPath(req.params.trackId);
+    if (!filePath) return res.status(404).json({ error: "Track file missing" });
+    try {
+      if (!(await streamAudioFile(req, res, filePath)) && !res.headersSent) {
+        return res.status(404).json({ error: "Track file missing" });
+      }
+    } catch (error) {
+      if (!res.headersSent) {
+        return res.status(500).json({ error: "Stream failed", message: error.message });
+      }
+    }
+    return undefined;
   });
 
   router.get("/file-stream/:albumId/:trackId", noCache, async (req, res) => {

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -8,10 +8,11 @@ import fsp from "fs/promises";
 import path from "path";
 import { logger } from "../../../services/logger.js";
 import {
+  buildCanonicalLibraryReadModel,
   findCanonicalTracksForAlbum,
-  getCanonicalLibraryReadModel,
   resolveCanonicalTrackPath,
 } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 import { stripFilesystemPaths } from "./canonical.js";
 import { streamAudioFile } from "../../../services/audioFileStream.js";
 
@@ -43,9 +44,11 @@ export function registerTracks(router) {
       const { albumId, releaseGroupMbid } = req.query;
 
       if (req.query.readPath === "canonical") {
-        const { albums, tracks } = getCanonicalLibraryReadModel({
+        const canonicalLibrary = getCanonicalLibrary({
           source: req.query.source || "lidarr",
+          availableOnly: true,
         });
+        const { albums, tracks } = buildCanonicalLibraryReadModel(canonicalLibrary);
         const album = [albumId, releaseGroupMbid]
           .filter(Boolean)
           .map((reference) =>

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -20,8 +20,8 @@ import {
   resolveArtworkUrl,
   resolveStreamPath,
   searchLibrary,
-  star,
-  unstar,
+  starMany,
+  unstarMany,
 } from "../services/subsonicLibraryService.js";
 
 const SUBSONIC_VERSION = "1.16.1";
@@ -32,6 +32,14 @@ const getParameter = (req, name) => {
   const value = req.query?.[name];
   return String(Array.isArray(value) ? value[0] || "" : value || "");
 };
+
+const getParameters = (req, names) =>
+  names.flatMap((name) => {
+    const value = req.query?.[name];
+    return (Array.isArray(value) ? value : [value])
+      .map((entry) => String(entry || "").trim())
+      .filter(Boolean);
+  });
 
 const escapeXml = (value) =>
   String(value)
@@ -278,9 +286,10 @@ async function handleSubsonicRequest(req, res) {
     });
   }
   if (method === "star" || method === "unstar") {
+    const targets = getParameters(req, ["id", "albumId", "artistId"]);
     const changed = method === "star"
-      ? star(user, getParameter(req, "id"))
-      : unstar(user, getParameter(req, "id"));
+      ? starMany(user, targets)
+      : unstarMany(user, targets);
     return changed
       ? sendResponse(res, format)
       : sendError(res, format, 70, "Requested data was not found");

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -274,9 +274,11 @@ async function handleSubsonicRequest(req, res) {
     return sendResponse(res, format, "ok", null, { starred: getStarred() });
   }
   if (method === "gettopsongs") {
+    const artist = String(getParameter(req, "artist") || "").trim();
+    if (!artist) return sendError(res, format, 10, "Required parameter is missing: artist");
     return sendResponse(res, format, "ok", null, {
       topSongs: {
-        song: getTopSongs(getParameter(req, "artist"), { count: getParameter(req, "count") }),
+        song: getTopSongs(artist, { count: getParameter(req, "count") }),
       },
     });
   }

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -1,15 +1,20 @@
 import express from "express";
 
 import { APP_NAME, APP_VERSION } from "../config/constants.js";
-import { resolveUser } from "../middleware/auth.js";
+import { resolveSubsonicTokenUser, resolveUser } from "../middleware/auth.js";
 import { streamAudioFile } from "../services/audioFileStream.js";
 import {
   getAlbum,
+  getAlbumList,
   getArtist,
+  getArtistInfo,
   getFlowPlaylist,
   getFlowPlaylists,
+  getGenres,
   getMusicDirectory,
   getSong,
+  getStarred,
+  getTopSongs,
   listArtists,
   resolveArtworkUrl,
   resolveStreamPath,
@@ -158,17 +163,38 @@ async function handleSubsonicRequest(req, res) {
   if (validation.error) return sendError(res, validation.format, ...validation.error);
 
   const { format, password, token, salt } = validation;
-  if (token && salt && !password) {
-    return sendError(res, format, 41, "Token authentication is not supported.");
-  }
-
-  const decodedPassword = decodePassword(password);
-  const user = decodedPassword == null ? null : resolveUser(getParameter(req, "u"), decodedPassword);
+  const decodedPassword = password ? decodePassword(password) : null;
+  const user = password
+    ? decodedPassword == null
+      ? null
+      : resolveUser(getParameter(req, "u"), decodedPassword)
+    : resolveSubsonicTokenUser(getParameter(req, "u"), token, salt);
   if (!user) return sendError(res, format, 40, "Wrong username or password");
   req.user = user;
 
   const method = String(req.params.method || "").replace(/\.view$/i, "").toLowerCase();
   if (method === "ping") return sendResponse(res, format);
+  if (method === "getuser") {
+    const isAdmin = req.user.role === "admin";
+    return sendResponse(res, format, "ok", null, {
+      user: {
+        username: req.user.username,
+        adminRole: isAdmin,
+        commentRole: false,
+        coverArtRole: true,
+        downloadRole: true,
+        folder: ["root"],
+        jukeboxRole: false,
+        playlistRole: Boolean(req.user.permissions?.accessFlow),
+        podcastRole: false,
+        scrobblingEnabled: false,
+        settingsRole: isAdmin,
+        shareRole: false,
+        streamRole: true,
+        uploadRole: false,
+      },
+    });
+  }
   if (method === "getlicense") {
     return sendResponse(res, format, "ok", null, { license: { valid: true } });
   }
@@ -176,6 +202,23 @@ async function handleSubsonicRequest(req, res) {
     return sendResponse(res, format, "ok", null, {
       musicFolders: { musicFolder: [{ id: "root", name: APP_NAME }] },
     });
+  }
+  if (method === "getalbumlist2") {
+    return sendResponse(res, format, "ok", null, {
+      albumList2: {
+        album: getAlbumList({
+          fromYear: getParameter(req, "fromYear"),
+          genre: getParameter(req, "genre"),
+          offset: getParameter(req, "offset"),
+          size: getParameter(req, "size"),
+          toYear: getParameter(req, "toYear"),
+          type: getParameter(req, "type"),
+        }),
+      },
+    });
+  }
+  if (method === "getgenres") {
+    return sendResponse(res, format, "ok", null, { genres: { genre: getGenres() } });
   }
   if (method === "getartists" || method === "getindexes") {
     const indexes = groupArtists(listArtists());
@@ -191,6 +234,12 @@ async function handleSubsonicRequest(req, res) {
     const artist = getArtist(getParameter(req, "id"));
     return artist
       ? sendResponse(res, format, "ok", null, { artist })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "getartistinfo") {
+    const artistInfo = getArtistInfo(getParameter(req, "id"));
+    return artistInfo
+      ? sendResponse(res, format, "ok", null, { artistInfo })
       : sendError(res, format, 70, "Requested data was not found");
   }
   if (method === "getalbum") {
@@ -220,6 +269,16 @@ async function handleSubsonicRequest(req, res) {
   }
   if (method === "getplaylists") {
     return sendResponse(res, format, "ok", null, { playlists: { playlist: getFlowPlaylists(user) } });
+  }
+  if (method === "getstarred") {
+    return sendResponse(res, format, "ok", null, { starred: getStarred() });
+  }
+  if (method === "gettopsongs") {
+    return sendResponse(res, format, "ok", null, {
+      topSongs: {
+        song: getTopSongs(getParameter(req, "artist"), { count: getParameter(req, "count") }),
+      },
+    });
   }
   if (method === "getplaylist") {
     const playlist = getFlowPlaylist(getParameter(req, "id"), user);

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -13,6 +13,7 @@ import {
   getGenres,
   getMusicDirectory,
   getSong,
+  getSongsByGenre,
   getStarred,
   getTopSongs,
   listArtists,
@@ -230,6 +231,18 @@ async function handleSubsonicRequest(req, res) {
   }
   if (method === "getgenres") {
     return sendResponse(res, format, "ok", null, { genres: { genre: getGenres() } });
+  }
+  if (method === "getsongsbygenre") {
+    const genre = getParameter(req, "genre").trim();
+    if (!genre) return sendError(res, format, 10, "Required parameter is missing: genre");
+    return sendResponse(res, format, "ok", null, {
+      songsByGenre: {
+        song: getSongsByGenre(genre, {
+          count: getParameter(req, "count"),
+          offset: getParameter(req, "offset"),
+        }),
+      },
+    });
   }
   if (method === "getartists" || method === "getindexes") {
     const indexes = groupArtists(listArtists());

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -262,7 +262,6 @@ async function handleSubsonicRequest(req, res) {
   }
   if (method === "search3" || method === "search2") {
     const query = getParameter(req, "query");
-    if (!query) return sendError(res, format, 10, "Required parameter is missing: query");
     return sendResponse(res, format, "ok", null, {
       [method === "search3" ? "searchResult3" : "searchResult2"]: searchLibrary(query, req.query),
     });

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -19,6 +19,8 @@ import {
   resolveArtworkUrl,
   resolveStreamPath,
   searchLibrary,
+  star,
+  unstar,
 } from "../services/subsonicLibraryService.js";
 
 const SUBSONIC_VERSION = "1.16.1";
@@ -269,8 +271,18 @@ async function handleSubsonicRequest(req, res) {
   if (method === "getplaylists") {
     return sendResponse(res, format, "ok", null, { playlists: { playlist: getFlowPlaylists(user) } });
   }
-  if (method === "getstarred") {
-    return sendResponse(res, format, "ok", null, { starred: getStarred() });
+  if (method === "getstarred" || method === "getstarred2") {
+    return sendResponse(res, format, "ok", null, {
+      [method === "getstarred" ? "starred" : "starred2"]: getStarred(user),
+    });
+  }
+  if (method === "star" || method === "unstar") {
+    const changed = method === "star"
+      ? star(user, getParameter(req, "id"))
+      : unstar(user, getParameter(req, "id"));
+    return changed
+      ? sendResponse(res, format)
+      : sendError(res, format, 70, "Requested data was not found");
   }
   if (method === "gettopsongs") {
     const artist = String(getParameter(req, "artist") || "").trim();

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -16,6 +16,7 @@ import {
   getStarred,
   getTopSongs,
   listArtists,
+  resolvePlaylistArtwork,
   resolveArtworkUrl,
   resolveStreamPath,
   searchLibrary,
@@ -306,6 +307,11 @@ async function handleSubsonicRequest(req, res) {
     return streamed || res.headersSent ? undefined : handleBinaryError(res, "Track file missing");
   }
   if (method === "getcoverart") {
+    const playlistArtwork = await resolvePlaylistArtwork(getParameter(req, "id"), user);
+    if (playlistArtwork) {
+      res.set("Cache-Control", "private, max-age=86400");
+      return res.sendFile(playlistArtwork.safePath);
+    }
     const artworkUrl = await resolveArtworkUrl(getParameter(req, "id"));
     if (!artworkUrl) return handleBinaryError(res, "Cover art not found");
     res.set("Cache-Control", "public, max-age=31536000, immutable");

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -307,7 +307,9 @@ async function handleSubsonicRequest(req, res) {
   }
   if (method === "getcoverart") {
     const artworkUrl = await resolveArtworkUrl(getParameter(req, "id"));
-    return artworkUrl ? res.redirect(302, artworkUrl) : handleBinaryError(res, "Cover art not found");
+    if (!artworkUrl) return handleBinaryError(res, "Cover art not found");
+    res.set("Cache-Control", "public, max-age=31536000, immutable");
+    return res.redirect(302, artworkUrl);
   }
   return sendError(res, format, 0, `Unsupported request: ${method}`);
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -62,9 +62,11 @@ const allowedCorsOrigins = String(process.env.CORS_ORIGIN || "")
   .filter(Boolean);
 
 const isSubsonicRequest = (req) => req.path === "/rest" || req.path.startsWith("/rest/");
+const isImageProxyRequest = (req) =>
+  req.path === "/api/image-proxy" || req.path.startsWith("/api/image-proxy/");
 
 function corsMiddleware(req, res, next) {
-  if (isSubsonicRequest(req)) {
+  if (isSubsonicRequest(req) || isImageProxyRequest(req)) {
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
@@ -171,6 +173,12 @@ app.use(
     crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" },
   }),
 );
+app.use((req, res, next) => {
+  if (isSubsonicRequest(req) || isImageProxyRequest(req)) {
+    res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+  }
+  next();
+});
 app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
 app.use(authMiddleware);

--- a/backend/server.js
+++ b/backend/server.js
@@ -61,7 +61,20 @@ const allowedCorsOrigins = String(process.env.CORS_ORIGIN || "")
   .map((v) => v.trim())
   .filter(Boolean);
 
+const isSubsonicRequest = (req) => req.path === "/rest" || req.path.startsWith("/rest/");
+
 function corsMiddleware(req, res, next) {
+  if (isSubsonicRequest(req)) {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    if (req.method === "OPTIONS") {
+      res.status(204).end();
+      return;
+    }
+    next();
+    return;
+  }
   if (allowedCorsOrigins.length === 0) {
     if (req.method === "OPTIONS") {
       res.status(403).end();

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -3,6 +3,8 @@ import { getCanonicalLibrary } from "./libraryQueryService.js";
 const firstAvailableFile = (track) =>
   (track.files || []).find((file) => file.available) || track.files?.[0] || null;
 
+const firstReadableFile = (track) => (track?.files || []).find((file) => file.available) || null;
+
 const recordMatches = (record, reference) => {
   const value = String(reference ?? "").trim();
   if (!value) return false;
@@ -82,6 +84,7 @@ const buildTrack = (track, album) => {
     hasFile: Boolean(file?.available),
     size: Number(file?.size || 0),
     quality: file?.quality || null,
+    streamFormat: file?.format || null,
     addedAt: null,
     source: file?.source || null,
     available: track.available,
@@ -113,6 +116,18 @@ export function buildCanonicalLibraryReadModel(library) {
 
 export function getCanonicalLibraryReadModel({ source = "lidarr", availableOnly = true } = {}) {
   return buildCanonicalLibraryReadModel(getCanonicalLibrary({ source, availableOnly }));
+}
+
+export function resolveCanonicalTrackPath(reference) {
+  const value = String(reference ?? "").trim();
+  if (!value) return null;
+  const library = getCanonicalLibrary({ availableOnly: false });
+  const track = library.tracks.find((candidate) =>
+    [candidate.id, candidate.identityKey, candidate.mbid].some(
+      (valueCandidate) => String(valueCandidate ?? "").trim() === value,
+    ),
+  );
+  return firstReadableFile(track)?.path || null;
 }
 
 export function findCanonicalArtist(artists, reference) {

--- a/backend/services/imageProxyService.js
+++ b/backend/services/imageProxyService.js
@@ -18,7 +18,9 @@ const MAX_SOURCE_IMAGE_PIXELS = 40_000_000;
 const IMAGE_PROFILES = {
   card: { maxPx: 512, maxBytes: 150 * 1024, quality: 70 },
   artist: { maxPx: 2048, maxBytes: 2 * 1024 * 1024, quality: 82 },
+  library: { maxPx: 512, maxBytes: 150 * 1024, quality: 70 },
 };
+const isPersistentProfile = (profile) => profile === "library";
 // ponytail: FIFO by mtime, touch on serve for LRU; raise/env only if disk pressure complains
 const IMAGE_PROXY_MAX_BYTES = (() => {
   const parsed = Number(process.env.AURRAL_IMAGE_PROXY_MAX_BYTES);
@@ -261,13 +263,14 @@ const pruneImageProxyCacheToLimit = async () => {
     return;
   }
 
-  let total = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  const evictableEntries = entries.filter((entry) => !isPersistentProfile(entry.profile));
+  let total = evictableEntries.reduce((sum, entry) => sum + entry.bytes, 0);
   if (total <= IMAGE_PROXY_MAX_BYTES) return;
 
-  entries.sort(
+  evictableEntries.sort(
     (a, b) => a.mtimeMs - b.mtimeMs || a.cacheKey.localeCompare(b.cacheKey),
   );
-  for (const entry of entries) {
+  for (const entry of evictableEntries) {
     if (total <= IMAGE_PROXY_MAX_BYTES) break;
     await removeCacheEntryFromDisk(
       entry.cacheKey,
@@ -804,7 +807,7 @@ export const handleImageProxyRequest = async (req, res) => {
   }
 
   res.set("Content-Type", cached.meta.contentType || "image/jpeg");
-  res.set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+  res.set("Cache-Control", "public, max-age=31536000, immutable");
   touchCacheEntry(cached.imagePath);
   return res.sendFile(path.basename(cached.imagePath), {
     root: IMAGE_PROXY_DIR,

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -70,6 +70,14 @@ export async function indexLidarrLibrary({ client } = {}) {
     client.getAllAlbums({ forceRefresh: true }),
     client.getRootFolders(),
   ]);
+  if (
+    Array.isArray(artists) &&
+    artists.length === 0 &&
+    Array.isArray(albums) &&
+    albums.length === 0
+  ) {
+    return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  }
   const artistById = new Map((Array.isArray(artists) ? artists : []).map((item) => [String(item.id), item]));
   const albumTrackData = await mapWithConcurrency(albums, 4, async (album) => {
     if (!album?.id) return { albumId: null, tracks: [], files: [] };
@@ -176,7 +184,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         result.filesIndexed += 1;
       }
     }
-    if (result.filesFailed === 0) {
+    if (result.filesFailed === 0 && result.filesIndexed > 0) {
       markUnseenFilesUnavailable(scanId, "lidarr");
     }
     return result;

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -1,4 +1,5 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
+import { invalidateCanonicalLibraryCache } from "./libraryQueryService.js";
 
 const now = () => Date.now();
 
@@ -73,6 +74,7 @@ export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName =
        metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
        updated_at = excluded.updated_at`,
   ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+  invalidateCanonicalLibraryCache();
   return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
 }
 
@@ -117,6 +119,7 @@ export function upsertLibraryAlbum({
     timestamp,
     timestamp,
   );
+  invalidateCanonicalLibraryCache();
   return db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
 }
 
@@ -141,6 +144,7 @@ export function upsertLibraryTrack({
        metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
        updated_at = excluded.updated_at`,
   ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+  invalidateCanonicalLibraryCache();
   return db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
 }
 
@@ -150,6 +154,7 @@ export function linkLibraryAlbumTrack({ albumId, trackId, discNumber = 1, trackN
       (album_id, track_id, disc_number, track_number, created_at)
      VALUES (?, ?, ?, ?, ?)`,
   ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+  invalidateCanonicalLibraryCache();
 }
 
 export function upsertLibraryMediaFile({
@@ -199,6 +204,7 @@ export function upsertLibraryMediaFile({
     timestamp,
     timestamp,
   );
+  invalidateCanonicalLibraryCache();
 }
 
 export function markUnseenFilesUnavailable(scanId, source) {
@@ -207,6 +213,7 @@ export function markUnseenFilesUnavailable(scanId, source) {
      SET available = 0, updated_at = ?
      WHERE source = ? AND (last_seen_scan_id IS NULL OR last_seen_scan_id != ?)`,
   ).run(now(), normalizeText(source), Number(scanId));
+  invalidateCanonicalLibraryCache();
 }
 
 export async function withLibraryScan(source, rootPath, run) {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1,6 +1,7 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
+const libraryCache = new Map();
 
 const parseJson = (value) => {
   if (!value) return null;
@@ -25,6 +26,9 @@ function createEntity(map, id, value) {
 
 export function getCanonicalLibrary({ source = null, availableOnly = false } = {}) {
   const sourceFilter = normalizeSource(source);
+  const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
+  const cached = libraryCache.get(cacheKey);
+  if (cached) return cached;
   const conditions = [];
   const parameters = [];
 
@@ -165,11 +169,17 @@ export function getCanonicalLibrary({ source = null, availableOnly = false } = {
     track.files.sort((left, right) => left.path.localeCompare(right.path));
   }
 
-  return {
+  const library = {
     artists: [...artists.values()],
     albums: [...albums.values()],
     tracks: [...tracks.values()],
   };
+  libraryCache.set(cacheKey, library);
+  return library;
+}
+
+export function invalidateCanonicalLibraryCache() {
+  libraryCache.clear();
 }
 
 export { normalizeSource };

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -859,8 +859,14 @@ async function checkNativePlaybackSection() {
   const sample = tracks.slice(0, PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT);
   const missing = [];
   for (const track of sample) {
-    const file = track.files?.find((entry) => entry.available);
-    if (!file?.path || !(await checkPathReadable(file.path, file.source))) {
+    let readable = false;
+    for (const file of track.files || []) {
+      if (file.available && file.path && (await checkPathReadable(file.path, file.source))) {
+        readable = true;
+        break;
+      }
+    }
+    if (!readable) {
       missing.push(track.title || "Unknown Track");
     }
   }

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { dbOps } from "../db/helpers/index.js";
+import { getCanonicalLibrary } from "./libraryQueryService.js";
 import { lidarrClient } from "./lidarrClient.js";
 import { slskdClient } from "./slskdClient.js";
 import { nzbgetClient } from "./nzbgetClient.js";
@@ -844,6 +845,43 @@ async function checkNavidromeSection() {
   return buildSection("navidrome", "Navidrome playback", steps);
 }
 
+async function checkNativePlaybackSection() {
+  const library = getCanonicalLibrary({ availableOnly: true });
+  const tracks = Array.isArray(library.tracks) ? library.tracks : [];
+  if (tracks.length === 0) {
+    return buildSection("native-playback", "Aurral-native playback", [
+      healthStep("indexed", "warn", "Canonical media is ready for native playback", {
+        fix: "Connect Lidarr, let the library index refresh, then run Storage Health again.",
+      }),
+    ]);
+  }
+
+  const sample = tracks.slice(0, PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT);
+  const missing = [];
+  for (const track of sample) {
+    const file = track.files?.find((entry) => entry.available);
+    if (!file?.path || !(await checkPathReadable(file.path, file.source))) {
+      missing.push(track.title || "Unknown Track");
+    }
+  }
+
+  const detail = `${tracks.length} canonical track${tracks.length === 1 ? "" : "s"} indexed`;
+  if (missing.length > 0) {
+    return buildSection("native-playback", "Aurral-native playback", [
+      healthStep("indexed", "fail", "Aurral-native playback can read indexed media", {
+        detail: `${missing.length} sampled track${missing.length === 1 ? " is" : "s are"} missing or unreadable`,
+        fix: "Restore the media mount or rescan the library so stale files become unavailable.",
+      }),
+    ]);
+  }
+
+  return buildSection("native-playback", "Aurral-native playback", [
+    healthStep("indexed", "pass", "Aurral-native playback can read indexed media", {
+      detail,
+    }),
+  ]);
+}
+
 function appendPortablePath(basePath, child) {
   return `${String(basePath || "").trim().replace(/\\/g, "/").replace(/\/+$/, "")}/${child}`;
 }
@@ -1025,6 +1063,7 @@ async function buildStorageHealthCheck() {
     await checkPathMappingsSection(),
     downloadsSection,
     lidarrSection,
+    await checkNativePlaybackSection(),
     await checkSlskdSection(),
     await checkNzbgetSection(),
     await checkSabnzbdSection(),

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -375,18 +375,69 @@ export function getAlbumList(options = {}) {
   if (type === "byYear" || options.fromYear || options.toYear) {
     const fromYear = Number.parseInt(options.fromYear, 10);
     const toYear = Number.parseInt(options.toYear, 10);
+    const lowerYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
+      ? Math.min(fromYear, toYear)
+      : fromYear;
+    const upperYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
+      ? Math.max(fromYear, toYear)
+      : toYear;
     albums = albums.filter((album) => {
       const releaseYear = year(album.releaseDate) || 0;
-      return (!Number.isFinite(fromYear) || releaseYear >= fromYear) &&
-        (!Number.isFinite(toYear) || releaseYear <= toYear);
+      return (!Number.isFinite(lowerYear) || releaseYear >= lowerYear) &&
+        (!Number.isFinite(upperYear) || releaseYear <= upperYear);
     });
   }
 
-  albums.sort((left, right) =>
+  const values = new Map(albums.map((album) => [album.id, albumData(library, album).value]));
+  const compareName = (left, right) =>
     `${left.title}\u0000${left.albumArtist}`.localeCompare(
       `${right.title}\u0000${right.albumArtist}`,
-    ),
-  );
+    );
+  const compareArtist = (left, right) =>
+    `${left.albumArtist}\u0000${left.title}`.localeCompare(
+      `${right.albumArtist}\u0000${right.title}`,
+    );
+  const compareReleaseDate = (left, right) => {
+    const leftDate = Date.parse(String(left.releaseDate || ""));
+    const rightDate = Date.parse(String(right.releaseDate || ""));
+    if (!Number.isFinite(leftDate) && !Number.isFinite(rightDate)) return compareName(left, right);
+    if (!Number.isFinite(leftDate)) return 1;
+    if (!Number.isFinite(rightDate)) return -1;
+    return rightDate - leftDate || compareName(left, right);
+  };
+  const compareYear = (left, right) => {
+    const leftYear = year(left.releaseDate) || 0;
+    const rightYear = year(right.releaseDate) || 0;
+    return leftYear - rightYear || compareName(left, right);
+  };
+  const compareGenre = (left, right) =>
+    `${values.get(left.id)?.genre || ""}\u0000${left.title}`.localeCompare(
+      `${values.get(right.id)?.genre || ""}\u0000${right.title}`,
+    );
+
+  if (type === "random") {
+    for (let index = albums.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(Math.random() * (index + 1));
+      [albums[index], albums[swapIndex]] = [albums[swapIndex], albums[index]];
+    }
+  } else if (type === "newest" || type === "recent") {
+    albums.sort(compareReleaseDate);
+  } else if (type === "alphabeticalByArtist") {
+    albums.sort(compareArtist);
+  } else if (type === "byYear") {
+    const fromYear = Number.parseInt(options.fromYear, 10);
+    const toYear = Number.parseInt(options.toYear, 10);
+    albums.sort((left, right) => {
+      const comparison = compareYear(left, right);
+      return Number.isFinite(fromYear) && Number.isFinite(toYear) && fromYear > toYear
+        ? -comparison
+        : comparison;
+    });
+  } else if (type === "byGenre") {
+    albums.sort(compareGenre);
+  } else {
+    albums.sort(compareName);
+  }
   const offset = normalizeOffset(options.offset);
   const size = normalizeLimit(options.size);
   return albums.slice(offset, offset + size).map((album) => toAlbumSummary(library, album));
@@ -420,7 +471,24 @@ export function getArtistInfo(value) {
 }
 
 export function getTopSongs(artist, options = {}) {
-  return searchLibrary(artist, { songCount: options.count }).song;
+  const target = String(artist || "").trim();
+  if (!target) return [];
+  const library = readLibrary();
+  const normalizedTarget = target.toLocaleLowerCase();
+  const artistRecord = library.artists.find(
+    (entry) =>
+      entry.identityKey === target || entry.name.toLocaleLowerCase() === normalizedTarget,
+  );
+  if (!artistRecord) return [];
+  const tracks = library.tracks.filter((track) => {
+    const album = findAlbumForTrack(library, track);
+    const trackArtist = findArtistForAlbum(library, album);
+    return (
+      trackArtist?.id === artistRecord.id ||
+      String(track.artistName || "").trim().toLocaleLowerCase() === normalizedTarget
+    );
+  });
+  return tracks.slice(0, normalizeLimit(options.count)).map((track) => toSong(library, track));
 }
 
 export function getFlowPlaylists(user) {

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -3,12 +3,13 @@ import { db } from "../config/db-sqlite.js";
 import { getCanonicalLibrary } from "./libraryQueryService.js";
 import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
 import { getArtistImage } from "./imageService.js";
-import { buildImageProxyUrl } from "./imageProxyService.js";
+import { buildImageProxyUrl, warmPublicImageUrl } from "./imageProxyService.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
 import { hasPermission } from "../middleware/auth.js";
 
 const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
+const LIBRARY_IMAGE_PROFILE = "library";
 
 const parseId = (value) => {
   const match = /^(artist|album|song|flow|flow-song|shared|shared-song):(.+)$/.exec(String(value || ""));
@@ -602,30 +603,62 @@ export function resolveStreamPath(value, user) {
   return file?.available && file.path ? file.path : null;
 }
 
-const cachedArtworkUrl = (key) => {
+const cachedArtworkUrl = async (key) => {
   const cached = dbOps.getImage(key);
   if (!cached?.imageUrl || cached.imageUrl === "NOT_FOUND") return null;
-  return buildImageProxyUrl(cached.imageUrl);
+  const artwork = await warmPublicImageUrl(cached.imageUrl, LIBRARY_IMAGE_PROFILE);
+  if (artwork && artwork !== cached.imageUrl) dbOps.setImage(key, artwork);
+  return artwork || buildImageProxyUrl(cached.imageUrl);
 };
 
 export async function resolveArtworkUrl(value) {
-  const library = readLibrary();
   const parsed = parseId(value);
+  if (!parsed) return null;
+
+  if (parsed.kind === "album" && parsed.key.startsWith("release-group:")) {
+    const releaseGroupMbid = parsed.key.slice("release-group:".length);
+    const cacheKey = `rg:${releaseGroupMbid}`;
+    const cached = await cachedArtworkUrl(cacheKey);
+    if (cached) return cached;
+    const result = await fetchReleaseGroupCoverUrl(releaseGroupMbid);
+    if (!result?.imageUrl) return null;
+    const artwork = await warmPublicImageUrl(result.imageUrl, LIBRARY_IMAGE_PROFILE);
+    if (artwork) dbOps.setImage(cacheKey, artwork);
+    return artwork;
+  }
+
+  const library = readLibrary();
   const entity = findCanonical(library, parsed);
   if (!entity) return null;
 
   if (parsed.kind === "artist") {
-    const cached = cachedArtworkUrl(entity.mbid || entity.identityKey);
+    const artistCacheKey = entity.mbid || entity.identityKey;
+    const cached = await cachedArtworkUrl(artistCacheKey);
     if (cached) return cached;
-    if (!entity.mbid) return null;
-    const result = await getArtistImage(entity.mbid, { artistName: entity.name });
-    return result?.url ? buildImageProxyUrl(result.url) : null;
+    const albums = artistAlbums(library, entity);
+    for (const album of albums) {
+      const cacheId = album.releaseGroupMbid || album.mbid;
+      const albumArtwork = cacheId ? await cachedArtworkUrl(`rg:${cacheId}`) : null;
+      if (albumArtwork) {
+        dbOps.setImage(artistCacheKey, albumArtwork);
+        return albumArtwork;
+      }
+    }
+    if (entity.mbid) {
+      const result = await getArtistImage(entity.mbid, { artistName: entity.name });
+      if (result?.url) {
+        const artwork = await warmPublicImageUrl(result.url, LIBRARY_IMAGE_PROFILE);
+        if (artwork) dbOps.setImage(artistCacheKey, artwork);
+        return artwork;
+      }
+    }
+    return null;
   }
 
   const album = parsed.kind === "album" ? entity : findAlbumForTrack(library, entity);
   if (!album) return null;
   const cacheId = album.releaseGroupMbid || album.mbid;
-  const cached = cacheId ? cachedArtworkUrl(`rg:${cacheId}`) : null;
+  const cached = cacheId ? await cachedArtworkUrl(`rg:${cacheId}`) : null;
   if (cached) return cached;
   if (!cacheId) return null;
   const artist = findArtistForAlbum(library, album);
@@ -633,7 +666,10 @@ export async function resolveArtworkUrl(value) {
     artistName: artist?.name || album.albumArtist || "",
     albumTitle: album.title,
   });
-  return result?.imageUrl ? buildImageProxyUrl(result.imageUrl) : null;
+  if (!result?.imageUrl) return null;
+  const artwork = await warmPublicImageUrl(result.imageUrl, LIBRARY_IMAGE_PROFILE);
+  if (artwork) dbOps.setImage(`rg:${cacheId}`, artwork);
+  return artwork;
 }
 
 export { idFor, parseId };

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -514,18 +514,32 @@ const starTarget = (value) => {
 };
 
 export function star(user, value) {
-  const parsed = starTarget(value);
-  if (!parsed || !user?.id) return false;
+  return starMany(user, [value]);
+}
+
+export function starMany(user, values) {
+  const parsed = values.map(starTarget);
+  if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
   const library = readLibrary();
-  if (!findCanonical(library, parsed)) return false;
-  addStarStmt.run(user.id, parsed.kind, parsed.key, Date.now());
+  if (parsed.some((target) => !findCanonical(library, target))) return false;
+  const addStars = db.transaction(() => {
+    for (const target of parsed) addStarStmt.run(user.id, target.kind, target.key, Date.now());
+  });
+  addStars();
   return true;
 }
 
 export function unstar(user, value) {
-  const parsed = starTarget(value);
-  if (!parsed || !user?.id) return false;
-  removeStarStmt.run(user.id, parsed.kind, parsed.key);
+  return unstarMany(user, [value]);
+}
+
+export function unstarMany(user, values) {
+  const parsed = values.map(starTarget);
+  if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
+  const removeStars = db.transaction(() => {
+    for (const target of parsed) removeStarStmt.run(user.id, target.kind, target.key);
+  });
+  removeStars();
   return true;
 }
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -1,4 +1,5 @@
 import { dbOps } from "../db/helpers/index.js";
+import { db } from "../config/db-sqlite.js";
 import { getCanonicalLibrary } from "./libraryQueryService.js";
 import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
 import { getArtistImage } from "./imageService.js";
@@ -224,7 +225,7 @@ function toPlaylistSong(playlist, kind, job) {
   const artist = protocolArtist(null, job.artistName || "Unknown Artist");
   const format = String(job.finalPath || "").split(".").pop()?.toLowerCase() || "mp3";
   const id = idFor(kind === "flow" ? "flow-song" : "shared-song", `${playlist.id}:${job.id}`);
-  const albumMbid = String(job.albumMbid || job.releaseGroupMbid || "").trim();
+  const albumMbid = String(job.releaseGroupMbid || job.albumMbid || "").trim();
   return {
     id,
     parent: idFor(kind, playlist.id),
@@ -465,8 +466,50 @@ export function getGenres() {
   return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
 }
 
-export function getStarred() {
-  return { album: [], artist: [], song: [] };
+const getStarsStmt = db.prepare(
+  "SELECT entity_kind, entity_key FROM subsonic_stars WHERE user_id = ? ORDER BY created_at, entity_kind, entity_key",
+);
+const addStarStmt = db.prepare(
+  "INSERT OR IGNORE INTO subsonic_stars (user_id, entity_kind, entity_key, created_at) VALUES (?, ?, ?, ?)",
+);
+const removeStarStmt = db.prepare(
+  "DELETE FROM subsonic_stars WHERE user_id = ? AND entity_kind = ? AND entity_key = ?",
+);
+
+const starTarget = (value) => {
+  const parsed = parseId(value);
+  return parsed && ["artist", "album", "song"].includes(parsed.kind) ? parsed : null;
+};
+
+export function star(user, value) {
+  const parsed = starTarget(value);
+  if (!parsed || !user?.id) return false;
+  const library = readLibrary();
+  if (!findCanonical(library, parsed)) return false;
+  addStarStmt.run(user.id, parsed.kind, parsed.key, Date.now());
+  return true;
+}
+
+export function unstar(user, value) {
+  const parsed = starTarget(value);
+  if (!parsed || !user?.id) return false;
+  removeStarStmt.run(user.id, parsed.kind, parsed.key);
+  return true;
+}
+
+export function getStarred(user) {
+  const starred = { album: [], artist: [], song: [] };
+  if (!user?.id) return starred;
+  const library = readLibrary();
+  for (const row of getStarsStmt.all(user.id)) {
+    const parsed = { kind: row.entity_kind, key: row.entity_key };
+    const entity = findCanonical(library, parsed);
+    if (!entity) continue;
+    if (parsed.kind === "artist") starred.artist.push(toArtistSummary(entity));
+    if (parsed.kind === "album") starred.album.push(toAlbumSummary(library, entity));
+    if (parsed.kind === "song") starred.song.push(toSong(library, entity));
+  }
+  return starred;
 }
 
 export function getArtistInfo(value) {

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -6,6 +6,7 @@ import { getArtistImage } from "./imageService.js";
 import { buildImageProxyUrl, warmPublicImageUrl } from "./imageProxyService.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
+import { playlistManager } from "./weeklyFlow/weeklyFlowPlaylistManager.js";
 import { hasPermission } from "../middleware/auth.js";
 
 const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
@@ -53,9 +54,14 @@ const genreNames = (value) =>
 
 const entityGenres = (entity) => {
   const metadata = entity?.metadata || {};
-  return genreNames(
-    metadata.common?.genre || metadata.genre || metadata.tags?.genre,
-  );
+  return [
+    metadata.genres,
+    metadata.common?.genre,
+    metadata.genre,
+    metadata.tags?.genre,
+  ]
+    .flatMap(genreNames)
+    .filter((genre, index, values) => values.indexOf(genre) === index);
 };
 
 const visibleFlows = (user) =>
@@ -89,7 +95,7 @@ const coverArtForAlbum = (album) => idFor("album", album.identityKey);
 const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   const artist = findArtistForAlbum(library, album);
   const file = firstFile(track);
-  const genres = entityGenres(track);
+  const genres = [...new Set([...entityGenres(artist), ...entityGenres(track)])];
   const relation = track.albums?.find((entry) => entry.albumId === album?.id);
   const artistValue = protocolArtist(artist, track.artistName || "Unknown Artist");
   const format = String(file?.format || "mp3").toLowerCase();
@@ -131,6 +137,7 @@ const albumData = (library, album) => {
   const tracks = albumTracks(library, album);
   const artistValue = protocolArtist(artist, album.albumArtist || "Unknown Artist");
   const genres = [
+    ...entityGenres(artist),
     ...entityGenres(album),
     ...tracks.flatMap((track) => entityGenres(track)),
   ].filter((genre, index, values) => values.indexOf(genre) === index);
@@ -172,21 +179,33 @@ const toAlbum = (library, album) => {
 
 const toArtist = (library, artist) => {
   const albums = artistAlbums(library, artist);
-  return {
+  const genres = entityGenres(artist);
+  const value = {
     id: idFor("artist", artist.identityKey),
     name: artist.name,
     coverArt: idFor("artist", artist.identityKey),
     albumCount: albums.length,
     album: albums.map((album) => toAlbumSummary(library, album)),
   };
+  if (genres.length) {
+    value.genre = genres[0];
+    value.genres = genres.map((name) => ({ name }));
+  }
+  return value;
 };
 
-const toArtistSummary = (artist) => ({
-  id: idFor("artist", artist.identityKey),
-  name: artist.name,
-  coverArt: idFor("artist", artist.identityKey),
-  albumCount: artist.albumIds.length,
-});
+const toArtistSummary = (artist) => {
+  const genres = entityGenres(artist);
+  return {
+    id: idFor("artist", artist.identityKey),
+    name: artist.name,
+    coverArt: idFor("artist", artist.identityKey),
+    albumCount: artist.albumIds.length,
+    ...(genres.length
+      ? { genre: genres[0], genres: genres.map((name) => ({ name })) }
+      : {}),
+  };
+};
 
 function readLibrary() {
   const library = getCanonicalLibrary({ availableOnly: false });
@@ -269,6 +288,12 @@ const flowJobs = (flow) =>
   downloadTracker
     .getByPlaylistType(flow.id)
     .filter((job) => job.status === "done" && job.finalPath);
+
+const playlistCoverArt = (jobs, kind, playlistId) => {
+  const job = jobs.find((entry) => entry.releaseGroupMbid || entry.albumMbid);
+  const albumMbid = String(job?.releaseGroupMbid || job?.albumMbid || "").trim();
+  return albumMbid ? idFor("album", `release-group:${albumMbid}`) : idFor(kind, playlistId);
+};
 
 export function listArtists() {
   const library = readLibrary();
@@ -453,14 +478,20 @@ export function getGenres() {
   const genres = new Map();
   for (const album of library.albums) {
     const tracks = albumTracks(library, album);
+    const artistGenres = entityGenres(findArtistForAlbum(library, album));
+    const albumMetadataGenres = entityGenres(album);
     const albumGenres = [
+      ...artistGenres,
       ...entityGenres(album),
       ...tracks.flatMap((track) => entityGenres(track)),
     ];
     for (const name of new Set(albumGenres)) {
       const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
       value.albumCount += 1;
-      value.songCount += tracks.filter((track) => entityGenres(track).includes(name)).length;
+      value.songCount +=
+        artistGenres.includes(name) || albumMetadataGenres.includes(name)
+          ? tracks.length
+          : tracks.filter((track) => entityGenres(track).includes(name)).length;
       genres.set(name, value);
     }
   }
@@ -545,6 +576,7 @@ export function getFlowPlaylists(user) {
       id: idFor("flow", flow.id),
       name: flow.name,
       owner: user.username,
+      coverArt: playlistCoverArt(jobs, "flow", flow.id),
       songCount: jobs.length,
       duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
       public: false,
@@ -560,6 +592,7 @@ export function getFlowPlaylists(user) {
       id: idFor("shared", playlist.id),
       name: playlist.name,
       owner: user.username,
+      coverArt: playlistCoverArt(jobs, "shared", playlist.id),
       songCount: jobs.length,
       duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
       public: false,
@@ -582,6 +615,7 @@ export function getFlowPlaylist(value, user) {
     id: idFor(kind, playlist.id),
     name: playlist.name,
     owner: user.username,
+    coverArt: playlistCoverArt(jobs, kind, playlist.id),
     songCount: jobs.length,
     duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
     public: false,
@@ -670,6 +704,13 @@ export async function resolveArtworkUrl(value) {
   const artwork = await warmPublicImageUrl(result.imageUrl, LIBRARY_IMAGE_PROFILE);
   if (artwork) dbOps.setImage(`rg:${cacheId}`, artwork);
   return artwork;
+}
+
+export async function resolvePlaylistArtwork(value, user) {
+  const parsed = parseId(value);
+  if (!parsed || !["flow", "shared"].includes(parsed.kind)) return null;
+  const playlist = playlistFromId(user, value);
+  return playlist ? playlistManager.resolveArtworkFile(playlist.id) : null;
 }
 
 export { idFor, parseId };

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -95,7 +95,11 @@ const coverArtForAlbum = (album) => idFor("album", album.identityKey);
 const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   const artist = findArtistForAlbum(library, album);
   const file = firstFile(track);
-  const genres = [...new Set([...entityGenres(artist), ...entityGenres(track)])];
+  const genres = [...new Set([
+    ...entityGenres(artist),
+    ...entityGenres(album),
+    ...entityGenres(track),
+  ])];
   const relation = track.albums?.find((entry) => entry.albumId === album?.id);
   const artistValue = protocolArtist(artist, track.artistName || "Unknown Artist");
   const format = String(file?.format || "mp3").toLowerCase();
@@ -289,11 +293,7 @@ const flowJobs = (flow) =>
     .getByPlaylistType(flow.id)
     .filter((job) => job.status === "done" && job.finalPath);
 
-const playlistCoverArt = (jobs, kind, playlistId) => {
-  const job = jobs.find((entry) => entry.releaseGroupMbid || entry.albumMbid);
-  const albumMbid = String(job?.releaseGroupMbid || job?.albumMbid || "").trim();
-  return albumMbid ? idFor("album", `release-group:${albumMbid}`) : idFor(kind, playlistId);
-};
+const playlistCoverArt = (kind, playlistId) => idFor(kind, playlistId);
 
 export function listArtists() {
   const library = readLibrary();
@@ -473,6 +473,24 @@ export function getAlbumList(options = {}) {
   return albums.slice(offset, offset + size).map((album) => toAlbumSummary(library, album));
 }
 
+export function getSongsByGenre(genre, options = {}) {
+  const target = String(genre || "").trim().toLocaleLowerCase();
+  if (!target) return [];
+  const library = readLibrary();
+  const tracks = library.tracks.filter((track) => {
+    const album = findAlbumForTrack(library, track);
+    const artist = findArtistForAlbum(library, album);
+    return [
+      ...entityGenres(artist),
+      ...entityGenres(album),
+      ...entityGenres(track),
+    ].some((value) => value.toLocaleLowerCase() === target);
+  });
+  const offset = normalizeOffset(options.offset);
+  const size = normalizeLimit(options.count);
+  return tracks.slice(offset, offset + size).map((track) => toSong(library, track));
+}
+
 export function getGenres() {
   const library = readLibrary();
   const genres = new Map();
@@ -590,7 +608,7 @@ export function getFlowPlaylists(user) {
       id: idFor("flow", flow.id),
       name: flow.name,
       owner: user.username,
-      coverArt: playlistCoverArt(jobs, "flow", flow.id),
+      coverArt: playlistCoverArt("flow", flow.id),
       songCount: jobs.length,
       duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
       public: false,
@@ -606,7 +624,7 @@ export function getFlowPlaylists(user) {
       id: idFor("shared", playlist.id),
       name: playlist.name,
       owner: user.username,
-      coverArt: playlistCoverArt(jobs, "shared", playlist.id),
+      coverArt: playlistCoverArt("shared", playlist.id),
       songCount: jobs.length,
       duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
       public: false,
@@ -629,7 +647,7 @@ export function getFlowPlaylist(value, user) {
     id: idFor(kind, playlist.id),
     name: playlist.name,
     owner: user.username,
-    coverArt: playlistCoverArt(jobs, kind, playlist.id),
+    coverArt: playlistCoverArt(kind, playlist.id),
     songCount: jobs.length,
     duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
     public: false,

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -10,7 +10,7 @@ import { hasPermission } from "../middleware/auth.js";
 const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
 
 const parseId = (value) => {
-  const match = /^(artist|album|song|flow|flow-song):(.+)$/.exec(String(value || ""));
+  const match = /^(artist|album|song|flow|flow-song|shared|shared-song):(.+)$/.exec(String(value || ""));
   if (!match) return null;
   try {
     return { kind: match[1], key: decodeURIComponent(match[2]) };
@@ -213,20 +213,21 @@ function findCanonical(library, parsed) {
   return null;
 }
 
-function flowFromId(user, value) {
+function playlistFromId(user, value) {
   const parsed = parseId(value);
-  if (!parsed || parsed.kind !== "flow") return null;
-  const flow = flowPlaylistConfig.getFlow(parsed.key);
-  return flow && visibleFlows(user).some((entry) => entry.id === flow.id) ? flow : null;
+  if (!parsed || !["flow", "shared"].includes(parsed.kind)) return null;
+  if (parsed.kind === "flow") return flowPlaylistConfig.getFlowForUser(user, parsed.key);
+  return flowPlaylistConfig.getSharedPlaylistForUser(user, parsed.key);
 }
 
-function toFlowSong(flow, job) {
+function toPlaylistSong(playlist, kind, job) {
   const artist = protocolArtist(null, job.artistName || "Unknown Artist");
   const format = String(job.finalPath || "").split(".").pop()?.toLowerCase() || "mp3";
-  const id = idFor("flow-song", `${flow.id}:${job.id}`);
+  const id = idFor(kind === "flow" ? "flow-song" : "shared-song", `${playlist.id}:${job.id}`);
+  const albumMbid = String(job.albumMbid || job.releaseGroupMbid || "").trim();
   return {
     id,
-    parent: idFor("flow", flow.id),
+    parent: idFor(kind, playlist.id),
     isDir: false,
     isVideo: false,
     title: job.trackName,
@@ -235,6 +236,7 @@ function toFlowSong(flow, job) {
     artistId: artist.id,
     albumArtists: [artist],
     artists: [artist],
+    coverArt: albumMbid ? idFor("album", `release-group:${albumMbid}`) : undefined,
     contentType: `audio/${format}`,
     created: PROTOCOL_DATE,
     track: job.trackNumber || 0,
@@ -247,16 +249,17 @@ function toFlowSong(flow, job) {
   };
 }
 
-function flowJobFromId(user, value) {
+function playlistJobFromId(user, value) {
   const parsed = parseId(value);
-  if (!parsed || parsed.kind !== "flow-song") return null;
+  if (!parsed || !["flow-song", "shared-song"].includes(parsed.kind)) return null;
   const separator = parsed.key.indexOf(":");
   if (separator < 1) return null;
-  const flow = flowFromId(user, idFor("flow", parsed.key.slice(0, separator)));
-  if (!flow) return null;
+  const kind = parsed.kind === "flow-song" ? "flow" : "shared";
+  const playlist = playlistFromId(user, idFor(kind, parsed.key.slice(0, separator)));
+  if (!playlist) return null;
   const job = downloadTracker.getJob(parsed.key.slice(separator + 1));
-  return job?.playlistType === flow.id && job.status === "done" && job.finalPath
-    ? { flow, job }
+  return job?.playlistType === playlist.id && job.status === "done" && job.finalPath
+    ? { kind, playlist, job }
     : null;
 }
 
@@ -288,8 +291,8 @@ export function getAlbum(value) {
 }
 
 export function getSong(value, user) {
-  const flowEntry = flowJobFromId(user, value);
-  if (flowEntry) return toFlowSong(flowEntry.flow, flowEntry.job);
+  const playlistEntry = playlistJobFromId(user, value);
+  if (playlistEntry) return toPlaylistSong(playlistEntry.playlist, playlistEntry.kind, playlistEntry.job);
 
   const library = readLibrary();
   const parsed = parseId(value);
@@ -492,7 +495,7 @@ export function getTopSongs(artist, options = {}) {
 }
 
 export function getFlowPlaylists(user) {
-  return visibleFlows(user).map((flow) => {
+  const flows = visibleFlows(user).map((flow) => {
     const jobs = flowJobs(flow);
     const playlist = {
       id: idFor("flow", flow.id),
@@ -507,28 +510,46 @@ export function getFlowPlaylists(user) {
     if (flow.description) playlist.comment = flow.description;
     return playlist;
   });
+  const sharedPlaylists = flowPlaylistConfig.getSharedPlaylistsForUser(user).map((playlist) => {
+    const jobs = flowJobs(playlist);
+    const value = {
+      id: idFor("shared", playlist.id),
+      name: playlist.name,
+      owner: user.username,
+      songCount: jobs.length,
+      duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
+      public: false,
+      created: new Date(playlist.createdAt || Date.now()).toISOString(),
+      changed: new Date(playlist.importedAt || playlist.createdAt || Date.now()).toISOString(),
+    };
+    if (playlist.description) value.comment = playlist.description;
+    return value;
+  });
+  return [...flows, ...sharedPlaylists];
 }
 
 export function getFlowPlaylist(value, user) {
-  const flow = flowFromId(user, value);
-  if (!flow) return null;
-  const jobs = flowJobs(flow);
+  const parsed = parseId(value);
+  const kind = parsed?.kind === "shared" ? "shared" : "flow";
+  const playlist = playlistFromId(user, value);
+  if (!playlist) return null;
+  const jobs = flowJobs(playlist);
   return {
-    id: idFor("flow", flow.id),
-    name: flow.name,
+    id: idFor(kind, playlist.id),
+    name: playlist.name,
     owner: user.username,
     songCount: jobs.length,
     duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
     public: false,
-    entry: jobs.map((job) => toFlowSong(flow, job)),
+    entry: jobs.map((job) => toPlaylistSong(playlist, kind, job)),
   };
 }
 
 export function resolveStreamPath(value, user) {
-  const flowEntry = flowJobFromId(user, value);
-  if (flowEntry) {
-    return flowEntry.job.status === "done" && flowEntry.job.finalPath
-      ? flowEntry.job.finalPath
+  const playlistEntry = playlistJobFromId(user, value);
+  if (playlistEntry) {
+    return playlistEntry.job.status === "done" && playlistEntry.job.finalPath
+      ? playlistEntry.job.finalPath
       : null;
   }
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -27,6 +27,8 @@ const seconds = (durationMs) => {
   return Number.isFinite(value) && value > 0 ? Math.round(value / 1000) : 0;
 };
 
+const PROTOCOL_DATE = "1970-01-01T00:00:00.000Z";
+
 const year = (value) => {
   const match = /^(\d{4})/.exec(String(value || ""));
   return match ? Number(match[1]) : null;
@@ -42,6 +44,18 @@ const normalizeOffset = (value) => {
   return Number.isFinite(parsed) ? Math.max(parsed, 0) : 0;
 };
 
+const genreNames = (value) =>
+  (Array.isArray(value) ? value : [value])
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean);
+
+const entityGenres = (entity) => {
+  const metadata = entity?.metadata || {};
+  return genreNames(
+    metadata.common?.genre || metadata.genre || metadata.tags?.genre,
+  );
+};
+
 const visibleFlows = (user) =>
   user && hasPermission(user, "accessFlow") ? flowPlaylistConfig.getFlowsForUser(user) : [];
 
@@ -52,6 +66,11 @@ const findAlbumForTrack = (library, track) => {
 
 const findArtistForAlbum = (library, album) =>
   library.artistsById.get(album?.artistId) || null;
+
+const protocolArtist = (artist, fallback = "Unknown Artist") => ({
+  id: idFor("artist", artist?.identityKey || `name:artist:${fallback.toLocaleLowerCase()}`),
+  name: artist?.name || fallback,
+});
 
 const albumTracks = (library, album) =>
   (album?.trackIds || [])
@@ -68,44 +87,77 @@ const coverArtForAlbum = (album) => idFor("album", album.identityKey);
 const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   const artist = findArtistForAlbum(library, album);
   const file = firstFile(track);
-  const genres = track.metadata?.common?.genre || track.metadata?.genre;
+  const genres = entityGenres(track);
   const relation = track.albums?.find((entry) => entry.albumId === album?.id);
-  return {
+  const artistValue = protocolArtist(artist, track.artistName || "Unknown Artist");
+  const format = String(file?.format || "mp3").toLowerCase();
+  const song = {
     id: idFor("song", track.identityKey),
-    parent: album ? idFor("album", album.identityKey) : null,
+    parent: album ? idFor("album", album.identityKey) : idFor("album", "unknown"),
     isDir: false,
+    isVideo: false,
     title: track.title,
-    album: album?.title || null,
-    artist: artist?.name || track.artistName || null,
-    albumId: album ? idFor("album", album.identityKey) : null,
-    artistId: artist ? idFor("artist", artist.identityKey) : null,
+    album: album?.title || "Unknown Album",
+    artist: artistValue.name,
+    albumId: album ? idFor("album", album.identityKey) : undefined,
+    artistId: artistValue.id,
+    albumArtists: [artistValue],
+    artists: [artistValue],
+    contentType: `audio/${format}`,
+    created: PROTOCOL_DATE,
     track: Number(relation?.trackNumber) || 0,
-    discNumber: Number(relation?.discNumber) || null,
-    year: year(album?.releaseDate),
-    genre: (Array.isArray(genres) ? genres[0] : genres) || null,
-    coverArt: album ? coverArtForAlbum(album) : null,
+    discNumber: Number(relation?.discNumber) || 1,
+    coverArt: album ? coverArtForAlbum(album) : undefined,
     duration: seconds(file?.durationMs),
     size: Number(file?.size || 0),
-    suffix: file?.format || null,
+    suffix: format,
+    path: idFor("song", track.identityKey),
     type: "music",
   };
+  const releaseYear = year(album?.releaseDate);
+  if (releaseYear != null) song.year = releaseYear;
+  const genre = (Array.isArray(genres) ? genres[0] : genres) || null;
+  if (genre) {
+    song.genre = genre;
+    song.genres = [{ name: genre }];
+  }
+  return song;
 };
 
 const albumData = (library, album) => {
   const artist = findArtistForAlbum(library, album);
   const tracks = albumTracks(library, album);
+  const artistValue = protocolArtist(artist, album.albumArtist || "Unknown Artist");
+  const genres = [
+    ...entityGenres(album),
+    ...tracks.flatMap((track) => entityGenres(track)),
+  ].filter((genre, index, values) => values.indexOf(genre) === index);
+  const value = {
+    id: idFor("album", album.identityKey),
+    name: album.title,
+    title: album.title,
+    album: album.title,
+    artist: artistValue.name,
+    artistId: artistValue.id,
+    artists: [artistValue],
+    parent: artistValue.id,
+    isDir: false,
+    isVideo: false,
+    created: PROTOCOL_DATE,
+    coverArt: coverArtForAlbum(album),
+    songCount: tracks.length,
+    duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
+    song: [],
+  };
+  const releaseYear = year(album.releaseDate);
+  if (releaseYear != null) value.year = releaseYear;
+  if (genres.length) {
+    value.genre = genres[0];
+    value.genres = genres.map((name) => ({ name }));
+  }
   return {
     tracks,
-    value: {
-      id: idFor("album", album.identityKey),
-      name: album.title,
-      artist: artist?.name || album.albumArtist || null,
-      artistId: artist ? idFor("artist", artist.identityKey) : null,
-      coverArt: coverArtForAlbum(album),
-      songCount: tracks.length,
-      duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
-      year: year(album.releaseDate),
-    },
+    value,
   };
 };
 
@@ -169,16 +221,28 @@ function flowFromId(user, value) {
 }
 
 function toFlowSong(flow, job) {
+  const artist = protocolArtist(null, job.artistName || "Unknown Artist");
+  const format = String(job.finalPath || "").split(".").pop()?.toLowerCase() || "mp3";
+  const id = idFor("flow-song", `${flow.id}:${job.id}`);
   return {
-    id: idFor("flow-song", `${flow.id}:${job.id}`),
+    id,
     parent: idFor("flow", flow.id),
     isDir: false,
+    isVideo: false,
     title: job.trackName,
-    album: job.albumName,
-    artist: job.artistName,
+    album: job.albumName || "Unknown Album",
+    artist: artist.name,
+    artistId: artist.id,
+    albumArtists: [artist],
+    artists: [artist],
+    contentType: `audio/${format}`,
+    created: PROTOCOL_DATE,
     track: job.trackNumber || 0,
-    year: job.releaseYear ? Number(job.releaseYear) : null,
+    discNumber: job.discNumber || 1,
     duration: seconds(job.durationMs),
+    size: Number(job.size || 0),
+    suffix: format,
+    path: id,
     type: "music",
   };
 }
@@ -286,7 +350,7 @@ export function searchLibrary(query, options = {}) {
       toArtistSummary,
     ),
     album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)).map(
-      (album) => toAlbumSummary(library, album),
+      (album) => toAlbum(library, album),
     ),
     song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)).map(
       (track) => toSong(library, track),
@@ -294,19 +358,86 @@ export function searchLibrary(query, options = {}) {
   };
 }
 
+export function getAlbumList(options = {}) {
+  const library = readLibrary();
+  const type = String(options.type || "alphabeticalByName");
+  let albums = [...library.albums];
+
+  if (type === "starred") return [];
+  if (options.genre) {
+    const genre = String(options.genre).toLocaleLowerCase();
+    albums = albums.filter((album) =>
+      albumData(library, album).value.genres?.some((entry) =>
+        entry.name.toLocaleLowerCase() === genre,
+      ),
+    );
+  }
+  if (type === "byYear" || options.fromYear || options.toYear) {
+    const fromYear = Number.parseInt(options.fromYear, 10);
+    const toYear = Number.parseInt(options.toYear, 10);
+    albums = albums.filter((album) => {
+      const releaseYear = year(album.releaseDate) || 0;
+      return (!Number.isFinite(fromYear) || releaseYear >= fromYear) &&
+        (!Number.isFinite(toYear) || releaseYear <= toYear);
+    });
+  }
+
+  albums.sort((left, right) =>
+    `${left.title}\u0000${left.albumArtist}`.localeCompare(
+      `${right.title}\u0000${right.albumArtist}`,
+    ),
+  );
+  const offset = normalizeOffset(options.offset);
+  const size = normalizeLimit(options.size);
+  return albums.slice(offset, offset + size).map((album) => toAlbumSummary(library, album));
+}
+
+export function getGenres() {
+  const library = readLibrary();
+  const genres = new Map();
+  for (const album of library.albums) {
+    const tracks = albumTracks(library, album);
+    const albumGenres = [
+      ...entityGenres(album),
+      ...tracks.flatMap((track) => entityGenres(track)),
+    ];
+    for (const name of new Set(albumGenres)) {
+      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
+      value.albumCount += 1;
+      value.songCount += tracks.filter((track) => entityGenres(track).includes(name)).length;
+      genres.set(name, value);
+    }
+  }
+  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+}
+
+export function getStarred() {
+  return { album: [], artist: [], song: [] };
+}
+
+export function getArtistInfo(value) {
+  return getArtist(value) ? { similarArtist: [] } : null;
+}
+
+export function getTopSongs(artist, options = {}) {
+  return searchLibrary(artist, { songCount: options.count }).song;
+}
+
 export function getFlowPlaylists(user) {
   return visibleFlows(user).map((flow) => {
     const jobs = flowJobs(flow);
-    return {
+    const playlist = {
       id: idFor("flow", flow.id),
       name: flow.name,
       owner: user.username,
       songCount: jobs.length,
       duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
+      public: false,
       created: new Date(flow.createdAt || Date.now()).toISOString(),
       changed: new Date(flow.lastRunAt || flow.createdAt || Date.now()).toISOString(),
-      comment: flow.description || null,
     };
+    if (flow.description) playlist.comment = flow.description;
+    return playlist;
   });
 }
 
@@ -320,6 +451,7 @@ export function getFlowPlaylist(value, user) {
     owner: user.username,
     songCount: jobs.length,
     duration: jobs.reduce((total, job) => total + seconds(job.durationMs), 0),
+    public: false,
     entry: jobs.map((job) => toFlowSong(flow, job)),
   };
 }

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,7 +7,6 @@ services:
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
-      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -42,6 +42,12 @@ The Plex adapter resolves snapshot paths to Plex rating keys. It keeps section I
 
 The registry and playback contract remain unchanged. Navidrome's Subsonic API behavior stays inside its adapter, and Plex retains its existing behavior. The registry checks saved settings, runs every configured destination, and records one destination failure without blocking another destination.
 
+## Native Aurral playback
+
+The built-in player reads canonical artists, albums, and tracks, then requests an authenticated Aurral stream for each canonical track. This path does not depend on Navidrome. Weekly Flow items keep their existing owner-scoped playlist stream, so a flow item remains playable without changing its ownership rules.
+
+The native playback health section reports whether canonical media is indexed and readable. A stale or missing file returns a clear stream failure and leaves the user with a library refresh path instead of silently falling back to a playback destination.
+
 ## Deliberate non-goals
 
 - Do not add a generic integration host.

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -52,7 +52,7 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 
 | Variable | Purpose |
 | -------- | ------- |
-| `CORS_ORIGIN` | Comma-separated browser origins allowed to call Aurral. Set this when a Subsonic client such as Feishin is served from another origin. |
+| `CORS_ORIGIN` | Comma-separated browser origins allowed to call Aurral's JSON API. Browser Subsonic clients do not need this setting. |
 
 ## Logging
 

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -48,6 +48,12 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | `OIDC_DOMAIN` | Optional IdP origin added to the `connect-src` content security policy. |
 | `SESSION_EXPIRY_HOURS` | Session lifetime in hours for password login, proxy auth, and native OIDC. Default `720` (30 days). |
 
+## Cross-origin clients
+
+| Variable | Purpose |
+| -------- | ------- |
+| `CORS_ORIGIN` | Comma-separated browser origins allowed to call Aurral. Set this when a Subsonic client such as Feishin is served from another origin. |
+
 ## Logging
 
 | Variable | Purpose |

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -79,9 +79,10 @@ const artists = await response.json();
 
 ## Cross-origin requests
 
-If a browser loads Aurral from another origin, set `CORS_ORIGIN`. Use commas to
-separate each permitted origin. By default, Aurral does not permit cross-origin
-requests.
+If a browser loads Aurral's JSON API from another origin, set `CORS_ORIGIN`. Use
+commas to separate each permitted origin. By default, Aurral does not permit
+cross-origin JSON API requests. The authenticated Subsonic API at `/rest` is
+available to browser Subsonic clients such as Feishin without this setting.
 
 The current CORS preflight allows the `Content-Type` and `Authorization`
 headers. It does not allow the `X-Api-Key` header. For a cross-origin browser

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -22,7 +22,6 @@ services:
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
-      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -22,6 +22,7 @@ services:
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+      - CORS_ORIGIN=${CORS_ORIGIN:-}
     volumes:
       - ${MEDIA_ROOT:-/srv/media}:/data
       - ./config:/config

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -25,9 +25,12 @@ Complete [Filesystem and mounts](/getting-started/storage/) first. The short ver
 6. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
 7. Open **Settings > System**, select **Run Checks** under **Storage Health**, and fix failed checks.
 8. Open **Settings > Lidarr** and select **Test library access**.
-9. Connect the download clients and playback server that you use.
+9. Connect the download clients and playback server that you use. Navidrome and Plex are optional
+   destinations. Aurral can play indexed media in the app without either one.
 
-The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral can read the files and write the Downloads Folder.
+The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral
+can read the files and write the Downloads Folder. The **Aurral-native playback** check reports
+whether indexed media is ready to play.
 
 ## Configure the other services
 

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -26,7 +26,7 @@ Complete [Filesystem and mounts](/getting-started/storage/) first. The short ver
 7. Open **Settings > System**, select **Run Checks** under **Storage Health**, and fix failed checks.
 8. Open **Settings > Lidarr** and select **Test library access**.
 9. Connect the download clients and playback server that you use. Navidrome and Plex are optional
-   destinations. Aurral can play indexed media in the app without either one.
+   destinations. Aurral can play indexed media in the app when the canonical file is readable.
 
 The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral
 can read the files and write the Downloads Folder. The **Aurral-native playback** check reports

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -9,11 +9,13 @@ Navidrome must be able to read and scan the Aurral download tree for that destin
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
-Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, and direct streaming with byte ranges. Completed flow entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
+Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, and direct streaming with byte ranges. Completed flow entries and accessible shared-playlist entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
 
 ## Connect a Subsonic client
 
 Point the client at the Aurral URL and use the Aurral account from onboarding. Aurral enables browser Subsonic clients on `/rest` without an additional CORS setting. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
+
+Use the Aurral URL as the Feishin server URL. Set the server type to `Subsonic`. Feishin then shows canonical tracks, flow playlists, and shared playlists that the account can access. A playlist entry remains playable while its canonical file is readable.
 
 Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -9,7 +9,7 @@ Navidrome must be able to read and scan the Aurral download tree for that destin
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
-Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, and direct streaming with byte ranges. Completed flow entries and accessible shared-playlist entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
+Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, direct streaming with byte ranges, and user-scoped favorites through `getStarred`, `star`, and `unstar`. Completed flow entries and accessible shared-playlist entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
 
 ## Connect a Subsonic client
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -3,7 +3,7 @@ title: Navidrome
 description: Connect Navidrome to play Aurral downloads and generated playlists.
 ---
 
-Navidrome is optional. Aurral can browse and play indexed media in the app without Navidrome. Aurral
+Navidrome is optional. Aurral can browse and play indexed media in the app without Navidrome when the canonical file is readable. Aurral
 also creates and updates Navidrome playlists through the Subsonic API when Navidrome is configured.
 Navidrome must be able to read and scan the Aurral download tree for that destination.
 
@@ -13,7 +13,7 @@ Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It suppo
 
 ## Connect a Subsonic client
 
-Point the client at the Aurral URL and use the Aurral account from onboarding. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication with `LEGACY_AUTHENTICATION=true`.
+Point the client at the Aurral URL and use the Aurral account from onboarding. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
 
 Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -13,7 +13,7 @@ Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It suppo
 
 ## Connect a Subsonic client
 
-Point the client at the Aurral URL and use the Aurral account from onboarding. If the client is served from another browser origin, add that exact origin to Aurral's `CORS_ORIGIN` environment variable and recreate the Aurral container. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
+Point the client at the Aurral URL and use the Aurral account from onboarding. Aurral enables browser Subsonic clients on `/rest` without an additional CORS setting. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
 
 Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -3,11 +3,19 @@ title: Navidrome
 description: Connect Navidrome to play Aurral downloads and generated playlists.
 ---
 
-Navidrome is optional. Aurral creates and updates Navidrome playlists through the Subsonic API. Navidrome must also be able to read and scan the Aurral download tree.
+Navidrome is optional. Aurral can browse and play indexed media in the app without Navidrome. Aurral
+also creates and updates Navidrome playlists through the Subsonic API when Navidrome is configured.
+Navidrome must be able to read and scan the Aurral download tree for that destination.
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
 Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, and direct streaming with byte ranges. Completed flow entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
+
+## Connect a Subsonic client
+
+Point the client at the Aurral URL and use the Aurral account from onboarding. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication with `LEGACY_AUTHENTICATION=true`.
+
+Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -13,7 +13,7 @@ Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It suppo
 
 ## Connect a Subsonic client
 
-Point the client at the Aurral URL and use the Aurral account from onboarding. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
+Point the client at the Aurral URL and use the Aurral account from onboarding. If the client is served from another browser origin, add that exact origin to Aurral's `CORS_ORIGIN` environment variable and recreate the Aurral container. Feishin can connect with its default token authentication when you use that configured account. Feishin can also use password authentication when you set `LEGACY_AUTHENTICATION=true` in Feishin's environment, not Aurral's. When Feishin locks server settings, also set `SERVER_LOCK=true` in Feishin's environment.
 
 Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -17,6 +17,8 @@ Point the client at the Aurral URL and use the Aurral account from onboarding. A
 
 Use the Aurral URL as the Feishin server URL. Set the server type to `Subsonic`. Feishin then shows canonical tracks, flow playlists, and shared playlists that the account can access. A playlist entry remains playable while its canonical file is readable.
 
+The native Subsonic responses include playlist artwork through `getPlaylists`, `getPlaylist`, and `getCoverArt`. They also expose genres from canonical artist, album, and track metadata through artist, album, song, and `getGenres` responses. The native path does not fetch metadata from a provider while browsing.
+
 Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
 
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:

--- a/frontend/src/components/GlobalPlayerBar.jsx
+++ b/frontend/src/components/GlobalPlayerBar.jsx
@@ -25,6 +25,7 @@ function formatTime(seconds) {
 function GlobalPlayerBar() {
   const {
     currentTrack,
+    playbackError,
     isActive,
     isPlaying,
     isLoading,
@@ -116,6 +117,11 @@ function GlobalPlayerBar() {
                 {metaLink(artistLabel, artistPath)}
                 {artistLabel && albumLabel ? " · " : null}
                 {metaLink(albumLabel, albumPath)}
+              </span>
+            ) : null}
+            {playbackError ? (
+              <span className="global-player__error" role="alert">
+                {playbackError}
               </span>
             ) : null}
           </div>

--- a/frontend/src/contexts/AudioQueueProvider.jsx
+++ b/frontend/src/contexts/AudioQueueProvider.jsx
@@ -88,14 +88,19 @@ function queueReducer(state, action) {
         playbackOrder: order,
         source: source ?? null,
         currentIndex: boundedStart,
+        error: null,
         queueRevision: state.queueRevision + 1,
         isShuffleEnabled: updateShufflePreference ? shuffle : state.isShuffleEnabled,
       };
     }
     case "SET_CURRENT_INDEX":
-      return { ...state, currentIndex: action.index };
+      return { ...state, currentIndex: action.index, error: null };
     case "SET_QUEUE_REVISION":
-      return { ...state, queueRevision: state.queueRevision + 1 };
+      return { ...state, error: null, queueRevision: state.queueRevision + 1 };
+    case "SET_ERROR":
+      return { ...state, error: action.error };
+    case "CLEAR_ERROR":
+      return { ...state, error: null };
     case "SET_SHUFFLE": {
       if (state.queue.length === 0 || state.currentIndex < 0) {
         return { ...state, isShuffleEnabled: action.enabled };
@@ -122,6 +127,7 @@ function queueReducer(state, action) {
         queue: [],
         currentIndex: -1,
         source: null,
+        error: null,
         isShuffleEnabled: false,
         playbackOrder: [],
         repeatMode: "off",
@@ -136,6 +142,7 @@ const initialQueueState = {
   queue: [],
   currentIndex: -1,
   source: null,
+  error: null,
   isShuffleEnabled: false,
   playbackOrder: [],
   repeatMode: "off",
@@ -185,6 +192,14 @@ export function AudioQueueProvider({ children }) {
       format: getHowlerFormat(formatKey),
       onloaderror: () => {
         loadedSignatureRef.current = null;
+        if (formatAttemptIndex + 1 >= formatAttempts.length) {
+          dispatch({
+            type: "SET_ERROR",
+            error: "This track is unavailable. Restore the file or refresh the library.",
+          });
+          playerRef.current.stop();
+          return;
+        }
         loadTrackAtIndexRef.current(playbackIndex, formatAttemptIndex + 1);
       },
       onend: () => {
@@ -299,6 +314,12 @@ export function AudioQueueProvider({ children }) {
   const togglePlayPause = useCallback(() => {
     if (stateRef.current.queue.length === 0) return;
     const activePlayer = playerRef.current;
+    if (stateRef.current.error) {
+      dispatch({ type: "CLEAR_ERROR" });
+      loadedSignatureRef.current = null;
+      loadTrackAtIndex(stateRef.current.currentIndex);
+      return;
+    }
     if (activePlayer.isPlaying) {
       activePlayer.pause();
       return;
@@ -393,6 +414,7 @@ export function AudioQueueProvider({ children }) {
       currentTrack,
       currentIndex: state.currentIndex,
       source: state.source,
+      playbackError: state.error,
       isActive,
       isPlaying: player.isPlaying,
       isLoading: player.isLoading,
@@ -435,6 +457,7 @@ export function AudioQueueProvider({ children }) {
       sharedVolume,
       state.queue,
       state.currentIndex,
+      state.error,
       state.source,
       state.isShuffleEnabled,
       state.repeatMode,

--- a/frontend/src/hooks/useArtistPreviewPlayback.js
+++ b/frontend/src/hooks/useArtistPreviewPlayback.js
@@ -46,6 +46,7 @@ export function useArtistPreviewPlayback({ mbid, artistName, enabled = true, isI
               const tracks = await getLibraryTracks(album.id, album.mbid || album.foreignAlbumId, {
                 artistName,
                 albumTitle: album.title,
+                readPath: "canonical",
               });
               for (const track of Array.isArray(tracks) ? tracks : []) {
                 if (!track?.preview_url || !track?.streamPath) continue;

--- a/frontend/src/pages/ArtistDetails/ReleasePage.jsx
+++ b/frontend/src/pages/ArtistDetails/ReleasePage.jsx
@@ -328,6 +328,7 @@ function ReleasePage() {
           releaseType: release["primary-type"] || "",
           releaseDate: release["first-release-date"] || "",
           deezerAlbumId: release._deezerAlbumId || "",
+          readPath: "canonical",
         };
 
         const nextTracks = libraryInfo?.libraryAlbumId

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -313,7 +313,8 @@ function Onboarding() {
                     <OnboardingHint>
                       Find your API key in Lidarr under Settings → General → Security. The
                       Downloads Folder and optional playback clients are configured in Settings
-                      after setup. Aurral can play indexed media directly.
+                      after setup. Aurral can play indexed media directly when the canonical file
+                      is readable.
                     </OnboardingHint>
                   </div>
                 </OnboardingStep>

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -311,8 +311,9 @@ function Onboarding() {
                       }}
                     />
                     <OnboardingHint>
-                      Find your API key in Lidarr under Settings → General → Security. Downloads
-                      folder, playback, and other clients are configured in Settings after setup.
+                      Find your API key in Lidarr under Settings → General → Security. The
+                      Downloads Folder and optional playback clients are configured in Settings
+                      after setup. Aurral can play indexed media directly.
                     </OnboardingHint>
                   </div>
                 </OnboardingStep>

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -106,6 +106,8 @@ export const getLibraryTracks = async (
   if (context.releaseType) params.releaseType = context.releaseType;
   if (context.releaseDate) params.releaseDate = context.releaseDate;
   if (context.deezerAlbumId) params.deezerAlbumId = context.deezerAlbumId;
+  if (context.readPath) params.readPath = context.readPath;
+  if (context.readPath === "canonical") params.source = context.source || "all";
   const data = await getData("/library/tracks", { params });
   const tracks = Array.isArray(data) ? data : [];
   return Promise.all(

--- a/frontend/src/utils/buildArtistPlaybackQueue.js
+++ b/frontend/src/utils/buildArtistPlaybackQueue.js
@@ -44,6 +44,7 @@ async function fetchReleaseGroupTracks(
       ? await getLibraryTracks(libraryAlbum.id, releaseGroupId, {
           ...context,
           albumTitle: libraryAlbum.title || context.albumTitle,
+          readPath: "canonical",
         })
       : await getReleaseGroupTracks(releaseGroupId, {
           artistMbid: artistMbid || "",
@@ -100,6 +101,7 @@ export async function buildArtistPlaybackQueue({
         tracks = await getLibraryTracks(album.id, album.mbid || album.foreignAlbumId, {
           artistName,
           albumTitle: album.title,
+          readPath: "canonical",
         });
         localCache[cacheKey] = tracks;
       }


### PR DESCRIPTION
Aurral can now browse and play its canonical library without requiring Navidrome. Lidarr remains the required library provider, and Navidrome remains supported as an optional destination.

This PR adds the native playback path and aligns a supported Subsonic client with it:

- Serve canonical browse, search, artwork, streaming, and playlist playback routes.
- Add user and playlist ownership checks, restart and stale or missing media handling, and provider recovery state.
- Surface native playback readiness in onboarding, settings, and health responses.
- Add Feishin-compatible metadata, discovery endpoints, playlist fields, and scoped token authentication.
- Update user and maintainer documentation.

Verification:

- `npm test`: 585 passed.
- `node --test .tests/subsonic/subsonic-canonical.int.test.js`: 8 passed.
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- Focused review regressions: 28 passed. TESTING.md stack: Feishin token-mode login, browse, artist and album views, and playback passed. Flow playlist playback passed in password mode.

Known limits:

- Exact-nightly validation must run after a nightly image contains this commit.
- The synthetic test fixture has no artwork cache data, so live artwork requests are fixture-limited; automated artwork redirect coverage passes.
- Token authentication is supported for the configured account. Password authentication supports other Aurral users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct authenticated playback from indexed media without requiring Navidrome or Plex.
  * Expanded Subsonic support with token authentication, shared playlists, richer metadata, album and genre browsing, starred items, artist details, and top songs.
  * Added cross-origin access for supported Subsonic and artwork requests.
* **Bug Fixes**
  * Prevented empty Lidarr scans from incorrectly marking existing media unavailable.
  * Improved canonical streaming and file availability handling.
* **Enhancements**
  * Added playback error messages, retry behavior, and media readability checks.
* **Documentation**
  * Updated setup and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->