### PR TITLE
feat(library): add native library experience

### DIFF
--- a/.tests/frontend/library-favorites-cache.test.js
+++ b/.tests/frontend/library-favorites-cache.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "vite";
+
+const jsonResponse = (value) => new Response(JSON.stringify(value), {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+
+test("an older favorites read cannot overwrite a newer mutation cache", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { getLibraryFavorites, updateLibraryFavorites } = await vite.ssrLoadModule(
+    "/src/utils/api/endpoints/library.js?favorites-race-test",
+  );
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (_url, init = {}) => new Promise((resolve) => {
+    requests.push({ method: init.method || "GET", resolve });
+  });
+  const waitForRequests = async (count) => {
+    while (requests.length < count) await new Promise((resolve) => setImmediate(resolve));
+  };
+
+  const staleFavorites = { artist: [], album: [], song: [], library: { tracks: [] } };
+  const freshFavorites = { artist: [], album: [], song: ["song:1"], library: { tracks: ["fresh"] } };
+  const read = getLibraryFavorites();
+  await waitForRequests(1);
+  const mutation = updateLibraryFavorites(["song:1"], true);
+  await waitForRequests(2);
+
+  requests[1].resolve(jsonResponse(freshFavorites));
+  assert.deepEqual(await mutation, freshFavorites);
+  requests[0].resolve(jsonResponse(staleFavorites));
+  assert.deepEqual(await read, staleFavorites);
+  assert.deepEqual(await getLibraryFavorites(), freshFavorites);
+  assert.equal(requests.length, 2);
+});

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -109,6 +109,22 @@ test("native favorites reuse Subsonic star identity and return current favorites
   assert.deepEqual(getResponse.body.artist.map((entry) => entry.id), [target]);
 });
 
+test("canonical library pages return bounded collection responses", () => {
+  const response = responseFor();
+  getRoute("GET /canonical")(
+    { query: { kind: "tracks", page: "1", pageSize: "1" } },
+    response,
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.kind, "tracks");
+  assert.equal(response.body.page, 1);
+  assert.equal(response.body.pageSize, 1);
+  assert.equal(response.body.total, 1);
+  assert.equal(response.body.items.length, 1);
+  assert.equal(response.body.items[0].artistName, "Favorite Artist");
+});
+
 test("native favorites rejects unknown targets without changing stars", () => {
   const response = responseFor();
   getRoute("POST /favorites")(

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -59,6 +59,29 @@ test.before(() => {
     format: "flac",
     available: true,
   });
+  const otherArtist = upsertLibraryArtist({
+    identityKey: "other-artist",
+    name: "Other Artist",
+  });
+  const otherAlbum = upsertLibraryAlbum({
+    identityKey: "other-album",
+    artistId: otherArtist.id,
+    title: "Other Album",
+    albumArtist: otherArtist.name,
+  });
+  const otherTrack = upsertLibraryTrack({
+    identityKey: "other-track",
+    title: "Other Track",
+    artistName: otherArtist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: otherAlbum.id, trackId: otherTrack.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: otherTrack.id,
+    source: "aurral",
+    path: "/library/Other Artist/Other Album/01 Other Track.flac",
+    format: "flac",
+    available: true,
+  });
 });
 
 test.after(async () => {
@@ -109,6 +132,15 @@ test("native favorites reuse Subsonic star identity and return current favorites
   assert.deepEqual(getResponse.body.artist.map((entry) => entry.id), [target]);
 });
 
+test("native favorites include the canonical favorite subset", () => {
+  const response = responseFor();
+  getRoute("GET /favorites")({ user }, response);
+
+  assert.deepEqual(response.body.library.artists.map((entry) => entry.name), ["Favorite Artist"]);
+  assert.deepEqual(response.body.library.albums.map((entry) => entry.title), ["Favorite Album"]);
+  assert.deepEqual(response.body.library.tracks.map((entry) => entry.title), ["Favorite Track"]);
+});
+
 test("canonical library pages return bounded collection responses", () => {
   const response = responseFor();
   getRoute("GET /canonical")(
@@ -120,7 +152,7 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.kind, "tracks");
   assert.equal(response.body.page, 1);
   assert.equal(response.body.pageSize, 1);
-  assert.equal(response.body.total, 1);
+  assert.equal(response.body.total, 2);
   assert.equal(response.body.items.length, 1);
   assert.equal(response.body.items[0].artistName, "Favorite Artist");
 });

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { userOps }, libraryService, libraryStore] =
+  await setupIsolatedBackend(
+    "canonical-favorites-route",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/services/subsonicLibraryService.js",
+    "backend/services/libraryMediaStore.js",
+  );
+
+const { registerCanonical } = await import(
+  "../../backend/routes/library/handlers/canonical.js"
+);
+const {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} = libraryStore;
+
+let user;
+let artist;
+
+test.before(() => {
+  resetDatabase(db);
+  user = userOps.getUserById(userOps.createUser("native", "hash").id);
+  artist = upsertLibraryArtist({
+    identityKey: "favorite-artist",
+    mbid: "11111111-1111-4111-8111-111111111111",
+    name: "Favorite Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: "favorite-album",
+    mbid: "22222222-2222-4222-8222-222222222222",
+    artistId: artist.id,
+    title: "Favorite Album",
+    albumArtist: artist.name,
+  });
+  const track = upsertLibraryTrack({
+    identityKey: "favorite-track",
+    mbid: "33333333-3333-4333-8333-333333333333",
+    title: "Favorite Track",
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    source: "aurral",
+    path: "/library/Favorite Artist/Favorite Album/01 Favorite Track.flac",
+    format: "flac",
+    available: true,
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+function getRoute(path) {
+  const routes = new Map();
+  registerCanonical({
+    get(routePath, ...handlers) {
+      routes.set(`GET ${routePath}`, handlers.at(-1));
+    },
+    post(routePath, ...handlers) {
+      routes.set(`POST ${routePath}`, handlers.at(-1));
+    },
+  });
+  return routes.get(path);
+}
+
+function responseFor() {
+  return {
+    body: null,
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(value) {
+      this.body = value;
+      return this;
+    },
+  };
+}
+
+test("native favorites reuse Subsonic star identity and return current favorites", () => {
+  const target = `artist:${encodeURIComponent(artist.identity_key)}`;
+  const postResponse = responseFor();
+  getRoute("POST /favorites")(
+    { user, body: { ids: [target], starred: true } },
+    postResponse,
+  );
+
+  assert.equal(postResponse.statusCode, 200);
+  assert.equal(postResponse.body.artist[0].id, target);
+
+  const getResponse = responseFor();
+  getRoute("GET /favorites")({ user }, getResponse);
+  assert.deepEqual(getResponse.body.artist.map((entry) => entry.id), [target]);
+});
+
+test("native favorites rejects unknown targets without changing stars", () => {
+  const response = responseFor();
+  getRoute("POST /favorites")(
+    { user, body: { ids: ["album:missing"], starred: true } },
+    response,
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error, "Invalid favorite target");
+  assert.equal(libraryService.getStarred(user).artist.length, 1);
+});

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -37,6 +37,7 @@ test.before(() => {
     identityKey: "favorite-artist",
     mbid: "11111111-1111-4111-8111-111111111111",
     name: "Favorite Artist",
+    metadata: { genres: ["Indie Rock"] },
   });
   const album = upsertLibraryAlbum({
     identityKey: "favorite-album",
@@ -62,6 +63,7 @@ test.before(() => {
   const otherArtist = upsertLibraryArtist({
     identityKey: "other-artist",
     name: "Other Artist",
+    metadata: { genres: ["Jazz"] },
   });
   const otherAlbum = upsertLibraryAlbum({
     identityKey: "other-album",
@@ -144,7 +146,7 @@ test("native favorites include the canonical favorite subset", () => {
 test("canonical library pages return bounded collection responses", () => {
   const response = responseFor();
   getRoute("GET /canonical")(
-    { query: { kind: "tracks", page: "1", pageSize: "1" } },
+    { user, query: { kind: "tracks", page: "1", pageSize: "1" } },
     response,
   );
 
@@ -155,6 +157,13 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.total, 2);
   assert.equal(response.body.items.length, 1);
   assert.equal(response.body.items[0].artistName, "Favorite Artist");
+
+  const artistResponse = responseFor();
+  getRoute("GET /canonical")(
+    { user, query: { kind: "artists", page: "1", pageSize: "1" } },
+    artistResponse,
+  );
+  assert.equal(artistResponse.body.items[0].userFavorite, true);
 });
 
 test("native favorites rejects unknown targets without changing stars", () => {
@@ -167,4 +176,25 @@ test("native favorites rejects unknown targets without changing stars", () => {
   assert.equal(response.statusCode, 400);
   assert.equal(response.body.error, "Invalid favorite target");
   assert.equal(libraryService.getStarred(user).artist.length, 1);
+});
+
+test("canonical pages filter, count, and paginate in the read query", () => {
+  const response = responseFor();
+  getRoute("GET /canonical")(
+    {
+      query: {
+        kind: "albums",
+        query: "Favorite",
+        genre: "indie rock",
+        page: "1",
+        pageSize: "1",
+      },
+    },
+    response,
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.total, 1);
+  assert.equal(response.body.hasMore, false);
+  assert.equal(response.body.items[0].title, "Favorite Album");
 });

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -72,7 +72,7 @@ test.before(() => {
     source: "aurral",
     path: "/library/Favorite Artist/Favorite Album/02 Favorite Track Two.flac",
     format: "flac",
-    available: true,
+    available: false,
   });
   const otherArtist = upsertLibraryArtist({
     identityKey: "other-artist",
@@ -175,8 +175,16 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.items.length, 1);
   assert.equal(response.body.items[0].artistName, "Favorite Artist");
   assert.equal(response.body.albums[0].trackCount, 2);
-  assert.equal(response.body.albums[0].availableTrackCount, 2);
+  assert.equal(response.body.albums[0].availableTrackCount, 1);
   assert.equal(response.body.hasMore, true);
+
+  const availableResponse = responseFor();
+  getRoute("GET /canonical")(
+    { user, query: { kind: "albums", page: "1", pageSize: "1", availableOnly: "true" } },
+    availableResponse,
+  );
+  assert.equal(availableResponse.body.items[0].trackCount, 2);
+  assert.equal(availableResponse.body.items[0].availableTrackCount, 1);
 
   const artistResponse = responseFor();
   getRoute("GET /canonical")(

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -60,6 +60,20 @@ test.before(() => {
     format: "flac",
     available: true,
   });
+  const secondTrack = upsertLibraryTrack({
+    identityKey: "favorite-track-two",
+    mbid: "44444444-4444-4444-8444-444444444444",
+    title: "Favorite Track Two",
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: secondTrack.id, trackNumber: 2 });
+  upsertLibraryMediaFile({
+    trackId: secondTrack.id,
+    source: "aurral",
+    path: "/library/Favorite Artist/Favorite Album/02 Favorite Track Two.flac",
+    format: "flac",
+    available: true,
+  });
   const otherArtist = upsertLibraryArtist({
     identityKey: "other-artist",
     name: "Other Artist",
@@ -140,7 +154,10 @@ test("native favorites include the canonical favorite subset", () => {
 
   assert.deepEqual(response.body.library.artists.map((entry) => entry.name), ["Favorite Artist"]);
   assert.deepEqual(response.body.library.albums.map((entry) => entry.title), ["Favorite Album"]);
-  assert.deepEqual(response.body.library.tracks.map((entry) => entry.title), ["Favorite Track"]);
+  assert.deepEqual(response.body.library.tracks.map((entry) => entry.title), [
+    "Favorite Track",
+    "Favorite Track Two",
+  ]);
 });
 
 test("canonical library pages return bounded collection responses", () => {
@@ -154,9 +171,12 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.kind, "tracks");
   assert.equal(response.body.page, 1);
   assert.equal(response.body.pageSize, 1);
-  assert.equal(response.body.total, 2);
+  assert.equal(response.body.total, 3);
   assert.equal(response.body.items.length, 1);
   assert.equal(response.body.items[0].artistName, "Favorite Artist");
+  assert.equal(response.body.albums[0].trackCount, 2);
+  assert.equal(response.body.albums[0].availableTrackCount, 2);
+  assert.equal(response.body.hasMore, true);
 
   const artistResponse = responseFor();
   getRoute("GET /canonical")(

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -152,3 +152,25 @@ test("canonical library responses do not expose filesystem paths", () => {
   assert.deepEqual(response.tracks[0].metadata, { nested: {} });
   assert.deepEqual(response.tracks[0].files, [{ id: 2, source: "aurral" }]);
 });
+
+test("canonical album responses proxy public metadata artwork", () => {
+  const remoteUrl = "https://cdn.example.test/cover.jpg?size=500";
+  const response = toPublicLibrary({
+    artists: [],
+    albums: [{
+      id: 1,
+      metadata: {
+        images: [
+          { url: "/MediaCover/Albums/1/cover.jpg" },
+          { remoteUrl },
+        ],
+      },
+    }],
+    tracks: [],
+  });
+
+  assert.equal(
+    response.albums[0].coverUrl,
+    "/api/image-proxy?src=" + encodeURIComponent(remoteUrl),
+  );
+});

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -238,10 +238,20 @@ db.exec(`
     ON lidarr_artist_id_map (lidarr_foreign_artist_id);
   CREATE INDEX IF NOT EXISTS idx_library_albums_artist_id
     ON library_albums (artist_id);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_title
+    ON library_albums (title COLLATE NOCASE);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_release_date
+    ON library_albums (release_date DESC);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_sort_name_name
+    ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
+  CREATE INDEX IF NOT EXISTS idx_library_tracks_title
+    ON library_tracks (title COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_track_id
     ON library_media_files (track_id);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_track_source_available
+    ON library_media_files (track_id, source, available);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_source_available
     ON library_media_files (source, available);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_scan_id
@@ -389,6 +399,8 @@ if (hasUniqueIndex(["path"])) {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_library_media_files_track_id
       ON library_media_files (track_id);
+    CREATE INDEX IF NOT EXISTS idx_library_media_files_track_source_available
+      ON library_media_files (track_id, source, available);
     CREATE INDEX IF NOT EXISTS idx_library_media_files_source_available
       ON library_media_files (source, available);
     CREATE INDEX IF NOT EXISTS idx_library_media_files_scan_id

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -5,7 +5,11 @@ import {
   getCanonicalLibrary,
   getCanonicalLibraryPage,
 } from "../../../services/libraryQueryService.js";
-import { getStarred, starMany, unstarMany } from "../../../services/subsonicLibraryService.js";
+import {
+  getStarredWithLibrary,
+  starMany,
+  unstarMany,
+} from "../../../services/subsonicLibraryService.js";
 
 const isFilesystemPathKey = (key) => key.toLowerCase().endsWith("path");
 
@@ -92,7 +96,8 @@ export function registerCanonical(router) {
   });
 
   router.get("/favorites", requireAuth, noCache, (req, res) => {
-    res.json(getStarred(req.user));
+    const { starred, library } = getStarredWithLibrary(req.user);
+    res.json({ ...starred, library: toPublicLibrary(library) });
   });
 
   router.post("/favorites", requireAuth, noCache, (req, res) => {
@@ -109,7 +114,8 @@ export function registerCanonical(router) {
     if (!changed) {
       return res.status(400).json({ error: "Invalid favorite target" });
     }
-    return res.json(getStarred(req.user));
+    const { starred, library } = getStarredWithLibrary(req.user);
+    return res.json({ ...starred, library: toPublicLibrary(library) });
   });
 }
 

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,5 +1,6 @@
 import { noCache } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
+import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 import { getStarred, starMany, unstarMany } from "../../../services/subsonicLibraryService.js";
 
@@ -15,10 +16,21 @@ export function stripFilesystemPaths(value) {
   );
 }
 
+function getAlbumCoverUrl(album) {
+  const image = (Array.isArray(album?.metadata?.images) ? album.metadata.images : []).find(
+    (entry) => /^https?:\/\//i.test(entry?.remoteUrl || entry?.imageUrl || entry?.url || ""),
+  );
+  const source = image?.remoteUrl || image?.imageUrl || image?.url;
+  return /^https?:\/\//i.test(source || "") ? buildImageProxyUrl(source) : null;
+}
+
 function toPublicLibrary(library) {
   return stripFilesystemPaths({
     artists: library.artists,
-    albums: library.albums,
+    albums: library.albums.map((album) => ({
+      ...album,
+      coverUrl: album.coverUrl || getAlbumCoverUrl(album),
+    })),
     tracks: library.tracks,
   });
 }

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -6,6 +6,7 @@ import {
   getCanonicalLibraryPage,
 } from "../../../services/libraryQueryService.js";
 import {
+  getStarredIdentityKeys,
   getStarredWithLibrary,
   starMany,
   unstarMany,
@@ -31,19 +32,25 @@ function getAlbumCoverUrl(album) {
   return /^https?:\/\//i.test(source || "") ? buildImageProxyUrl(source) : null;
 }
 
-function toPublicLibrary(library) {
+function toPublicLibrary(library, favoriteKeys = null) {
+  const publicEntity = (kind, entity) => favoriteKeys
+    ? { ...entity, userFavorite: favoriteKeys.has(`${kind}:${entity.identityKey}`) }
+    : entity;
   return stripFilesystemPaths({
-    artists: library.artists,
+    artists: library.artists.map((artist) => publicEntity("artist", artist)),
     albums: library.albums.map((album) => ({
       ...album,
       coverUrl: album.coverUrl || getAlbumCoverUrl(album),
+      ...(favoriteKeys
+        ? { userFavorite: favoriteKeys.has(`album:${album.identityKey}`) }
+        : {}),
     })),
-    tracks: library.tracks,
+    tracks: library.tracks.map((track) => publicEntity("song", track)),
   });
 }
 
-export function toPublicLibraryPage(page) {
-  const collections = toPublicLibrary(page);
+export function toPublicLibraryPage(page, favoriteKeys = null) {
+  const collections = toPublicLibrary(page, favoriteKeys);
   const items = page.kind === "artists"
     ? collections.artists
     : page.kind === "albums"
@@ -61,6 +68,7 @@ export function toPublicLibraryPage(page) {
 export function registerCanonical(router) {
   router.get("/canonical", noCache, (req, res) => {
     try {
+      const favoriteKeys = req.user ? getStarredIdentityKeys(req.user) : null;
       if (req.query.kind) {
         return res.json(toPublicLibraryPage(getCanonicalLibraryPage({
           source: req.query.source,
@@ -74,13 +82,13 @@ export function registerCanonical(router) {
           direction: req.query.direction,
           artistId: req.query.artistId,
           albumId: req.query.albumId,
-        })));
+        }), favoriteKeys));
       }
       const library = getCanonicalLibrary({
         source: req.query.source,
         availableOnly: req.query.availableOnly === "true",
       });
-      return res.json(toPublicLibrary(library));
+      return res.json(toPublicLibrary(library, favoriteKeys));
     } catch (error) {
       if (
         error.message.startsWith("Unsupported library source:") ||

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,7 +1,10 @@
 import { noCache } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
-import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
+import {
+  getCanonicalLibrary,
+  getCanonicalLibraryPage,
+} from "../../../services/libraryQueryService.js";
 import { getStarred, starMany, unstarMany } from "../../../services/subsonicLibraryService.js";
 
 const isFilesystemPathKey = (key) => key.toLowerCase().endsWith("path");
@@ -35,16 +38,50 @@ function toPublicLibrary(library) {
   });
 }
 
+export function toPublicLibraryPage(page) {
+  const collections = toPublicLibrary(page);
+  const items = page.kind === "artists"
+    ? collections.artists
+    : page.kind === "albums"
+      ? collections.albums
+      : page.kind === "tracks"
+        ? collections.tracks
+        : stripFilesystemPaths(page.items);
+  return {
+    ...stripFilesystemPaths(page),
+    ...collections,
+    items,
+  };
+}
+
 export function registerCanonical(router) {
   router.get("/canonical", noCache, (req, res) => {
     try {
+      if (req.query.kind) {
+        return res.json(toPublicLibraryPage(getCanonicalLibraryPage({
+          source: req.query.source,
+          availableOnly: req.query.availableOnly === "true",
+          kind: req.query.kind,
+          page: req.query.page,
+          pageSize: req.query.pageSize,
+          query: req.query.query,
+          genre: req.query.genre,
+          sort: req.query.sort,
+          direction: req.query.direction,
+          artistId: req.query.artistId,
+          albumId: req.query.albumId,
+        })));
+      }
       const library = getCanonicalLibrary({
         source: req.query.source,
         availableOnly: req.query.availableOnly === "true",
       });
       return res.json(toPublicLibrary(library));
     } catch (error) {
-      if (error.message.startsWith("Unsupported library source:")) {
+      if (
+        error.message.startsWith("Unsupported library source:") ||
+        error.message.startsWith("Unsupported library page kind:")
+      ) {
         return res.status(400).json({ error: error.message });
       }
       return res.status(500).json({

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,5 +1,7 @@
 import { noCache } from "../../../middleware/cache.js";
+import { requireAuth } from "../../../middleware/requirePermission.js";
 import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
+import { getStarred, starMany, unstarMany } from "../../../services/subsonicLibraryService.js";
 
 const isFilesystemPathKey = (key) => key.toLowerCase().endsWith("path");
 
@@ -38,6 +40,27 @@ export function registerCanonical(router) {
         message: error.message,
       });
     }
+  });
+
+  router.get("/favorites", requireAuth, noCache, (req, res) => {
+    res.json(getStarred(req.user));
+  });
+
+  router.post("/favorites", requireAuth, noCache, (req, res) => {
+    const ids = Array.isArray(req.body?.ids)
+      ? req.body.ids.map((id) => String(id || "").trim()).filter(Boolean)
+      : [];
+    if (ids.length === 0 || ids.length > 100 || typeof req.body?.starred !== "boolean") {
+      return res.status(400).json({
+        error: "ids and starred are required",
+      });
+    }
+
+    const changed = req.body.starred ? starMany(req.user, ids) : unstarMany(req.user, ids);
+    if (!changed) {
+      return res.status(400).json({ error: "Invalid favorite target" });
+    }
+    return res.json(getStarred(req.user));
   });
 }
 

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -15,6 +15,17 @@ const normalizeKeyPart = (value) =>
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
 
+let libraryScanDepth = 0;
+let libraryCacheInvalidationPending = false;
+
+const invalidateLibraryCache = () => {
+  if (libraryScanDepth > 0) {
+    libraryCacheInvalidationPending = true;
+    return;
+  }
+  invalidateCanonicalLibraryCache();
+};
+
 export function buildIdentityKey(prefix, value) {
   const normalized = normalizeText(value);
   if (!normalized) return null;
@@ -74,7 +85,7 @@ export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName =
        metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
        updated_at = excluded.updated_at`,
   ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
   return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
 }
 
@@ -119,7 +130,7 @@ export function upsertLibraryAlbum({
     timestamp,
     timestamp,
   );
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
   return db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
 }
 
@@ -144,7 +155,7 @@ export function upsertLibraryTrack({
        metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
        updated_at = excluded.updated_at`,
   ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
   return db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
 }
 
@@ -154,7 +165,7 @@ export function linkLibraryAlbumTrack({ albumId, trackId, discNumber = 1, trackN
       (album_id, track_id, disc_number, track_number, created_at)
      VALUES (?, ?, ?, ?, ?)`,
   ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
 }
 
 export function upsertLibraryMediaFile({
@@ -204,7 +215,7 @@ export function upsertLibraryMediaFile({
     timestamp,
     timestamp,
   );
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
 }
 
 export function markUnseenFilesUnavailable(scanId, source) {
@@ -213,10 +224,11 @@ export function markUnseenFilesUnavailable(scanId, source) {
      SET available = 0, updated_at = ?
      WHERE source = ? AND (last_seen_scan_id IS NULL OR last_seen_scan_id != ?)`,
   ).run(now(), normalizeText(source), Number(scanId));
-  invalidateCanonicalLibraryCache();
+  invalidateLibraryCache();
 }
 
 export async function withLibraryScan(source, rootPath, run) {
+  libraryScanDepth += 1;
   const scanId = beginLibraryScan({ source, rootPath });
   try {
     const result = await run(scanId);
@@ -225,6 +237,12 @@ export async function withLibraryScan(source, rootPath, run) {
   } catch (error) {
     finishLibraryScan(scanId, { status: "failed", error: error.message });
     throw error;
+  } finally {
+    libraryScanDepth -= 1;
+    if (libraryScanDepth === 0 && libraryCacheInvalidationPending) {
+      libraryCacheInvalidationPending = false;
+      invalidateCanonicalLibraryCache();
+    }
   }
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -479,7 +479,7 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly) {
   return buildLibraryFromRows(rows);
 }
 
-function getAlbumStats(albumIds, sourceFilter, availableOnly) {
+function getAlbumStats(albumIds, sourceFilter) {
   if (!albumIds.length) return new Map();
   const conditions = [`album_track.album_id IN (${albumIds.map(() => "?").join(",")})`];
   const parameters = [...albumIds];
@@ -487,7 +487,6 @@ function getAlbumStats(albumIds, sourceFilter, availableOnly) {
     conditions.push("media.source = ?");
     parameters.push(sourceFilter);
   }
-  if (availableOnly === true) conditions.push("media.available = 1");
   const rows = db.prepare(
     `SELECT
        album_track.album_id AS album_id,
@@ -589,7 +588,6 @@ export function getCanonicalLibraryPage({
   const albumStats = getAlbumStats(
     library.albums.map((album) => album.id),
     sourceFilter,
-    availableOnly,
   );
   const collection = ids
     .map((id) => library[normalizedKind].find((entity) => String(entity.id) === String(id)))

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -27,103 +27,46 @@ function createEntity(map, id, value) {
   return map.get(id);
 }
 
-export function getCanonicalLibrary({ source = null, availableOnly = false, favoriteKeys = null } = {}) {
-  const sourceFilter = normalizeSource(source);
-  const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
-  const favoriteTargets = Array.isArray(favoriteKeys)
-    ? favoriteKeys.filter((target) =>
-        target && ["artist", "album", "song"].includes(target.kind) && String(target.key || "").trim(),
-      )
-    : null;
-  if (favoriteTargets && favoriteTargets.length === 0) {
-    return { artists: [], albums: [], tracks: [] };
-  }
-  if (!favoriteTargets) {
-    const cached = libraryCache.get(cacheKey);
-    if (cached) return cached;
-  }
-  const conditions = [];
-  const parameters = [];
+const CANONICAL_SELECT = `SELECT
+  artist.id AS artist_id,
+  artist.identity_key AS artist_identity_key,
+  artist.mbid AS artist_mbid,
+  artist.name AS artist_name,
+  artist.sort_name AS artist_sort_name,
+  artist.metadata_json AS artist_metadata_json,
+  album.id AS album_id,
+  album.identity_key AS album_identity_key,
+  album.mbid AS album_mbid,
+  album.release_group_mbid AS album_release_group_mbid,
+  album.title AS album_title,
+  album.album_artist AS album_artist,
+  album.release_date AS album_release_date,
+  album.metadata_json AS album_metadata_json,
+  track.id AS track_id,
+  track.identity_key AS track_identity_key,
+  track.mbid AS track_mbid,
+  track.title AS track_title,
+  track.artist_name AS track_artist_name,
+  track.metadata_json AS track_metadata_json,
+  album_track.disc_number,
+  album_track.track_number,
+  media.id AS media_id,
+  media.source AS media_source,
+  media.path AS media_path,
+  media.format AS media_format,
+  media.size AS media_size,
+  media.mtime_ms AS media_mtime_ms,
+  media.duration_ms AS media_duration_ms,
+  media.quality_json AS media_quality_json,
+  media.available AS media_available`;
 
-  if (sourceFilter) {
-    conditions.push("media.source = ?");
-    parameters.push(sourceFilter);
-  }
-  if (availableOnly === true) conditions.push("media.available = 1");
-  if (favoriteTargets) {
-    const targetQueries = [];
-    const add = (query, kind) => {
-      const keys = favoriteTargets
-        .filter((target) => target.kind === kind)
-        .map((target) => String(target.key).trim());
-      if (!keys.length) return;
-      targetQueries.push(query.replace("?", keys.map(() => "?").join(",")));
-      parameters.push(...keys);
-    };
-    add("SELECT id FROM library_tracks WHERE identity_key IN (?)", "song");
-    add(
-      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
-        "JOIN library_albums AS album ON album.id = album_track.album_id " +
-        "WHERE album.identity_key IN (?)",
-      "album",
-    );
-    add(
-      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
-        "JOIN library_albums AS album ON album.id = album_track.album_id " +
-        "JOIN library_artists AS artist ON artist.id = album.artist_id " +
-        "WHERE artist.identity_key IN (?)",
-      "artist",
-    );
-    if (!targetQueries.length) return { artists: [], albums: [], tracks: [] };
-    conditions.push(`media.track_id IN (${targetQueries.join(" UNION ")})`);
-  }
+const CANONICAL_FROM = `FROM library_media_files AS media
+  JOIN library_tracks AS track ON track.id = media.track_id
+  JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+  JOIN library_albums AS album ON album.id = album_track.album_id
+  JOIN library_artists AS artist ON artist.id = album.artist_id`;
 
-  const rows = db
-    .prepare(
-      `SELECT
-        artist.id AS artist_id,
-        artist.identity_key AS artist_identity_key,
-        artist.mbid AS artist_mbid,
-        artist.name AS artist_name,
-        artist.sort_name AS artist_sort_name,
-        artist.metadata_json AS artist_metadata_json,
-        album.id AS album_id,
-        album.identity_key AS album_identity_key,
-        album.mbid AS album_mbid,
-        album.release_group_mbid AS album_release_group_mbid,
-        album.title AS album_title,
-        album.album_artist AS album_artist,
-        album.release_date AS album_release_date,
-        album.metadata_json AS album_metadata_json,
-        track.id AS track_id,
-        track.identity_key AS track_identity_key,
-        track.mbid AS track_mbid,
-        track.title AS track_title,
-        track.artist_name AS track_artist_name,
-        track.metadata_json AS track_metadata_json,
-        album_track.disc_number,
-        album_track.track_number,
-        media.id AS media_id,
-        media.source AS media_source,
-        media.path AS media_path,
-        media.format AS media_format,
-        media.size AS media_size,
-        media.mtime_ms AS media_mtime_ms,
-        media.duration_ms AS media_duration_ms,
-        media.quality_json AS media_quality_json,
-        media.available AS media_available
-      FROM library_media_files AS media
-      JOIN library_tracks AS track ON track.id = media.track_id
-      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
-      JOIN library_albums AS album ON album.id = album_track.album_id
-      JOIN library_artists AS artist ON artist.id = album.artist_id
-      ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
-      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
-        album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
-        track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
-    )
-    .all(...parameters);
-
+function buildLibraryFromRows(rows) {
   const artists = new Map();
   const albums = new Map();
   const tracks = new Map();
@@ -192,9 +135,7 @@ export function getCanonicalLibrary({ source = null, availableOnly = false, favo
       quality: parseJson(row.media_quality_json),
       available: Boolean(row.media_available),
     };
-    if (!track.files.some((entry) => entry.id === file.id)) {
-      track.files.push(file);
-    }
+    if (!track.files.some((entry) => entry.id === file.id)) track.files.push(file);
     if (file.available) {
       artist.available = true;
       album.available = true;
@@ -209,11 +150,75 @@ export function getCanonicalLibrary({ source = null, availableOnly = false, favo
     track.files.sort((left, right) => left.path.localeCompare(right.path));
   }
 
-  const library = {
+  return {
     artists: [...artists.values()],
     albums: [...albums.values()],
     tracks: [...tracks.values()],
   };
+}
+
+export function getCanonicalLibrary({ source = null, availableOnly = false, favoriteKeys = null } = {}) {
+  const sourceFilter = normalizeSource(source);
+  const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
+  const favoriteTargets = Array.isArray(favoriteKeys)
+    ? favoriteKeys.filter((target) =>
+        target && ["artist", "album", "song"].includes(target.kind) && String(target.key || "").trim(),
+      )
+    : null;
+  if (favoriteTargets && favoriteTargets.length === 0) {
+    return { artists: [], albums: [], tracks: [] };
+  }
+  if (!favoriteTargets) {
+    const cached = libraryCache.get(cacheKey);
+    if (cached) return cached;
+  }
+  const conditions = [];
+  const parameters = [];
+
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+  if (favoriteTargets) {
+    const targetQueries = [];
+    const add = (query, kind) => {
+      const keys = favoriteTargets
+        .filter((target) => target.kind === kind)
+        .map((target) => String(target.key).trim());
+      if (!keys.length) return;
+      targetQueries.push(query.replace("?", keys.map(() => "?").join(",")));
+      parameters.push(...keys);
+    };
+    add("SELECT id FROM library_tracks WHERE identity_key IN (?)", "song");
+    add(
+      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
+        "JOIN library_albums AS album ON album.id = album_track.album_id " +
+        "WHERE album.identity_key IN (?)",
+      "album",
+    );
+    add(
+      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
+        "JOIN library_albums AS album ON album.id = album_track.album_id " +
+        "JOIN library_artists AS artist ON artist.id = album.artist_id " +
+        "WHERE artist.identity_key IN (?)",
+      "artist",
+    );
+    if (!targetQueries.length) return { artists: [], albums: [], tracks: [] };
+    conditions.push(`media.track_id IN (${targetQueries.join(" UNION ")})`);
+  }
+
+  const rows = db
+    .prepare(
+      `${CANONICAL_SELECT}
+      ${CANONICAL_FROM}
+      ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
+      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
+        album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
+        track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+    )
+    .all(...parameters);
+  const library = buildLibraryFromRows(rows);
   if (!favoriteTargets) libraryCache.set(cacheKey, library);
   return library;
 }
@@ -227,24 +232,6 @@ const metadataGenres = (entity) => {
     .map(text)
     .filter(Boolean)
     .filter((value, index, values) => values.indexOf(value) === index);
-};
-
-const hasGenre = (genre, ...entities) => {
-  if (!genre) return true;
-  const wanted = genre.toLocaleLowerCase();
-  return entities.flatMap(metadataGenres).some((value) => value.toLocaleLowerCase() === wanted);
-};
-
-const matchesQuery = (entity, query, artist, album) => {
-  if (!query) return true;
-  return [
-    entity?.name,
-    entity?.title,
-    entity?.artistName,
-    entity?.albumArtist,
-    artist?.name,
-    album?.title,
-  ].some((value) => text(value).toLocaleLowerCase().includes(query));
 };
 
 const genreStatsFor = (library) => {
@@ -271,6 +258,227 @@ const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 const pageSize = (value) =>
   Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
 
+const genreStatsCache = new Map();
+const GENRE_METADATA_PATHS = ["$.genres", "$.genre", "$.common.genre", "$.tags.genre"];
+
+const escapeLike = (value) => value.replace(/[\\%_]/g, "\\$&");
+
+const mediaSourceClause = (sourceFilter, alias = "page_media") => {
+  const conditions = [];
+  const parameters = [];
+  if (sourceFilter) {
+    conditions.push(`${alias}.source = ?`);
+    parameters.push(sourceFilter);
+  }
+  return { conditions, parameters };
+};
+
+const pageMediaExists = (kind, sourceFilter, availableOnly) => {
+  const { conditions, parameters } = mediaSourceClause(sourceFilter);
+  if (availableOnly === true) conditions.push("page_media.available = 1");
+  const conditionSql = conditions.length ? conditions.join(" AND ") : "1 = 1";
+  if (kind === "artists") {
+    return {
+      sql: `EXISTS (
+        SELECT 1
+        FROM library_albums AS page_album
+        JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
+        JOIN library_media_files AS page_media ON page_media.track_id = page_album_track.track_id
+        WHERE page_album.artist_id = artist.id AND ${conditionSql}
+      )`,
+      parameters,
+    };
+  }
+  if (kind === "albums") {
+    return {
+      sql: `EXISTS (
+        SELECT 1
+        FROM library_album_tracks AS page_album_track
+        JOIN library_media_files AS page_media ON page_media.track_id = page_album_track.track_id
+        WHERE page_album_track.album_id = album.id AND ${conditionSql}
+      )`,
+      parameters,
+    };
+  }
+  return {
+    sql: `EXISTS (
+      SELECT 1 FROM library_media_files AS page_media
+      WHERE page_media.track_id = track.id AND ${conditionSql}
+    )`,
+    parameters,
+  };
+};
+
+const genrePredicate = (aliases, genre) => {
+  const clauses = [];
+  const parameters = [];
+  aliases.forEach((alias) => {
+    GENRE_METADATA_PATHS.forEach((path) => {
+      clauses.push(
+        `EXISTS (
+          SELECT 1 FROM json_each(COALESCE(${alias}.metadata_json, '{}'), '${path}') AS genre_value
+          WHERE lower(CAST(genre_value.value AS TEXT)) = lower(?)
+        )`,
+      );
+      parameters.push(genre);
+    });
+  });
+  return { sql: `(${clauses.join(" OR ")})`, parameters };
+};
+
+function buildPageQuery({
+  kind,
+  sourceFilter,
+  availableOnly,
+  query,
+  genre,
+  sort,
+  direction,
+  artistId,
+  albumId,
+}) {
+  const where = [];
+  const parameters = [];
+  const media = pageMediaExists(kind, sourceFilter, availableOnly);
+  where.push(media.sql);
+  parameters.push(...media.parameters);
+
+  let from;
+  let idExpression;
+  let searchableFields;
+  let genreAliases;
+  if (kind === "artists") {
+    from = "FROM library_artists AS artist";
+    idExpression = "artist.id";
+    searchableFields = ["artist.name"];
+    genreAliases = ["artist"];
+    if (artistId) {
+      where.push("artist.id = ?");
+      parameters.push(Number(artistId));
+    }
+    if (albumId) {
+      where.push("EXISTS (SELECT 1 FROM library_albums AS filter_album WHERE filter_album.id = ? AND filter_album.artist_id = artist.id)");
+      parameters.push(Number(albumId));
+    }
+  } else if (kind === "albums") {
+    from = "FROM library_albums AS album JOIN library_artists AS artist ON artist.id = album.artist_id";
+    idExpression = "album.id";
+    searchableFields = ["album.title", "album.album_artist", "artist.name"];
+    genreAliases = ["artist", "album"];
+    if (artistId) {
+      where.push("album.artist_id = ?");
+      parameters.push(Number(artistId));
+    }
+    if (albumId) {
+      where.push("album.id = ?");
+      parameters.push(Number(albumId));
+    }
+  } else {
+    from = `FROM library_tracks AS track
+      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+      JOIN library_albums AS album ON album.id = album_track.album_id
+      JOIN library_artists AS artist ON artist.id = album.artist_id`;
+    idExpression = "track.id";
+    searchableFields = [
+      "track.title",
+      "track.artist_name",
+      "album.title",
+      "album.album_artist",
+      "artist.name",
+    ];
+    genreAliases = ["artist", "album", "track"];
+    if (artistId) {
+      where.push("artist.id = ?");
+      parameters.push(Number(artistId));
+    }
+    if (albumId) {
+      where.push("album.id = ?");
+      parameters.push(Number(albumId));
+    }
+  }
+
+  if (query) {
+    const pattern = `%${escapeLike(query)}%`;
+    where.push(`(${searchableFields.map((field) =>
+      `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...searchableFields.map(() => pattern));
+  }
+  if (genre) {
+    const predicate = genrePredicate(genreAliases, genre);
+    where.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+
+  const orderDirection = direction === "desc" ? "DESC" : "ASC";
+  let orderBy;
+  if (sort === "newest" && kind === "albums") {
+    orderBy = `coalesce(album.release_date, '') ${direction === "desc" ? "ASC" : "DESC"}, album.title COLLATE NOCASE ${orderDirection}`;
+  } else if (sort === "artist" && kind !== "artists") {
+    orderBy = `artist.name COLLATE NOCASE ${orderDirection}, ${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
+  } else if (kind === "artists") {
+    orderBy = `coalesce(artist.sort_name, artist.name) COLLATE NOCASE ${orderDirection}, artist.name COLLATE NOCASE ${orderDirection}`;
+  } else {
+    orderBy = `${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
+  }
+
+  return {
+    from,
+    idExpression,
+    where: where.join(" AND "),
+    parameters,
+    orderBy,
+  };
+}
+
+function getCanonicalGenreStats({ sourceFilter, availableOnly }) {
+  const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
+  const cached = genreStatsCache.get(cacheKey);
+  if (cached) return cached;
+  const artistMedia = pageMediaExists("artists", sourceFilter, availableOnly);
+  const albumMedia = pageMediaExists("albums", sourceFilter, availableOnly);
+  const trackMedia = pageMediaExists("tracks", sourceFilter, availableOnly);
+  const artists = db.prepare(
+    `SELECT artist.metadata_json FROM library_artists AS artist WHERE ${artistMedia.sql}`,
+  ).all(...artistMedia.parameters);
+  const albums = db.prepare(
+    `SELECT album.metadata_json
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE ${albumMedia.sql}`,
+  ).all(...albumMedia.parameters);
+  const tracks = db.prepare(
+    `SELECT track.metadata_json FROM library_tracks AS track WHERE ${trackMedia.sql}`,
+  ).all(...trackMedia.parameters);
+  const stats = genreStatsFor({
+    artists: artists.map((row) => ({ metadata: parseJson(row.metadata_json) })),
+    albums: albums.map((row) => ({ metadata: parseJson(row.metadata_json) })),
+    tracks: tracks.map((row) => ({ metadata: parseJson(row.metadata_json) })),
+  });
+  genreStatsCache.set(cacheKey, stats);
+  return stats;
+}
+
+function getPageLibrary(kind, ids, sourceFilter, availableOnly) {
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
+  const alias = kind === "artists" ? "artist" : kind === "albums" ? "album" : "track";
+  const conditions = [`${alias}.id IN (${ids.map(() => "?").join(",")})`];
+  const parameters = [...ids];
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+  const rows = db.prepare(
+    `${CANONICAL_SELECT}
+     ${CANONICAL_FROM}
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
+       album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
+       track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+  ).all(...parameters);
+  return buildLibraryFromRows(rows);
+}
+
 export function getCanonicalLibraryPage({
   source = null,
   availableOnly = false,
@@ -288,73 +496,78 @@ export function getCanonicalLibraryPage({
   if (!PAGE_KINDS.has(normalizedKind)) {
     throw new Error(`Unsupported library page kind: ${normalizedKind}`);
   }
-
-  const library = getCanonicalLibrary({ source, availableOnly });
-  const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
-  const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));
+  const sourceFilter = normalizeSource(source);
   const normalizedQuery = text(query).toLocaleLowerCase();
   const normalizedGenre = text(genre);
-
-  let collection = normalizedKind === "genres" ? genreStatsFor(library) : library[normalizedKind];
-  if (normalizedKind !== "genres") {
-    collection = collection.filter((entity) => {
-      const album = normalizedKind === "tracks"
-        ? albumsById.get(String(entity.albums?.[0]?.albumId))
-        : entity;
-      const artist = normalizedKind === "artists"
-        ? entity
-        : artistsById.get(String(album?.artistId));
-      const belongsToArtist = !artistId || (
-        normalizedKind === "artists"
-          ? String(entity.id) === String(artistId)
-          : String(artist?.id) === String(artistId)
-      );
-      const belongsToAlbum = !albumId || (
-        normalizedKind === "albums"
-          ? String(entity.id) === String(albumId)
-          : entity.albums?.some((entry) => String(entry.albumId) === String(albumId))
-      );
-      return (
-        belongsToArtist &&
-        belongsToAlbum &&
-        hasGenre(normalizedGenre, artist, album, entity) &&
-        matchesQuery(entity, normalizedQuery, artist, album)
-      );
-    });
-  } else if (normalizedQuery) {
-    collection = collection.filter((genreEntry) =>
-      genreEntry.name.toLocaleLowerCase().includes(normalizedQuery),
-    );
-  }
-
-  collection = [...collection].sort((left, right) => {
-    if (normalizedKind === "genres") return left.name.localeCompare(right.name);
-    if (sort === "newest" && normalizedKind === "albums") {
-      return text(right.releaseDate).localeCompare(text(left.releaseDate));
-    }
-    if (sort === "artist" && normalizedKind !== "artists") {
-      const leftArtist = artistsById.get(String(
-        normalizedKind === "tracks"
-          ? albumsById.get(String(left.albums?.[0]?.albumId))?.artistId
-          : left.artistId,
-      ));
-      const rightArtist = artistsById.get(String(
-        normalizedKind === "tracks"
-          ? albumsById.get(String(right.albums?.[0]?.albumId))?.artistId
-          : right.artistId,
-      ));
-      return text(leftArtist?.name).localeCompare(text(rightArtist?.name));
-    }
-    return text(left.name || left.title).localeCompare(text(right.name || right.title));
-  });
-  if (direction === "desc") collection.reverse();
-
+  const normalizedDirection = text(direction).toLocaleLowerCase();
   const currentPage = pageNumber(page);
   const currentPageSize = pageSize(requestedPageSize);
-  const total = collection.length;
+
+  if (normalizedKind === "genres") {
+    let collection = getCanonicalGenreStats({ sourceFilter, availableOnly });
+    if (normalizedQuery) {
+      collection = collection.filter((entry) =>
+        entry.name.toLocaleLowerCase().includes(normalizedQuery),
+      );
+    }
+    if (normalizedDirection === "desc") collection = [...collection].reverse();
+    const total = collection.length;
+    const items = collection.slice(
+      (currentPage - 1) * currentPageSize,
+      currentPage * currentPageSize,
+    );
+    return {
+      kind: normalizedKind,
+      page: currentPage,
+      pageSize: currentPageSize,
+      total,
+      hasMore: currentPage * currentPageSize < total,
+      items,
+      artists: [],
+      albums: [],
+      tracks: [],
+      genres: getCanonicalGenreStats({ sourceFilter, availableOnly }),
+    };
+  }
+
+  const queryDefinition = buildPageQuery({
+    kind: normalizedKind,
+    sourceFilter,
+    availableOnly,
+    query: normalizedQuery,
+    genre: normalizedGenre,
+    sort: text(sort).toLocaleLowerCase(),
+    direction: normalizedDirection,
+    artistId,
+    albumId,
+  });
+  const total = db.prepare(
+    `SELECT COUNT(DISTINCT ${queryDefinition.idExpression}) AS total
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}`,
+  ).get(...queryDefinition.parameters).total;
+  const ids = db.prepare(
+    `SELECT ${queryDefinition.idExpression} AS page_id
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}
+     GROUP BY ${queryDefinition.idExpression}
+     ORDER BY ${queryDefinition.orderBy}
+     LIMIT ? OFFSET ?`,
+  ).all(
+    ...queryDefinition.parameters,
+    currentPageSize,
+    (currentPage - 1) * currentPageSize,
+  ).map((row) => row.page_id);
+  const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly);
+  const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
+  const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));
+  const tracksById = new Map(library.tracks.map((track) => [String(track.id), track]));
+  const collection = ids
+    .map((id) => library[normalizedKind].find((entity) => String(entity.id) === String(id)))
+    .filter(Boolean);
   const withAlbumStats = (album) => {
     const availableTrackCount = album.trackIds.filter((trackId) =>
-      library.tracks.find((track) => track.id === trackId)?.available,
+      tracksById.get(String(trackId))?.available,
     ).length;
     return {
       ...album,
@@ -362,10 +575,7 @@ export function getCanonicalLibraryPage({
       availableTrackCount,
     };
   };
-  const items = collection.slice(
-    (currentPage - 1) * currentPageSize,
-    currentPage * currentPageSize,
-  ).map((entity) => normalizedKind === "albums" ? withAlbumStats(entity) : entity);
+  const items = collection.map((entity) => normalizedKind === "albums" ? withAlbumStats(entity) : entity);
 
   const relatedAlbums = normalizedKind === "tracks"
     ? [...new Set(items.flatMap((track) =>
@@ -393,12 +603,13 @@ export function getCanonicalLibraryPage({
     artists: relatedArtists,
     albums: relatedAlbums,
     tracks: normalizedKind === "tracks" ? items : [],
-    genres: genreStatsFor(library),
+    genres: getCanonicalGenreStats({ sourceFilter, availableOnly }),
   };
 }
 
 export function invalidateCanonicalLibraryCache() {
   libraryCache.clear();
+  genreStatsCache.clear();
 }
 
 export { normalizeSource };

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -479,6 +479,31 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly) {
   return buildLibraryFromRows(rows);
 }
 
+function getAlbumStats(albumIds, sourceFilter, availableOnly) {
+  if (!albumIds.length) return new Map();
+  const conditions = [`album_track.album_id IN (${albumIds.map(() => "?").join(",")})`];
+  const parameters = [...albumIds];
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+  const rows = db.prepare(
+    `SELECT
+       album_track.album_id AS album_id,
+       COUNT(DISTINCT album_track.track_id) AS track_count,
+       COUNT(DISTINCT CASE WHEN media.available = 1 THEN album_track.track_id END) AS available_track_count
+     FROM library_album_tracks AS album_track
+     JOIN library_media_files AS media ON media.track_id = album_track.track_id
+     WHERE ${conditions.join(" AND ")}
+     GROUP BY album_track.album_id`,
+  ).all(...parameters);
+  return new Map(rows.map((row) => [String(row.album_id), {
+    trackCount: Number(row.track_count),
+    availableTrackCount: Number(row.available_track_count),
+  }]));
+}
+
 export function getCanonicalLibraryPage({
   source = null,
   availableOnly = false,
@@ -561,18 +586,20 @@ export function getCanonicalLibraryPage({
   const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly);
   const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
   const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));
-  const tracksById = new Map(library.tracks.map((track) => [String(track.id), track]));
+  const albumStats = getAlbumStats(
+    library.albums.map((album) => album.id),
+    sourceFilter,
+    availableOnly,
+  );
   const collection = ids
     .map((id) => library[normalizedKind].find((entity) => String(entity.id) === String(id)))
     .filter(Boolean);
   const withAlbumStats = (album) => {
-    const availableTrackCount = album.trackIds.filter((trackId) =>
-      tracksById.get(String(trackId))?.available,
-    ).length;
+    const stats = albumStats.get(String(album.id));
     return {
       ...album,
-      trackCount: album.trackIds.length,
-      availableTrackCount,
+      trackCount: stats?.trackCount ?? album.trackIds.length,
+      availableTrackCount: stats?.availableTrackCount ?? 0,
     };
   };
   const items = collection.map((entity) => normalizedKind === "albums" ? withAlbumStats(entity) : entity);

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -2,6 +2,9 @@ import { db, dbHelpers } from "../config/db-sqlite.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
+const PAGE_KINDS = new Set(["artists", "albums", "tracks", "genres"]);
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 100;
 
 const parseJson = (value) => {
   if (!value) return null;
@@ -176,6 +179,185 @@ export function getCanonicalLibrary({ source = null, availableOnly = false } = {
   };
   libraryCache.set(cacheKey, library);
   return library;
+}
+
+const text = (value) => String(value || "").trim();
+
+const metadataGenres = (entity) => {
+  const metadata = entity?.metadata || {};
+  return [metadata.genres, metadata.genre, metadata.common?.genre, metadata.tags?.genre]
+    .flatMap((value) => (Array.isArray(value) ? value : [value]))
+    .map(text)
+    .filter(Boolean)
+    .filter((value, index, values) => values.indexOf(value) === index);
+};
+
+const hasGenre = (genre, ...entities) => {
+  if (!genre) return true;
+  const wanted = genre.toLocaleLowerCase();
+  return entities.flatMap(metadataGenres).some((value) => value.toLocaleLowerCase() === wanted);
+};
+
+const matchesQuery = (entity, query, artist, album) => {
+  if (!query) return true;
+  return [
+    entity?.name,
+    entity?.title,
+    entity?.artistName,
+    entity?.albumArtist,
+    artist?.name,
+    album?.title,
+  ].some((value) => text(value).toLocaleLowerCase().includes(query));
+};
+
+const genreStatsFor = (library) => {
+  const stats = new Map();
+  const add = (genre, kind) => {
+    const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
+    entry[kind] += 1;
+    stats.set(genre, entry);
+  };
+  library.artists.forEach((artist) =>
+    metadataGenres(artist).forEach((genre) => add(genre, "artists")),
+  );
+  library.albums.forEach((album) =>
+    metadataGenres(album).forEach((genre) => add(genre, "albums")),
+  );
+  library.tracks.forEach((track) =>
+    metadataGenres(track).forEach((genre) => add(genre, "tracks")),
+  );
+  return [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+};
+
+const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
+
+const pageSize = (value) =>
+  Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
+
+export function getCanonicalLibraryPage({
+  source = null,
+  availableOnly = false,
+  kind = "albums",
+  page = 1,
+  pageSize: requestedPageSize = DEFAULT_PAGE_SIZE,
+  query = "",
+  genre = "",
+  sort = "name",
+  direction = "asc",
+  artistId = null,
+  albumId = null,
+} = {}) {
+  const normalizedKind = text(kind).toLocaleLowerCase();
+  if (!PAGE_KINDS.has(normalizedKind)) {
+    throw new Error(`Unsupported library page kind: ${normalizedKind}`);
+  }
+
+  const library = getCanonicalLibrary({ source, availableOnly });
+  const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
+  const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  const normalizedGenre = text(genre);
+
+  let collection = normalizedKind === "genres" ? genreStatsFor(library) : library[normalizedKind];
+  if (normalizedKind !== "genres") {
+    collection = collection.filter((entity) => {
+      const album = normalizedKind === "tracks"
+        ? albumsById.get(String(entity.albums?.[0]?.albumId))
+        : entity;
+      const artist = normalizedKind === "artists"
+        ? entity
+        : artistsById.get(String(album?.artistId));
+      const belongsToArtist = !artistId || (
+        normalizedKind === "artists"
+          ? String(entity.id) === String(artistId)
+          : String(artist?.id) === String(artistId)
+      );
+      const belongsToAlbum = !albumId || (
+        normalizedKind === "albums"
+          ? String(entity.id) === String(albumId)
+          : entity.albums?.some((entry) => String(entry.albumId) === String(albumId))
+      );
+      return (
+        belongsToArtist &&
+        belongsToAlbum &&
+        hasGenre(normalizedGenre, artist, album, entity) &&
+        matchesQuery(entity, normalizedQuery, artist, album)
+      );
+    });
+  } else if (normalizedQuery) {
+    collection = collection.filter((genreEntry) =>
+      genreEntry.name.toLocaleLowerCase().includes(normalizedQuery),
+    );
+  }
+
+  collection = [...collection].sort((left, right) => {
+    if (normalizedKind === "genres") return left.name.localeCompare(right.name);
+    if (sort === "newest" && normalizedKind === "albums") {
+      return text(right.releaseDate).localeCompare(text(left.releaseDate));
+    }
+    if (sort === "artist" && normalizedKind !== "artists") {
+      const leftArtist = artistsById.get(String(
+        normalizedKind === "tracks"
+          ? albumsById.get(String(left.albums?.[0]?.albumId))?.artistId
+          : left.artistId,
+      ));
+      const rightArtist = artistsById.get(String(
+        normalizedKind === "tracks"
+          ? albumsById.get(String(right.albums?.[0]?.albumId))?.artistId
+          : right.artistId,
+      ));
+      return text(leftArtist?.name).localeCompare(text(rightArtist?.name));
+    }
+    return text(left.name || left.title).localeCompare(text(right.name || right.title));
+  });
+  if (direction === "desc") collection.reverse();
+
+  const currentPage = pageNumber(page);
+  const currentPageSize = pageSize(requestedPageSize);
+  const total = collection.length;
+  const withAlbumStats = (album) => {
+    const availableTrackCount = album.trackIds.filter((trackId) =>
+      library.tracks.find((track) => track.id === trackId)?.available,
+    ).length;
+    return {
+      ...album,
+      trackCount: album.trackIds.length,
+      availableTrackCount,
+    };
+  };
+  const items = collection.slice(
+    (currentPage - 1) * currentPageSize,
+    currentPage * currentPageSize,
+  ).map((entity) => normalizedKind === "albums" ? withAlbumStats(entity) : entity);
+
+  const relatedAlbums = normalizedKind === "tracks"
+    ? [...new Set(items.flatMap((track) =>
+        track.albums.map((entry) => String(entry.albumId))))]
+        .map((id) => albumsById.get(id))
+        .filter(Boolean)
+        .map(withAlbumStats)
+    : normalizedKind === "albums" ? items : [];
+  const relatedArtists = normalizedKind === "artists"
+    ? items
+    : relatedAlbums
+      .map((album) => artistsById.get(String(album.artistId)))
+      .filter(Boolean)
+      .filter((artist, index, values) =>
+        values.findIndex((candidate) => candidate.id === artist.id) === index,
+      );
+
+  return {
+    kind: normalizedKind,
+    page: currentPage,
+    pageSize: currentPageSize,
+    total,
+    hasMore: currentPage * currentPageSize < total,
+    items,
+    artists: relatedArtists,
+    albums: relatedAlbums,
+    tracks: normalizedKind === "tracks" ? items : [],
+    genres: genreStatsFor(library),
+  };
 }
 
 export function invalidateCanonicalLibraryCache() {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -27,11 +27,21 @@ function createEntity(map, id, value) {
   return map.get(id);
 }
 
-export function getCanonicalLibrary({ source = null, availableOnly = false } = {}) {
+export function getCanonicalLibrary({ source = null, availableOnly = false, favoriteKeys = null } = {}) {
   const sourceFilter = normalizeSource(source);
   const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
-  const cached = libraryCache.get(cacheKey);
-  if (cached) return cached;
+  const favoriteTargets = Array.isArray(favoriteKeys)
+    ? favoriteKeys.filter((target) =>
+        target && ["artist", "album", "song"].includes(target.kind) && String(target.key || "").trim(),
+      )
+    : null;
+  if (favoriteTargets && favoriteTargets.length === 0) {
+    return { artists: [], albums: [], tracks: [] };
+  }
+  if (!favoriteTargets) {
+    const cached = libraryCache.get(cacheKey);
+    if (cached) return cached;
+  }
   const conditions = [];
   const parameters = [];
 
@@ -40,6 +50,33 @@ export function getCanonicalLibrary({ source = null, availableOnly = false } = {
     parameters.push(sourceFilter);
   }
   if (availableOnly === true) conditions.push("media.available = 1");
+  if (favoriteTargets) {
+    const targetQueries = [];
+    const add = (query, kind) => {
+      const keys = favoriteTargets
+        .filter((target) => target.kind === kind)
+        .map((target) => String(target.key).trim());
+      if (!keys.length) return;
+      targetQueries.push(query.replace("?", keys.map(() => "?").join(",")));
+      parameters.push(...keys);
+    };
+    add("SELECT id FROM library_tracks WHERE identity_key IN (?)", "song");
+    add(
+      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
+        "JOIN library_albums AS album ON album.id = album_track.album_id " +
+        "WHERE album.identity_key IN (?)",
+      "album",
+    );
+    add(
+      "SELECT album_track.track_id FROM library_album_tracks AS album_track " +
+        "JOIN library_albums AS album ON album.id = album_track.album_id " +
+        "JOIN library_artists AS artist ON artist.id = album.artist_id " +
+        "WHERE artist.identity_key IN (?)",
+      "artist",
+    );
+    if (!targetQueries.length) return { artists: [], albums: [], tracks: [] };
+    conditions.push(`media.track_id IN (${targetQueries.join(" UNION ")})`);
+  }
 
   const rows = db
     .prepare(
@@ -177,7 +214,7 @@ export function getCanonicalLibrary({ source = null, availableOnly = false } = {
     albums: [...albums.values()],
     tracks: [...tracks.values()],
   };
-  libraryCache.set(cacheKey, library);
+  if (!favoriteTargets) libraryCache.set(cacheKey, library);
   return library;
 }
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -211,17 +211,18 @@ const toArtistSummary = (artist) => {
   };
 };
 
+const indexLibrary = (library) => ({
+  ...library,
+  artistsById: new Map(library.artists.map((artist) => [artist.id, artist])),
+  albumsById: new Map(library.albums.map((album) => [album.id, album])),
+  tracksById: new Map(library.tracks.map((track) => [track.id, track])),
+  artistsByIdentity: new Map(library.artists.map((artist) => [artist.identityKey, artist])),
+  albumsByIdentity: new Map(library.albums.map((album) => [album.identityKey, album])),
+  tracksByIdentity: new Map(library.tracks.map((track) => [track.identityKey, track])),
+});
+
 function readLibrary() {
-  const library = getCanonicalLibrary({ availableOnly: false });
-  return {
-    ...library,
-    artistsById: new Map(library.artists.map((artist) => [artist.id, artist])),
-    albumsById: new Map(library.albums.map((album) => [album.id, album])),
-    tracksById: new Map(library.tracks.map((track) => [track.id, track])),
-    artistsByIdentity: new Map(library.artists.map((artist) => [artist.identityKey, artist])),
-    albumsByIdentity: new Map(library.albums.map((album) => [album.identityKey, album])),
-    tracksByIdentity: new Map(library.tracks.map((track) => [track.identityKey, track])),
-  };
+  return indexLibrary(getCanonicalLibrary({ availableOnly: false }));
 }
 
 function findCanonical(library, parsed) {
@@ -562,11 +563,11 @@ export function unstarMany(user, values) {
   return true;
 }
 
-export function getStarred(user) {
+const starredRows = (user) => (user?.id ? getStarsStmt.all(user.id) : []);
+
+const buildStarred = (library, rows) => {
   const starred = { album: [], artist: [], song: [] };
-  if (!user?.id) return starred;
-  const library = readLibrary();
-  for (const row of getStarsStmt.all(user.id)) {
+  for (const row of rows) {
     const parsed = { kind: row.entity_kind, key: row.entity_key };
     const entity = findCanonical(library, parsed);
     if (!entity) continue;
@@ -575,6 +576,18 @@ export function getStarred(user) {
     if (parsed.kind === "song") starred.song.push(toSong(library, entity));
   }
   return starred;
+};
+
+export function getStarredWithLibrary(user) {
+  const rows = starredRows(user);
+  const library = getCanonicalLibrary({
+    favoriteKeys: rows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),
+  });
+  return { starred: buildStarred(indexLibrary(library), rows), library };
+}
+
+export function getStarred(user) {
+  return getStarredWithLibrary(user).starred;
 }
 
 export function getArtistInfo(value) {

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -565,6 +565,10 @@ export function unstarMany(user, values) {
 
 const starredRows = (user) => (user?.id ? getStarsStmt.all(user.id) : []);
 
+export function getStarredIdentityKeys(user) {
+  return new Set(starredRows(user).map((row) => `${row.entity_kind}:${row.entity_key}`));
+}
+
 const buildStarred = (library, rows) => {
   const starred = { album: [], artist: [], song: [] };
   for (const row of rows) {

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -1,11 +1,28 @@
 ---
 title: Library
-description: Browse artists in Lidarr.
+description: Browse and play your canonical music library.
 ---
 
-Library is a visual browser for artists in Lidarr.
+Library reads Aurral's canonical music library. Open **Library** in the sidebar
+to see the overview and browse these sections:
 
-You can search and sort the artists. You can also open an artist page and see the monitoring status.
+- **Library** opens with recently added albums and a compact track list.
+- **Favorites** shows starred artists, albums, and tracks.
+- **Albums** shows album artwork, track availability, and sorting.
+- **Tracks** shows playable tracks, artist and album links, and missing files.
+- **Album Artists** and **Artists** show the canonical artist records.
+- **Genres** links to the album list filtered by genre.
+
+Select a track or album to play it with Aurral's built-in player. Artists open
+their full discovery pages, while albums with canonical identifiers open the
+existing release view. Tracks without an available file stay visible but
+cannot play. The page reports stale library data, partial or missing files,
+provider health problems, and empty results.
+
+Navidrome remains optional. Lidarr remains the required library provider.
+
+Use the collection search fields to filter artists, albums, tracks, or genres.
+Artist pages continue to show monitoring status and discovery actions.
 
 Artist pages show library status, release groups, tags, similar artists, previews, and album actions.
 On an artist release page, you can search for a release by title. You can show all releases,

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -22,8 +22,7 @@ missing files, provider health problems, and empty results.
 
 Navidrome remains optional. Lidarr remains the required library provider.
 
-Use the collection search fields to filter artists, albums, tracks, or genres.
-Artist pages continue to show monitoring status and discovery actions.
+Use the search field in the toolbar to filter the current section.
 
 Artist pages show library status, release groups, tags, similar artists, previews, and album actions.
 On an artist release page, you can search for a release by title. You can show all releases,

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -13,11 +13,12 @@ to see the overview and browse these sections:
 - **Album Artists** and **Artists** show the canonical artist records.
 - **Genres** links to the album list filtered by genre.
 
-Select a track or album to play it with Aurral's built-in player. Artists open
-their full discovery pages, while albums with canonical identifiers open the
-existing release view. Tracks without an available file stay visible but
-cannot play. The page reports stale library data, partial or missing files,
-provider health problems, and empty results.
+Select a track or album to play it with Aurral's built-in player. Artists and
+albums open listening-first library pages with their tracks, playback controls,
+and favorites. Those pages link to the full Discover artist or release page
+when a canonical identifier is available. Tracks without an available file
+stay visible but cannot play. The page reports stale library data, partial or
+missing files, provider health problems, and empty results.
 
 Navidrome remains optional. Lidarr remains the required library provider.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -259,7 +259,7 @@ function AppContent() {
                       <Route path="/discover/playlists/:presetId" element={<DiscoverPlaylistDetailPage />} />
                       <Route path="/discover/playlists" element={<DiscoverPlaylistsPage />} />
                       <Route path="/discover/news" element={<NewsPage />} />
-                      <Route path="/library" element={<LibraryPage />} />
+                      <Route path="/library/:section?" element={<LibraryPage />} />
                       <Route
                         path="/playlists"
                         element={

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -259,6 +259,8 @@ function AppContent() {
                       <Route path="/discover/playlists/:presetId" element={<DiscoverPlaylistDetailPage />} />
                       <Route path="/discover/playlists" element={<DiscoverPlaylistsPage />} />
                       <Route path="/discover/news" element={<NewsPage />} />
+                      <Route path="/library/album/:albumId" element={<LibraryPage />} />
+                      <Route path="/library/artist/:artistId" element={<LibraryPage />} />
                       <Route path="/library/:section?" element={<LibraryPage />} />
                       <Route
                         path="/playlists"

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_ACTIVITY_VIEW,
   buildActivityPath,
 } from "../navigation/activityNavConfig";
+import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { useDiscoverRecent } from "../contexts/DiscoverRecentProvider";
 import {
   getDiscoverArtistPath,
@@ -76,6 +77,7 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   const activeDiscoverRecentPath =
     getDiscoverArtistPath(currentDiscoverPath) || currentDiscoverPath;
   const isOnSettings = location.pathname.startsWith("/settings");
+  const isOnLibrary = location.pathname === "/library" || location.pathname.startsWith("/library/");
   const isOnShows = location.pathname.startsWith("/shows");
   const isOnNews = location.pathname.startsWith("/discover/news");
   const isOnActivity =
@@ -97,6 +99,12 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
     const segment = location.pathname.replace(/^\/shows\/?/, "").split("/")[0];
     return segment || DEFAULT_SHOWS_FILTER;
   }, [isOnShows, location.pathname]);
+
+  const activeLibraryView = useMemo(() => {
+    if (!isOnLibrary) return null;
+    const segment = location.pathname.replace(/^\/library\/?/, "").split("/")[0];
+    return LIBRARY_VIEWS.some((view) => view.id === segment) ? segment : DEFAULT_LIBRARY_VIEW;
+  }, [isOnLibrary, location.pathname]);
 
   const activeActivityView = useMemo(() => {
     if (!isOnActivity) return null;
@@ -143,13 +151,14 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
       if (item.section === "discover") {
         return isDiscoverSectionActive;
       }
+      if (item.section === "library") return isOnLibrary;
       if (item.section === "shows") return isOnShows;
       if (item.section === "news") return isOnNews;
       if (item.section === "activity") return isOnActivity;
       if (item.path === "/discover" && location.pathname === "/") return true;
       return location.pathname === item.path;
     },
-    [isDiscoverSectionActive, isOnActivity, isOnNews, isOnShows, location.pathname],
+    [isDiscoverSectionActive, isOnActivity, isOnLibrary, isOnNews, isOnShows, location.pathname],
   );
 
   const navItems = useMemo(() => {
@@ -161,7 +170,13 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
         section: "discover",
         subnav: discoverRecentPages,
       },
-      { path: "/library", label: "Library", icon: Library },
+      {
+        path: "/library",
+        label: "Library",
+        icon: Library,
+        section: "library",
+        subnav: LIBRARY_VIEWS,
+      },
       ...(ticketmasterConfigured
         ? [
             {
@@ -276,9 +291,10 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
         {item.subnav.map((entry) => {
           const active = activeId === entry.id;
           const targetPath =
-            item.section === "activity"
+            entry.path ||
+            (item.section === "activity"
               ? buildActivityPath(entry.id)
-              : `${item.basePath}/${entry.id}`;
+              : `${item.basePath}/${entry.id}`);
           const showReviewAlert = item.section === "activity" && entry.id === "review" && hasReviewAlert;
           return (
             <Link
@@ -369,11 +385,13 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
               const activeSubnavId =
                 item.section === "discover"
                   ? discoverRecentPages.find((entry) => entry.path === activeDiscoverRecentPath)?.id
-                  : item.section === "shows"
-                    ? activeShowsFilter
-                    : item.section === "activity"
-                      ? activeActivityView
-                      : null;
+                  : item.section === "library"
+                    ? activeLibraryView
+                    : item.section === "shows"
+                      ? activeShowsFilter
+                      : item.section === "activity"
+                        ? activeActivityView
+                        : null;
 
               return (
                 <div key={item.path} className={getNavGroupClassName(item, active)}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7595,7 +7595,6 @@ textarea {
   gap: 0.2rem;
   margin-top: 0.7rem;
   padding: 0.35rem 0 0.4rem;
-  border-top: 1px solid var(--aurral-border);
 }
 
 .native-library-search {
@@ -8004,7 +8003,7 @@ button.native-library-card__artist:focus-visible {
 
 .native-library-grid.is-list {
   grid-template-columns: 1fr;
-  gap: 0;
+  gap: 0.15rem;
 }
 
 .native-library-grid.is-list .native-library-card {
@@ -8013,7 +8012,6 @@ button.native-library-card__artist:focus-visible {
   align-items: center;
   gap: 0.7rem;
   padding: 0.45rem 0;
-  border-bottom: 1px solid var(--aurral-border);
 }
 
 .native-library-grid.is-list .native-library-card__cover {
@@ -8050,7 +8048,6 @@ button.native-library-card__artist:focus-visible {
   align-items: center;
   gap: 0.55rem;
   padding: 0.3rem 0.45rem;
-  border-bottom: 1px solid var(--aurral-border);
   color: var(--aurral-text-muted);
   font-size: 0.74rem;
 }
@@ -8210,7 +8207,6 @@ button.native-library-card__artist:focus-visible {
   min-height: 2.7rem;
   padding: 0.35rem 0.55rem;
   border: 0;
-  border-bottom: 1px solid var(--aurral-border);
   background: transparent;
   color: var(--aurral-text-muted);
   font: inherit;
@@ -8311,8 +8307,6 @@ button.native-library-genre-row:focus-visible {
   grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr);
   align-items: end;
   gap: 1.5rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--aurral-border);
 }
 
 .native-library-detail__cover {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7456,10 +7456,1021 @@ textarea {
   cursor: pointer;
 }
 
-@media (min-width: 640px) {
-  .library-page__sort-button {
-    min-width: 168px;
+.native-library-page {
+  min-height: 100%;
+  padding: 1.25rem clamp(1rem, 2.5vw, 2rem) 8rem;
+  color: var(--aurral-text);
+}
+
+.native-library-header {
+  border-bottom: 1px solid var(--aurral-border);
+}
+
+.native-library-title-row {
+  display: flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.native-library-title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.native-library-title-play {
+  display: inline-flex;
+  width: 2.35rem;
+  height: 2.35rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  background: var(--aurral-text);
+  color: var(--aurral-surface);
+  cursor: pointer;
+}
+
+.native-library-title-play:hover:not(:disabled),
+.native-library-title-play:focus-visible {
+  background: var(--aurral-text-muted);
+}
+
+.native-library-title-play:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.native-library-title-play svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.native-library-title .page-title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0;
+  color: var(--aurral-text);
+  font-size: clamp(1.35rem, 2.2vw, 1.9rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.native-library-count {
+  display: inline-flex;
+  min-width: 1.8rem;
+  min-height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--aurral-border-strong);
+  border-radius: 0.25rem;
+  color: var(--aurral-text-muted);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.native-library-section-heading button,
+.native-library-back {
+  border: 0;
+  padding: 0.25rem 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+}
+
+.native-library-section-heading button:hover,
+.native-library-section-heading button:focus-visible,
+.native-library-back:hover,
+.native-library-back:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.native-library-icon-button {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--aurral-radius-sm);
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+}
+
+.native-library-icon-button:hover,
+.native-library-icon-button:focus-visible,
+.native-library-icon-button.is-active {
+  background: var(--aurral-surface-selected);
+  color: var(--aurral-text);
+}
+
+.native-library-icon-button svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.native-library-toolbar {
+  display: flex;
+  min-height: 2.35rem;
+  align-items: center;
+  gap: 0.2rem;
+  margin-top: 0.7rem;
+  padding: 0.35rem 0 0.4rem;
+  border-top: 1px solid var(--aurral-border);
+}
+
+.native-library-search {
+  display: flex;
+  width: min(20rem, 45vw);
+  min-width: 8rem;
+  align-items: center;
+  gap: 0.45rem;
+  height: 2rem;
+  padding: 0 0.55rem;
+  border: 1px solid var(--aurral-border);
+  border-radius: var(--aurral-radius-sm);
+  color: var(--aurral-text-subtle);
+}
+
+.native-library-search:focus-within {
+  border-color: var(--aurral-border-strong);
+}
+
+.native-library-search svg {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex: 0 0 auto;
+}
+
+.native-library-search input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--aurral-text);
+  font: inherit;
+  font-size: 0.76rem;
+}
+
+.native-library-search input::placeholder {
+  color: var(--aurral-text-subtle);
+}
+
+.native-library-search > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+}
+
+.native-library-search > button svg {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+.native-library-sort {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  color: var(--aurral-text);
+}
+
+.native-library-sort select {
+  max-width: 8rem;
+  padding: 0 1.25rem 0 0.25rem;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.native-library-toolbar-divider {
+  width: 1px;
+  height: 1.35rem;
+  margin: 0 0.35rem;
+  background: var(--aurral-border);
+}
+
+.native-library-toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+.native-library-view-toggle {
+  display: inline-flex;
+  gap: 0.1rem;
+}
+
+.native-library-filter-panel {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0;
+  border-top: 1px solid var(--aurral-border);
+  color: var(--aurral-text-muted);
+  font-size: 0.72rem;
+}
+
+.native-library-filter-panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.native-library-filter-panel select {
+  min-width: 10rem;
+  height: 1.9rem;
+  padding: 0 1.5rem 0 0.45rem;
+  border: 1px solid var(--aurral-border);
+  border-radius: var(--aurral-radius-sm);
+  background: transparent;
+  color: var(--aurral-text);
+  font: inherit;
+}
+
+.native-library-filter-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  padding: 0.25rem 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+  font: inherit;
+}
+
+.native-library-filter-reset:hover,
+.native-library-filter-reset:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-filter-reset svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.native-library-notice {
+  margin: 0.9rem 0 0;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--aurral-border);
+  color: var(--aurral-text-muted);
+  font-size: 0.72rem;
+}
+
+.native-library-content {
+  padding-top: 1.35rem;
+}
+
+.native-library-home,
+.native-library-favorites {
+  display: grid;
+  gap: 2rem;
+}
+
+.native-library-section {
+  min-width: 0;
+}
+
+.native-library-section-heading {
+  display: flex;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.native-library-section-heading > div {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.native-library-section-heading h2 {
+  margin: 0;
+  color: var(--aurral-text);
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.native-library-section-heading span {
+  color: var(--aurral-text-subtle);
+  font-size: 0.68rem;
+}
+
+.native-library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(9.5rem, 100%), 1fr));
+  gap: 1.1rem 0.75rem;
+}
+
+.native-library-grid--artists {
+  grid-template-columns: repeat(auto-fill, minmax(min(8.75rem, 100%), 1fr));
+}
+
+.native-library-card {
+  min-width: 0;
+}
+
+.native-library-card__cover-wrap {
+  position: relative;
+}
+
+.native-library-card__cover {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  border-radius: var(--aurral-radius-sm);
+  background: var(--aurral-surface-raised);
+  cursor: pointer;
+}
+
+.native-library-card__cover:hover:not(:disabled),
+.native-library-card__cover:focus-visible {
+  filter: brightness(1.1);
+}
+
+.native-library-card__cover:disabled,
+.native-library-card__title:disabled {
+  cursor: default;
+}
+
+.native-library-card__cover--round {
+  border-radius: 50%;
+}
+
+.native-library-card__cover > img,
+.native-library-card__cover > .native-library-cover-fallback {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.native-library-card__cover--round > img,
+.native-library-card__cover--round > .native-library-cover-fallback {
+  border-radius: 50%;
+}
+
+.native-library-cover-fallback {
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  background: var(--aurral-surface-raised);
+  color: var(--aurral-text-muted);
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 600;
+  letter-spacing: -0.08em;
+}
+
+.native-library-cover-fallback.is-compact {
+  font-size: 0.95rem;
+}
+
+.native-library-artist-image,
+.native-library-artist-image .artist-image-root {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.native-library-artist-image .artist-image-media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.native-library-card__play {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 0.45rem;
+  display: inline-flex;
+  width: 1.9rem;
+  height: 1.9rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--aurral-border-strong);
+  border-radius: 50%;
+  background: var(--aurral-surface);
+  color: var(--aurral-text);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.native-library-card:hover .native-library-card__play,
+.native-library-card__play:focus-visible {
+  opacity: 1;
+}
+
+.native-library-card__play:disabled {
+  display: none;
+}
+
+.native-library-card__play svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.native-library-card__body {
+  min-width: 0;
+  margin-top: 0.45rem;
+}
+
+.native-library-card__title-row {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.native-library-card__title {
+  min-width: 0;
+  overflow: hidden;
+  flex: 1;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.native-library-card__title:hover:not(:disabled) {
+  color: var(--aurral-text-muted);
+}
+
+.native-library-card__artist,
+.native-library-card__meta {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: default;
+  font: inherit;
+  font-size: 0.69rem;
+  line-height: 1.35;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+button.native-library-card__artist {
+  cursor: pointer;
+}
+
+button.native-library-card__artist:hover,
+button.native-library-card__artist:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-favorite {
+  display: inline-flex;
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text-subtle);
+  cursor: pointer;
+  opacity: 0;
+}
+
+.native-library-card:hover .native-library-favorite,
+.native-library-card:focus-within .native-library-favorite,
+.native-library-favorite:focus-visible,
+.native-library-favorite.is-active {
+  opacity: 1;
+}
+
+.native-library-favorite:hover,
+.native-library-favorite.is-active {
+  color: var(--aurral-text);
+}
+
+.native-library-favorite:disabled {
+  cursor: wait;
+  opacity: 0.35;
+}
+
+.native-library-favorite svg {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+.native-library-grid.is-list {
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+.native-library-grid.is-list .native-library-card {
+  display: grid;
+  grid-template-columns: 3.5rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--aurral-border);
+}
+
+.native-library-grid.is-list .native-library-card__cover {
+  width: 3.5rem;
+}
+
+.native-library-grid.is-list .native-library-card__body {
+  margin-top: 0;
+}
+
+.native-library-grid.is-list .native-library-card__play {
+  display: none;
+}
+
+.native-library-grid.is-list .native-library-card__cover--round,
+.native-library-grid.is-list .native-library-card__cover--round > img,
+.native-library-grid.is-list .native-library-card__cover--round > .native-library-cover-fallback {
+  border-radius: 50%;
+}
+
+.native-library-track-list {
+  min-width: 0;
+  overflow-x: auto;
+  border-top: 1px solid var(--aurral-border);
+}
+
+.native-library-track {
+  --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem;
+  display: grid;
+  min-width: 44rem;
+  min-height: 3.2rem;
+  grid-template-columns: var(--native-library-track-columns);
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.3rem 0.45rem;
+  border-bottom: 1px solid var(--aurral-border);
+  color: var(--aurral-text-muted);
+  font-size: 0.74rem;
+}
+
+.native-library-track--heading {
+  min-height: 2rem;
+  border-bottom: 0;
+  color: var(--aurral-text-subtle);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.native-library-track:not(.native-library-track--heading):hover,
+.native-library-track.is-active {
+  background: var(--aurral-surface-selected);
+}
+
+.native-library-track.is-active .native-library-track__title > span {
+  color: var(--aurral-accent);
+}
+
+.native-library-track__play,
+.native-library-track__cover,
+.native-library-track__title,
+.native-library-track__link {
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.native-library-track__play {
+  display: inline-flex;
+  width: 1.75rem;
+  height: 1.75rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: var(--aurral-text-muted);
+  opacity: 0;
+}
+
+.native-library-track:hover .native-library-track__play,
+.native-library-track__play:focus-visible,
+.native-library-track.is-active .native-library-track__play {
+  opacity: 1;
+}
+
+.native-library-track__play:disabled {
+  cursor: default;
+  opacity: 0.3;
+}
+
+.native-library-track__play svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.native-library-track__number {
+  color: var(--aurral-text-subtle);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.native-library-track__cover {
+  display: flex;
+  width: 2.35rem;
+  height: 2.35rem;
+  overflow: hidden;
+  border-radius: 0.2rem;
+  background: var(--aurral-surface-raised);
+}
+
+.native-library-track__cover > img,
+.native-library-track__cover > .native-library-cover-fallback {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.native-library-track__title {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.native-library-track__title > span,
+.native-library-track__title > small,
+.native-library-track__link,
+.native-library-track__time {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.native-library-track__title > span {
+  color: var(--aurral-text);
+  font-size: 0.77rem;
+}
+
+.native-library-track__title > small {
+  display: none;
+  margin-top: 0.1rem;
+  color: var(--aurral-text-subtle);
+  font-size: 0.66rem;
+}
+
+.native-library-track__link {
+  color: var(--aurral-text-muted);
+}
+
+.native-library-track__link:hover,
+.native-library-track__link:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-track__time {
+  color: var(--aurral-text-subtle);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.native-library-track__time.is-missing {
+  color: var(--aurral-text-muted);
+  font-size: 0.65rem;
+}
+
+.native-library-track__favorite {
+  opacity: 0;
+}
+
+.native-library-track:hover .native-library-track__favorite,
+.native-library-track:focus-within .native-library-track__favorite,
+.native-library-track__favorite:focus-visible,
+.native-library-track__favorite.is-active {
+  opacity: 1;
+}
+
+.native-library-genre-list {
+  min-width: 0;
+  overflow-x: auto;
+  border-top: 1px solid var(--aurral-border);
+}
+
+.native-library-genre-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 5rem 5rem 5rem;
+  min-width: 30rem;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  min-height: 2.7rem;
+  padding: 0.35rem 0.55rem;
+  border: 0;
+  border-bottom: 1px solid var(--aurral-border);
+  background: transparent;
+  color: var(--aurral-text-muted);
+  font: inherit;
+  font-size: 0.73rem;
+  text-align: left;
+}
+
+button.native-library-genre-row {
+  cursor: pointer;
+}
+
+button.native-library-genre-row:hover,
+button.native-library-genre-row:focus-visible {
+  background: var(--aurral-surface-selected);
+  color: var(--aurral-text);
+}
+
+.native-library-genre-row--heading {
+  min-height: 2rem;
+  border-bottom: 0;
+  color: var(--aurral-text-subtle);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.native-library-genre-row strong {
+  color: var(--aurral-text);
+  font-weight: 600;
+}
+
+.native-library-state {
+  display: flex;
+  min-height: 13rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 2rem;
+  color: var(--aurral-text-muted);
+  text-align: center;
+}
+
+.native-library-state strong {
+  color: var(--aurral-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.native-library-state span {
+  max-width: 25rem;
+  font-size: 0.74rem;
+}
+
+.native-library-state__action,
+.native-library-page-play {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  margin-top: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--aurral-border-strong);
+  border-radius: var(--aurral-radius-sm);
+  background: var(--aurral-text);
+  color: var(--aurral-surface);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+}
+
+.native-library-state__action:hover,
+.native-library-state__action:focus-visible,
+.native-library-page-play:hover:not(:disabled),
+.native-library-page-play:focus-visible {
+  background: var(--aurral-text-muted);
+}
+
+.native-library-state__action:disabled,
+.native-library-page-play:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.native-library-page-play svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.native-library-album-detail {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.native-library-album-detail__header {
+  display: grid;
+  grid-template-columns: minmax(7rem, 11rem) minmax(0, 1fr);
+  align-items: end;
+  gap: 1rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--aurral-border);
+}
+
+.native-library-album-detail__cover {
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: var(--aurral-radius-sm);
+  background: var(--aurral-surface-raised);
+}
+
+.native-library-album-detail__cover > img,
+.native-library-album-detail__cover > .native-library-cover-fallback {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.native-library-kicker {
+  margin: 0 0 0.35rem;
+  color: var(--aurral-text-subtle);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.native-library-album-detail h2 {
+  margin: 0;
+  color: var(--aurral-text);
+  font-size: clamp(1.2rem, 3vw, 2rem);
+  letter-spacing: -0.04em;
+}
+
+.native-library-album-detail p {
+  margin: 0.35rem 0 0;
+  color: var(--aurral-text-muted);
+  font-size: 0.78rem;
+}
+
+.native-library-album-detail .native-library-card__artist {
+  margin-top: 0.35rem;
+}
+
+.native-library-back {
+  justify-self: start;
+}
+
+:where(
+  .native-library-page button,
+  .native-library-page input,
+  .native-library-page select
+):focus-visible {
+  outline: 2px solid var(--aurral-ring);
+  outline-offset: 2px;
+}
+
+@media (max-width: 760px) {
+  .native-library-page {
     padding-inline: 1rem;
+  }
+
+  .native-library-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .native-library-search {
+    width: 100%;
+    order: -1;
+  }
+
+  .native-library-track {
+    --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem;
+    min-width: 32rem;
+  }
+
+  .native-library-track__artist,
+  .native-library-track__album {
+    display: none;
+  }
+
+  .native-library-track__title > small {
+    display: block;
+  }
+}
+
+@media (max-width: 560px) {
+  .native-library-title-row {
+    align-items: flex-start;
+  }
+
+  .native-library-title .page-title {
+    font-size: 1.35rem;
+  }
+
+  .native-library-sort select {
+    max-width: 5.5rem;
+  }
+
+  .native-library-filter-panel {
+    flex-wrap: wrap;
+  }
+
+  .native-library-filter-panel label {
+    flex: 1 1 100%;
+  }
+
+  .native-library-filter-panel select {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .native-library-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem 0.65rem;
+  }
+
+  .native-library-grid--artists {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .native-library-grid.is-list .native-library-card {
+    grid-template-columns: 3rem minmax(0, 1fr);
+  }
+
+  .native-library-grid.is-list .native-library-card__cover {
+    width: 3rem;
+  }
+
+  .native-library-track {
+    --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem;
+    min-width: 0;
+    gap: 0.4rem;
+  }
+
+  .native-library-track__number,
+  .native-library-track__link {
+    display: none;
+  }
+
+  .native-library-track__title > span {
+    font-size: 0.72rem;
+  }
+
+  .native-library-genre-row {
+    grid-template-columns: minmax(0, 1fr) 3rem 3rem 3rem;
+    min-width: 0;
+    gap: 0.35rem;
+    padding-inline: 0.25rem;
+  }
+
+  .native-library-album-detail__header {
+    grid-template-columns: 6rem minmax(0, 1fr);
+    gap: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .native-library-card__play {
+    transition: none;
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7967,8 +7967,8 @@ button.native-library-card__artist:focus-visible {
 
 .native-library-favorite {
   display: inline-flex;
-  width: 1.4rem;
-  height: 1.4rem;
+  width: 1.5rem;
+  height: 1.5rem;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -8042,6 +8042,7 @@ button.native-library-card__artist:focus-visible {
 
 .native-library-track {
   --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem;
+
   display: grid;
   min-width: 44rem;
   min-height: 3.2rem;
@@ -8480,6 +8481,7 @@ button.native-library-genre-row:focus-visible {
 
   .native-library-track {
     --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem;
+
     min-width: 32rem;
   }
 
@@ -8538,6 +8540,7 @@ button.native-library-genre-row:focus-visible {
 
   .native-library-track {
     --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem;
+
     min-width: 0;
     gap: 0.4rem;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8300,21 +8300,21 @@ button.native-library-genre-row:focus-visible {
   height: 0.8rem;
 }
 
-.native-library-album-detail {
+.native-library-detail {
   display: grid;
-  gap: 1.25rem;
+  gap: 2rem;
 }
 
-.native-library-album-detail__header {
+.native-library-detail__hero {
   display: grid;
-  grid-template-columns: minmax(7rem, 11rem) minmax(0, 1fr);
+  grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr);
   align-items: end;
-  gap: 1rem;
-  padding-bottom: 1.25rem;
+  gap: 1.5rem;
+  padding-bottom: 1.5rem;
   border-bottom: 1px solid var(--aurral-border);
 }
 
-.native-library-album-detail__cover {
+.native-library-detail__cover {
   width: 100%;
   aspect-ratio: 1;
   overflow: hidden;
@@ -8322,12 +8322,18 @@ button.native-library-genre-row:focus-visible {
   background: var(--aurral-surface-raised);
 }
 
-.native-library-album-detail__cover > img,
-.native-library-album-detail__cover > .native-library-cover-fallback {
+.native-library-detail__cover > img,
+.native-library-detail__cover > .native-library-cover-fallback,
+.native-library-detail__cover .native-library-detail__artist-image,
+.native-library-detail__cover .native-library-detail__artist-image .artist-image-root {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.native-library-detail__body {
+  min-width: 0;
 }
 
 .native-library-kicker {
@@ -8338,25 +8344,115 @@ button.native-library-genre-row:focus-visible {
   text-transform: uppercase;
 }
 
-.native-library-album-detail h2 {
+.native-library-detail h2 {
   margin: 0;
   color: var(--aurral-text);
-  font-size: clamp(1.2rem, 3vw, 2rem);
+  font-size: clamp(1.7rem, 4vw, 3rem);
   letter-spacing: -0.04em;
 }
 
-.native-library-album-detail p {
+.native-library-detail p,
+.native-library-detail__meta {
   margin: 0.35rem 0 0;
   color: var(--aurral-text-muted);
   font-size: 0.78rem;
 }
 
-.native-library-album-detail .native-library-card__artist {
+.native-library-detail__artist {
+  display: block;
+  max-width: 100%;
   margin-top: 0.35rem;
+  overflow: hidden;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.native-library-detail__artist:hover,
+.native-library-detail__artist:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 0.35rem;
+}
+
+.native-library-detail__actions .native-library-favorite {
+  width: 2rem;
+  height: 2rem;
+  opacity: 1;
+}
+
+.native-library-detail__discover {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 2rem;
+  border: 0;
+  padding: 0.3rem 0.2rem;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+}
+
+.native-library-detail__discover:hover,
+.native-library-detail__discover:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-detail__discover svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.native-library-detail__section {
+  display: grid;
+  min-width: 0;
+  gap: 0.7rem;
+}
+
+.native-library-detail__section-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.native-library-detail__section-heading h3 {
+  margin: 0;
+  color: var(--aurral-text);
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.native-library-detail__section-heading span {
+  color: var(--aurral-text-subtle);
+  font-size: 0.68rem;
 }
 
 .native-library-back {
   justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.native-library-back svg {
+  width: 0.8rem;
+  height: 0.8rem;
 }
 
 :where(
@@ -8462,7 +8558,7 @@ button.native-library-genre-row:focus-visible {
     padding-inline: 0.25rem;
   }
 
-  .native-library-album-detail__header {
+  .native-library-detail__hero {
     grid-template-columns: 6rem minmax(0, 1fr);
     gap: 0.75rem;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7538,8 +7538,7 @@ textarea {
   line-height: 1;
 }
 
-.native-library-section-heading button,
-.native-library-back {
+.native-library-section-heading button {
   border: 0;
   padding: 0.25rem 0;
   background: transparent;
@@ -7550,9 +7549,7 @@ textarea {
 }
 
 .native-library-section-heading button:hover,
-.native-library-section-heading button:focus-visible,
-.native-library-back:hover,
-.native-library-back:focus-visible {
+.native-library-section-heading button:focus-visible {
   color: var(--aurral-text);
 }
 
@@ -7784,6 +7781,33 @@ textarea {
 .native-library-section-heading span {
   color: var(--aurral-text-subtle);
   font-size: 0.68rem;
+}
+
+.native-library-genre-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.native-library-genre-card {
+  display: flex;
+  min-width: 0;
+  min-height: 2.4rem;
+  align-items: center;
+  padding: 0.45rem 0.65rem;
+  border-radius: var(--aurral-radius-sm);
+  background: var(--aurral-surface-raised);
+  color: var(--aurral-text-muted);
+  font-size: 0.74rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.native-library-genre-card:hover,
+.native-library-genre-card:focus-visible {
+  background: var(--aurral-surface-hover);
+  color: var(--aurral-text);
 }
 
 .native-library-grid {
@@ -8171,7 +8195,7 @@ button.native-library-card__artist:focus-visible {
 .native-library-track__time {
   color: var(--aurral-text-subtle);
   font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-align: center;
 }
 
 .native-library-track__time.is-missing {
@@ -8446,18 +8470,6 @@ button.native-library-genre-row:focus-visible {
   font-size: 0.68rem;
 }
 
-.native-library-back {
-  justify-self: start;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-}
-
-.native-library-back svg {
-  width: 0.8rem;
-  height: 0.8rem;
-}
-
 :where(
   .native-library-page button,
   .native-library-page input,
@@ -8549,6 +8561,10 @@ button.native-library-genre-row:focus-visible {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .native-library-genre-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .native-library-grid.is-list .native-library-card {
     grid-template-columns: 3rem minmax(0, 1fr);
   }
@@ -8587,7 +8603,8 @@ button.native-library-genre-row:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .native-library-card__play {
+  .native-library-card__play,
+  .native-library-genre-card {
     transition: none;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8341,6 +8341,10 @@ button.native-library-genre-row:focus-visible {
   gap: 1.5rem;
 }
 
+.native-library-detail__hero--artist {
+  grid-template-columns: minmax(9.6rem, 14.4rem) minmax(0, 1fr);
+}
+
 .native-library-detail__cover {
   width: 100%;
   aspect-ratio: 1;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7926,7 +7926,7 @@ textarea {
   color: var(--aurral-text);
   cursor: pointer;
   font: inherit;
-  font-size: 0.78rem;
+  font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.35;
   text-align: left;
@@ -8463,6 +8463,23 @@ button.native-library-genre-row:focus-visible {
 ):focus-visible {
   outline: 2px solid var(--aurral-ring);
   outline-offset: 2px;
+}
+
+@media (pointer: coarse) {
+  .native-library-icon-button,
+  .native-library-title-play,
+  .native-library-page-play,
+  .native-library-state__action {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+
+  .native-library-favorite,
+  .native-library-card__play,
+  .native-library-track__play {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 }
 
 @media (max-width: 760px) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8035,7 +8035,6 @@ button.native-library-card__artist:focus-visible {
 .native-library-track-list {
   min-width: 0;
   overflow-x: auto;
-  border-top: 1px solid var(--aurral-border);
 }
 
 .native-library-track {
@@ -8194,7 +8193,6 @@ button.native-library-card__artist:focus-visible {
 .native-library-genre-list {
   min-width: 0;
   overflow-x: auto;
-  border-top: 1px solid var(--aurral-border);
 }
 
 .native-library-genre-row {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7466,6 +7466,10 @@ textarea {
   border-bottom: 1px solid var(--aurral-border);
 }
 
+.native-library-header--home {
+  border-bottom: 0;
+}
+
 .native-library-title-row {
   display: flex;
   min-height: 3rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8249,6 +8249,16 @@ button.native-library-genre-row:focus-visible {
   text-align: center;
 }
 
+.native-library-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 1rem 0 0.25rem;
+  color: var(--aurral-text-muted);
+  font-size: 0.72rem;
+}
+
 .native-library-state strong {
   color: var(--aurral-text);
   font-size: 0.9rem;

--- a/frontend/src/navigation/libraryNavConfig.js
+++ b/frontend/src/navigation/libraryNavConfig.js
@@ -1,0 +1,10 @@
+export const DEFAULT_LIBRARY_VIEW = "home";
+
+export const LIBRARY_VIEWS = [
+  { id: "favorites", label: "Favorites", path: "/library/favorites" },
+  { id: "albums", label: "Albums", path: "/library/albums" },
+  { id: "tracks", label: "Tracks", path: "/library/tracks" },
+  { id: "album-artists", label: "Album Artists", path: "/library/album-artists" },
+  { id: "artists", label: "Artists", path: "/library/artists" },
+  { id: "genres", label: "Genres", path: "/library/genres" },
+];

--- a/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
@@ -327,6 +327,7 @@ export default function DiscoverPlaylistDetailPage() {
         showPlaybackControls={false}
         hideAlbumColumn={!hasAlbumMetadata}
         hideStatusColumn
+        hideQualityColumn
         emptyMessage="No tracks in this playlist."
         playlistTriggerVariant="expand"
         playlists={sharedPlaylists}

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1493,7 +1493,7 @@ function LibraryPage() {
 
   return (
     <main className="library-page native-library-page">
-      <header className="native-library-header">
+      <header className={`native-library-header${section === "home" ? " native-library-header--home" : ""}`}>
         <div className="native-library-title-row">
           <div className="native-library-title">
             <TooltipButton

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -531,7 +531,7 @@ function LibraryPage() {
   const toggleFavorite = useCallback(
     async (kind, entity) => {
       const id = favoriteId(kind, entity);
-      if (!id || id.endsWith(":")) return;
+      if (!id || id.endsWith(":") || pendingFavorite) return;
       const nextStarred = !favoriteIds.has(id);
       if (isPreviewLibrary) {
         setFavoriteIds((current) => {
@@ -568,7 +568,7 @@ function LibraryPage() {
         setPendingFavorite(null);
       }
     },
-    [favoriteIds, isPreviewLibrary, showError],
+    [favoriteIds, isPreviewLibrary, pendingFavorite, showError],
   );
 
   const playTrack = useCallback(
@@ -780,7 +780,7 @@ function LibraryPage() {
             <FavoriteButton
               className="native-library-track__favorite"
               active={favoriteIds.has(favoriteId("song", track))}
-              pending={pendingFavorite === favoriteId("song", track)}
+              pending={Boolean(pendingFavorite)}
               label={track.title || "track"}
               onClick={() => toggleFavorite("song", track)}
             />
@@ -825,7 +825,7 @@ function LibraryPage() {
           </button>
           <FavoriteButton
             active={favoriteIds.has(favoriteId("artist", artist))}
-            pending={pendingFavorite === favoriteId("artist", artist)}
+            pending={Boolean(pendingFavorite)}
             label={artist.name || "artist"}
             onClick={() => toggleFavorite("artist", artist)}
           />
@@ -880,7 +880,7 @@ function LibraryPage() {
             </button>
             <FavoriteButton
               active={favoriteIds.has(favoriteId("album", album))}
-              pending={pendingFavorite === favoriteId("album", album)}
+              pending={Boolean(pendingFavorite)}
               label={album.title || "album"}
               onClick={() => toggleFavorite("album", album)}
             />
@@ -1054,7 +1054,7 @@ function LibraryPage() {
               </button>
               <FavoriteButton
                 active={favoriteIds.has(favoriteId("album", libraryAlbum))}
-                pending={pendingFavorite === favoriteId("album", libraryAlbum)}
+                pending={Boolean(pendingFavorite)}
                 label={libraryAlbum.title || "album"}
                 onClick={() => toggleFavorite("album", libraryAlbum)}
               />
@@ -1129,7 +1129,7 @@ function LibraryPage() {
               </button>
               <FavoriteButton
                 active={favoriteIds.has(favoriteId("artist", libraryArtist))}
-                pending={pendingFavorite === favoriteId("artist", libraryArtist)}
+                pending={Boolean(pendingFavorite)}
                 label={libraryArtist.name || "artist"}
                 onClick={() => toggleFavorite("artist", libraryArtist)}
               />

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   ArrowDownAZ,
+  ArrowLeft,
   ArrowUpZA,
+  ExternalLink,
   Grid3X3,
   Heart,
   List,
@@ -70,6 +72,16 @@ const formatDuration = (durationMs) => {
   );
 };
 
+const formatLongDuration = (durationMs) => {
+  const seconds = Math.max(0, Math.floor(Number(durationMs || 0) / 1000));
+  if (!seconds) return "";
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  return hours
+    ? hours + "h " + (minutes % 60) + "m"
+    : minutes + "m " + (seconds % 60) + "s";
+};
+
 const entityMatches = (entity, query) => {
   if (!query) return true;
   return [entity?.name, entity?.title, entity?.artistName, entity?.albumArtist, entity?.albumName]
@@ -123,7 +135,11 @@ function EmptyState({ title, message }) {
 
 function LibraryPage() {
   const navigate = useNavigate();
-  const { section: routeSection } = useParams();
+  const {
+    section: routeSection,
+    albumId: routeAlbumId,
+    artistId: routeArtistId,
+  } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { bootstrap } = useAuth();
   const { showError } = useToast();
@@ -137,7 +153,6 @@ function LibraryPage() {
   const [viewMode, setViewMode] = useState("grid");
   const [searchOpen, setSearchOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
-  const [selectedAlbumId, setSelectedAlbumId] = useState(null);
   const [covers, setCovers] = useState({});
   const [pendingFavorite, setPendingFavorite] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -146,9 +161,11 @@ function LibraryPage() {
   const [retryKey, setRetryKey] = useState(0);
 
   const section = LIBRARY_VIEW_IDS.has(routeSection) ? routeSection : DEFAULT_LIBRARY_VIEW;
+  const isDetail = Boolean(routeAlbumId || routeArtistId);
   const tab = section === "home" || section === "album-artists" ? "artists" : section;
   const selectedGenre = searchParams.get("genre") || "";
   const forcePreview = import.meta.env.DEV && searchParams.get("preview") === "1";
+  const previewQuery = forcePreview ? "?preview=1" : "";
   const sectionLabel = LIBRARY_VIEWS.find((view) => view.id === section)?.label || "Library";
   const librarySource = useMemo(() => ({ type: "native-library", id: "library" }), []);
   const normalizedQuery = query.trim().toLocaleLowerCase();
@@ -175,7 +192,6 @@ function LibraryPage() {
     setViewMode(section === "tracks" || section === "genres" ? "list" : "grid");
     setSearchOpen(false);
     setFiltersOpen(false);
-    setSelectedAlbumId(null);
   }, [section]);
 
   useEffect(() => {
@@ -420,12 +436,8 @@ function LibraryPage() {
     [library.albums],
   );
   const homeTracks = library.tracks.slice(0, 12);
-  const selectedAlbum =
-    selectedAlbumId == null ? null : albumsById.get(String(selectedAlbumId)) || null;
-  const selectedAlbumTracks = useMemo(
-    () => getAlbumTracks(selectedAlbum),
-    [getAlbumTracks, selectedAlbum],
-  );
+  const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
+  const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
 
   const coverItems = useMemo(() => {
     const items = library.albums
@@ -583,6 +595,13 @@ function LibraryPage() {
   );
 
   const handleArtistOpen = (artist) => {
+    if (!artist?.id) return;
+    navigate("/library/artist/" + encodeURIComponent(artist.id) + previewQuery, {
+      state: { artistName: artist.name, libraryArtist: artist },
+    });
+  };
+
+  const handleDiscoverArtistOpen = (artist) => {
     if (!artist?.mbid) return;
     navigate("/artist/" + encodeURIComponent(artist.mbid), {
       state: { artistName: artist.name, inLibrary: true, libraryArtist: artist },
@@ -590,6 +609,13 @@ function LibraryPage() {
   };
 
   const handleAlbumOpen = (album) => {
+    if (!album?.id) return;
+    navigate("/library/album/" + encodeURIComponent(album.id) + previewQuery, {
+      state: { albumTitle: album.title, libraryAlbum: album },
+    });
+  };
+
+  const handleDiscoverAlbumOpen = (album) => {
     const artist = getArtistForAlbum(album);
     if (artist?.mbid && (album?.releaseGroupMbid || album?.mbid)) {
       navigateToLibraryAlbum(navigate, album, {
@@ -597,27 +623,23 @@ function LibraryPage() {
         artistName: artist.name,
         coverUrl: getAlbumCover(album),
       });
-      return;
     }
-    setSelectedAlbumId(album?.id || null);
   };
 
   const favoriteCount =
     favoriteArtists.length + favoriteAlbums.length + favoriteTracks.length;
   const activeCount =
-    selectedAlbum != null
-      ? selectedAlbumTracks.length
-      : section === "home"
-        ? library.artists.length + library.albums.length + library.tracks.length
-        : section === "favorites"
-          ? favoriteCount
-          : tab === "artists"
-            ? sortedArtists.length
-            : tab === "albums"
-              ? sortedAlbums.length
-              : tab === "tracks"
-                ? sortedTracks.length
-                : sortedGenres.length;
+    section === "home"
+      ? library.artists.length + library.albums.length + library.tracks.length
+      : section === "favorites"
+        ? favoriteCount
+        : tab === "artists"
+          ? sortedArtists.length
+          : tab === "albums"
+            ? sortedAlbums.length
+            : tab === "tracks"
+              ? sortedTracks.length
+              : sortedGenres.length;
   const sortOptions =
     section === "albums"
       ? [
@@ -637,7 +659,7 @@ function LibraryPage() {
             : [];
 
   const collectionTracks = useMemo(() => {
-    if (selectedAlbum) return selectedAlbumTracks;
+    if (libraryAlbum) return getAlbumTracks(libraryAlbum);
     if (section === "favorites") return favoriteTracks;
     if (section === "albums") return sortedAlbums.flatMap(getAlbumTracks);
     if (section === "tracks") return sortedTracks;
@@ -647,10 +669,9 @@ function LibraryPage() {
     favoriteTracks,
     filteredTracks,
     getAlbumTracks,
+    libraryAlbum,
     library.tracks,
     section,
-    selectedAlbum,
-    selectedAlbumTracks,
     selectedGenre,
     sortedAlbums,
     sortedTracks,
@@ -731,7 +752,7 @@ function LibraryPage() {
               <span>{track.title || "Unknown Track"}</span>
               <small>{artistName}</small>
             </button>
-            {artist?.mbid ? (
+            {artist ? (
               <button
                 type="button"
                 className="native-library-track__link native-library-track__artist"
@@ -775,7 +796,6 @@ function LibraryPage() {
         type="button"
         className="native-library-card__cover native-library-card__cover--round"
         onClick={() => handleArtistOpen(artist)}
-        disabled={!artist.mbid}
         aria-label={"Open " + (artist.name || "artist")}
       >
         {artist.mbid ? (
@@ -798,7 +818,6 @@ function LibraryPage() {
             type="button"
             className="native-library-card__title"
             onClick={() => handleArtistOpen(artist)}
-            disabled={!artist.mbid}
             title={artist.name}
           >
             {artist.name || "Unknown Artist"}
@@ -865,7 +884,7 @@ function LibraryPage() {
               onClick={() => toggleFavorite("album", album)}
             />
           </div>
-          {artist?.mbid ? (
+          {artist ? (
             <button
               type="button"
               className="native-library-card__artist"
@@ -977,60 +996,218 @@ function LibraryPage() {
     </div>
   );
 
-  const renderAlbumDetail = () => {
-    const artist = getArtistForAlbum(selectedAlbum);
-    const availability = albumAvailability(selectedAlbum);
+  const renderLibraryAlbumDetail = () => {
+    if (!libraryAlbum) return null;
+    const artist = getArtistForAlbum(libraryAlbum);
+    const albumTracks = getAlbumTracks(libraryAlbum);
+    const availability = albumAvailability(libraryAlbum);
+    const durationMs = albumTracks.reduce(
+      (total, track) => total + Number(firstAvailableFile(track)?.durationMs || 0),
+      0,
+    );
     return (
-      <section className="native-library-album-detail">
+      <section className="native-library-detail">
         <button
           type="button"
           className="native-library-back"
-          onClick={() => setSelectedAlbumId(null)}
+          onClick={() => navigate("/library/albums" + previewQuery)}
         >
-          Back to {sectionLabel}
+          <ArrowLeft aria-hidden="true" /> Back to Albums
         </button>
-        <div className="native-library-album-detail__header">
-          <div className="native-library-album-detail__cover">
-            <Cover src={getAlbumCover(selectedAlbum)} label={selectedAlbum.title} />
+        <div className="native-library-detail__hero">
+          <div className="native-library-detail__cover">
+            <Cover src={getAlbumCover(libraryAlbum)} label={libraryAlbum.title} />
           </div>
-          <div>
+          <div className="native-library-detail__body">
             <p className="native-library-kicker">Album</p>
-            <h2>{selectedAlbum.title}</h2>
-            {artist?.mbid ? (
+            <h2>{libraryAlbum.title || "Unknown Album"}</h2>
+            {artist ? (
               <button
                 type="button"
-                className="native-library-card__artist"
+                className="native-library-detail__artist"
                 onClick={() => handleArtistOpen(artist)}
               >
                 {artist.name}
               </button>
             ) : (
-              <p>{artist?.name || selectedAlbum.albumArtist || "Unknown Artist"}</p>
+              <p>{libraryAlbum.albumArtist || "Unknown Artist"}</p>
             )}
-            <p className="native-library-card__meta">
-              {yearOf(selectedAlbum.releaseDate)
-                ? yearOf(selectedAlbum.releaseDate) + " · "
-                : ""}
-              {availability.available}/{availability.total} available
+            <p className="native-library-detail__meta">
+              {[yearOf(libraryAlbum.releaseDate), availability.total + " tracks", formatLongDuration(durationMs)]
+                .filter(Boolean)
+                .join(" · ")}
             </p>
-            <button
-              type="button"
-              className="native-library-page-play"
-              onClick={() => playTracks(selectedAlbumTracks)}
-              disabled={!selectedAlbumTracks.some((track) => firstAvailableFile(track))}
-            >
-              <Play aria-hidden="true" fill="currentColor" /> Play
-            </button>
+            <div className="native-library-detail__actions">
+              <button
+                type="button"
+                className="native-library-page-play"
+                onClick={() => playTracks(albumTracks)}
+                disabled={!albumTracks.some((track) => firstAvailableFile(track))}
+              >
+                <Play aria-hidden="true" fill="currentColor" /> Play
+              </button>
+              <FavoriteButton
+                active={favoriteIds.has(favoriteId("album", libraryAlbum))}
+                pending={pendingFavorite === favoriteId("album", libraryAlbum)}
+                label={libraryAlbum.title || "album"}
+                onClick={() => toggleFavorite("album", libraryAlbum)}
+              />
+              {artist?.mbid && (libraryAlbum.releaseGroupMbid || libraryAlbum.mbid) && (
+                <button
+                  type="button"
+                  className="native-library-detail__discover"
+                  onClick={() => handleDiscoverAlbumOpen(libraryAlbum)}
+                >
+                  <ExternalLink aria-hidden="true" /> Discover
+                </button>
+              )}
+            </div>
           </div>
         </div>
-        {renderTrackList(selectedAlbumTracks, selectedAlbum.title + " tracks")}
+        <section className="native-library-detail__section">
+          <div className="native-library-detail__section-heading">
+            <h3>Tracks</h3>
+            <span>{availability.total}</span>
+          </div>
+          {renderTrackList(albumTracks, libraryAlbum.title + " tracks")}
+        </section>
       </section>
     );
   };
 
-  const content = selectedAlbum
-    ? renderAlbumDetail()
-    : section === "home"
+  const renderLibraryArtistDetail = () => {
+    if (!libraryArtist) return null;
+    const artistAlbums = library.albums.filter(
+      (album) => String(album.artistId) === String(libraryArtist.id),
+    );
+    const artistTracks = artistAlbums.flatMap(getAlbumTracks);
+    return (
+      <section className="native-library-detail">
+        <button
+          type="button"
+          className="native-library-back"
+          onClick={() => navigate("/library/artists" + previewQuery)}
+        >
+          <ArrowLeft aria-hidden="true" /> Back to Artists
+        </button>
+        <div className="native-library-detail__hero native-library-detail__hero--artist">
+          <div className="native-library-detail__cover">
+            {libraryArtist.mbid ? (
+              <ArtistImage
+                mbid={libraryArtist.mbid}
+                artistName={libraryArtist.name}
+                alt={libraryArtist.name || ""}
+                className="native-library-detail__artist-image"
+                showLoading={false}
+                enablePreviewPlayback={false}
+                isInLibrary
+              />
+            ) : (
+              <Cover label={libraryArtist.name} />
+            )}
+          </div>
+          <div className="native-library-detail__body">
+            <p className="native-library-kicker">Artist</p>
+            <h2>{libraryArtist.name || "Unknown Artist"}</h2>
+            <p className="native-library-detail__meta">
+              {artistAlbums.length} album{artistAlbums.length === 1 ? "" : "s"}
+            </p>
+            <div className="native-library-detail__actions">
+              <button
+                type="button"
+                className="native-library-page-play"
+                onClick={() => playTracks(artistTracks)}
+                disabled={!artistTracks.some((track) => firstAvailableFile(track))}
+              >
+                <Play aria-hidden="true" fill="currentColor" /> Play
+              </button>
+              <FavoriteButton
+                active={favoriteIds.has(favoriteId("artist", libraryArtist))}
+                pending={pendingFavorite === favoriteId("artist", libraryArtist)}
+                label={libraryArtist.name || "artist"}
+                onClick={() => toggleFavorite("artist", libraryArtist)}
+              />
+              {libraryArtist.mbid && (
+                <button
+                  type="button"
+                  className="native-library-detail__discover"
+                  onClick={() => handleDiscoverArtistOpen(libraryArtist)}
+                >
+                  <ExternalLink aria-hidden="true" /> Discover
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+        <section className="native-library-detail__section">
+          <div className="native-library-detail__section-heading">
+            <h3>Albums</h3>
+            <span>{artistAlbums.length}</span>
+          </div>
+          {artistAlbums.length ? (
+            <div className="native-library-grid">{artistAlbums.map(renderAlbumCard)}</div>
+          ) : (
+            <EmptyState title="No albums" message="No indexed albums belong to this artist." />
+          )}
+        </section>
+        <section className="native-library-detail__section">
+          <div className="native-library-detail__section-heading">
+            <h3>Tracks</h3>
+            <span>{artistTracks.length}</span>
+          </div>
+          {artistTracks.length ? (
+            renderTrackList(artistTracks, libraryArtist.name + " tracks")
+          ) : (
+            <EmptyState title="No tracks" message="No indexed tracks belong to this artist." />
+          )}
+        </section>
+      </section>
+    );
+  };
+
+  const renderLibraryDetail = () =>
+    libraryAlbum ? renderLibraryAlbumDetail() : renderLibraryArtistDetail();
+
+  const providerWarning = bootstrap?.lidarr?.circuitOpen === true;
+
+  if (isDetail) {
+    return (
+      <main className="library-page native-library-page">
+        {providerWarning && (
+          <p className="native-library-notice" role="status">
+            Lidarr is unavailable. Showing the last indexed library.
+          </p>
+        )}
+        {loading && (
+          <div className="native-library-state" role="status">
+            Loading library…
+          </div>
+        )}
+        {!loading && error && (
+          <div className="native-library-state" role="alert">
+            <strong>Library unavailable</strong>
+            <span>{error}</span>
+            <button
+              type="button"
+              className="native-library-state__action"
+              onClick={() => setRetryKey((value) => value + 1)}
+            >
+              Try again
+            </button>
+          </div>
+        )}
+        {!loading && !error && !libraryAlbum && !libraryArtist && (
+          <EmptyState title="Not found" message="This library item is no longer indexed." />
+        )}
+        {!loading && !error && (libraryAlbum || libraryArtist) && (
+          <div className="native-library-content">{renderLibraryDetail()}</div>
+        )}
+      </main>
+    );
+  }
+
+  const content =
+    section === "home"
       ? renderHome()
       : section === "favorites"
         ? renderFavorites()
@@ -1059,16 +1236,12 @@ function LibraryPage() {
               ? renderTrackList(sortedTracks, "Library tracks")
               : renderGenres();
 
-  const providerWarning = bootstrap?.lidarr?.circuitOpen === true;
-  const pageTitle =
-    selectedAlbum ? selectedAlbum.title : section === "home" ? "Library" : sectionLabel;
+  const pageTitle = section === "home" ? "Library" : sectionLabel;
   const pageCount =
-    selectedAlbum != null
-      ? selectedAlbumTracks.length
-      : section === "home"
-        ? library.artists.length + library.albums.length + library.tracks.length
-        : activeCount;
-  const showToolbar = !selectedAlbum && section !== "home";
+    section === "home"
+      ? library.artists.length + library.albums.length + library.tracks.length
+      : activeCount;
+  const showToolbar = section !== "home";
   const hasActiveFilters = Boolean(selectedGenre);
 
   return (
@@ -1287,7 +1460,7 @@ function LibraryPage() {
           </button>
         </div>
       )}
-      {!loading && !error && activeCount === 0 && !selectedAlbum && (
+      {!loading && !error && activeCount === 0 && (
         <EmptyState
           title={
             query || selectedGenre
@@ -1303,7 +1476,7 @@ function LibraryPage() {
           }
         />
       )}
-      {!loading && !error && (activeCount > 0 || selectedAlbum) && (
+      {!loading && !error && activeCount > 0 && (
         <div className="native-library-content">{content}</div>
       )}
     </main>

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -905,7 +905,7 @@ function LibraryPage() {
         aria-hidden="true"
       >
         <span />
-        <span>#</span>
+        <span className="native-library-track__number">#</span>
         <span />
         <span>Title</span>
         <span>Artist</span>

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   ArrowDownAZ,
@@ -154,6 +154,7 @@ function LibraryPage() {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [covers, setCovers] = useState({});
   const [pendingFavorite, setPendingFavorite] = useState(null);
+  const favoriteMutationInFlightRef = useRef(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [isPreviewLibrary, setIsPreviewLibrary] = useState(false);
@@ -531,7 +532,7 @@ function LibraryPage() {
   const toggleFavorite = useCallback(
     async (kind, entity) => {
       const id = favoriteId(kind, entity);
-      if (!id || id.endsWith(":") || pendingFavorite) return;
+      if (!id || id.endsWith(":") || favoriteMutationInFlightRef.current) return;
       const nextStarred = !favoriteIds.has(id);
       if (isPreviewLibrary) {
         setFavoriteIds((current) => {
@@ -543,6 +544,7 @@ function LibraryPage() {
         return;
       }
       const previous = favoriteIds;
+      favoriteMutationInFlightRef.current = true;
       setPendingFavorite(id);
       setFavoriteIds((current) => {
         const next = new Set(current);
@@ -565,10 +567,11 @@ function LibraryPage() {
         setFavoriteIds(previous);
         showError(requestError.response?.data?.message || "Failed to update favorites");
       } finally {
+        favoriteMutationInFlightRef.current = false;
         setPendingFavorite(null);
       }
     },
-    [favoriteIds, isPreviewLibrary, pendingFavorite, showError],
+    [favoriteIds, isPreviewLibrary, showError],
   );
 
   const playTrack = useCallback(

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 
 import ArtistImage from "../components/ArtistImage";
+import TooltipButton from "../components/TooltipButton";
 import { useAuth } from "../contexts/AuthContext";
 import { useAudioQueue } from "../contexts/audioQueueContext";
 import { useToast } from "../contexts/ToastContext";
@@ -109,17 +110,16 @@ function Cover({ src, label, round = false, compact = false }) {
 
 function FavoriteButton({ active, pending, label, onClick, className = "" }) {
   return (
-    <button
-      type="button"
+    <TooltipButton
       className={"native-library-favorite " + className + (active ? " is-active" : "")}
       onClick={onClick}
       disabled={pending}
+      label={active ? "Remove from favorites" : "Add to favorites"}
       aria-label={active ? "Remove " + label + " from favorites" : "Add " + label + " to favorites"}
       aria-pressed={active}
-      title={active ? "Remove from favorites" : "Add to favorites"}
     >
       <Heart aria-hidden="true" fill={active ? "currentColor" : "none"} />
-    </button>
+    </TooltipButton>
   );
 }
 
@@ -444,10 +444,11 @@ function LibraryPage() {
     const items = library.albums
       .map((album) => ({
         mbid: album.mbid || album.releaseGroupMbid,
+        coverUrl: album.coverUrl,
         artistName: getArtistForAlbum(album)?.name || album.albumArtist,
         albumTitle: album.title,
       }))
-      .filter((item) => item.mbid);
+      .filter((item) => item.mbid && !item.coverUrl);
     return items
       .filter(
         (item, index, values) =>
@@ -475,7 +476,7 @@ function LibraryPage() {
   }, [coverItems]);
 
   const getAlbumCover = useCallback(
-    (album) => covers[album?.mbid || album?.releaseGroupMbid] || "",
+    (album) => album?.coverUrl || covers[album?.mbid || album?.releaseGroupMbid] || "",
     [covers],
   );
 
@@ -716,11 +717,11 @@ function LibraryPage() {
             key={track.id}
             role="listitem"
           >
-            <button
-              type="button"
+            <TooltipButton
               className="native-library-track__play"
               onClick={() => playTrack(track, tracks)}
               disabled={!file || (active && isLoading)}
+              label={(active && isPlaying ? "Pause " : "Play ") + track.title}
               aria-label={(active && isPlaying ? "Pause " : "Play ") + track.title}
             >
               {active && isPlaying ? (
@@ -728,7 +729,7 @@ function LibraryPage() {
               ) : (
                 <Play aria-hidden="true" fill="currentColor" />
               )}
-            </button>
+            </TooltipButton>
             <span className="native-library-track__number" aria-hidden="true">
               {index + 1}
             </span>
@@ -861,15 +862,15 @@ function LibraryPage() {
           >
             <Cover src={getAlbumCover(album)} label={album.title} />
           </button>
-          <button
-            type="button"
+          <TooltipButton
             className="native-library-card__play"
             onClick={() => playTracks(albumTracks)}
             disabled={!albumTracks.some((track) => firstAvailableFile(track))}
+            label={"Play " + (album.title || "album")}
             aria-label={"Play " + (album.title || "album")}
           >
             <Play aria-hidden="true" fill="currentColor" />
-          </button>
+          </TooltipButton>
         </div>
         <div className="native-library-card__body">
           <div className="native-library-card__title-row">
@@ -1263,15 +1264,14 @@ function LibraryPage() {
       <header className="native-library-header">
         <div className="native-library-title-row">
           <div className="native-library-title">
-            <button
-              type="button"
+            <TooltipButton
               className="native-library-title-play"
               onClick={() => playTracks(collectionTracks)}
               disabled={!collectionPlayable}
-              aria-label={"Play " + pageTitle}
+              label={"Play " + pageTitle}
             >
               <Play aria-hidden="true" fill="currentColor" />
-            </button>
+            </TooltipButton>
             <h1 className="page-title">
               {pageTitle}
               {pageCount != null && (
@@ -1281,26 +1281,24 @@ function LibraryPage() {
           </div>
           <div className="native-library-header-actions">
             {showToolbar ? (
-              <button
-                type="button"
+              <TooltipButton
                 className={`native-library-icon-button${searchOpen ? " is-active" : ""}`}
                 onClick={() => setSearchOpen((value) => !value)}
+                label={searchOpen ? "Close search" : "Search"}
                 aria-label={searchOpen ? "Close search" : "Search " + sectionLabel.toLocaleLowerCase()}
                 aria-pressed={searchOpen}
-                title={searchOpen ? "Close search" : "Search"}
               >
                 <Search aria-hidden="true" />
-              </button>
+              </TooltipButton>
             ) : (
-              <button
-                type="button"
+              <TooltipButton
                 className="native-library-icon-button"
                 onClick={() => setRetryKey((value) => value + 1)}
+                label="Refresh"
                 aria-label="Refresh library"
-                title="Refresh"
               >
                 <RefreshCw aria-hidden="true" />
-              </button>
+              </TooltipButton>
             )}
           </div>
         </div>
@@ -1319,9 +1317,9 @@ function LibraryPage() {
                     autoFocus
                   />
                   {query && (
-                    <button type="button" onClick={() => setQuery("")} aria-label="Clear search">
+                    <TooltipButton onClick={() => setQuery("")} label="Clear search">
                       <X aria-hidden="true" />
-                    </button>
+                    </TooltipButton>
                   )}
                 </label>
               )}
@@ -1342,67 +1340,62 @@ function LibraryPage() {
                     </select>
                   </label>
                   <span className="native-library-toolbar-divider" aria-hidden="true" />
-                  <button
-                    type="button"
+                  <TooltipButton
                     className="native-library-icon-button"
                     onClick={() =>
                       setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
                     }
+                    label={sortDirection === "asc" ? "Descending" : "Ascending"}
                     aria-label={sortDirection === "asc" ? "Sort descending" : "Sort ascending"}
-                    title={sortDirection === "asc" ? "Descending" : "Ascending"}
                   >
                     {sortDirection === "asc" ? (
                       <ArrowDownAZ aria-hidden="true" />
                     ) : (
                       <ArrowUpZA aria-hidden="true" />
                     )}
-                  </button>
+                  </TooltipButton>
                 </>
               )}
               {section !== "genres" && (
-                <button
-                  type="button"
+                <TooltipButton
                   className={`native-library-icon-button${hasActiveFilters ? " is-active" : ""}`}
                   onClick={() => setFiltersOpen((value) => !value)}
+                  label="Filters"
                   aria-label="Filter library"
                   aria-pressed={filtersOpen}
-                  title="Filters"
                 >
                   <ListFilter aria-hidden="true" />
-                </button>
+                </TooltipButton>
               )}
-              <button
-                type="button"
+              <TooltipButton
                 className="native-library-icon-button"
                 onClick={() => setRetryKey((value) => value + 1)}
+                label="Refresh"
                 aria-label="Refresh library"
-                title="Refresh"
               >
                 <RefreshCw aria-hidden="true" />
-              </button>
+              </TooltipButton>
               <span className="native-library-toolbar-spacer" aria-hidden="true" />
               {(tab === "artists" || tab === "albums") && (
                 <div className="native-library-view-toggle" aria-label="Library view">
-                  <button
-                    type="button"
+                  <TooltipButton
                     className={`native-library-icon-button${viewMode === "grid" ? " is-active" : ""}`}
                     onClick={() => setViewMode("grid")}
+                    label="Grid view"
                     aria-label="Grid view"
-                    title="Grid view"
                     aria-pressed={viewMode === "grid"}
                   >
                     <Grid3X3 aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
+                  </TooltipButton>
+                  <TooltipButton
                     className={`native-library-icon-button${viewMode === "list" ? " is-active" : ""}`}
                     onClick={() => setViewMode("list")}
+                    label="List view"
                     aria-label="List view"
-                    title="List view"
                     aria-pressed={viewMode === "list"}
                   >
                     <List aria-hidden="true" />
-                  </button>
+                  </TooltipButton>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   ArrowDownAZ,
   ArrowLeft,
@@ -570,11 +570,27 @@ function LibraryPage() {
         .slice(0, 12),
     [library.albums],
   );
+  const homeGenres = useMemo(
+    () =>
+      [...genreStats]
+        .sort(
+          (left, right) =>
+            right.tracks - left.tracks ||
+            right.albums - left.albums ||
+            left.name.localeCompare(right.name),
+        )
+        .slice(0, 12),
+    [genreStats],
+  );
   const homeTracks = library.tracks.slice(0, 12);
   const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
   const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
   useDocumentTitle(
-    isDetail ? libraryAlbum?.title || libraryArtist?.name || "Library" : "Library",
+    isDetail
+      ? libraryAlbum?.title || libraryArtist?.name || "Library"
+      : section === "albums" && selectedGenre
+        ? selectedGenre
+        : "Library",
   );
 
   const coverItems = useMemo(() => {
@@ -847,7 +863,7 @@ function LibraryPage() {
         <span>Title</span>
         <span>Artist</span>
         <span>Album</span>
-        <span>Time</span>
+        <span className="native-library-track__time">Time</span>
         <span />
       </div>
       <div role="list" aria-label={label}>
@@ -1057,7 +1073,7 @@ function LibraryPage() {
     );
   };
 
-  const renderSectionHeader = (title, count, path = "") => (
+  const renderSectionHeader = (title, count, path = "", actionLabel = "View all") => (
     <div className="native-library-section-heading">
       <div>
         <h2>{title}</h2>
@@ -1065,7 +1081,7 @@ function LibraryPage() {
       </div>
       {path && (
         <button type="button" onClick={() => navigate(path)}>
-          View all
+          {actionLabel}
         </button>
       )}
     </div>
@@ -1073,6 +1089,26 @@ function LibraryPage() {
 
   const renderHome = () => (
     <div className="native-library-home">
+      {homeGenres.length > 0 && (
+        <section className="native-library-section">
+          {renderSectionHeader("Genres", null, "/library/genres" + previewQuery, "View more")}
+          <div className="native-library-genre-grid">
+            {homeGenres.map((genre) => (
+              <Link
+                className="native-library-genre-card"
+                key={genre.name}
+                to={
+                  "/library/albums?genre=" +
+                  encodeURIComponent(genre.name) +
+                  (forcePreview ? "&preview=1" : "")
+                }
+              >
+                {genre.name}
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
       {homeAlbums.length > 0 && (
         <section className="native-library-section">
           {renderSectionHeader("Recently added", library.albums.length, "/library/albums")}
@@ -1166,13 +1202,6 @@ function LibraryPage() {
     );
     return (
       <section className="native-library-detail">
-        <button
-          type="button"
-          className="native-library-back"
-          onClick={() => navigate("/library/albums" + previewQuery)}
-        >
-          <ArrowLeft aria-hidden="true" /> Back to Albums
-        </button>
         <div className="native-library-detail__hero">
           <div className="native-library-detail__cover">
             <Cover src={getAlbumCover(libraryAlbum)} label={libraryAlbum.title} />
@@ -1242,13 +1271,6 @@ function LibraryPage() {
     const artistTracks = artistAlbums.flatMap(getAlbumTracks);
     return (
       <section className="native-library-detail">
-        <button
-          type="button"
-          className="native-library-back"
-          onClick={() => navigate("/library/artists" + previewQuery)}
-        >
-          <ArrowLeft aria-hidden="true" /> Back to Artists
-        </button>
         <div className="native-library-detail__hero native-library-detail__hero--artist">
           <div className="native-library-detail__cover">
             {libraryArtist.mbid ? (
@@ -1400,7 +1422,12 @@ function LibraryPage() {
               ? renderTrackList(sortedTracks, "Library tracks")
               : renderGenres();
 
-  const pageTitle = section === "home" ? "Library" : sectionLabel;
+  const pageTitle =
+    section === "home"
+      ? "Library"
+      : section === "albums" && selectedGenre
+        ? selectedGenre
+        : sectionLabel;
   const totalPages =
     pageData?.kind === tab ? Math.ceil(pageData.total / pageData.pageSize) : 0;
   const pageCount =

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -182,8 +182,6 @@ function LibraryPage() {
     [library.tracks],
   );
 
-  useDocumentTitle("Library");
-
   useEffect(() => {
     setQuery("");
     setSortMode("name");
@@ -437,6 +435,9 @@ function LibraryPage() {
   const homeTracks = library.tracks.slice(0, 12);
   const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
   const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
+  useDocumentTitle(
+    isDetail ? libraryAlbum?.title || libraryArtist?.name || "Library" : "Library",
+  );
 
   const coverItems = useMemo(() => {
     const items = library.albums
@@ -595,9 +596,7 @@ function LibraryPage() {
 
   const handleArtistOpen = (artist) => {
     if (!artist?.id) return;
-    navigate("/library/artist/" + encodeURIComponent(artist.id) + previewQuery, {
-      state: { artistName: artist.name, libraryArtist: artist },
-    });
+    navigate("/library/artist/" + encodeURIComponent(artist.id) + previewQuery);
   };
 
   const handleDiscoverArtistOpen = (artist) => {
@@ -609,9 +608,7 @@ function LibraryPage() {
 
   const handleAlbumOpen = (album) => {
     if (!album?.id) return;
-    navigate("/library/album/" + encodeURIComponent(album.id) + previewQuery, {
-      state: { albumTitle: album.title, libraryAlbum: album },
-    });
+    navigate("/library/album/" + encodeURIComponent(album.id) + previewQuery);
   };
 
   const handleDiscoverAlbumOpen = (album) => {
@@ -1178,33 +1175,38 @@ function LibraryPage() {
     libraryAlbum ? renderLibraryAlbumDetail() : renderLibraryArtistDetail();
 
   const providerWarning = bootstrap?.lidarr?.circuitOpen === true;
+  const renderStatus = () => (
+    <>
+      {providerWarning && (
+        <p className="native-library-notice" role="status">
+          Lidarr is unavailable. Showing the last indexed library.
+        </p>
+      )}
+      {loading && (
+        <div className="native-library-state" role="status">
+          Loading library…
+        </div>
+      )}
+      {!loading && error && (
+        <div className="native-library-state" role="alert">
+          <strong>Library unavailable</strong>
+          <span>{error}</span>
+          <button
+            type="button"
+            className="native-library-state__action"
+            onClick={() => setRetryKey((value) => value + 1)}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+    </>
+  );
 
   if (isDetail) {
     return (
       <main className="library-page native-library-page">
-        {providerWarning && (
-          <p className="native-library-notice" role="status">
-            Lidarr is unavailable. Showing the last indexed library.
-          </p>
-        )}
-        {loading && (
-          <div className="native-library-state" role="status">
-            Loading library…
-          </div>
-        )}
-        {!loading && error && (
-          <div className="native-library-state" role="alert">
-            <strong>Library unavailable</strong>
-            <span>{error}</span>
-            <button
-              type="button"
-              className="native-library-state__action"
-              onClick={() => setRetryKey((value) => value + 1)}
-            >
-              Try again
-            </button>
-          </div>
-        )}
+        {renderStatus()}
         {!loading && !error && !libraryAlbum && !libraryArtist && (
           <EmptyState title="Not found" message="This library item is no longer indexed." />
         )}
@@ -1434,29 +1436,7 @@ function LibraryPage() {
         )}
       </header>
 
-      {providerWarning && (
-        <p className="native-library-notice" role="status">
-          Lidarr is unavailable. Showing the last indexed library.
-        </p>
-      )}
-      {loading && (
-        <div className="native-library-state" role="status">
-          Loading library…
-        </div>
-      )}
-      {!loading && error && (
-        <div className="native-library-state" role="alert">
-          <strong>Library unavailable</strong>
-          <span>{error}</span>
-          <button
-            type="button"
-            className="native-library-state__action"
-            onClick={() => setRetryKey((value) => value + 1)}
-          >
-            Try again
-          </button>
-        </div>
-      )}
+      {renderStatus()}
       {!loading && !error && activeCount === 0 && (
         <EmptyState
           title={

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -84,6 +84,41 @@ const formatLongDuration = (durationMs) => {
     : minutes + "m " + (seconds % 60) + "s";
 };
 
+const TOP_ARTIST_TRACK_LIMIT = 10;
+
+const trackRating = (track) => {
+  const value = track?.rating ?? track?.metadata?.rating ?? track?.metadata?.tags?.rating;
+  const rating = Array.isArray(value) ? value[0] : value;
+  const score = rating && typeof rating === "object" ? rating.rating : rating;
+  return Number.isFinite(Number(score)) ? Number(score) : null;
+};
+
+const trackRecency = (track, albumsById) => {
+  const fileTimes = (track?.files || [])
+    .filter((file) => file.available)
+    .map((file) => Number(file.mtimeMs))
+    .filter(Number.isFinite);
+  const albumTimes = (track?.albums || [])
+    .map((relation) => albumsById.get(String(relation.albumId))?.releaseDate)
+    .map((releaseDate) => Date.parse(String(releaseDate || "")))
+    .filter(Number.isFinite);
+  return Math.max(...fileTimes, ...albumTimes, 0);
+};
+
+const topArtistTracks = (tracks, albumsById) => {
+  const hasRatings = tracks.some((track) => trackRating(track) !== null);
+  return [...tracks]
+    .sort((left, right) => {
+      if (hasRatings) {
+        const ratingDifference = (trackRating(right) ?? -1) - (trackRating(left) ?? -1);
+        if (ratingDifference) return ratingDifference;
+      }
+      const recencyDifference = trackRecency(right, albumsById) - trackRecency(left, albumsById);
+      return recencyDifference || text(left?.title).localeCompare(text(right?.title));
+    })
+    .slice(0, TOP_ARTIST_TRACK_LIMIT);
+};
+
 const entityMatches = (entity, query) => {
   if (!query) return true;
   return [entity?.name, entity?.title, entity?.artistName, entity?.albumArtist, entity?.albumName]
@@ -1269,6 +1304,7 @@ function LibraryPage() {
       (album) => String(album.artistId) === String(libraryArtist.id),
     );
     const artistTracks = artistAlbums.flatMap(getAlbumTracks);
+    const artistTopTracks = topArtistTracks(artistTracks, albumsById);
     return (
       <section className="native-library-detail">
         <div className="native-library-detail__hero native-library-detail__hero--artist">
@@ -1333,11 +1369,11 @@ function LibraryPage() {
         </section>
         <section className="native-library-detail__section">
           <div className="native-library-detail__section-heading">
-            <h3>Tracks</h3>
-            <span>{artistTracks.length}</span>
+            <h3>Top tracks</h3>
+            <span>{artistTopTracks.length}</span>
           </div>
-          {artistTracks.length ? (
-            renderTrackList(artistTracks, libraryArtist.name + " tracks")
+          {artistTopTracks.length ? (
+            renderTrackList(artistTopTracks, libraryArtist.name + " top tracks")
           ) : (
             <EmptyState title="No tracks" message="No indexed tracks belong to this artist." />
           )}

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -12,7 +12,6 @@ import {
   Play,
   RefreshCw,
   Search,
-  SlidersHorizontal,
   X,
 } from "lucide-react";
 
@@ -630,7 +629,7 @@ function LibraryPage() {
     favoriteArtists.length + favoriteAlbums.length + favoriteTracks.length;
   const activeCount =
     section === "home"
-      ? library.artists.length + library.albums.length + library.tracks.length
+      ? library.albums.length + library.tracks.length
       : section === "favorites"
         ? favoriteCount
         : tab === "artists"
@@ -687,8 +686,11 @@ function LibraryPage() {
   };
 
   const renderTrackList = (tracks, label) => (
-    <div className="native-library-track-list" role="table" aria-label={label}>
-      <div className="native-library-track native-library-track--heading" role="row">
+    <div className="native-library-track-list">
+      <div
+        className="native-library-track native-library-track--heading"
+        aria-hidden="true"
+      >
         <span />
         <span>#</span>
         <span />
@@ -698,7 +700,8 @@ function LibraryPage() {
         <span>Time</span>
         <span />
       </div>
-      {tracks.map((track, index) => {
+      <div role="list" aria-label={label}>
+        {tracks.map((track, index) => {
         const album = getAlbumForTrack(track);
         const artist = getArtistForAlbum(album);
         const file = firstAvailableFile(track);
@@ -711,7 +714,7 @@ function LibraryPage() {
           <div
             className={"native-library-track" + (active ? " is-active" : "")}
             key={track.id}
-            role="row"
+            role="listitem"
           >
             <button
               type="button"
@@ -785,8 +788,9 @@ function LibraryPage() {
               onClick={() => toggleFavorite("song", track)}
             />
           </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 
@@ -970,29 +974,34 @@ function LibraryPage() {
   };
 
   const renderGenres = () => (
-    <div className="native-library-genre-list" role="table" aria-label="Library genres">
-      <div className="native-library-genre-row native-library-genre-row--heading" role="row">
+    <div className="native-library-genre-list">
+      <div
+        className="native-library-genre-row native-library-genre-row--heading"
+        aria-hidden="true"
+      >
         <span>Genre</span>
         <span>Artists</span>
         <span>Albums</span>
         <span>Tracks</span>
       </div>
-      {sortedGenres.map((genre) => (
-        <button
-          type="button"
-          className="native-library-genre-row"
-          key={genre.name}
-          onClick={() =>
-            navigate("/library/albums?genre=" + encodeURIComponent(genre.name))
-          }
-          role="row"
-        >
-          <strong>{genre.name}</strong>
-          <span>{genre.artists}</span>
-          <span>{genre.albums}</span>
-          <span>{genre.tracks}</span>
-        </button>
-      ))}
+      <div role="list" aria-label="Library genres">
+        {sortedGenres.map((genre) => (
+          <div role="listitem" key={genre.name}>
+            <button
+              type="button"
+              className="native-library-genre-row"
+              onClick={() =>
+                navigate("/library/albums?genre=" + encodeURIComponent(genre.name))
+              }
+            >
+              <strong>{genre.name}</strong>
+              <span>{genre.artists}</span>
+              <span>{genre.albums}</span>
+              <span>{genre.tracks}</span>
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 
@@ -1239,7 +1248,7 @@ function LibraryPage() {
   const pageTitle = section === "home" ? "Library" : sectionLabel;
   const pageCount =
     section === "home"
-      ? library.artists.length + library.albums.length + library.tracks.length
+      ? library.albums.length + library.tracks.length
       : activeCount;
   const showToolbar = section !== "home";
   const hasActiveFilters = Boolean(selectedGenre);
@@ -1390,18 +1399,6 @@ function LibraryPage() {
                     <List aria-hidden="true" />
                   </button>
                 </div>
-              )}
-              {section !== "genres" && (
-                <button
-                  type="button"
-                  className={`native-library-icon-button${filtersOpen ? " is-active" : ""}`}
-                  onClick={() => setFiltersOpen((value) => !value)}
-                  aria-label="Library filter options"
-                  aria-pressed={filtersOpen}
-                  title="Filter options"
-                >
-                  <SlidersHorizontal aria-hidden="true" />
-                </button>
               )}
             </div>
             {filtersOpen && section !== "genres" && (

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -257,7 +257,6 @@ function LibraryPage() {
             albumId: routeAlbumId,
             page: 1,
             pageSize,
-            signal: controller.signal,
           })
         : Promise.all([
             getCanonicalLibraryPage({
@@ -265,14 +264,12 @@ function LibraryPage() {
               artistId: routeArtistId,
               page: 1,
               pageSize,
-              signal: controller.signal,
             }),
             getCanonicalLibraryPage({
               kind: "tracks",
               artistId: routeArtistId,
               page: 1,
               pageSize,
-              signal: controller.signal,
             }),
           ])
       : section === "favorites"
@@ -284,13 +281,11 @@ function LibraryPage() {
               page: 1,
               pageSize: 12,
               sort: "newest",
-              signal: controller.signal,
             }),
             getCanonicalLibraryPage({
               kind: "tracks",
               page: 1,
               pageSize: 12,
-              signal: controller.signal,
             }),
           ])
         : getCanonicalLibraryPage({
@@ -301,7 +296,6 @@ function LibraryPage() {
             genre: selectedGenre,
             sort: sortMode,
             direction: sortDirection,
-            signal: controller.signal,
           });
 
     const favoritesRequest = Promise.resolve(null);
@@ -1483,7 +1477,9 @@ function LibraryPage() {
         ? selectedGenre
         : sectionLabel;
   const totalPages =
-    pageData?.kind === tab ? Math.ceil(pageData.total / pageData.pageSize) : 0;
+    pageData?.kind === tab && tab !== "genres"
+      ? Math.ceil(pageData.total / pageData.pageSize)
+      : 0;
   const pageCount =
     section === "home"
       ? pageData?.total ?? library.albums.length + library.tracks.length

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1,564 +1,1312 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { getLibraryArtists } from "../utils/api/endpoints/library.js";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  ArrowDownAZ,
+  ArrowUpZA,
+  Grid3X3,
+  Heart,
+  List,
+  ListFilter,
+  Play,
+  RefreshCw,
+  Search,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
+
 import ArtistImage from "../components/ArtistImage";
-
-import { useNavigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import { useAudioQueue } from "../contexts/audioQueueContext";
+import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
-import { ArrowDown, ArrowUp, ChevronDown, LayoutGrid, List, Loader, Music, AlertCircle, Search } from "lucide-react";
-const PAGE_SIZE = 48;
-const ALPHABET = ["#", ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
-const SORT_OPTIONS = [
-  { value: "name", label: "Name" },
-  { value: "added", label: "Date Added" },
-  { value: "albums", label: "Album Count" },
-];
+import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
+import {
+  getCanonicalLibrary,
+  getLibraryFavorites,
+  updateLibraryFavorites,
+} from "../utils/api/endpoints/library.js";
+import { buildAuthenticatedApiUrl } from "../utils/api/core.js";
+import { navigateToLibraryAlbum } from "../utils/searchNavigation";
+import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
+import { libraryPreviewData, libraryPreviewFavorites } from "./libraryPreviewData";
 
-const getArtistName = (artist) =>
-  String(artist?.artistName || artist?.sortName || artist?.name || "").trim();
+const LIBRARY_VIEW_IDS = new Set(LIBRARY_VIEWS.map((view) => view.id));
 
-const getArtistRouteId = (artist) =>
-  String(artist?.mbid || "").trim();
+const text = (value) => String(value || "").trim();
 
-const letterKeyFor = (artist) => {
-  const letter = (getArtistName(artist)[0] || "#").toUpperCase();
-  return /^[A-Z]$/.test(letter) ? letter : "#";
+const metadataGenres = (entity) => {
+  const metadata = entity?.metadata || {};
+  return [metadata.genres, metadata.genre, metadata.common?.genre, metadata.tags?.genre]
+    .flatMap((value) => (Array.isArray(value) ? value : [value]))
+    .map(text)
+    .filter(Boolean)
+    .filter((value, index, values) => values.indexOf(value) === index);
 };
 
-const getAddedTime = (artist) => {
-  const time = Date.parse(artist?.added || artist?.addedAt || "");
-  return Number.isFinite(time) ? time : null;
+const hasGenre = (genre, ...entities) => {
+  if (!genre) return true;
+  const wanted = genre.toLocaleLowerCase();
+  return entities.flatMap(metadataGenres).some((value) => value.toLocaleLowerCase() === wanted);
 };
 
-const compareNullableNumbers = (left, right, sortDirection) => {
-  if (left === null && right === null) return 0;
-  if (left === null) return 1;
-  if (right === null) return -1;
-  const diff = left - right;
-  return sortDirection === "asc" ? diff : -diff;
+const yearOf = (value) => {
+  const match = /^(\d{4})/.exec(text(value));
+  return match ? match[1] : "";
 };
 
-const sortArtists = (items, sortKey, sortDirection) =>
-  [...items].sort((a, b) => {
-    let diff = 0;
-    if (sortKey === "name") {
-      diff = getArtistName(a).localeCompare(getArtistName(b));
-    } else if (sortKey === "added") {
-      diff = compareNullableNumbers(getAddedTime(a), getAddedTime(b), sortDirection);
-      if (diff !== 0) return diff;
-    } else if (sortKey === "albums") {
-      diff = (a.statistics?.albumCount || 0) - (b.statistics?.albumCount || 0);
-    }
-    if (diff !== 0) return sortDirection === "asc" ? diff : -diff;
-    return getArtistName(a).localeCompare(getArtistName(b));
-  });
+const favoriteId = (kind, entity) =>
+  kind + ":" + encodeURIComponent(text(entity?.identityKey));
+
+const firstAvailableFile = (track) =>
+  (track?.files || []).find((file) => file.available) || null;
+
+const formatDuration = (durationMs) => {
+  const seconds = Math.max(0, Math.floor(Number(durationMs || 0) / 1000));
+  if (!seconds) return "";
+  return (
+    Math.floor(seconds / 60) +
+    ":" +
+    String(seconds % 60).padStart(2, "0")
+  );
+};
+
+const entityMatches = (entity, query) => {
+  if (!query) return true;
+  return [entity?.name, entity?.title, entity?.artistName, entity?.albumArtist, entity?.albumName]
+    .some((value) => text(value).toLocaleLowerCase().includes(query));
+};
+
+function Cover({ src, label, round = false, compact = false }) {
+  if (src) {
+    return <img src={src} alt="" loading="lazy" decoding="async" />;
+  }
+
+  return (
+    <span
+      className={
+        "native-library-cover-fallback" +
+        (round ? " is-round" : "") +
+        (compact ? " is-compact" : "")
+      }
+      role="img"
+      aria-label={label || "Unknown artwork"}
+    >
+      {text(label).slice(0, 1).toUpperCase() || "—"}
+    </span>
+  );
+}
+
+function FavoriteButton({ active, pending, label, onClick, className = "" }) {
+  return (
+    <button
+      type="button"
+      className={"native-library-favorite " + className + (active ? " is-active" : "")}
+      onClick={onClick}
+      disabled={pending}
+      aria-label={active ? "Remove " + label + " from favorites" : "Add " + label + " to favorites"}
+      aria-pressed={active}
+      title={active ? "Remove from favorites" : "Add to favorites"}
+    >
+      <Heart aria-hidden="true" fill={active ? "currentColor" : "none"} />
+    </button>
+  );
+}
+
+function EmptyState({ title, message }) {
+  return (
+    <div className="native-library-state">
+      <strong>{title}</strong>
+      <span>{message}</span>
+    </div>
+  );
+}
 
 function LibraryPage() {
-  const [artists, setArtists] = useState([]);
+  const navigate = useNavigate();
+  const { section: routeSection } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { bootstrap } = useAuth();
+  const { showError } = useToast();
+  const { playQueue, currentTrack, isPlaying, isLoading, togglePlayPause, matchesSource } =
+    useAudioQueue();
+  const [library, setLibrary] = useState({ artists: [], albums: [], tracks: [] });
+  const [favoriteIds, setFavoriteIds] = useState(() => new Set());
+  const [query, setQuery] = useState("");
+  const [sortMode, setSortMode] = useState("name");
+  const [sortDirection, setSortDirection] = useState("asc");
+  const [viewMode, setViewMode] = useState("grid");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [selectedAlbumId, setSelectedAlbumId] = useState(null);
+  const [covers, setCovers] = useState({});
+  const [pendingFavorite, setPendingFavorite] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [sortKey, setSortKey] = useState("name");
-  const [sortDirection, setSortDirection] = useState("asc");
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [isPreviewLibrary, setIsPreviewLibrary] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
-  const [sortMenuOpen, setSortMenuOpen] = useState(false);
-  const [gridColumns, setGridColumns] = useState(() => {
-    const saved = localStorage.getItem("libraryGridColumns");
-    const val = parseInt(saved, 10);
-    return val >= 2 && val <= 10 ? val : 6;
-  });
-  const [viewMode, setViewMode] = useState(() =>
-    localStorage.getItem("libraryViewMode") || "grid"
+
+  const section = LIBRARY_VIEW_IDS.has(routeSection) ? routeSection : DEFAULT_LIBRARY_VIEW;
+  const tab = section === "home" || section === "album-artists" ? "artists" : section;
+  const selectedGenre = searchParams.get("genre") || "";
+  const forcePreview = import.meta.env.DEV && searchParams.get("preview") === "1";
+  const sectionLabel = LIBRARY_VIEWS.find((view) => view.id === section)?.label || "Library";
+  const librarySource = useMemo(() => ({ type: "native-library", id: "library" }), []);
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  const artistsById = useMemo(
+    () => new Map(library.artists.map((artist) => [String(artist.id), artist])),
+    [library.artists],
   );
-  const [activeLetter, setActiveLetter] = useState(null);
-  const activeLetterRef = useRef(null);
-  const sentinelRef = useRef(null);
-  const toolbarRef = useRef(null);
-  const navigate = useNavigate();
+  const albumsById = useMemo(
+    () => new Map(library.albums.map((album) => [String(album.id), album])),
+    [library.albums],
+  );
+  const tracksById = useMemo(
+    () => new Map(library.tracks.map((track) => [String(track.id), track])),
+    [library.tracks],
+  );
 
   useDocumentTitle("Library");
 
-  const selectedSort = SORT_OPTIONS.find((option) => option.value === sortKey) || SORT_OPTIONS[0];
-  const SortDirectionIcon = sortDirection === "asc" ? ArrowUp : ArrowDown;
+  useEffect(() => {
+    setQuery("");
+    setSortMode("name");
+    setSortDirection("asc");
+    setViewMode(section === "tracks" || section === "genres" ? "list" : "grid");
+    setSearchOpen(false);
+    setFiltersOpen(false);
+    setSelectedAlbumId(null);
+  }, [section]);
 
   useEffect(() => {
     const controller = new AbortController();
-    const fetchArtists = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await getLibraryArtists({ signal: controller.signal });
+    setLoading(true);
+    setError(null);
+    setIsPreviewLibrary(false);
+
+    if (forcePreview) {
+      setLibrary(libraryPreviewData);
+      setFavoriteIds(new Set(libraryPreviewFavorites));
+      setIsPreviewLibrary(true);
+      setLoading(false);
+      return () => controller.abort();
+    }
+
+    Promise.all([
+      getCanonicalLibrary({ signal: controller.signal }),
+      getLibraryFavorites({ signal: controller.signal }),
+    ])
+      .then(([nextLibrary, starred]) => {
+        if (controller.signal.aborted) return;
+        const normalizedLibrary = {
+          artists: Array.isArray(nextLibrary?.artists) ? nextLibrary.artists : [],
+          albums: Array.isArray(nextLibrary?.albums) ? nextLibrary.albums : [],
+          tracks: Array.isArray(nextLibrary?.tracks) ? nextLibrary.tracks : [],
+        };
+        const usePreview =
+          import.meta.env.DEV &&
+          normalizedLibrary.artists.length === 0 &&
+          normalizedLibrary.albums.length === 0 &&
+          normalizedLibrary.tracks.length === 0;
+        setLibrary(usePreview ? libraryPreviewData : normalizedLibrary);
+        setIsPreviewLibrary(usePreview);
+        const nextFavorites = new Set(
+          ["artist", "album", "song"].flatMap((kind) =>
+            (Array.isArray(starred?.[kind]) ? starred[kind] : []).map((entry) => entry.id),
+          ),
+        );
+        setFavoriteIds(usePreview ? new Set(libraryPreviewFavorites) : nextFavorites);
+      })
+      .catch((requestError) => {
         if (!controller.signal.aborted) {
-          setArtists(data);
+          setError(
+            requestError.response?.data?.message ||
+              requestError.response?.data?.error ||
+              "Failed to load the canonical library",
+          );
         }
-      } catch (err) {
-        if (!controller.signal.aborted) {
-          setError(err.response?.data?.message || "Failed to fetch artists from library");
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
-      }
-    };
-    fetchArtists();
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
     return () => controller.abort();
-  }, [retryKey]);
+  }, [forcePreview, retryKey]);
 
-  useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [searchTerm, sortKey, sortDirection]);
+  const getAlbumTracks = useCallback(
+    (album) => album?.trackIds?.map((id) => tracksById.get(String(id))).filter(Boolean) || [],
+    [tracksById],
+  );
 
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (toolbarRef.current && !toolbarRef.current.contains(event.target)) {
-        setSortMenuOpen(false);
-      }
-    };
-    const handleKeyDown = (event) => {
-      if (event.key === "Escape") {
-        setSortMenuOpen(false);
-      }
-    };
-    document.addEventListener("pointerdown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
+  const getAlbumForTrack = useCallback(
+    (track) => (track?.albums?.[0] ? albumsById.get(String(track.albums[0].albumId)) : null),
+    [albumsById],
+  );
 
-  const onSentinel = useCallback((entries) => {
-    if (entries[0].isIntersecting) {
-      setVisibleCount((prev) => prev + PAGE_SIZE);
-    }
-  }, []);
+  const getArtistForAlbum = useCallback(
+    (album) => (album ? artistsById.get(String(album.artistId)) : null),
+    [artistsById],
+  );
 
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(onSentinel, { rootMargin: "200px" });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [onSentinel, loading, error]);
-
-  const handleSortOptionClick = useCallback(
-    (option) => {
-      if (sortKey === option.value) {
-        setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
-        setSortMenuOpen(false);
-        return;
-      }
-      setSortKey(option.value);
-      setSortMenuOpen(false);
+  const albumAvailability = useCallback(
+    (album) => {
+      const tracks = getAlbumTracks(album);
+      const total = tracks.length || (album?.trackIds || []).length;
+      const available = tracks.filter((track) => firstAvailableFile(track)).length;
+      return { total, available };
     },
-    [sortKey],
+    [getAlbumTracks],
   );
 
-  const filteredArtists = useMemo(() => {
-    let filtered = artists;
-
-    if (searchTerm.trim()) {
-      const normalizedSearch = searchTerm.trim().toLowerCase();
-      filtered = filtered.filter((artist) =>
-        getArtistName(artist).toLowerCase().includes(normalizedSearch),
-      );
-    }
-
-    return sortArtists(filtered, sortKey, sortDirection);
-  }, [artists, searchTerm, sortKey, sortDirection]);
-
-  const visibleArtists = useMemo(
-    () => filteredArtists.slice(0, visibleCount),
-    [filteredArtists, visibleCount],
+  const filteredArtists = useMemo(
+    () =>
+      library.artists.filter(
+        (artist) =>
+          hasGenre(selectedGenre, artist) && entityMatches(artist, normalizedQuery),
+      ),
+    [library.artists, normalizedQuery, selectedGenre],
   );
 
-  const groupedArtists = useMemo(() => {
-    if (viewMode !== "list") return null;
-    const groups = new Map();
-    for (const artist of visibleArtists) {
-      const key = letterKeyFor(artist);
-      if (!groups.has(key)) groups.set(key, []);
-      groups.get(key).push(artist);
-    }
-    return [...groups.entries()].sort(([a], [b]) => {
-      if (a === "#" && b === "#") return 0;
-      if (a === "#") return -1;
-      if (b === "#") return 1;
-      return a.localeCompare(b);
+  const filteredAlbums = useMemo(
+    () =>
+      library.albums.filter((album) => {
+        const artist = getArtistForAlbum(album);
+        return (
+          hasGenre(selectedGenre, artist, album) &&
+          entityMatches({ ...album, artistName: artist?.name }, normalizedQuery)
+        );
+      }),
+    [getArtistForAlbum, library.albums, normalizedQuery, selectedGenre],
+  );
+
+  const filteredTracks = useMemo(
+    () =>
+      library.tracks.filter((track) => {
+        const album = getAlbumForTrack(track);
+        const artist = getArtistForAlbum(album);
+        return (
+          hasGenre(selectedGenre, artist, album, track) &&
+          entityMatches(
+            {
+              ...track,
+              albumName: album?.title,
+              artistName: artist?.name || track.artistName,
+            },
+            normalizedQuery,
+          )
+        );
+      }),
+    [getAlbumForTrack, getArtistForAlbum, library.tracks, normalizedQuery, selectedGenre],
+  );
+
+  const genreStats = useMemo(() => {
+    const stats = new Map();
+    const add = (genre, kind) => {
+      const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
+      entry[kind] += 1;
+      stats.set(genre, entry);
+    };
+    library.artists.forEach((artist) =>
+      metadataGenres(artist).forEach((genre) => add(genre, "artists")),
+    );
+    library.albums.forEach((album) =>
+      metadataGenres(album).forEach((genre) => add(genre, "albums")),
+    );
+    library.tracks.forEach((track) =>
+      metadataGenres(track).forEach((genre) => add(genre, "tracks")),
+    );
+    return [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+  }, [library.albums, library.artists, library.tracks]);
+
+  const visibleGenreStats = useMemo(
+    () =>
+      genreStats.filter(
+        (genre) =>
+          !normalizedQuery ||
+          genre.name.toLocaleLowerCase().includes(normalizedQuery),
+      ),
+    [genreStats, normalizedQuery],
+  );
+
+  const favoriteArtists = useMemo(
+    () =>
+      library.artists.filter(
+        (artist) =>
+          favoriteIds.has(favoriteId("artist", artist)) &&
+          entityMatches(artist, normalizedQuery),
+      ),
+    [favoriteIds, library.artists, normalizedQuery],
+  );
+
+  const favoriteAlbums = useMemo(
+    () =>
+      library.albums.filter((album) => {
+        const artist = getArtistForAlbum(album);
+        return (
+          favoriteIds.has(favoriteId("album", album)) &&
+          entityMatches({ ...album, artistName: artist?.name }, normalizedQuery)
+        );
+      }),
+    [favoriteIds, getArtistForAlbum, library.albums, normalizedQuery],
+  );
+
+  const favoriteTracks = useMemo(
+    () =>
+      library.tracks.filter((track) => {
+        const album = getAlbumForTrack(track);
+        const artist = getArtistForAlbum(album);
+        return (
+          favoriteIds.has(favoriteId("song", track)) &&
+          entityMatches(
+            {
+              ...track,
+              albumName: album?.title,
+              artistName: artist?.name || track.artistName,
+            },
+            normalizedQuery,
+          )
+        );
+      }),
+    [favoriteIds, getAlbumForTrack, getArtistForAlbum, library.tracks, normalizedQuery],
+  );
+
+  const sortedArtists = useMemo(() => {
+    const items = [...filteredArtists];
+    items.sort((left, right) => text(left.name).localeCompare(text(right.name)));
+    return sortDirection === "asc" ? items : items.reverse();
+  }, [filteredArtists, sortDirection]);
+
+  const sortedAlbums = useMemo(() => {
+    const items = [...filteredAlbums];
+    items.sort((left, right) => {
+      if (sortMode === "newest") {
+        return text(right.releaseDate).localeCompare(text(left.releaseDate));
+      }
+      if (sortMode === "artist") {
+        return text(getArtistForAlbum(left)?.name).localeCompare(
+          text(getArtistForAlbum(right)?.name),
+        );
+      }
+      return text(left.title).localeCompare(text(right.title));
     });
-  }, [visibleArtists, viewMode]);
+    return sortDirection === "asc" ? items : items.reverse();
+  }, [filteredAlbums, getArtistForAlbum, sortDirection, sortMode]);
 
-  const presentLetters = useMemo(() => {
-    if (viewMode !== "list") return null;
-    return new Set(filteredArtists.map(letterKeyFor));
-  }, [filteredArtists, viewMode]);
-
-  const pendingLetterRef = useRef(null);
-
-  const scrollToLetter = useCallback(
-    (letter) => {
-      const target = document.getElementById(`library-group-${letter}`);
-      if (target) {
-        target.scrollIntoView({ behavior: "smooth" });
-        return;
+  const sortedTracks = useMemo(() => {
+    const items = [...filteredTracks];
+    items.sort((left, right) => {
+      if (sortMode === "artist") {
+        return text(getArtistForAlbum(getAlbumForTrack(left))?.name).localeCompare(
+          text(getArtistForAlbum(getAlbumForTrack(right))?.name),
+        );
       }
-      const index = filteredArtists.findIndex((artist) => letterKeyFor(artist) === letter);
-      if (index === -1) return;
-      pendingLetterRef.current = letter;
-      setVisibleCount(Math.ceil((index + 1) / PAGE_SIZE) * PAGE_SIZE);
-    },
-    [filteredArtists],
+      return text(left.title).localeCompare(text(right.title));
+    });
+    return sortDirection === "asc" ? items : items.reverse();
+  }, [filteredTracks, getAlbumForTrack, getArtistForAlbum, sortDirection, sortMode]);
+
+  const sortedGenres = useMemo(() => {
+    const items = [...visibleGenreStats].sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+    return sortDirection === "asc" ? items : items.reverse();
+  }, [sortDirection, visibleGenreStats]);
+
+  const homeAlbums = useMemo(
+    () =>
+      [...library.albums]
+        .sort((left, right) => text(right.releaseDate).localeCompare(text(left.releaseDate)))
+        .slice(0, 12),
+    [library.albums],
+  );
+  const homeTracks = library.tracks.slice(0, 12);
+  const selectedAlbum =
+    selectedAlbumId == null ? null : albumsById.get(String(selectedAlbumId)) || null;
+  const selectedAlbumTracks = useMemo(
+    () => getAlbumTracks(selectedAlbum),
+    [getAlbumTracks, selectedAlbum],
   );
 
-  useEffect(() => {
-    const letter = pendingLetterRef.current;
-    if (!letter) return;
-    pendingLetterRef.current = null;
-    document.getElementById(`library-group-${letter}`)?.scrollIntoView({ behavior: "smooth" });
-  }, [groupedArtists]);
+  const coverItems = useMemo(() => {
+    const items = library.albums
+      .map((album) => ({
+        mbid: album.mbid || album.releaseGroupMbid,
+        artistName: getArtistForAlbum(album)?.name || album.albumArtist,
+        albumTitle: album.title,
+      }))
+      .filter((item) => item.mbid);
+    return items
+      .filter(
+        (item, index, values) =>
+          values.findIndex((candidate) => candidate.mbid === item.mbid) === index,
+      )
+      .slice(0, 80);
+  }, [getArtistForAlbum, library.albums]);
 
   useEffect(() => {
-    if (viewMode !== "list" || !groupedArtists) return;
-
-    const handleScroll = () => {
-      const headers = document.querySelectorAll(".library-page__list-letter");
-      let active = null;
-      for (const h of headers) {
-        if (h.getBoundingClientRect().top <= 140) active = h.textContent.trim();
-      }
-      if (active !== activeLetterRef.current) {
-        activeLetterRef.current = active;
-        setActiveLetter(active);
-      }
+    if (!coverItems.length) return undefined;
+    let cancelled = false;
+    getReleaseGroupCoversBatch(coverItems)
+      .then((result) => {
+        if (cancelled) return;
+        const next = {};
+        coverItems.forEach((item) => {
+          if (result?.[item.mbid]?.image) next[item.mbid] = result[item.mbid].image;
+        });
+        if (Object.keys(next).length) setCovers((current) => ({ ...current, ...next }));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
     };
+  }, [coverItems]);
 
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [viewMode, groupedArtists]);
+  const getAlbumCover = useCallback(
+    (album) => covers[album?.mbid || album?.releaseGroupMbid] || "",
+    [covers],
+  );
 
-  const navigateToArtist = useCallback(
-    (artist) => {
-      const routeId = getArtistRouteId(artist);
-      if (!routeId) return;
-      navigate(`/artist/${encodeURIComponent(routeId)}`, {
-        state: {
-          artistName: getArtistName(artist),
-          inLibrary: true,
-          libraryArtist: artist,
-        },
+  const buildPlayableTrack = useCallback(
+    (track) => {
+      const album = getAlbumForTrack(track);
+      const artist = getArtistForAlbum(album);
+      const file = firstAvailableFile(track);
+      return {
+        id: track.id,
+        title: track.title,
+        artist: artist?.name || track.artistName || "Unknown Artist",
+        album: album?.title || "Unknown Album",
+        src:
+          file?.previewUrl ||
+          (file
+            ? buildAuthenticatedApiUrl(
+                "/library/canonical-stream/" + encodeURIComponent(track.id),
+              )
+            : ""),
+        streamFormat: file?.format || null,
+        quality: file?.quality || null,
+        artistMbid: artist?.mbid || null,
+        albumMbid: album?.mbid || album?.releaseGroupMbid || null,
+        artwork: getAlbumCover(album),
+      };
+    },
+    [getAlbumCover, getAlbumForTrack, getArtistForAlbum],
+  );
+
+  const playTracks = useCallback(
+    (tracks, startTrack = null, shuffle = false) => {
+      const playable = tracks.map(buildPlayableTrack).filter((track) => track.src);
+      if (!playable.length) {
+        showError("No playable files are available in this selection.");
+        return;
+      }
+      const startIndex = startTrack
+        ? Math.max(
+            0,
+            playable.findIndex((track) => String(track.id) === String(startTrack.id)),
+          )
+        : 0;
+      playQueue(playable, {
+        startIndex: startIndex < 0 ? 0 : startIndex,
+        shuffle,
+        source: librarySource,
+        updateShufflePreference: false,
       });
     },
-    [navigate],
+    [buildPlayableTrack, librarySource, playQueue, showError],
   );
 
-  const artistCountLabel = loading
-    ? "Loading..."
-    : `${artists.length} artist${artists.length !== 1 ? "s" : ""} in your collection`;
+  const toggleFavorite = useCallback(
+    async (kind, entity) => {
+      const id = favoriteId(kind, entity);
+      if (!id || id.endsWith(":")) return;
+      const nextStarred = !favoriteIds.has(id);
+      if (isPreviewLibrary) {
+        setFavoriteIds((current) => {
+          const next = new Set(current);
+          if (nextStarred) next.add(id);
+          else next.delete(id);
+          return next;
+        });
+        return;
+      }
+      const previous = favoriteIds;
+      setPendingFavorite(id);
+      setFavoriteIds((current) => {
+        const next = new Set(current);
+        if (nextStarred) next.add(id);
+        else next.delete(id);
+        return next;
+      });
+      try {
+        const starred = await updateLibraryFavorites([id], nextStarred);
+        setFavoriteIds(
+          new Set(
+            ["artist", "album", "song"].flatMap((group) =>
+              (Array.isArray(starred?.[group]) ? starred[group] : []).map(
+                (entry) => entry.id,
+              ),
+            ),
+          ),
+        );
+      } catch (requestError) {
+        setFavoriteIds(previous);
+        showError(requestError.response?.data?.message || "Failed to update favorites");
+      } finally {
+        setPendingFavorite(null);
+      }
+    },
+    [favoriteIds, isPreviewLibrary, showError],
+  );
 
-  return (
-    <div className="library-page">
-      <header className="library-page__header">
-        <h1 className="page-title">Your Library</h1>
-        <p className="page-subtitle">{artistCountLabel}</p>
+  const playTrack = useCallback(
+    (track, context) => {
+      const playable = buildPlayableTrack(track);
+      if (!playable.src) return;
+      if (
+        String(currentTrack?.id) === String(playable.id) &&
+        matchesSource(librarySource)
+      ) {
+        togglePlayPause();
+        return;
+      }
+      playTracks(context || [track], track);
+    },
+    [
+      buildPlayableTrack,
+      currentTrack?.id,
+      librarySource,
+      matchesSource,
+      playTracks,
+      togglePlayPause,
+    ],
+  );
 
-        <div ref={toolbarRef} className="library-page__toolbar global-search">
-          <div className="global-search__box">
-            <div className="global-search__scope-wrap">
+  const handleArtistOpen = (artist) => {
+    if (!artist?.mbid) return;
+    navigate("/artist/" + encodeURIComponent(artist.mbid), {
+      state: { artistName: artist.name, inLibrary: true, libraryArtist: artist },
+    });
+  };
+
+  const handleAlbumOpen = (album) => {
+    const artist = getArtistForAlbum(album);
+    if (artist?.mbid && (album?.releaseGroupMbid || album?.mbid)) {
+      navigateToLibraryAlbum(navigate, album, {
+        artistMbid: artist.mbid,
+        artistName: artist.name,
+        coverUrl: getAlbumCover(album),
+      });
+      return;
+    }
+    setSelectedAlbumId(album?.id || null);
+  };
+
+  const favoriteCount =
+    favoriteArtists.length + favoriteAlbums.length + favoriteTracks.length;
+  const activeCount =
+    selectedAlbum != null
+      ? selectedAlbumTracks.length
+      : section === "home"
+        ? library.artists.length + library.albums.length + library.tracks.length
+        : section === "favorites"
+          ? favoriteCount
+          : tab === "artists"
+            ? sortedArtists.length
+            : tab === "albums"
+              ? sortedAlbums.length
+              : tab === "tracks"
+                ? sortedTracks.length
+                : sortedGenres.length;
+  const sortOptions =
+    section === "albums"
+      ? [
+          { value: "name", label: "Name" },
+          { value: "artist", label: "Artist" },
+          { value: "newest", label: "Newest" },
+        ]
+      : section === "tracks"
+        ? [
+            { value: "name", label: "Name" },
+            { value: "artist", label: "Artist" },
+          ]
+        : section === "artists" || section === "album-artists"
+          ? [{ value: "name", label: "Name" }]
+          : section === "genres"
+            ? [{ value: "name", label: "Name" }]
+            : [];
+
+  const collectionTracks = useMemo(() => {
+    if (selectedAlbum) return selectedAlbumTracks;
+    if (section === "favorites") return favoriteTracks;
+    if (section === "albums") return sortedAlbums.flatMap(getAlbumTracks);
+    if (section === "tracks") return sortedTracks;
+    if (section === "genres" && selectedGenre) return filteredTracks;
+    return library.tracks;
+  }, [
+    favoriteTracks,
+    filteredTracks,
+    getAlbumTracks,
+    library.tracks,
+    section,
+    selectedAlbum,
+    selectedAlbumTracks,
+    selectedGenre,
+    sortedAlbums,
+    sortedTracks,
+  ]);
+
+  const collectionPlayable = collectionTracks.some((track) => firstAvailableFile(track));
+
+  const updateGenreFilter = (genre) => {
+    const next = new URLSearchParams(searchParams);
+    if (genre) next.set("genre", genre);
+    else next.delete("genre");
+    setSearchParams(next);
+  };
+
+  const renderTrackList = (tracks, label) => (
+    <div className="native-library-track-list" role="table" aria-label={label}>
+      <div className="native-library-track native-library-track--heading" role="row">
+        <span />
+        <span>#</span>
+        <span />
+        <span>Title</span>
+        <span>Artist</span>
+        <span>Album</span>
+        <span>Time</span>
+        <span />
+      </div>
+      {tracks.map((track, index) => {
+        const album = getAlbumForTrack(track);
+        const artist = getArtistForAlbum(album);
+        const file = firstAvailableFile(track);
+        const active =
+          String(currentTrack?.id) === String(track.id) &&
+          matchesSource(librarySource);
+        const artistName = artist?.name || track.artistName || "Unknown Artist";
+        const albumName = album?.title || "Unknown Album";
+        return (
+          <div
+            className={"native-library-track" + (active ? " is-active" : "")}
+            key={track.id}
+            role="row"
+          >
+            <button
+              type="button"
+              className="native-library-track__play"
+              onClick={() => playTrack(track, tracks)}
+              disabled={!file || (active && isLoading)}
+              aria-label={(active && isPlaying ? "Pause " : "Play ") + track.title}
+            >
+              {active && isPlaying ? (
+                <span aria-hidden="true">Ⅱ</span>
+              ) : (
+                <Play aria-hidden="true" fill="currentColor" />
+              )}
+            </button>
+            <span className="native-library-track__number" aria-hidden="true">
+              {index + 1}
+            </span>
+            {album ? (
               <button
                 type="button"
-                onClick={() => setSortMenuOpen((open) => !open)}
-                className={`global-search__scope-button library-page__sort-button${sortMenuOpen ? " is-open" : ""}`}
-                aria-haspopup="listbox"
-                aria-expanded={sortMenuOpen}
-                aria-controls="library-sort-menu"
-                aria-label="Sort library"
+                className="native-library-track__cover"
+                onClick={() => handleAlbumOpen(album)}
+                aria-label={"Open " + albumName}
               >
-                <span className="library-page__sort-label">{selectedSort.label}</span>
-                <SortDirectionIcon className="artist-icon-xs library-page__sort-direction" />
-                <ChevronDown
-                  className={`artist-icon-sm${sortMenuOpen ? " artist-chevron--open" : ""}`}
-                />
+                <Cover src={getAlbumCover(album)} label={albumName} compact />
               </button>
-
-              {sortMenuOpen && (
-                <div
-                  id="library-sort-menu"
-                  className="artist-options-menu library-page__sort-menu"
-                  role="listbox"
-                  aria-label="Library sort options"
-                >
-                  {SORT_OPTIONS.map((option) => {
-                    const active = sortKey === option.value;
-                    const DirectionIcon = sortDirection === "asc" ? ArrowUp : ArrowDown;
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() => handleSortOptionClick(option)}
-                        className={`artist-menu-item${active ? " is-active" : ""}`}
-                        role="option"
-                        aria-selected={active}
-                      >
-                        <span>{option.label}</span>
-                        <span>{active && <DirectionIcon className="artist-icon-xs" />}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            <div className="global-search__divider" />
-
-            <div className="global-search__input-wrap">
-              <Search className="global-search__icon" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder=""
-                className="global-search__input"
-                autoComplete="off"
-                aria-label="Search library"
-              />
-              {!searchTerm && <div className="global-search__placeholder">Search library...</div>}
-            </div>
-
-          </div>
-
-          <div className="library-page__view-controls">
-            {viewMode === "grid" && (
-              <input
-                type="range"
-                min="2"
-                max="10"
-                value={gridColumns}
-                onChange={(e) => {
-                  const val = parseInt(e.target.value, 10);
-                  setGridColumns(val);
-                  localStorage.setItem("libraryGridColumns", String(val));
-                }}
-                className="library-page__grid-slider"
-                aria-label="Grid columns"
-                title={`${gridColumns} columns`}
-              />
+            ) : (
+              <span className="native-library-track__cover">
+                <Cover label={albumName} compact />
+              </span>
             )}
             <button
               type="button"
-              onClick={() => {
-                const next = viewMode === "grid" ? "list" : "grid";
-                setViewMode(next);
-                localStorage.setItem("libraryViewMode", next);
-              }}
-              className="btn btn-icon-square library-page__view-toggle"
-              aria-label={viewMode === "grid" ? "Switch to list view" : "Switch to grid view"}
-              title={viewMode === "grid" ? "List view" : "Grid view"}
+              className="native-library-track__title"
+              onClick={() => playTrack(track, tracks)}
+              title={track.title || "Unknown Track"}
             >
-              {viewMode === "grid" ? <List className="artist-icon-sm" /> : <LayoutGrid className="artist-icon-sm" />}
+              <span>{track.title || "Unknown Track"}</span>
+              <small>{artistName}</small>
+            </button>
+            {artist?.mbid ? (
+              <button
+                type="button"
+                className="native-library-track__link native-library-track__artist"
+                onClick={() => handleArtistOpen(artist)}
+              >
+                {artistName}
+              </button>
+            ) : (
+              <span className="native-library-track__link native-library-track__artist">{artistName}</span>
+            )}
+            {album ? (
+              <button
+                type="button"
+                className="native-library-track__link native-library-track__album"
+                onClick={() => handleAlbumOpen(album)}
+              >
+                {albumName}
+              </button>
+            ) : (
+              <span className="native-library-track__link native-library-track__album">{albumName}</span>
+            )}
+            <span className={"native-library-track__time" + (!file ? " is-missing" : "")}>
+              {file ? formatDuration(file.durationMs) : "Unavailable"}
+            </span>
+            <FavoriteButton
+              className="native-library-track__favorite"
+              active={favoriteIds.has(favoriteId("song", track))}
+              pending={pendingFavorite === favoriteId("song", track)}
+              label={track.title || "track"}
+              onClick={() => toggleFavorite("song", track)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const renderArtistCard = (artist) => (
+    <article className="native-library-card native-library-card--artist" key={artist.id}>
+      <button
+        type="button"
+        className="native-library-card__cover native-library-card__cover--round"
+        onClick={() => handleArtistOpen(artist)}
+        disabled={!artist.mbid}
+        aria-label={"Open " + (artist.name || "artist")}
+      >
+        {artist.mbid ? (
+          <ArtistImage
+            mbid={artist.mbid}
+            artistName={artist.name}
+            alt={artist.name || ""}
+            className="native-library-artist-image"
+            showLoading={false}
+            enablePreviewPlayback={false}
+            isInLibrary
+          />
+        ) : (
+          <Cover label={artist.name} round />
+        )}
+      </button>
+      <div className="native-library-card__body">
+        <div className="native-library-card__title-row">
+          <button
+            type="button"
+            className="native-library-card__title"
+            onClick={() => handleArtistOpen(artist)}
+            disabled={!artist.mbid}
+            title={artist.name}
+          >
+            {artist.name || "Unknown Artist"}
+          </button>
+          <FavoriteButton
+            active={favoriteIds.has(favoriteId("artist", artist))}
+            pending={pendingFavorite === favoriteId("artist", artist)}
+            label={artist.name || "artist"}
+            onClick={() => toggleFavorite("artist", artist)}
+          />
+        </div>
+        <span className="native-library-card__meta">
+          {artist.albumIds?.length || 0} album{artist.albumIds?.length === 1 ? "" : "s"}
+        </span>
+      </div>
+    </article>
+  );
+
+  const renderAlbumCard = (album) => {
+    const artist = getArtistForAlbum(album);
+    const albumTracks = getAlbumTracks(album);
+    const availability = albumAvailability(album);
+    const meta =
+      availability.total && availability.available < availability.total
+        ? availability.available + "/" + availability.total + " available"
+        : (yearOf(album.releaseDate) ? yearOf(album.releaseDate) + " · " : "") +
+          (availability.total || 0) +
+          " tracks";
+    return (
+      <article className="native-library-card" key={album.id}>
+        <div className="native-library-card__cover-wrap">
+          <button
+            type="button"
+            className="native-library-card__cover"
+            onClick={() => handleAlbumOpen(album)}
+            aria-label={"Open " + (album.title || "album")}
+          >
+            <Cover src={getAlbumCover(album)} label={album.title} />
+          </button>
+          <button
+            type="button"
+            className="native-library-card__play"
+            onClick={() => playTracks(albumTracks)}
+            disabled={!albumTracks.some((track) => firstAvailableFile(track))}
+            aria-label={"Play " + (album.title || "album")}
+          >
+            <Play aria-hidden="true" fill="currentColor" />
+          </button>
+        </div>
+        <div className="native-library-card__body">
+          <div className="native-library-card__title-row">
+            <button
+              type="button"
+              className="native-library-card__title"
+              onClick={() => handleAlbumOpen(album)}
+              title={album.title}
+            >
+              {album.title || "Unknown Album"}
+            </button>
+            <FavoriteButton
+              active={favoriteIds.has(favoriteId("album", album))}
+              pending={pendingFavorite === favoriteId("album", album)}
+              label={album.title || "album"}
+              onClick={() => toggleFavorite("album", album)}
+            />
+          </div>
+          {artist?.mbid ? (
+            <button
+              type="button"
+              className="native-library-card__artist"
+              onClick={() => handleArtistOpen(artist)}
+            >
+              {artist.name}
+            </button>
+          ) : (
+            <span className="native-library-card__artist">
+              {artist?.name || album.albumArtist || "Unknown Artist"}
+            </span>
+          )}
+          <span className="native-library-card__meta">{meta}</span>
+        </div>
+      </article>
+    );
+  };
+
+  const renderSectionHeader = (title, count, path = "") => (
+    <div className="native-library-section-heading">
+      <div>
+        <h2>{title}</h2>
+        {count != null && <span>{count}</span>}
+      </div>
+      {path && (
+        <button type="button" onClick={() => navigate(path)}>
+          View all
+        </button>
+      )}
+    </div>
+  );
+
+  const renderHome = () => (
+    <div className="native-library-home">
+      {homeAlbums.length > 0 && (
+        <section className="native-library-section">
+          {renderSectionHeader("Recently added", library.albums.length, "/library/albums")}
+          <div className="native-library-grid">{homeAlbums.map(renderAlbumCard)}</div>
+        </section>
+      )}
+      {homeTracks.length > 0 && (
+        <section className="native-library-section">
+          {renderSectionHeader("Tracks", library.tracks.length, "/library/tracks")}
+          {renderTrackList(homeTracks, "Library tracks")}
+        </section>
+      )}
+    </div>
+  );
+
+  const renderFavorites = () => {
+    if (!favoriteCount) {
+      return (
+        <EmptyState
+          title="No favorites"
+          message="Artists, albums, and tracks you favorite will appear here."
+        />
+      );
+    }
+    return (
+      <div className="native-library-favorites">
+        {favoriteArtists.length > 0 && (
+          <section className="native-library-section">
+            {renderSectionHeader("Artists", favoriteArtists.length)}
+            <div className="native-library-grid native-library-grid--artists">
+              {favoriteArtists.map(renderArtistCard)}
+            </div>
+          </section>
+        )}
+        {favoriteAlbums.length > 0 && (
+          <section className="native-library-section">
+            {renderSectionHeader("Albums", favoriteAlbums.length)}
+            <div className="native-library-grid">{favoriteAlbums.map(renderAlbumCard)}</div>
+          </section>
+        )}
+        {favoriteTracks.length > 0 && (
+          <section className="native-library-section">
+            {renderSectionHeader("Tracks", favoriteTracks.length)}
+            {renderTrackList(favoriteTracks, "Favorite tracks")}
+          </section>
+        )}
+      </div>
+    );
+  };
+
+  const renderGenres = () => (
+    <div className="native-library-genre-list" role="table" aria-label="Library genres">
+      <div className="native-library-genre-row native-library-genre-row--heading" role="row">
+        <span>Genre</span>
+        <span>Artists</span>
+        <span>Albums</span>
+        <span>Tracks</span>
+      </div>
+      {sortedGenres.map((genre) => (
+        <button
+          type="button"
+          className="native-library-genre-row"
+          key={genre.name}
+          onClick={() =>
+            navigate("/library/albums?genre=" + encodeURIComponent(genre.name))
+          }
+          role="row"
+        >
+          <strong>{genre.name}</strong>
+          <span>{genre.artists}</span>
+          <span>{genre.albums}</span>
+          <span>{genre.tracks}</span>
+        </button>
+      ))}
+    </div>
+  );
+
+  const renderAlbumDetail = () => {
+    const artist = getArtistForAlbum(selectedAlbum);
+    const availability = albumAvailability(selectedAlbum);
+    return (
+      <section className="native-library-album-detail">
+        <button
+          type="button"
+          className="native-library-back"
+          onClick={() => setSelectedAlbumId(null)}
+        >
+          Back to {sectionLabel}
+        </button>
+        <div className="native-library-album-detail__header">
+          <div className="native-library-album-detail__cover">
+            <Cover src={getAlbumCover(selectedAlbum)} label={selectedAlbum.title} />
+          </div>
+          <div>
+            <p className="native-library-kicker">Album</p>
+            <h2>{selectedAlbum.title}</h2>
+            {artist?.mbid ? (
+              <button
+                type="button"
+                className="native-library-card__artist"
+                onClick={() => handleArtistOpen(artist)}
+              >
+                {artist.name}
+              </button>
+            ) : (
+              <p>{artist?.name || selectedAlbum.albumArtist || "Unknown Artist"}</p>
+            )}
+            <p className="native-library-card__meta">
+              {yearOf(selectedAlbum.releaseDate)
+                ? yearOf(selectedAlbum.releaseDate) + " · "
+                : ""}
+              {availability.available}/{availability.total} available
+            </p>
+            <button
+              type="button"
+              className="native-library-page-play"
+              onClick={() => playTracks(selectedAlbumTracks)}
+              disabled={!selectedAlbumTracks.some((track) => firstAvailableFile(track))}
+            >
+              <Play aria-hidden="true" fill="currentColor" /> Play
             </button>
           </div>
         </div>
-      </header>
+        {renderTrackList(selectedAlbumTracks, selectedAlbum.title + " tracks")}
+      </section>
+    );
+  };
 
-      {loading && (
-        <div className="artist-loading">
-          <Loader className="artist-spinner artist-spinner--large animate-spin" />
-        </div>
-      )}
+  const content = selectedAlbum
+    ? renderAlbumDetail()
+    : section === "home"
+      ? renderHome()
+      : section === "favorites"
+        ? renderFavorites()
+        : tab === "artists"
+          ? (
+            <div
+              className={
+                "native-library-grid native-library-grid--artists" +
+                (viewMode === "list" ? " is-list" : "")
+              }
+            >
+              {sortedArtists.map(renderArtistCard)}
+            </div>
+          )
+          : tab === "albums"
+            ? (
+              <div
+                className={
+                  "native-library-grid" + (viewMode === "list" ? " is-list" : "")
+                }
+              >
+                {sortedAlbums.map(renderAlbumCard)}
+              </div>
+            )
+            : tab === "tracks"
+              ? renderTrackList(sortedTracks, "Library tracks")
+              : renderGenres();
 
-      {error && (
-        <div className="artist-error-panel" role="alert">
-          <AlertCircle className="artist-error-icon" aria-hidden="true" />
-          <h2 className="artist-error-title">Error Loading Library</h2>
-          <p className="artist-error-copy">{error}</p>
-          <button
-            type="button"
-            onClick={() => setRetryKey((k) => k + 1)}
-            className="btn btn-secondary btn--bold btn-min-h library-page__retry-button"
-          >
-            Try Again
-          </button>
-        </div>
-      )}
+  const providerWarning = bootstrap?.lidarr?.circuitOpen === true;
+  const pageTitle =
+    selectedAlbum ? selectedAlbum.title : section === "home" ? "Library" : sectionLabel;
+  const pageCount =
+    selectedAlbum != null
+      ? selectedAlbumTracks.length
+      : section === "home"
+        ? library.artists.length + library.albums.length + library.tracks.length
+        : activeCount;
+  const showToolbar = !selectedAlbum && section !== "home";
+  const hasActiveFilters = Boolean(selectedGenre);
 
-      {!loading && !error && artists.length === 0 && (
-        <div className="search-empty-panel">
-          <div className="search-empty-panel__icon" aria-hidden="true">
-            <Music className="artist-icon-lg" />
+  return (
+    <main className="library-page native-library-page">
+      <header className="native-library-header">
+        <div className="native-library-title-row">
+          <div className="native-library-title">
+            <button
+              type="button"
+              className="native-library-title-play"
+              onClick={() => playTracks(collectionTracks)}
+              disabled={!collectionPlayable}
+              aria-label={"Play " + pageTitle}
+            >
+              <Play aria-hidden="true" fill="currentColor" />
+            </button>
+            <h1 className="page-title">
+              {pageTitle}
+              {pageCount != null && (
+                <span className="native-library-count">{pageCount}</span>
+              )}
+            </h1>
           </div>
-          <h2 className="search-empty-panel__title">No Artists in Library</h2>
-          <p className="search-empty-panel__message">
-            Your library is empty. Search and add artists in Lidarr.
-          </p>
-          <button
-            type="button"
-            onClick={() => navigate("/search")}
-            className="btn btn-secondary btn--bold btn-min-h library-page__empty-action"
-          >
-            Search for Artists
-          </button>
+          <div className="native-library-header-actions">
+            {showToolbar ? (
+              <button
+                type="button"
+                className={`native-library-icon-button${searchOpen ? " is-active" : ""}`}
+                onClick={() => setSearchOpen((value) => !value)}
+                aria-label={searchOpen ? "Close search" : "Search " + sectionLabel.toLocaleLowerCase()}
+                aria-pressed={searchOpen}
+                title={searchOpen ? "Close search" : "Search"}
+              >
+                <Search aria-hidden="true" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="native-library-icon-button"
+                onClick={() => setRetryKey((value) => value + 1)}
+                aria-label="Refresh library"
+                title="Refresh"
+              >
+                <RefreshCw aria-hidden="true" />
+              </button>
+            )}
+          </div>
         </div>
-      )}
-
-      {!loading && !error && filteredArtists.length > 0 && (
-        <section className="library-page__content">
-          {searchTerm && (
-            <p className="artist-count library-page__result-count">
-              Showing {filteredArtists.length.toLocaleString()} of {artists.length.toLocaleString()}{" "}
-              artists
-            </p>
-          )}
-
-          <div
-            className={viewMode === "list" ? "library-page__list" : "artist-albums-grid"}
-            style={viewMode === "grid" ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
-          >
-            {viewMode === "list" && groupedArtists
-              ? <>
-                  <nav className="library-page__alphabet" aria-label="Jump to letter">
-                    {ALPHABET.map((letter) => {
-                      const isActive = activeLetter === letter;
-                      const isPresent = presentLetters?.has(letter) ?? false;
-                      return (
-                        <button
-                          key={letter}
-                          type="button"
-                          className={`library-page__alphabet-letter${isActive ? " is-active" : ""}${!isPresent ? " is-missing" : ""}`}
-                          onClick={() => scrollToLetter(letter)}
-                          disabled={!isPresent}
-                          aria-label={`Jump to ${letter}`}
-                        >
-                          {letter}
-                        </button>
-                      );
-                    })}
-                  </nav>
-                  {groupedArtists.map(([letter, group]) => (
-                  <div key={letter} id={`library-group-${letter}`} className="library-page__list-group">
-                    <span className="library-page__list-letter">{letter}</span>
-                    <div className="library-page__list-items">
-                      {group.map((artist) => {
-                        const artistName = getArtistName(artist) || "Unknown Artist";
-                        const routeId = getArtistRouteId(artist);
-                        const monitorOption =
-                          artist.addOptions?.monitor ||
-                          artist.monitorNewItems ||
-                          artist.monitorOption ||
-                          "none";
-                        const isMonitored = artist.monitored && monitorOption !== "none";
-                        return (
-                          <button
-                            type="button"
-                            key={artist.id}
-                            className="artist-release-card"
-                            onClick={() => navigateToArtist(artist)}
-                            disabled={!routeId}
-                            aria-label={`Open ${artistName}`}
-                          >
-                            <div className="artist-release-card__cover">
-                              <ArtistImage
-                                mbid={routeId}
-                                artistName={artistName}
-                                alt={artistName}
-                                className="artist-image-fill"
-                                showLoading={false}
-                                enablePreviewPlayback
-                                isInLibrary
-                              />
-                              {isMonitored && (
-                                <span
-                                  className="library-page__monitored-dot artist-status-dot artist-status-dot--complete"
-                                  title="Monitored"
-                                />
-                              )}
-                            </div>
-                            <span className="artist-release-card__title" title={artistName}>
-                              {artistName}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))}
+        {showToolbar && (
+          <>
+            <div className="native-library-toolbar">
+              {searchOpen && (
+                <label className="native-library-search">
+                  <Search aria-hidden="true" />
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder={"Search " + sectionLabel.toLocaleLowerCase()}
+                    aria-label={"Search " + sectionLabel.toLocaleLowerCase()}
+                    autoFocus
+                  />
+                  {query && (
+                    <button type="button" onClick={() => setQuery("")} aria-label="Clear search">
+                      <X aria-hidden="true" />
+                    </button>
+                  )}
+                </label>
+              )}
+              {sortOptions.length > 0 && (
+                <>
+                  <label className="native-library-sort">
+                    <span className="sr-only">Sort {sectionLabel.toLocaleLowerCase()} by</span>
+                    <select
+                      value={sortMode}
+                      onChange={(event) => setSortMode(event.target.value)}
+                      aria-label={"Sort " + sectionLabel.toLocaleLowerCase()}
+                    >
+                      {sortOptions.map((option) => (
+                        <option value={option.value} key={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <span className="native-library-toolbar-divider" aria-hidden="true" />
+                  <button
+                    type="button"
+                    className="native-library-icon-button"
+                    onClick={() =>
+                      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
+                    }
+                    aria-label={sortDirection === "asc" ? "Sort descending" : "Sort ascending"}
+                    title={sortDirection === "asc" ? "Descending" : "Ascending"}
+                  >
+                    {sortDirection === "asc" ? (
+                      <ArrowDownAZ aria-hidden="true" />
+                    ) : (
+                      <ArrowUpZA aria-hidden="true" />
+                    )}
+                  </button>
                 </>
-              : visibleArtists.map((artist) => {
-              const artistName = getArtistName(artist) || "Unknown Artist";
-              const routeId = getArtistRouteId(artist);
-              const monitorOption =
-                artist.addOptions?.monitor ||
-                artist.monitorNewItems ||
-                artist.monitorOption ||
-                "none";
-              const isMonitored = artist.monitored && monitorOption !== "none";
-
-              return (
+              )}
+              {section !== "genres" && (
                 <button
                   type="button"
-                  key={artist.id}
-                  className="artist-release-card"
-                  onClick={() => navigateToArtist(artist)}
-                  disabled={!routeId}
-                  aria-label={`Open ${artistName}`}
+                  className={`native-library-icon-button${hasActiveFilters ? " is-active" : ""}`}
+                  onClick={() => setFiltersOpen((value) => !value)}
+                  aria-label="Filter library"
+                  aria-pressed={filtersOpen}
+                  title="Filters"
                 >
-                  <div className="artist-release-card__cover">
-                    <ArtistImage
-                      mbid={routeId}
-                      artistName={artistName}
-                      alt={artistName}
-                      className="artist-image-fill"
-                      showLoading={false}
-                      enablePreviewPlayback
-                      isInLibrary
-                    />
-                    {isMonitored && (
-                      <span
-                        className="library-page__monitored-dot artist-status-dot artist-status-dot--complete"
-                        title="Monitored"
-                      />
-                    )}
-                  </div>
-
-                  <span className="artist-release-card__title" title={artistName}>
-                    {artistName}
-                  </span>
+                  <ListFilter aria-hidden="true" />
                 </button>
-              );
-            })}
-          </div>
-
-          {visibleCount < filteredArtists.length && (
-            <div ref={sentinelRef} className="search-load-more">
-              <span className="search-load-more__inner">
-                <Loader className="artist-spinner animate-spin" />
-                Loading...
-              </span>
+              )}
+              <button
+                type="button"
+                className="native-library-icon-button"
+                onClick={() => setRetryKey((value) => value + 1)}
+                aria-label="Refresh library"
+                title="Refresh"
+              >
+                <RefreshCw aria-hidden="true" />
+              </button>
+              <span className="native-library-toolbar-spacer" aria-hidden="true" />
+              {(tab === "artists" || tab === "albums") && (
+                <div className="native-library-view-toggle" aria-label="Library view">
+                  <button
+                    type="button"
+                    className={`native-library-icon-button${viewMode === "grid" ? " is-active" : ""}`}
+                    onClick={() => setViewMode("grid")}
+                    aria-label="Grid view"
+                    title="Grid view"
+                    aria-pressed={viewMode === "grid"}
+                  >
+                    <Grid3X3 aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className={`native-library-icon-button${viewMode === "list" ? " is-active" : ""}`}
+                    onClick={() => setViewMode("list")}
+                    aria-label="List view"
+                    title="List view"
+                    aria-pressed={viewMode === "list"}
+                  >
+                    <List aria-hidden="true" />
+                  </button>
+                </div>
+              )}
+              {section !== "genres" && (
+                <button
+                  type="button"
+                  className={`native-library-icon-button${filtersOpen ? " is-active" : ""}`}
+                  onClick={() => setFiltersOpen((value) => !value)}
+                  aria-label="Library filter options"
+                  aria-pressed={filtersOpen}
+                  title="Filter options"
+                >
+                  <SlidersHorizontal aria-hidden="true" />
+                </button>
+              )}
             </div>
-          )}
-        </section>
-      )}
+            {filtersOpen && section !== "genres" && (
+              <div className="native-library-filter-panel">
+                <label>
+                  <span>Genre</span>
+                  <select
+                    value={selectedGenre}
+                    onChange={(event) => updateGenreFilter(event.target.value)}
+                    aria-label="Filter by genre"
+                  >
+                    <option value="">All genres</option>
+                    {genreStats.map((genre) => (
+                      <option value={genre.name} key={genre.name}>
+                        {genre.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {selectedGenre && (
+                  <button
+                    type="button"
+                    className="native-library-filter-reset"
+                    onClick={() => updateGenreFilter("")}
+                  >
+                    <X aria-hidden="true" />
+                    Clear
+                  </button>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </header>
 
-      {!loading && !error && artists.length > 0 && filteredArtists.length === 0 && (
-        <div className="search-empty-panel">
-          <div className="search-empty-panel__icon" aria-hidden="true">
-            <Music className="artist-icon-lg" />
-          </div>
-          <h2 className="search-empty-panel__title">No Artists Found</h2>
-          <p className="search-empty-panel__message">
-            No artists match your search &quot;{searchTerm}&quot;
-          </p>
+      {providerWarning && (
+        <p className="native-library-notice" role="status">
+          Lidarr is unavailable. Showing the last indexed library.
+        </p>
+      )}
+      {loading && (
+        <div className="native-library-state" role="status">
+          Loading library…
+        </div>
+      )}
+      {!loading && error && (
+        <div className="native-library-state" role="alert">
+          <strong>Library unavailable</strong>
+          <span>{error}</span>
           <button
             type="button"
-            onClick={() => setSearchTerm("")}
-            className="btn btn-secondary btn--bold btn-min-h library-page__empty-action"
+            className="native-library-state__action"
+            onClick={() => setRetryKey((value) => value + 1)}
           >
-            Clear Search
+            Try again
           </button>
         </div>
       )}
-    </div>
+      {!loading && !error && activeCount === 0 && !selectedAlbum && (
+        <EmptyState
+          title={
+            query || selectedGenre
+              ? "No matches"
+              : section === "favorites"
+                ? "No favorites"
+                : "Your library is empty"
+          }
+          message={
+            query || selectedGenre
+              ? "Try a different search or clear the filter."
+              : "Indexed music will appear here when the library is ready."
+          }
+        />
+      )}
+      {!loading && !error && (activeCount > 0 || selectedAlbum) && (
+        <div className="native-library-content">{content}</div>
+      )}
+    </main>
   );
 }
 

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   ArrowDownAZ,
   ArrowLeft,
+  ArrowRight,
   ArrowUpZA,
   ExternalLink,
   Grid3X3,
@@ -24,6 +25,7 @@ import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
 import {
   getCanonicalLibrary,
+  getCanonicalLibraryPage,
   getLibraryFavorites,
   updateLibraryFavorites,
 } from "../utils/api/endpoints/library.js";
@@ -144,7 +146,7 @@ function LibraryPage() {
   const { showError } = useToast();
   const { playQueue, currentTrack, isPlaying, isLoading, togglePlayPause, matchesSource } =
     useAudioQueue();
-  const [library, setLibrary] = useState({ artists: [], albums: [], tracks: [] });
+  const [library, setLibrary] = useState({ artists: [], albums: [], tracks: [], genres: [] });
   const [favoriteIds, setFavoriteIds] = useState(() => new Set());
   const [query, setQuery] = useState("");
   const [sortMode, setSortMode] = useState("name");
@@ -159,6 +161,11 @@ function LibraryPage() {
   const [error, setError] = useState(null);
   const [isPreviewLibrary, setIsPreviewLibrary] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+  const [pageIndex, setPageIndex] = useState(1);
+  const [pageData, setPageData] = useState(null);
+  const albumTrackCacheRef = useRef(new Map());
+
+  const pageSize = 100;
 
   const section = LIBRARY_VIEW_IDS.has(routeSection) ? routeSection : DEFAULT_LIBRARY_VIEW;
   const isDetail = Boolean(routeAlbumId || routeArtistId);
@@ -190,6 +197,8 @@ function LibraryPage() {
     setViewMode(section === "tracks" || section === "genres" ? "list" : "grid");
     setSearchOpen(false);
     setFiltersOpen(false);
+    setPageIndex(1);
+    setPageData(null);
   }, [section]);
 
   useEffect(() => {
@@ -202,26 +211,105 @@ function LibraryPage() {
       setLibrary(libraryPreviewData);
       setFavoriteIds(new Set(libraryPreviewFavorites));
       setIsPreviewLibrary(true);
+      setPageData(null);
       setLoading(false);
       return () => controller.abort();
     }
 
-    Promise.all([
-      getCanonicalLibrary({ signal: controller.signal }),
-      getLibraryFavorites({ signal: controller.signal }),
-    ])
-      .then(([nextLibrary, starred]) => {
+    const pageRequest = isDetail
+      ? routeAlbumId
+        ? getCanonicalLibraryPage({
+            kind: "tracks",
+            albumId: routeAlbumId,
+            page: 1,
+            pageSize,
+            signal: controller.signal,
+          })
+        : Promise.all([
+            getCanonicalLibraryPage({
+              kind: "albums",
+              artistId: routeArtistId,
+              page: 1,
+              pageSize,
+              signal: controller.signal,
+            }),
+            getCanonicalLibraryPage({
+              kind: "tracks",
+              artistId: routeArtistId,
+              page: 1,
+              pageSize,
+              signal: controller.signal,
+            }),
+          ])
+      : section === "favorites"
+        ? getCanonicalLibrary({ signal: controller.signal })
+      : section === "home"
+        ? Promise.all([
+            getCanonicalLibraryPage({
+              kind: "albums",
+              page: 1,
+              pageSize: 12,
+              sort: "newest",
+              signal: controller.signal,
+            }),
+            getCanonicalLibraryPage({
+              kind: "tracks",
+              page: 1,
+              pageSize: 12,
+              signal: controller.signal,
+            }),
+          ])
+        : getCanonicalLibraryPage({
+            kind: tab,
+            page: pageIndex,
+            pageSize,
+            query: normalizedQuery,
+            genre: selectedGenre,
+            sort: sortMode,
+            direction: sortDirection,
+            signal: controller.signal,
+          });
+
+    Promise.all([pageRequest, getLibraryFavorites({ signal: controller.signal })])
+      .then(([nextData, starred]) => {
         if (controller.signal.aborted) return;
-        const normalizedLibrary = {
-          artists: Array.isArray(nextLibrary?.artists) ? nextLibrary.artists : [],
-          albums: Array.isArray(nextLibrary?.albums) ? nextLibrary.albums : [],
-          tracks: Array.isArray(nextLibrary?.tracks) ? nextLibrary.tracks : [],
-        };
+        const pageResults = Array.isArray(nextData) ? nextData : [nextData];
+        const normalizedLibrary = pageResults.reduce(
+          (result, page) => {
+            ["artists", "albums", "tracks"].forEach((kind) => {
+              (Array.isArray(page?.[kind]) ? page[kind] : []).forEach((entity) => {
+                if (!result[kind].some((candidate) => String(candidate.id) === String(entity.id))) {
+                  result[kind].push(entity);
+                }
+              });
+            });
+            if (Array.isArray(page?.genres) && page.genres.length > result.genres.length) {
+              result.genres = page.genres;
+            }
+            return result;
+          },
+          { artists: [], albums: [], tracks: [], genres: [] },
+        );
         const usePreview =
           import.meta.env.DEV &&
+          pageResults.every((page) => Number(page?.total || 0) === 0) &&
+          !normalizedQuery &&
+          !selectedGenre &&
           normalizedLibrary.artists.length === 0 &&
           normalizedLibrary.albums.length === 0 &&
           normalizedLibrary.tracks.length === 0;
+        if (usePreview || isDetail || section === "favorites") {
+          setPageData(null);
+        } else {
+          setPageData(
+            section === "home"
+              ? {
+                  kind: "home",
+                  total: pageResults.reduce((count, page) => count + Number(page?.total || 0), 0),
+                }
+              : nextData,
+          );
+        }
         setLibrary(usePreview ? libraryPreviewData : normalizedLibrary);
         setIsPreviewLibrary(usePreview);
         const nextFavorites = new Set(
@@ -245,12 +333,58 @@ function LibraryPage() {
       });
 
     return () => controller.abort();
-  }, [forcePreview, retryKey]);
+  }, [
+    forcePreview,
+    isDetail,
+    normalizedQuery,
+    pageIndex,
+    routeAlbumId,
+    routeArtistId,
+    retryKey,
+    section,
+    selectedGenre,
+    sortDirection,
+    sortMode,
+    tab,
+  ]);
 
   const getAlbumTracks = useCallback(
-    (album) => album?.trackIds?.map((id) => tracksById.get(String(id))).filter(Boolean) || [],
+    (album) => {
+      const cached = albumTrackCacheRef.current.get(String(album?.id));
+      return cached || album?.trackIds?.map((id) => tracksById.get(String(id))).filter(Boolean) || [];
+    },
     [tracksById],
   );
+
+  const loadAlbumTracks = useCallback(async (album) => {
+    if (!album?.id) return [];
+    const cacheKey = String(album.id);
+    const cached = albumTrackCacheRef.current.get(cacheKey);
+    if (cached) return cached;
+    const page = await getCanonicalLibraryPage({
+      kind: "tracks",
+      albumId: album.id,
+      page: 1,
+      pageSize,
+    });
+    const tracks = Array.isArray(page?.items) ? page.items : [];
+    albumTrackCacheRef.current.set(cacheKey, tracks);
+    setLibrary((current) => {
+      const merge = (kind) => [
+        ...(current[kind] || []),
+        ...(Array.isArray(page?.[kind]) ? page[kind] : []),
+      ].filter((entity, index, values) =>
+        values.findIndex((candidate) => String(candidate.id) === String(entity.id)) === index,
+      );
+      return {
+        ...current,
+        artists: merge("artists"),
+        albums: merge("albums"),
+        tracks: merge("tracks"),
+      };
+    });
+    return tracks;
+  }, []);
 
   const getAlbumForTrack = useCallback(
     (track) => (track?.albums?.[0] ? albumsById.get(String(track.albums[0].albumId)) : null),
@@ -265,8 +399,10 @@ function LibraryPage() {
   const albumAvailability = useCallback(
     (album) => {
       const tracks = getAlbumTracks(album);
-      const total = tracks.length || (album?.trackIds || []).length;
-      const available = tracks.filter((track) => firstAvailableFile(track)).length;
+      const total = album?.trackCount || tracks.length || (album?.trackIds || []).length;
+      const available = album?.availableTrackCount != null && tracks.length !== total
+        ? album.availableTrackCount
+        : tracks.filter((track) => firstAvailableFile(track)).length;
       return { total, available };
     },
     [getAlbumTracks],
@@ -314,6 +450,7 @@ function LibraryPage() {
   );
 
   const genreStats = useMemo(() => {
+    if (library.genres?.length) return library.genres;
     const stats = new Map();
     const add = (genre, kind) => {
       const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
@@ -330,7 +467,7 @@ function LibraryPage() {
       metadataGenres(track).forEach((genre) => add(genre, "tracks")),
     );
     return [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
-  }, [library.albums, library.artists, library.tracks]);
+  }, [library.albums, library.artists, library.genres, library.tracks]);
 
   const visibleGenreStats = useMemo(
     () =>
@@ -530,6 +667,15 @@ function LibraryPage() {
     [buildPlayableTrack, librarySource, playQueue, showError],
   );
 
+  const playAlbum = useCallback(async (album) => {
+    try {
+      const tracks = await loadAlbumTracks(album);
+      playTracks(tracks);
+    } catch (requestError) {
+      showError(requestError.response?.data?.message || "Failed to load album tracks");
+    }
+  }, [loadAlbumTracks, playTracks, showError]);
+
   const toggleFavorite = useCallback(
     async (kind, entity) => {
       const id = favoriteId(kind, entity);
@@ -630,9 +776,11 @@ function LibraryPage() {
     favoriteArtists.length + favoriteAlbums.length + favoriteTracks.length;
   const activeCount =
     section === "home"
-      ? library.albums.length + library.tracks.length
+      ? pageData?.total ?? library.albums.length + library.tracks.length
       : section === "favorites"
         ? favoriteCount
+        : pageData?.kind === tab
+          ? pageData.total
         : tab === "artists"
           ? sortedArtists.length
           : tab === "albums"
@@ -680,6 +828,7 @@ function LibraryPage() {
   const collectionPlayable = collectionTracks.some((track) => firstAvailableFile(track));
 
   const updateGenreFilter = (genre) => {
+    setPageIndex(1);
     const next = new URLSearchParams(searchParams);
     if (genre) next.set("genre", genre);
     else next.delete("genre");
@@ -864,8 +1013,8 @@ function LibraryPage() {
           </button>
           <TooltipButton
             className="native-library-card__play"
-            onClick={() => playTracks(albumTracks)}
-            disabled={!albumTracks.some((track) => firstAvailableFile(track))}
+            onClick={() => playAlbum(album)}
+            disabled={!albumTracks.length && !album.trackCount && !album.trackIds?.length}
             label={"Play " + (album.title || "album")}
             aria-label={"Play " + (album.title || "album")}
           >
@@ -1252,9 +1401,11 @@ function LibraryPage() {
               : renderGenres();
 
   const pageTitle = section === "home" ? "Library" : sectionLabel;
+  const totalPages =
+    pageData?.kind === tab ? Math.ceil(pageData.total / pageData.pageSize) : 0;
   const pageCount =
     section === "home"
-      ? library.albums.length + library.tracks.length
+      ? pageData?.total ?? library.albums.length + library.tracks.length
       : activeCount;
   const showToolbar = section !== "home";
   const hasActiveFilters = Boolean(selectedGenre);
@@ -1311,13 +1462,22 @@ function LibraryPage() {
                   <input
                     type="search"
                     value={query}
-                    onChange={(event) => setQuery(event.target.value)}
+                    onChange={(event) => {
+                      setPageIndex(1);
+                      setQuery(event.target.value);
+                    }}
                     placeholder={"Search " + sectionLabel.toLocaleLowerCase()}
                     aria-label={"Search " + sectionLabel.toLocaleLowerCase()}
                     autoFocus
                   />
                   {query && (
-                    <TooltipButton onClick={() => setQuery("")} label="Clear search">
+                    <TooltipButton
+                      onClick={() => {
+                        setPageIndex(1);
+                        setQuery("");
+                      }}
+                      label="Clear search"
+                    >
                       <X aria-hidden="true" />
                     </TooltipButton>
                   )}
@@ -1329,7 +1489,10 @@ function LibraryPage() {
                     <span className="sr-only">Sort {sectionLabel.toLocaleLowerCase()} by</span>
                     <select
                       value={sortMode}
-                      onChange={(event) => setSortMode(event.target.value)}
+                      onChange={(event) => {
+                        setPageIndex(1);
+                        setSortMode(event.target.value);
+                      }}
                       aria-label={"Sort " + sectionLabel.toLocaleLowerCase()}
                     >
                       {sortOptions.map((option) => (
@@ -1342,9 +1505,10 @@ function LibraryPage() {
                   <span className="native-library-toolbar-divider" aria-hidden="true" />
                   <TooltipButton
                     className="native-library-icon-button"
-                    onClick={() =>
-                      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
-                    }
+                    onClick={() => {
+                      setPageIndex(1);
+                      setSortDirection((value) => (value === "asc" ? "desc" : "asc"));
+                    }}
                     label={sortDirection === "asc" ? "Descending" : "Ascending"}
                     aria-label={sortDirection === "asc" ? "Sort descending" : "Sort ascending"}
                   >
@@ -1451,6 +1615,31 @@ function LibraryPage() {
       )}
       {!loading && !error && activeCount > 0 && (
         <div className="native-library-content">{content}</div>
+      )}
+      {!loading && !error && totalPages > 1 && (
+        <nav className="native-library-pagination" aria-label={sectionLabel + " pages"}>
+          <TooltipButton
+            className="native-library-icon-button"
+            onClick={() => setPageIndex((value) => Math.max(1, value - 1))}
+            disabled={pageIndex === 1}
+            label="Previous page"
+            aria-label="Previous page"
+          >
+            <ArrowLeft aria-hidden="true" />
+          </TooltipButton>
+          <span>
+            Page {pageIndex} of {totalPages}
+          </span>
+          <TooltipButton
+            className="native-library-icon-button"
+            onClick={() => setPageIndex((value) => Math.min(totalPages, value + 1))}
+            disabled={pageIndex === totalPages}
+            label="Next page"
+            aria-label="Next page"
+          >
+            <ArrowRight aria-hidden="true" />
+          </TooltipButton>
+        </nav>
       )}
     </main>
   );

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -304,9 +304,7 @@ function LibraryPage() {
             signal: controller.signal,
           });
 
-    const favoritesRequest = section === "favorites"
-      ? Promise.resolve(null)
-      : getLibraryFavorites();
+    const favoritesRequest = Promise.resolve(null);
 
     Promise.all([pageRequest, favoritesRequest])
       .then(([nextData, starred]) => {
@@ -353,13 +351,25 @@ function LibraryPage() {
         setLibrary(usePreview ? libraryPreviewData : normalizedLibrary);
         setIsPreviewLibrary(usePreview);
         const favoriteData = section === "favorites" ? nextData : starred;
-        const nextFavorites = new Set(
-          ["artist", "album", "song"].flatMap((kind) =>
-            (Array.isArray(favoriteData?.[kind]) ? favoriteData[kind] : []).map(
-              (entry) => entry.id,
-            ),
-          ),
-        );
+        const nextFavorites = section === "favorites"
+          ? new Set(
+              ["artist", "album", "song"].flatMap((kind) =>
+                (Array.isArray(favoriteData?.[kind]) ? favoriteData[kind] : []).map(
+                  (entry) => entry.id,
+                ),
+              ),
+            )
+          : new Set(
+              ["artists", "albums", "tracks"].flatMap((kind) =>
+                pageResults
+                  .flatMap((page) => (Array.isArray(page?.[kind]) ? page[kind] : []))
+                  .filter((entity) => entity.userFavorite)
+                  .map((entity) => favoriteId(
+                    kind === "artists" ? "artist" : kind === "albums" ? "album" : "song",
+                    entity,
+                  )),
+              ),
+            );
         setFavoriteIds(usePreview ? new Set(libraryPreviewFavorites) : nextFavorites);
       })
       .catch((requestError) => {

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -24,7 +24,6 @@ import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
 import {
-  getCanonicalLibrary,
   getCanonicalLibraryPage,
   getLibraryFavorites,
   updateLibraryFavorites,
@@ -277,7 +276,7 @@ function LibraryPage() {
             }),
           ])
       : section === "favorites"
-        ? getCanonicalLibrary({ signal: controller.signal })
+        ? getLibraryFavorites()
       : section === "home"
         ? Promise.all([
             getCanonicalLibraryPage({
@@ -305,10 +304,16 @@ function LibraryPage() {
             signal: controller.signal,
           });
 
-    Promise.all([pageRequest, getLibraryFavorites({ signal: controller.signal })])
+    const favoritesRequest = section === "favorites"
+      ? Promise.resolve(null)
+      : getLibraryFavorites();
+
+    Promise.all([pageRequest, favoritesRequest])
       .then(([nextData, starred]) => {
         if (controller.signal.aborted) return;
-        const pageResults = Array.isArray(nextData) ? nextData : [nextData];
+        const pageResults = section === "favorites"
+          ? [nextData?.library || { artists: [], albums: [], tracks: [] }]
+          : Array.isArray(nextData) ? nextData : [nextData];
         const normalizedLibrary = pageResults.reduce(
           (result, page) => {
             ["artists", "albums", "tracks"].forEach((kind) => {
@@ -347,9 +352,12 @@ function LibraryPage() {
         }
         setLibrary(usePreview ? libraryPreviewData : normalizedLibrary);
         setIsPreviewLibrary(usePreview);
+        const favoriteData = section === "favorites" ? nextData : starred;
         const nextFavorites = new Set(
           ["artist", "album", "song"].flatMap((kind) =>
-            (Array.isArray(starred?.[kind]) ? starred[kind] : []).map((entry) => entry.id),
+            (Array.isArray(favoriteData?.[kind]) ? favoriteData[kind] : []).map(
+              (entry) => entry.id,
+            ),
           ),
         );
         setFavoriteIds(usePreview ? new Set(libraryPreviewFavorites) : nextFavorites);

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -447,6 +447,7 @@ export function FlowTracksPanel({
   showPlaybackControls = true,
   hideAlbumColumn = false,
   hideStatusColumn = false,
+  hideQualityColumn = false,
   allowBulkEdit = false,
   onBulkDelete,
   onBulkReSearch,
@@ -796,9 +797,11 @@ export function FlowTracksPanel({
                     className="flow-page__tracks-table-status-head"
                   />
                 )}
-                <th className="flow-page__tracks-table-quality-head" scope="col">
-                  Quality
-                </th>
+                {hideQualityColumn ? null : (
+                  <th className="flow-page__tracks-table-quality-head" scope="col">
+                    Quality
+                  </th>
+                )}
                 <th
                   className="flow-page__tracks-table-actions-head"
                   aria-hidden="true"
@@ -830,7 +833,7 @@ export function FlowTracksPanel({
                 const isReSearching = reSearchingTrackIds[track.id] === true;
                 const isDeleting = deletingTrackId === track.id;
                 const isCurrent = track.id === currentTrackId && isCurrentPlaying;
-                const quality = getTrackQualityMeta(track);
+                const quality = hideQualityColumn ? null : getTrackQualityMeta(track);
                 return (
                   <tr
                     key={track.id}
@@ -920,14 +923,16 @@ export function FlowTracksPanel({
                         <TrackStatusDot status={track.status} />
                       </td>
                     )}
-                    <td className="flow-page__tracks-table-quality-cell">
-                      <span className="flow-page__tracks-table-cell-text">{quality.label}</span>
-                      {quality.state ? (
-                        <span className={`flow-page__quality-state flow-page__quality-state--${track.qualityState}`}>
-                          {quality.state}
-                        </span>
-                      ) : null}
-                    </td>
+                    {hideQualityColumn ? null : (
+                      <td className="flow-page__tracks-table-quality-cell">
+                        <span className="flow-page__tracks-table-cell-text">{quality.label}</span>
+                        {quality.state ? (
+                          <span className={`flow-page__quality-state flow-page__quality-state--${track.qualityState}`}>
+                            {quality.state}
+                          </span>
+                        ) : null}
+                      </td>
+                    )}
                     <td className="flow-page__tracks-table-actions-cell">
                       {editMode ? null : (
                       <div className="flow-page__tracks-actions">

--- a/frontend/src/pages/libraryPreviewData.js
+++ b/frontend/src/pages/libraryPreviewData.js
@@ -1,0 +1,109 @@
+const catalog = [
+  {
+    artist: "The Night Archive",
+    artistId: "preview-artist-night-archive",
+    albums: [
+      { title: "Static Bloom", year: "2024", genres: ["Indie", "Electronic"] },
+      { title: "Afterimage", year: "2022", genres: ["Alternative", "Dream Pop"] },
+    ],
+  },
+  {
+    artist: "Mara Vale",
+    artistId: "preview-artist-mara-vale",
+    albums: [
+      { title: "Common Weather", year: "2023", genres: ["Folk", "Singer-Songwriter"] },
+      { title: "Small Hours", year: "2020", genres: ["Folk", "Acoustic"] },
+    ],
+  },
+  {
+    artist: "Glass District",
+    artistId: "preview-artist-glass-district",
+    albums: [
+      { title: "Soft Machines", year: "2025", genres: ["Post-Punk", "Rock"] },
+      { title: "Signal Loss", year: "2021", genres: ["Rock", "Industrial"] },
+    ],
+  },
+  {
+    artist: "June Meridian",
+    artistId: "preview-artist-june-meridian",
+    albums: [
+      { title: "Blue Hour", year: "2024", genres: ["Pop", "Soul"] },
+      { title: "Open Water", year: "2019", genres: ["Soul", "R&B"] },
+    ],
+  },
+];
+
+const PREVIEW_AUDIO_URL = "data:audio/wav;base64,UklGRrQBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YZABAACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA";
+
+const tracksForAlbum = (album, albumIndex) => [
+  "Opening Scene",
+  "Common Ground",
+  "Side Street",
+  "Last Light",
+].map((title, trackIndex) => ({
+  id: `preview-track-${albumIndex + 1}-${trackIndex + 1}`,
+  identityKey: `preview-track:${albumIndex + 1}-${trackIndex + 1}`,
+  mbid: null,
+  title,
+  artistName: album.artist,
+  metadata: { genres: album.genres },
+  albums: [{ albumId: album.id, discNumber: 1, trackNumber: trackIndex + 1 }],
+  files: [{
+    source: "aurral",
+    format: "wav",
+    durationMs: 174000 + trackIndex * 11000,
+    quality: { bitrate: 320 },
+    available: true,
+    previewUrl: PREVIEW_AUDIO_URL,
+  }],
+  sources: ["aurral"],
+  available: true,
+}));
+
+const albums = catalog.flatMap((artist, artistIndex) =>
+  artist.albums.map((album, albumIndex) => ({
+    id: `preview-album-${artistIndex + 1}-${albumIndex + 1}`,
+    identityKey: `preview-album:${artistIndex + 1}-${albumIndex + 1}`,
+    mbid: null,
+    releaseGroupMbid: null,
+    artistId: artist.artistId,
+    title: album.title,
+    albumArtist: artist.artist,
+    releaseDate: album.year,
+    metadata: { genres: album.genres },
+    trackIds: [],
+    sources: ["aurral"],
+    available: true,
+  })),
+);
+
+const artists = catalog.map((entry) => ({
+  id: entry.artistId,
+  identityKey: `preview-artist:${entry.artistId}`,
+  mbid: null,
+  name: entry.artist,
+  sortName: entry.artist,
+  metadata: { genres: [...new Set(entry.albums.flatMap((album) => album.genres))] },
+  albumIds: albums.filter((album) => album.artistId === entry.artistId).map((album) => album.id),
+  sources: ["aurral"],
+  available: true,
+}));
+
+const tracks = albums.flatMap((album, index) => {
+  const artist = artists.find((entry) => entry.id === album.artistId);
+  const albumTracks = tracksForAlbum({
+    ...album,
+    artist: artist.name,
+    genres: album.metadata.genres,
+  }, index);
+  album.trackIds = albumTracks.map((track) => track.id);
+  return albumTracks;
+});
+
+export const libraryPreviewData = { artists, albums, tracks };
+
+export const libraryPreviewFavorites = new Set([
+  "artist:preview-artist%3Apreview-artist-night-archive",
+  "album:preview-album%3A1-1",
+  "song:preview-track%3A1-1",
+]);

--- a/frontend/src/utils/api/core.js
+++ b/frontend/src/utils/api/core.js
@@ -178,7 +178,8 @@ export const setLibraryLookupCacheEntry = (id, value) => {
 export const setCoverCacheEntry = (key, value) => {
   if (!key) return;
   const images = Array.isArray(value?.images) ? value.images : [];
-  const ttlMs = images.length > 0 ? COVER_CACHE_TTL_MS : EMPTY_COVER_CACHE_TTL_MS;
+  const hasArtwork = images.length > 0 || Boolean(value?.image || value?.imageUrl || value?.coverUrl);
+  const ttlMs = hasArtwork ? COVER_CACHE_TTL_MS : EMPTY_COVER_CACHE_TTL_MS;
   if (coverResponseCache.has(key)) coverResponseCache.delete(key);
   coverResponseCache.set(key, { value, expiresAt: Date.now() + ttlMs });
   if (coverResponseCache.size > MAX_COVER_CACHE_SIZE) {

--- a/frontend/src/utils/api/endpoints/artists.js
+++ b/frontend/src/utils/api/endpoints/artists.js
@@ -49,6 +49,11 @@ export const getReleaseGroupRatingsBatch = (ids = []) =>
 
 const RELEASE_GROUP_COVER_BATCH_SIZE = 24;
 
+const normalizeCoverPart = (value) => String(value || "").trim().toLowerCase();
+
+const releaseGroupCoverCacheKey = (mbid, artistName = "", albumTitle = "") =>
+  `release-group:${mbid}:${normalizeCoverPart(artistName)}:${normalizeCoverPart(albumTitle)}`;
+
 export const getReleaseGroupTracks = async (mbid, context = {}) => {
   const params = {};
   if (context.artistMbid) params.artistMbid = context.artistMbid;
@@ -95,6 +100,16 @@ export const getReleaseGroupCoversBatch = async (items = []) => {
   if (!normalizedItems.length) {
     return {};
   }
+  const covers = {};
+  const uncachedItems = [];
+  normalizedItems.forEach((item) => {
+    const cached = getCoverCacheEntry(
+      releaseGroupCoverCacheKey(item.mbid, item.artistName, item.albumTitle),
+    );
+    if (cached) covers[item.mbid] = cached;
+    else uncachedItems.push(item);
+  });
+  if (!uncachedItems.length) return covers;
   const batchKey = normalizedItems
     .map(
       (item) =>
@@ -106,12 +121,22 @@ export const getReleaseGroupCoversBatch = async (items = []) => {
     return coverInflightRequests.get(batchKey);
   }
   const request = (async () => {
-    const covers = {};
-    for (let index = 0; index < normalizedItems.length; index += RELEASE_GROUP_COVER_BATCH_SIZE) {
+    for (let index = 0; index < uncachedItems.length; index += RELEASE_GROUP_COVER_BATCH_SIZE) {
+      const batch = uncachedItems.slice(index, index + RELEASE_GROUP_COVER_BATCH_SIZE);
       const data = await postData("/artists/release-groups/covers", {
-        items: normalizedItems.slice(index, index + RELEASE_GROUP_COVER_BATCH_SIZE),
+        items: batch,
       });
-      Object.assign(covers, data?.covers || {});
+      const batchCovers = data?.covers || {};
+      Object.assign(covers, batchCovers);
+      Object.entries(batchCovers).forEach(([mbid, cover]) => {
+        const item = batch.find((candidate) => candidate.mbid === mbid);
+        if (item && !cover?.transientError) {
+          setCoverCacheEntry(
+            releaseGroupCoverCacheKey(mbid, item.artistName, item.albumTitle),
+            cover,
+          );
+        }
+      });
     }
     return covers;
   })()
@@ -126,11 +151,7 @@ export const getReleaseGroupCover = async (
   mbid,
   { artistName = "", albumTitle = "", bypassCache = false } = {},
 ) => {
-  const normalizedArtistName =
-    typeof artistName === "string" ? artistName.trim().toLowerCase() : "";
-  const normalizedAlbumTitle =
-    typeof albumTitle === "string" ? albumTitle.trim().toLowerCase() : "";
-  const cacheKey = `release-group:${mbid}:${normalizedArtistName}:${normalizedAlbumTitle}`;
+  const cacheKey = releaseGroupCoverCacheKey(mbid, artistName, albumTitle);
   if (!bypassCache) {
     const cached = getCoverCacheEntry(cacheKey);
     if (cached) {

--- a/frontend/src/utils/api/endpoints/artists.js
+++ b/frontend/src/utils/api/endpoints/artists.js
@@ -47,6 +47,8 @@ export const getArtistAppearsOnPage = (
 export const getReleaseGroupRatingsBatch = (ids = []) =>
   postData("/artists/release-groups/ratings", { ids });
 
+const RELEASE_GROUP_COVER_BATCH_SIZE = 24;
+
 export const getReleaseGroupTracks = async (mbid, context = {}) => {
   const params = {};
   if (context.artistMbid) params.artistMbid = context.artistMbid;
@@ -103,10 +105,16 @@ export const getReleaseGroupCoversBatch = async (items = []) => {
   if (coverInflightRequests.has(batchKey)) {
     return coverInflightRequests.get(batchKey);
   }
-  const request = postData("/artists/release-groups/covers", {
-    items: normalizedItems,
-  })
-    .then((data) => data?.covers || {})
+  const request = (async () => {
+    const covers = {};
+    for (let index = 0; index < normalizedItems.length; index += RELEASE_GROUP_COVER_BATCH_SIZE) {
+      const data = await postData("/artists/release-groups/covers", {
+        items: normalizedItems.slice(index, index + RELEASE_GROUP_COVER_BATCH_SIZE),
+      });
+      Object.assign(covers, data?.covers || {});
+    }
+    return covers;
+  })()
     .finally(() => {
       coverInflightRequests.delete(batchKey);
     });

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -68,22 +68,29 @@ export const clearCanonicalLibraryPageCache = () => libraryPageCache.clear();
 
 let libraryFavoritesCache = null;
 let libraryFavoritesRequest = null;
+let libraryFavoritesGeneration = 0;
 
 export const getLibraryFavorites = () => {
   const token = getRequestToken();
+  const generation = libraryFavoritesGeneration;
   if (
     libraryFavoritesCache?.token === token &&
+    libraryFavoritesCache?.generation === generation &&
     Date.now() < libraryFavoritesCache.expiresAt
   ) {
     return Promise.resolve(libraryFavoritesCache.data);
   }
-  if (libraryFavoritesRequest?.token === token) return libraryFavoritesRequest.promise;
+  if (
+    libraryFavoritesRequest?.token === token &&
+    libraryFavoritesRequest?.generation === generation
+  ) return libraryFavoritesRequest.promise;
   let promise;
   promise = getData("/library/favorites")
     .then((data) => {
-      if (getRequestToken() === token) {
+      if (getRequestToken() === token && libraryFavoritesGeneration === generation) {
         libraryFavoritesCache = {
           token,
+          generation,
           data,
           expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
         };
@@ -93,21 +100,24 @@ export const getLibraryFavorites = () => {
     .finally(() => {
       if (libraryFavoritesRequest?.promise === promise) libraryFavoritesRequest = null;
     });
-  libraryFavoritesRequest = { token, promise };
+  libraryFavoritesRequest = { token, generation, promise };
   return promise;
 };
 
 export const updateLibraryFavorites = async (ids, starred) => {
   const token = getRequestToken();
+  const generation = ++libraryFavoritesGeneration;
   const data = await postData("/library/favorites", { ids, starred });
-  if (getRequestToken() === token) {
-    libraryFavoritesCache = {
-      token,
-      data,
-      expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
-    };
-  } else {
-    libraryFavoritesCache = null;
+  if (libraryFavoritesGeneration === generation) {
+    libraryFavoritesGeneration += 1;
+    libraryFavoritesCache = getRequestToken() === token
+      ? {
+        token,
+        generation: libraryFavoritesGeneration,
+        data,
+        expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
+      }
+      : null;
   }
   clearCanonicalLibraryPageCache();
   return data;

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -98,12 +98,17 @@ export const getLibraryFavorites = () => {
 };
 
 export const updateLibraryFavorites = async (ids, starred) => {
+  const token = getRequestToken();
   const data = await postData("/library/favorites", { ids, starred });
-  libraryFavoritesCache = {
-    token: getRequestToken(),
-    data,
-    expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
-  };
+  if (getRequestToken() === token) {
+    libraryFavoritesCache = {
+      token,
+      data,
+      expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
+    };
+  } else {
+    libraryFavoritesCache = null;
+  }
   clearCanonicalLibraryPageCache();
   return data;
 };

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -23,6 +23,26 @@ export const getCanonicalLibrary = (options = {}) =>
     signal: options.signal,
   });
 
+export const getCanonicalLibraryPage = (options = {}) =>
+  getData("/library/canonical", {
+    params: Object.fromEntries(
+      Object.entries({
+        kind: options.kind,
+        page: options.page,
+        pageSize: options.pageSize,
+        query: options.query,
+        genre: options.genre,
+        sort: options.sort,
+        direction: options.direction,
+        artistId: options.artistId,
+        albumId: options.albumId,
+        source: options.source || "all",
+        availableOnly: options.availableOnly === true ? "true" : "false",
+      }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
+    ),
+    signal: options.signal,
+  });
+
 export const getLibraryFavorites = (options = {}) =>
   getData("/library/favorites", { signal: options.signal });
 

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -14,6 +14,21 @@ const SLOW_LIBRARY_REQUEST_TIMEOUT_MS = 90000;
 export const getLibraryArtists = (options = {}) =>
   getData("/library/artists", options);
 
+export const getCanonicalLibrary = (options = {}) =>
+  getData("/library/canonical", {
+    params: {
+      source: options.source || "all",
+      availableOnly: options.availableOnly === true ? "true" : "false",
+    },
+    signal: options.signal,
+  });
+
+export const getLibraryFavorites = (options = {}) =>
+  getData("/library/favorites", { signal: options.signal });
+
+export const updateLibraryFavorites = (ids, starred) =>
+  postData("/library/favorites", { ids, starred });
+
 export const getLibraryArtist = async (mbid) => {
   const artist = await getData(`/library/artists/${mbid}`);
   if (artist && !artist.foreignArtistId) {

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -12,6 +12,10 @@ import {
 const buildStreamUrl = (path) => buildAuthenticatedApiUrl(path);
 const SLOW_LIBRARY_REQUEST_TIMEOUT_MS = 90000;
 const LIBRARY_FAVORITES_CACHE_TTL_MS = 30000;
+const LIBRARY_PAGE_CACHE_TTL_MS = 15000;
+const MAX_LIBRARY_PAGE_CACHE_SIZE = 100;
+const libraryPageCache = new Map();
+const libraryPageRequests = new Map();
 
 export const getLibraryArtists = (options = {}) =>
   getData("/library/artists", options);
@@ -25,25 +29,42 @@ export const getCanonicalLibrary = (options = {}) =>
     signal: options.signal,
   });
 
-export const getCanonicalLibraryPage = (options = {}) =>
-  getData("/library/canonical", {
-    params: Object.fromEntries(
-      Object.entries({
-        kind: options.kind,
-        page: options.page,
-        pageSize: options.pageSize,
-        query: options.query,
-        genre: options.genre,
-        sort: options.sort,
-        direction: options.direction,
-        artistId: options.artistId,
-        albumId: options.albumId,
-        source: options.source || "all",
-        availableOnly: options.availableOnly === true ? "true" : "false",
-      }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
-    ),
-    signal: options.signal,
-  });
+export const getCanonicalLibraryPage = (options = {}) => {
+  const params = Object.fromEntries(
+    Object.entries({
+      kind: options.kind,
+      page: options.page,
+      pageSize: options.pageSize,
+      query: options.query,
+      genre: options.genre,
+      sort: options.sort,
+      direction: options.direction,
+      artistId: options.artistId,
+      albumId: options.albumId,
+      source: options.source || "all",
+      availableOnly: options.availableOnly === true ? "true" : "false",
+    }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
+  );
+  const cacheKey = `${getRequestToken()}:${JSON.stringify(params)}`;
+  const cached = libraryPageCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) return Promise.resolve(cached.data);
+  if (cached) libraryPageCache.delete(cacheKey);
+  if (libraryPageRequests.has(cacheKey)) return libraryPageRequests.get(cacheKey);
+  const request = getData("/library/canonical", { params })
+    .then((data) => {
+      libraryPageCache.delete(cacheKey);
+      libraryPageCache.set(cacheKey, { data, expiresAt: Date.now() + LIBRARY_PAGE_CACHE_TTL_MS });
+      if (libraryPageCache.size > MAX_LIBRARY_PAGE_CACHE_SIZE) {
+        libraryPageCache.delete(libraryPageCache.keys().next().value);
+      }
+      return data;
+    })
+    .finally(() => libraryPageRequests.delete(cacheKey));
+  libraryPageRequests.set(cacheKey, request);
+  return request;
+};
+
+export const clearCanonicalLibraryPageCache = () => libraryPageCache.clear();
 
 let libraryFavoritesCache = null;
 let libraryFavoritesRequest = null;
@@ -83,6 +104,7 @@ export const updateLibraryFavorites = async (ids, starred) => {
     data,
     expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
   };
+  clearCanonicalLibraryPageCache();
   return data;
 };
 

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -6,10 +6,12 @@ import {
   libraryLookupCache,
   setLibraryLookupCacheEntry,
   buildAuthenticatedApiUrl,
+  getRequestToken,
 } from "../core.js";
 
 const buildStreamUrl = (path) => buildAuthenticatedApiUrl(path);
 const SLOW_LIBRARY_REQUEST_TIMEOUT_MS = 90000;
+const LIBRARY_FAVORITES_CACHE_TTL_MS = 30000;
 
 export const getLibraryArtists = (options = {}) =>
   getData("/library/artists", options);
@@ -43,11 +45,46 @@ export const getCanonicalLibraryPage = (options = {}) =>
     signal: options.signal,
   });
 
-export const getLibraryFavorites = (options = {}) =>
-  getData("/library/favorites", { signal: options.signal });
+let libraryFavoritesCache = null;
+let libraryFavoritesRequest = null;
 
-export const updateLibraryFavorites = (ids, starred) =>
-  postData("/library/favorites", { ids, starred });
+export const getLibraryFavorites = () => {
+  const token = getRequestToken();
+  if (
+    libraryFavoritesCache?.token === token &&
+    Date.now() < libraryFavoritesCache.expiresAt
+  ) {
+    return Promise.resolve(libraryFavoritesCache.data);
+  }
+  if (libraryFavoritesRequest?.token === token) return libraryFavoritesRequest.promise;
+  let promise;
+  promise = getData("/library/favorites")
+    .then((data) => {
+      if (getRequestToken() === token) {
+        libraryFavoritesCache = {
+          token,
+          data,
+          expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
+        };
+      }
+      return data;
+    })
+    .finally(() => {
+      if (libraryFavoritesRequest?.promise === promise) libraryFavoritesRequest = null;
+    });
+  libraryFavoritesRequest = { token, promise };
+  return promise;
+};
+
+export const updateLibraryFavorites = async (ids, starred) => {
+  const data = await postData("/library/favorites", { ids, starred });
+  libraryFavoritesCache = {
+    token: getRequestToken(),
+    data,
+    expiresAt: Date.now() + LIBRARY_FAVORITES_CACHE_TTL_MS,
+  };
+  return data;
+};
 
 export const getLibraryArtist = async (mbid) => {
   const artist = await getData(`/library/artists/${mbid}`);

--- a/frontend/src/utils/searchNavigation.js
+++ b/frontend/src/utils/searchNavigation.js
@@ -76,7 +76,7 @@ export function buildLibraryAlbumNavigationItem(
   return {
     type: "album",
     id: releaseGroupMbid,
-    title: libraryAlbum.albumName || "",
+    title: libraryAlbum.albumName || libraryAlbum.title || "",
     artistMbid,
     artistName: artistName || libraryAlbum.artistName || "",
     releaseDate: libraryAlbum.releaseDate || "",

--- a/frontend/src/utils/searchNavigation.js
+++ b/frontend/src/utils/searchNavigation.js
@@ -71,7 +71,8 @@ export function buildLibraryAlbumNavigationItem(
   libraryAlbum,
   { artistMbid, artistName, coverUrl = "" } = {},
 ) {
-  const releaseGroupMbid = libraryAlbum?.mbid || libraryAlbum?.foreignAlbumId || null;
+  const releaseGroupMbid =
+    libraryAlbum?.releaseGroupMbid || libraryAlbum?.mbid || libraryAlbum?.foreignAlbumId || null;
   if (!releaseGroupMbid || !artistMbid) return null;
   return {
     type: "album",


### PR DESCRIPTION
The app had canonical playback and library reads, but no first-class Aurral library surface for browsing that music.

This adds the native Library home and child views for favorites, albums, tracks, album artists, artists, and genres. It reuses canonical reads and playback, links artists into discovery pages, adds canonical favorite routes, handles missing and stale media states, and keeps the compact Feishin-inspired search, sort, filter, and view controls.

Verification:
- npm test: 588/588
- canonical favorites route test: 2/2
- frontend lint
- backend lint
- frontend build
- docs build
- git diff --check
- live desktop and mobile preview checks for library routes, search, filtering, and sorting

Known limitation: preview fixtures provide deterministic empty-provider UI data; real artwork remains provider-backed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified Library for browsing artists, albums, tracks, genres, and favorites.
  * Added search, filtering, sorting, pagination, grid/list views, playback, and detail pages.
  * Added favorite management with optimistic updates and favorite indicators.
  * Added album artwork retrieval and improved responsive layouts.
  * Added dedicated library navigation and canonical album and artist pages.

* **Bug Fixes**
  * Improved artwork caching and proxy handling.
  * Prevented stale library data during scans and updates.
  * Hid unavailable quality details where they do not apply.

* **Documentation**
  * Expanded Library documentation with navigation, playback, availability, and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->