### PR TITLE
feat(scrobbling): add local play history and scrobbling

### DIFF
--- a/.tests/auth/listening-history.test.js
+++ b/.tests/auth/listening-history.test.js
@@ -117,7 +117,7 @@ test("legacy lastfm_username still resolves as a lastfm profile", () => {
   assert.equal(stored?.lastfmUsername, "legacybob");
 });
 
-test("resolveListenHistorySettings falls back to integrations default username", () => {
+test("resolveListenHistorySettings does not use a global username", () => {
   const settings = {
     integrations: {
       lastfm: {
@@ -128,9 +128,18 @@ test("resolveListenHistorySettings falls back to integrations default username",
   };
   assert.deepEqual(resolveListenHistorySettings({}, settings), {
     listenHistoryProvider: "lastfm",
-    listenHistoryUsername: "leefamous",
+    listenHistoryUsername: null,
     listenHistoryUrl: null,
-    lastfmUsername: "leefamous",
+    lastfmUsername: null,
+  });
+});
+
+test("local history is a valid profile without an external identity", () => {
+  assert.deepEqual(resolveListenHistorySettings({ listenHistoryProvider: "local" }), {
+    listenHistoryProvider: "local",
+    listenHistoryUsername: null,
+    listenHistoryUrl: null,
+    lastfmUsername: null,
   });
 });
 

--- a/.tests/discovery/discovery-refresh-scheduler.test.js
+++ b/.tests/discovery/discovery-refresh-scheduler.test.js
@@ -18,6 +18,7 @@ const {
   discoveryNeedsRefresh,
   enqueueDiscoveryRefresh,
   markDiscoveryRefreshDequeued,
+  recoverDeadDiscoveryRefresh,
   scheduleNextDiscoveryRefresh,
 } = refreshScheduler;
 const { getDiscoveryCache } = discoveryIndex;
@@ -122,6 +123,30 @@ test("enqueueDiscoveryRefresh treats force as success when already updating", ()
   const result = enqueueDiscoveryRefresh({ reason: "manual", force: true });
   assert.equal(result.enqueued, true);
   assert.equal(result.reason, "already_updating");
+});
+
+test("recoverDeadDiscoveryRefresh clears jobs and locks owned by dead local workers", () => {
+  clearDiscoveryRefreshJobs();
+  const workerId = "aurral-99999999";
+  const lock = honkerDbModule.getHonkerDb().tryLock(
+    "discovery-global-refresh",
+    workerId,
+    3600,
+  );
+  assert.ok(lock);
+  const jobId = honkerDbModule.getDiscoveryRefreshQueue().enqueue({ reason: "manual" });
+  const claimed = honkerDbModule.getDiscoveryRefreshQueue().claimOne(workerId);
+  assert.equal(claimed?.id, jobId);
+
+  assert.equal(recoverDeadDiscoveryRefresh(), true);
+  assert.equal(
+    honkerDbModule.getHonkerDb().query(
+      "SELECT COUNT(*) AS count FROM _honker_live WHERE id = ?",
+      [jobId],
+    )[0]?.count,
+    0,
+  );
+  assert.equal(honkerDbModule.isHonkerLockHeld("discovery-global-refresh"), false);
 });
 
 test("enqueueDiscoveryRefresh deduplicates when refresh queue lock is held", () => {

--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -10,6 +10,7 @@ const repoRoot = join(__dirname, "..", "..");
 
 const RESET_TABLES = [
   "sessions",
+  "lastfm_link_states",
   "subsonic_stars",
   "play_events",
   "honker_task_runs",

--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -11,6 +11,7 @@ const repoRoot = join(__dirname, "..", "..");
 const RESET_TABLES = [
   "sessions",
   "subsonic_stars",
+  "play_events",
   "honker_task_runs",
   "slskd_transfer_history",
   "playlist_download_jobs",

--- a/.tests/history/play-events.test.js
+++ b/.tests/history/play-events.test.js
@@ -7,9 +7,11 @@ import {
   setupIsolatedBackend,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, playEvents] = await setupIsolatedBackend(
+const [isolatedState, playEvents, scrobbleStore, honkerDbModule] = await setupIsolatedBackend(
   "play-events",
   "backend/services/playEventService.js",
+  "backend/services/scrobbleConnectionStore.js",
+  "backend/services/honkerDb.js",
 );
 const { db } = await import("../../backend/config/db-sqlite.js");
 
@@ -46,4 +48,24 @@ test("records local plays and aggregates artists without provider access", () =>
     playcount: 2,
     lastPlayedAt: 1700000001000,
   });
+});
+
+test("pins each scrobble delivery to the connection active when the play was recorded", () => {
+  const userId = db.prepare("SELECT id FROM users WHERE username = ?").get("listener").id;
+  const connection = scrobbleStore.scrobbleConnectionStore.saveConnection(userId, "lastfm", {
+    token: "session-token",
+    displayName: "listener",
+  });
+  const event = playEvents.recordPlayEvent(userId, {
+    trackId: "song:one",
+    title: "One",
+    artist: "Artist A",
+  });
+  const row = honkerDbModule.getHonkerDb().query(
+    "SELECT payload FROM _honker_live WHERE queue = ?",
+    ["_outbox:play-events"],
+  )[0];
+
+  assert.equal(JSON.parse(row.payload).eventId, event.id);
+  assert.equal(JSON.parse(row.payload).connectionRevision, connection.connectionRevision);
 });

--- a/.tests/history/play-events.test.js
+++ b/.tests/history/play-events.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, playEvents] = await setupIsolatedBackend(
+  "play-events",
+  "backend/services/playEventService.js",
+);
+const { db } = await import("../../backend/config/db-sqlite.js");
+
+test.beforeEach(() => {
+  resetDatabase(db);
+  db.prepare("INSERT INTO users (username, password_hash) VALUES (?, ?)").run("listener", "test");
+});
+
+test.after(async () => cleanupIsolatedState(isolatedState));
+
+test("records local plays and aggregates artists without provider access", () => {
+  const first = playEvents.recordPlayEvent(1, {
+    trackId: "song:one",
+    title: "One",
+    artist: "Artist A",
+    album: "Album",
+    durationMs: 180000,
+    playedAt: 1700000000,
+    source: "subsonic",
+  });
+  playEvents.recordPlayEvent(1, {
+    trackId: "song:two",
+    title: "Two",
+    artist: "Artist A",
+    playedAt: 1700000001,
+    source: "native-player",
+  });
+
+  assert.equal(first.playedAt, 1700000000000);
+  assert.equal(playEvents.getPlayHistory(1).length, 2);
+  assert.deepEqual(playEvents.getTopPlayedArtists(1)[0], {
+    artistName: "Artist A",
+    mbid: null,
+    playcount: 2,
+    lastPlayedAt: 1700000001000,
+  });
+});

--- a/.tests/scrobbling/callback.test.js
+++ b/.tests/scrobbling/callback.test.js
@@ -3,14 +3,14 @@ import test from "node:test";
 
 import { callbackUrl } from "../../backend/routes/scrobbling.js";
 
-test("Last.fm callback uses the forwarded host and preserves signed state", () => {
+test("Last.fm callback uses the request host and preserves signed state", () => {
   const request = {
     protocol: "http",
     get(name) {
       return {
-        host: "localhost:3001",
-        "x-forwarded-host": "192.168.4.115:3009",
-        "x-forwarded-proto": "http",
+        host: "192.168.4.115:3009",
+        "x-forwarded-host": "attacker.example",
+        "x-forwarded-proto": "https",
       }[String(name).toLowerCase()] || undefined;
     },
   };

--- a/.tests/scrobbling/callback.test.js
+++ b/.tests/scrobbling/callback.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { callbackUrl } from "../../backend/routes/scrobbling.js";
 
-test("Last.fm callback uses the forwarded public host", () => {
+test("Last.fm callback uses the forwarded host and preserves signed state", () => {
   const request = {
     protocol: "http",
     get(name) {
@@ -15,8 +15,8 @@ test("Last.fm callback uses the forwarded public host", () => {
     },
   };
 
-  assert.equal(
-    new URL(callbackUrl(request, "state-token")).origin,
-    "http://192.168.4.115:3009",
-  );
+  const callback = new URL(callbackUrl(request, "encoded-payload.signature"));
+
+  assert.equal(callback.origin, "http://192.168.4.115:3009");
+  assert.equal(callback.searchParams.get("uid"), "encoded-payload.signature");
 });

--- a/.tests/scrobbling/callback.test.js
+++ b/.tests/scrobbling/callback.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { callbackUrl } from "../../backend/routes/scrobbling.js";
+
+test("Last.fm callback uses the forwarded public host", () => {
+  const request = {
+    protocol: "http",
+    get(name) {
+      return {
+        host: "localhost:3001",
+        "x-forwarded-host": "192.168.4.115:3009",
+        "x-forwarded-proto": "http",
+      }[String(name).toLowerCase()] || undefined;
+    },
+  };
+
+  assert.equal(
+    new URL(callbackUrl(request, "state-token")).origin,
+    "http://192.168.4.115:3009",
+  );
+});

--- a/.tests/scrobbling/callback.test.js
+++ b/.tests/scrobbling/callback.test.js
@@ -20,3 +20,15 @@ test("Last.fm callback uses the request host and preserves signed state", () => 
   assert.equal(callback.origin, "http://192.168.4.115:3009");
   assert.equal(callback.searchParams.get("uid"), "encoded-payload.signature");
 });
+
+test("Last.fm callback uses the configured public origin when available", () => {
+  const previous = process.env.AURRAL_PUBLIC_URL;
+  process.env.AURRAL_PUBLIC_URL = "https://aurral.example.com";
+  try {
+    const callback = new URL(callbackUrl({ protocol: "http", get: () => "attacker.example" }, "state"));
+    assert.equal(callback.origin, "https://aurral.example.com");
+  } finally {
+    if (previous === undefined) delete process.env.AURRAL_PUBLIC_URL;
+    else process.env.AURRAL_PUBLIC_URL = previous;
+  }
+});

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -40,7 +40,7 @@ export const defaultData = {
       },
       lastfm: {
         apiKey: "",
-        username: "",
+        apiSecret: "",
         discoveryPeriod: "1month",
         discoveryAutoRefreshHours: 168,
         discoveryRecommendationsPerRefresh: 200,

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -76,6 +76,19 @@ db.exec(`
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   );
 
+  CREATE TABLE IF NOT EXISTS lastfm_link_states (
+    token_hash TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    browser_nonce_hash TEXT NOT NULL,
+    expires_at INTEGER NOT NULL,
+    consumed_at INTEGER,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_lastfm_link_states_expiry
+    ON lastfm_link_states(expires_at);
+
   CREATE TABLE IF NOT EXISTS subsonic_stars (
     user_id INTEGER NOT NULL,
     entity_kind TEXT NOT NULL,

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -85,6 +85,26 @@ db.exec(`
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   );
 
+  CREATE TABLE IF NOT EXISTS play_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    track_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    artist TEXT NOT NULL,
+    album TEXT,
+    artist_mbid TEXT,
+    album_mbid TEXT,
+    track_mbid TEXT,
+    duration_ms INTEGER,
+    played_at INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_play_events_user_played_at
+    ON play_events(user_id, played_at DESC);
+
   CREATE TABLE IF NOT EXISTS playlist_download_jobs (
     id TEXT PRIMARY KEY,
     artist_name TEXT NOT NULL,

--- a/backend/config/encryption.js
+++ b/backend/config/encryption.js
@@ -47,6 +47,7 @@ const SENSITIVE_PATHS = [
   ["nzbget", "password"],
   ["gotify", "token"],
   ["lastfm", "apiKey"],
+  ["lastfm", "apiSecret"],
 ];
 
 function getAt(obj, path) {

--- a/backend/db/helpers/users.js
+++ b/backend/db/helpers/users.js
@@ -183,7 +183,7 @@ export const userOps = {
         : existing.listenHistoryUrl,
     );
     const resolvedUsername =
-      listenHistoryProvider === "koito" ? null : listenHistoryUsername;
+      ["koito", "local"].includes(listenHistoryProvider) ? null : listenHistoryUsername;
     const resolvedUrl =
       listenHistoryProvider === "koito" ? listenHistoryUrl : null;
     const lastfmUsername =

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,7 +1,6 @@
 import crypto from "crypto";
 import os from "os";
 import { dbOps, userOps } from "../db/helpers/index.js";
-import { getDefaultListenHistoryProfile } from "../services/listeningHistory.js";
 import { createSession, getSessionByToken } from "../config/session-helpers.js";
 import { hashPassword, verifyPassword, needsRehash } from "./passwordHash.js";
 
@@ -510,11 +509,7 @@ function migrateLegacyAdmin() {
   const authPassword = settings.integrations?.general?.authPassword;
   if (!onboardingComplete || !authPassword) return;
   const hash = hashPassword(authPassword);
-  const created = userOps.createUser(authUser, hash, "admin", null);
-  const initialListenHistory = getDefaultListenHistoryProfile(settings);
-  if (created && initialListenHistory) {
-    userOps.updateUser(created.id, initialListenHistory);
-  }
+  userOps.createUser(authUser, hash, "admin", null);
 }
 
 export function resolveUser(username, password) {
@@ -682,6 +677,7 @@ export const authMiddleware = (req, res, next) => {
       req.path === "/api/auth/login" ||
       req.path === "/api/auth/oidc/login" ||
       req.path === "/api/auth/oidc/exchange"
+      || (req.method === "GET" && req.path === "/api/scrobbling/lastfm/link/callback")
     ) {
       return next();
     }

--- a/backend/routes/discovery/handlers/admin.js
+++ b/backend/routes/discovery/handlers/admin.js
@@ -17,7 +17,7 @@ export function registerAdmin(router) {
       reason: "manual",
       force: true,
     });
-    if (!result.enqueued) {
+    if (!result.enqueued || result.reason === "already_updating") {
       return res.status(409).json({
         message: "Discovery update already in progress",
         isUpdating: true,

--- a/backend/routes/onboarding.js
+++ b/backend/routes/onboarding.js
@@ -1,7 +1,6 @@
 import express from "express";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hashPassword } from "../middleware/passwordHash.js";
-import { getDefaultListenHistoryProfile } from "../services/listeningHistory.js";
 import { defaultData } from "../config/constants.js";
 import { requirePasswordStrength, reconcileLocalNetworkBypassSetting } from "../middleware/auth.js";
 import { validateDownloadFolderPath } from "../services/downloadFolderConfig.js";
@@ -180,11 +179,7 @@ router.post("/complete", async (req, res) => {
     const authPasswordFinal = integrations?.general?.authPassword || "";
     if (authPasswordFinal && userOps.getAllUsers().length === 0) {
       const hash = hashPassword(authPasswordFinal);
-      const created = userOps.createUser(authUserFinal, hash, "admin", null);
-      const initialListenHistory = getDefaultListenHistoryProfile(nextSettings);
-      if (created && initialListenHistory) {
-        userOps.updateUser(created.id, initialListenHistory);
-      }
+      userOps.createUser(authUserFinal, hash, "admin", null);
     }
 
     reconcileLocalNetworkBypassSetting();

--- a/backend/routes/playEvents.js
+++ b/backend/routes/playEvents.js
@@ -1,0 +1,20 @@
+import express from "express";
+import { requireAuth } from "../middleware/requirePermission.js";
+import { getPlayHistory, recordPlayEvent } from "../services/playEventService.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+router.get("/", (req, res) => {
+  res.json({ events: getPlayHistory(req.user.id, req.query) });
+});
+
+router.post("/", (req, res) => {
+  try {
+    res.status(201).json({ event: recordPlayEvent(req.user.id, req.body) });
+  } catch (error) {
+    res.status(400).json({ error: error.message || "Could not record play event" });
+  }
+});
+
+export default router;

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -31,7 +31,7 @@ const verifyLinkToken = (token) => {
 export const callbackUrl = (req, token) => {
   const protocol = String(req.get("x-forwarded-proto") || req.protocol).split(",")[0].trim();
   const host = String(req.get("x-forwarded-host") || req.get("host")).split(",")[0].trim();
-  return `${protocol}://${host}/api/scrobbling/lastfm/link/callback?uid=${encode(token)}`;
+  return `${protocol}://${host}/api/scrobbling/lastfm/link/callback?uid=${encodeURIComponent(token)}`;
 };
 
 router.get("/status", requireAuth, (req, res) => {

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -1,15 +1,39 @@
 import express from "express";
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { db } from "../config/db-sqlite.js";
 import { getLastfmApiKey, getLastfmApiSecret, lastfmGetSession, listenbrainzValidateToken } from "../services/apiClients/index.js";
 import { userOps } from "../db/helpers/index.js";
-import { requireAuth } from "../middleware/requirePermission.js";
+import { requireAuth, requirePermission } from "../middleware/requirePermission.js";
 import { validateExternalUrl } from "../middleware/urlValidator.js";
-import { normalizeKoitoBaseUrl } from "../services/koitoClient.js";
+import { getKoitoListenBrainzBaseUrl, normalizeKoitoBaseUrl } from "../services/koitoClient.js";
 import { getScrobbleEncryptionKey, scrobbleConnectionStore } from "../services/scrobbleConnectionStore.js";
+import { logger } from "../services/logger.js";
 
 const router = express.Router();
+const LASTFM_LINK_COOKIE = "aurral_lastfm_link";
+const LASTFM_LINK_TTL_MS = 10 * 60 * 1000;
+const providerErrorStatus = (error) => {
+  const status = Number(error?.response?.status);
+  return status >= 400 && status < 500 ? 400 : 502;
+};
 const encode = (value) => Buffer.from(value).toString("base64url");
 const decode = (value) => Buffer.from(String(value || ""), "base64url").toString("utf8");
+const hash = (value) => createHash("sha256").update(String(value || "")).digest("hex");
+
+const insertLinkStateStmt = db.prepare(`
+  INSERT INTO lastfm_link_states
+    (token_hash, user_id, browser_nonce_hash, expires_at, created_at)
+  VALUES (?, ?, ?, ?, ?)
+`);
+const pruneLinkStatesStmt = db.prepare(
+  "DELETE FROM lastfm_link_states WHERE expires_at <= ? OR consumed_at IS NOT NULL",
+);
+const consumeLinkStateStmt = db.prepare(`
+  UPDATE lastfm_link_states
+  SET consumed_at = ?
+  WHERE token_hash = ? AND user_id = ? AND browser_nonce_hash = ?
+    AND expires_at > ? AND consumed_at IS NULL
+`);
 
 const createLinkToken = (userId) => {
   const payload = `${userId}.${Date.now() + 10 * 60 * 1000}.${randomBytes(12).toString("hex")}`;
@@ -28,9 +52,60 @@ const verifyLinkToken = (token) => {
   return Math.trunc(Number(userId));
 };
 
+const createLinkState = (userId) => {
+  const token = createLinkToken(userId);
+  const browserNonce = randomBytes(32).toString("base64url");
+  const expiresAt = Date.now() + LASTFM_LINK_TTL_MS;
+  db.transaction(() => {
+    pruneLinkStatesStmt.run(Date.now());
+    insertLinkStateStmt.run(hash(token), userId, hash(browserNonce), expiresAt, Date.now());
+  })();
+  return { token, browserNonce };
+};
+
+export const consumeLinkState = (token, userId, browserNonce) => {
+  if (!token || !Number.isFinite(Number(userId)) || !browserNonce) return false;
+  return consumeLinkStateStmt.run(
+    Date.now(),
+    hash(token),
+    Math.trunc(Number(userId)),
+    hash(browserNonce),
+    Date.now(),
+  ).changes === 1;
+};
+
+const readCookie = (header, name) => {
+  const entry = String(header || "")
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${name}=`));
+  if (!entry) return "";
+  try {
+    return decodeURIComponent(entry.slice(name.length + 1));
+  } catch {
+    return "";
+  }
+};
+
+const setLinkCookie = (res, req, value, maxAge = Math.floor(LASTFM_LINK_TTL_MS / 1000)) => {
+  const attributes = [
+    "Path=/api/scrobbling/lastfm/link/callback",
+    `Max-Age=${Math.max(0, Math.trunc(maxAge))}`,
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (req.protocol === "https") attributes.push("Secure");
+  res.setHeader("Set-Cookie", `${LASTFM_LINK_COOKIE}=${encodeURIComponent(value)}; ${attributes.join("; ")}`);
+};
+
+const normalizeLinkToken = (value) => {
+  const token = String(value || "").trim();
+  return token.includes(".") ? token : decode(token);
+};
+
 export const callbackUrl = (req, token) => {
-  const protocol = String(req.get("x-forwarded-proto") || req.protocol).split(",")[0].trim();
-  const host = String(req.get("x-forwarded-host") || req.get("host")).split(",")[0].trim();
+  const protocol = String(req.protocol || "http").trim();
+  const host = String(req.get("host") || "").trim();
   return `${protocol}://${host}/api/scrobbling/lastfm/link/callback?uid=${encodeURIComponent(token)}`;
 };
 
@@ -45,7 +120,8 @@ router.get("/lastfm/link", requireAuth, (req, res) => {
   if (!configured) {
     return res.status(400).json({ error: "Last.fm API key and secret are required first." });
   }
-  const token = createLinkToken(req.user.id);
+  const { token, browserNonce } = createLinkState(req.user.id);
+  setLinkCookie(res, req, browserNonce);
   res.json({
     configured: true,
     connected: scrobbleConnectionStore.getConnection(req.user.id, "lastfm") != null,
@@ -54,22 +130,61 @@ router.get("/lastfm/link", requireAuth, (req, res) => {
 });
 
 router.get("/lastfm/link/callback", async (req, res) => {
+  res.setHeader("Cache-Control", "no-store");
+  const clearCookie = () => setLinkCookie(res, req, "", 0);
+  const stateToken = normalizeLinkToken(req.query.uid);
+  const token = String(req.query.token || "").trim();
+  if (!stateToken || !token) {
+    clearCookie();
+    return res.status(400).send("Invalid Last.fm link state");
+  }
+
+  let userId;
   try {
-    const userId = verifyLinkToken(req.query.uid);
-    const token = String(req.query.token || "").trim();
-    if (!userId) return res.status(400).send("Invalid Last.fm link state");
-    if (!token) return res.status(400).send("Last.fm did not return an authorization token");
-    const session = await lastfmGetSession(token);
-    const key = session?.session?.key;
-    if (!key) return res.status(400).send("Last.fm did not return a session");
+    userId = verifyLinkToken(stateToken);
+  } catch (error) {
+    logger.error("scrobbling", "Last.fm link state verification failed", {
+      message: error?.message || String(error),
+    });
+    clearCookie();
+    return res.status(500).send("Last.fm connection failed");
+  }
+  if (userId == null || !consumeLinkState(stateToken, userId, readCookie(req.headers.cookie, LASTFM_LINK_COOKIE))) {
+    clearCookie();
+    return res.status(400).send("Invalid Last.fm link state");
+  }
+
+  let session;
+  try {
+    session = await lastfmGetSession(token);
+  } catch (error) {
+    logger.error("scrobbling", "Last.fm session exchange failed", {
+      message: error?.message || String(error),
+      status: error?.response?.status || null,
+    });
+    clearCookie();
+    const status = providerErrorStatus(error);
+    return res.status(status).send(status === 400 ? "Last.fm authorization failed" : "Last.fm is unavailable");
+  }
+  const key = session?.session?.key;
+  if (!key) {
+    clearCookie();
+    return res.status(400).send("Last.fm did not return a session");
+  }
+  try {
     scrobbleConnectionStore.saveConnection(userId, "lastfm", {
       token: key,
       displayName: session.session.name,
     });
-    return res.type("html").send("<p>Last.fm connected. You can close this window.</p>");
-  } catch {
-    return res.status(400).send("Last.fm connection failed");
+  } catch (error) {
+    logger.error("scrobbling", "Last.fm connection could not be saved", {
+      message: error?.message || String(error),
+    });
+    clearCookie();
+    return res.status(500).send("Last.fm connection could not be saved");
   }
+  clearCookie();
+  return res.type("html").send("<p>Last.fm connected. You can close this window.</p>");
 });
 
 router.delete("/lastfm/link", requireAuth, (req, res) => {
@@ -83,18 +198,32 @@ router.get("/listenbrainz/link", requireAuth, (req, res) => {
 });
 
 router.put("/listenbrainz/link", requireAuth, async (req, res) => {
+  const token = String(req.body?.token || "").trim();
+  if (!token) return res.status(400).json({ error: "Token is required" });
+  let validation;
   try {
-    const token = String(req.body?.token || "").trim();
-    if (!token) return res.status(400).json({ error: "Token is required" });
-    const validation = await listenbrainzValidateToken(token);
-    if (!validation?.valid) return res.status(400).json({ error: "Invalid token" });
+    validation = await listenbrainzValidateToken(token);
+  } catch (error) {
+    logger.warn("scrobbling", "ListenBrainz token validation failed", {
+      message: error?.message || String(error),
+      status: error?.response?.status || null,
+    });
+    return res.status(providerErrorStatus(error)).json({
+      error: providerErrorStatus(error) === 400 ? "Invalid token" : "ListenBrainz is unavailable",
+    });
+  }
+  if (!validation?.valid) return res.status(400).json({ error: "Invalid token" });
+  try {
     const connection = scrobbleConnectionStore.saveConnection(req.user.id, "listenbrainz", {
       token,
       displayName: validation.user_name,
     });
     return res.json({ connected: true, displayName: connection.displayName });
   } catch (error) {
-    return res.status(400).json({ error: error.message || "Could not validate token" });
+    logger.error("scrobbling", "ListenBrainz connection could not be saved", {
+      message: error?.message || String(error),
+    });
+    return res.status(500).json({ error: "ListenBrainz connection could not be saved" });
   }
 });
 
@@ -103,17 +232,39 @@ router.delete("/listenbrainz/link", requireAuth, (req, res) => {
   res.status(204).end();
 });
 
-router.put("/koito/link", requireAuth, (req, res) => {
+router.put("/koito/link", requirePermission("accessSettings"), async (req, res) => {
   const rawUrl = String(req.body?.url || userOps.getUserById(req.user.id)?.listenHistoryUrl || "").trim();
   const validation = validateExternalUrl(rawUrl);
   const token = String(req.body?.token || "").trim();
   if (!validation.valid || !token) return res.status(400).json({ error: validation.error || "Token is required" });
-  const connection = scrobbleConnectionStore.saveConnection(req.user.id, "koito", {
-    token,
-    baseUrl: normalizeKoitoBaseUrl(validation.url),
-    displayName: normalizeKoitoBaseUrl(validation.url),
-  });
-  res.json({ connected: true, displayName: connection.displayName });
+  const baseUrl = normalizeKoitoBaseUrl(validation.url);
+  try {
+    const tokenValidation = await listenbrainzValidateToken(
+      token,
+      getKoitoListenBrainzBaseUrl(baseUrl),
+    );
+    if (!tokenValidation?.valid) return res.status(400).json({ error: "Invalid Koito API key" });
+  } catch (error) {
+    logger.warn("scrobbling", "Koito token validation failed", {
+      message: error?.message || String(error),
+      status: error?.response?.status || null,
+    });
+    const status = providerErrorStatus(error);
+    return res.status(status).json({ error: status === 400 ? "Invalid Koito API key" : "Koito is unavailable" });
+  }
+  try {
+    const connection = scrobbleConnectionStore.saveConnection(req.user.id, "koito", {
+      token,
+      baseUrl,
+      displayName: new URL(baseUrl).host,
+    });
+    return res.json({ connected: true, displayName: connection.displayName });
+  } catch (error) {
+    logger.error("scrobbling", "Koito connection could not be saved", {
+      message: error?.message || String(error),
+    });
+    return res.status(500).json({ error: "Koito connection could not be saved" });
+  }
 });
 
 router.delete("/koito/link", requireAuth, (req, res) => {

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -1,0 +1,122 @@
+import express from "express";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { getLastfmApiKey, getLastfmApiSecret, lastfmGetSession, listenbrainzValidateToken } from "../services/apiClients/index.js";
+import { userOps } from "../db/helpers/index.js";
+import { requireAuth } from "../middleware/requirePermission.js";
+import { validateExternalUrl } from "../middleware/urlValidator.js";
+import { normalizeKoitoBaseUrl } from "../services/koitoClient.js";
+import { getScrobbleEncryptionKey, scrobbleConnectionStore } from "../services/scrobbleConnectionStore.js";
+
+const router = express.Router();
+const encode = (value) => Buffer.from(value).toString("base64url");
+const decode = (value) => Buffer.from(String(value || ""), "base64url").toString("utf8");
+
+const createLinkToken = (userId) => {
+  const payload = `${userId}.${Date.now() + 10 * 60 * 1000}.${randomBytes(12).toString("hex")}`;
+  const signature = createHmac("sha256", getScrobbleEncryptionKey()).update(payload).digest("base64url");
+  return `${encode(payload)}.${signature}`;
+};
+
+const verifyLinkToken = (token) => {
+  const [encodedPayload, signature] = String(token || "").split(".");
+  if (!encodedPayload || !signature) return null;
+  const payload = decode(encodedPayload);
+  const expected = createHmac("sha256", getScrobbleEncryptionKey()).update(payload).digest("base64url");
+  if (signature.length !== expected.length || !timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
+  const [userId, expiresAt] = payload.split(".");
+  if (!Number.isFinite(Number(userId)) || Number(expiresAt) <= Date.now()) return null;
+  return Math.trunc(Number(userId));
+};
+
+const callbackUrl = (req, token) => {
+  const protocol = String(req.get("x-forwarded-proto") || req.protocol).split(",")[0].trim();
+  return `${protocol}://${req.get("host")}/api/scrobbling/lastfm/link/callback?uid=${encode(token)}`;
+};
+
+router.get("/status", requireAuth, (req, res) => {
+  const status = scrobbleConnectionStore.getPublicStatus(req.user.id);
+  status.lastfm.configured = Boolean(getLastfmApiKey() && getLastfmApiSecret());
+  res.json(status);
+});
+
+router.get("/lastfm/link", requireAuth, (req, res) => {
+  const configured = Boolean(getLastfmApiKey() && getLastfmApiSecret());
+  if (!configured) {
+    return res.status(400).json({ error: "Last.fm API key and secret are required first." });
+  }
+  const token = createLinkToken(req.user.id);
+  res.json({
+    configured: true,
+    connected: scrobbleConnectionStore.getConnection(req.user.id, "lastfm") != null,
+    authorizeUrl: `https://www.last.fm/api/auth/?api_key=${encodeURIComponent(getLastfmApiKey())}&cb=${encodeURIComponent(callbackUrl(req, token))}`,
+  });
+});
+
+router.get("/lastfm/link/callback", async (req, res) => {
+  try {
+    const userId = verifyLinkToken(req.query.uid);
+    const token = String(req.query.token || "").trim();
+    if (!userId || !token) return res.status(400).send("Invalid Last.fm link request");
+    const session = await lastfmGetSession(token);
+    const key = session?.session?.key;
+    if (!key) return res.status(400).send("Last.fm did not return a session");
+    scrobbleConnectionStore.saveConnection(userId, "lastfm", {
+      token: key,
+      displayName: session.session.name,
+    });
+    return res.type("html").send("<p>Last.fm connected. You can close this window.</p>");
+  } catch {
+    return res.status(400).send("Last.fm connection failed");
+  }
+});
+
+router.delete("/lastfm/link", requireAuth, (req, res) => {
+  scrobbleConnectionStore.deleteConnection(req.user.id, "lastfm");
+  res.status(204).end();
+});
+
+router.get("/listenbrainz/link", requireAuth, (req, res) => {
+  const connection = scrobbleConnectionStore.getConnection(req.user.id, "listenbrainz");
+  res.json({ connected: Boolean(connection), displayName: connection?.displayName || null });
+});
+
+router.put("/listenbrainz/link", requireAuth, async (req, res) => {
+  try {
+    const token = String(req.body?.token || "").trim();
+    if (!token) return res.status(400).json({ error: "Token is required" });
+    const validation = await listenbrainzValidateToken(token);
+    if (!validation?.valid) return res.status(400).json({ error: "Invalid token" });
+    const connection = scrobbleConnectionStore.saveConnection(req.user.id, "listenbrainz", {
+      token,
+      displayName: validation.user_name,
+    });
+    return res.json({ connected: true, displayName: connection.displayName });
+  } catch (error) {
+    return res.status(400).json({ error: error.message || "Could not validate token" });
+  }
+});
+
+router.delete("/listenbrainz/link", requireAuth, (req, res) => {
+  scrobbleConnectionStore.deleteConnection(req.user.id, "listenbrainz");
+  res.status(204).end();
+});
+
+router.put("/koito/link", requireAuth, (req, res) => {
+  const rawUrl = String(req.body?.url || userOps.getUserById(req.user.id)?.listenHistoryUrl || "").trim();
+  const validation = validateExternalUrl(rawUrl);
+  const token = String(req.body?.token || "").trim();
+  if (!validation.valid || !token) return res.status(400).json({ error: validation.error || "Token is required" });
+  const connection = scrobbleConnectionStore.saveConnection(req.user.id, "koito", {
+    token,
+    baseUrl: normalizeKoitoBaseUrl(validation.url),
+    displayName: normalizeKoitoBaseUrl(validation.url),
+  });
+  res.json({ connected: true, displayName: connection.displayName });
+});
+
+router.delete("/koito/link", requireAuth, (req, res) => {
+  scrobbleConnectionStore.deleteConnection(req.user.id, "koito");
+  res.status(204).end();
+});
+
+export default router;

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -95,7 +95,7 @@ const setLinkCookie = (res, req, value, maxAge = Math.floor(LASTFM_LINK_TTL_MS /
     "SameSite=Lax",
   ];
   if (req.protocol === "https") attributes.push("Secure");
-  res.setHeader("Set-Cookie", `${LASTFM_LINK_COOKIE}=${encodeURIComponent(value)}; ${attributes.join("; ")}`);
+  res.append("Set-Cookie", `${LASTFM_LINK_COOKIE}=${encodeURIComponent(value)}; ${attributes.join("; ")}`);
 };
 
 const normalizeLinkToken = (value) => {
@@ -104,6 +104,15 @@ const normalizeLinkToken = (value) => {
 };
 
 export const callbackUrl = (req, token) => {
+  const configuredOrigin = String(process.env.AURRAL_PUBLIC_URL || "").trim();
+  if (configuredOrigin) {
+    try {
+      const url = new URL(configuredOrigin);
+      if (["http:", "https:"].includes(url.protocol) && !url.username && !url.password) {
+        return `${url.origin}/api/scrobbling/lastfm/link/callback?uid=${encodeURIComponent(token)}`;
+      }
+    } catch {}
+  }
   const protocol = String(req.protocol || "http").trim();
   const host = String(req.get("host") || "").trim();
   return `${protocol}://${host}/api/scrobbling/lastfm/link/callback?uid=${encodeURIComponent(token)}`;

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -28,9 +28,10 @@ const verifyLinkToken = (token) => {
   return Math.trunc(Number(userId));
 };
 
-const callbackUrl = (req, token) => {
+export const callbackUrl = (req, token) => {
   const protocol = String(req.get("x-forwarded-proto") || req.protocol).split(",")[0].trim();
-  return `${protocol}://${req.get("host")}/api/scrobbling/lastfm/link/callback?uid=${encode(token)}`;
+  const host = String(req.get("x-forwarded-host") || req.get("host")).split(",")[0].trim();
+  return `${protocol}://${host}/api/scrobbling/lastfm/link/callback?uid=${encode(token)}`;
 };
 
 router.get("/status", requireAuth, (req, res) => {
@@ -56,7 +57,8 @@ router.get("/lastfm/link/callback", async (req, res) => {
   try {
     const userId = verifyLinkToken(req.query.uid);
     const token = String(req.query.token || "").trim();
-    if (!userId || !token) return res.status(400).send("Invalid Last.fm link request");
+    if (!userId) return res.status(400).send("Invalid Last.fm link state");
+    if (!token) return res.status(400).send("Last.fm did not return an authorization token");
     const session = await lastfmGetSession(token);
     const key = session?.session?.key;
     if (!key) return res.status(400).send("Last.fm did not return a session");

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -24,6 +24,7 @@ import {
   starMany,
   unstarMany,
 } from "../services/subsonicLibraryService.js";
+import { recordPlayEvent } from "../services/playEventService.js";
 
 const SUBSONIC_VERSION = "1.16.1";
 const SUBSONIC_NAMESPACE = "http://subsonic.org/restapi";
@@ -186,7 +187,14 @@ async function handleSubsonicRequest(req, res) {
       ? null
       : resolveUser(getParameter(req, "u"), decodedPassword)
     : resolveSubsonicTokenUser(getParameter(req, "u"), token, salt);
-  if (!user) return sendError(res, format, 40, "Wrong username or password");
+  if (!user) {
+    return sendError(
+      res,
+      format,
+      token && salt ? 41 : 40,
+      token && salt ? "Token authentication failed" : "Wrong username or password",
+    );
+  }
   req.user = user;
 
   const method = String(req.params.method || "").replace(/\.view$/i, "").toLowerCase();
@@ -204,7 +212,7 @@ async function handleSubsonicRequest(req, res) {
         jukeboxRole: false,
         playlistRole: Boolean(req.user.permissions?.accessFlow),
         podcastRole: false,
-        scrobblingEnabled: false,
+        scrobblingEnabled: true,
         settingsRole: isAdmin,
         shareRole: false,
         streamRole: true,
@@ -212,6 +220,28 @@ async function handleSubsonicRequest(req, res) {
         videoConversionRole: false,
       },
     });
+  }
+  if (method === "scrobble") {
+    const ids = getParameters(req, ["id"]);
+    if (ids.length === 0) return sendError(res, format, 10, "Required parameter is missing: id");
+    const times = getParameters(req, ["time"]);
+    const submission = !["false", "0", "no"].includes(getParameter(req, "submission").toLowerCase());
+    if (submission) {
+      ids.forEach((id, index) => {
+        const song = getSong(id, user);
+        if (!song) return;
+        recordPlayEvent(user.id, {
+          trackId: song.id,
+          title: song.title,
+          artist: song.artist,
+          album: song.album,
+          durationMs: Number(song.duration || 0) * 1000,
+          playedAt: times[index] || undefined,
+          source: "subsonic",
+        });
+      });
+    }
+    return sendResponse(res, format);
   }
   if (method === "getlicense") {
     return sendResponse(res, format, "ok", null, { license: { valid: true } });

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -191,8 +191,8 @@ async function handleSubsonicRequest(req, res) {
     return sendError(
       res,
       format,
-      token && salt ? 41 : 40,
-      token && salt ? "Token authentication failed" : "Wrong username or password",
+      password ? 40 : 41,
+      password ? "Wrong username or password" : "Token authentication failed",
     );
   }
   req.user = user;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -43,6 +43,14 @@ const buildListenHistoryUpdates = (body, existing) => {
         : existing.listenHistoryProvider,
   );
 
+  if (provider === "local") {
+    return {
+      listenHistoryProvider: "local",
+      listenHistoryUsername: null,
+      listenHistoryUrl: null,
+    };
+  }
+
   if (provider === "koito") {
     const rawUrl = hasListenHistoryUrlUpdate ? body.listenHistoryUrl : existing.listenHistoryUrl;
     const trimmedUrl = normalizeListenHistoryUrl(rawUrl);

--- a/backend/server.js
+++ b/backend/server.js
@@ -39,6 +39,8 @@ import lidarrFeedRouter from "./routes/lidarrFeed.js";
 import inboxRouter from "./routes/inbox.js";
 import newsRouter from "./routes/news.js";
 import subsonicRouter from "./routes/subsonic.js";
+import scrobblingRouter from "./routes/scrobbling.js";
+import playEventsRouter from "./routes/playEvents.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -217,6 +219,8 @@ app.use("/api/weekly-flow", (req, res) => {
   res.redirect(308, target);
 });
 app.use("/api/auth", authRouter);
+app.use("/api/scrobbling", scrobblingRouter);
+app.use("/api/play-events", playEventsRouter);
 app.use("/api/image-proxy", imageProxyRouter);
 app.use("/rest", subsonicRouter);
 

--- a/backend/services/apiClients/config.js
+++ b/backend/services/apiClients/config.js
@@ -8,6 +8,11 @@ export const getLastfmApiKey = () => {
   return settings.integrations?.lastfm?.apiKey || process.env.LASTFM_API_KEY;
 };
 
+export const getLastfmApiSecret = () => {
+  const settings = dbOps.getSettings();
+  return settings.integrations?.lastfm?.apiSecret || process.env.LASTFM_API_SECRET;
+};
+
 export const getTicketmasterApiKey = () => {
   const settings = dbOps.getSettings();
   const configuredValue = settings.integrations?.ticketmaster?.apiKey;

--- a/backend/services/apiClients/index.js
+++ b/backend/services/apiClients/index.js
@@ -1,5 +1,6 @@
 export {
   getLastfmApiKey,
+  getLastfmApiSecret,
   getTicketmasterApiKey,
   getNewsSettings,
   normalizeNewsFeeds,
@@ -22,9 +23,13 @@ export {
   musicbrainzResolveArtistMbidByName,
 } from "./musicbrainz.js";
 
-export { lastfmRequest } from "./lastfm.js";
+export { lastfmRequest, lastfmGetSession, lastfmScrobble } from "./lastfm.js";
 
-export { listenbrainzRequest } from "./listenbrainz.js";
+export {
+  listenbrainzRequest,
+  listenbrainzSubmit,
+  listenbrainzValidateToken,
+} from "./listenbrainz.js";
 
 export {
   getDeezerArtistById,

--- a/backend/services/apiClients/lastfm.js
+++ b/backend/services/apiClients/lastfm.js
@@ -1,10 +1,11 @@
 import axios from "../../../lib/axiosFetch.js";
 import https from "https";
+import { createHash } from "node:crypto";
 import createRateLimiter from "./rateLimiter.js";
 import createCache from "./simpleCache.js";
 import { logger } from "../logger.js";
 import { LASTFM_API } from "../../config/constants.js";
-import { getLastfmApiKey } from "./config.js";
+import { getLastfmApiKey, getLastfmApiSecret } from "./config.js";
 import { runSharedInflight } from "../sharedInflight.js";
 
 const lastfmCache = createCache(300);
@@ -25,6 +26,45 @@ const LASTFM_MAX_RETRIES = 2;
 
 const lastfmInflightRequests = new Map();
 const lastfmErrorLogAt = new Map();
+
+const signedLastfmRequest = async (method, params = {}) => {
+  const apiKey = getLastfmApiKey();
+  const apiSecret = getLastfmApiSecret();
+  if (!apiKey || !apiSecret) throw new Error("Last.fm API credentials are not configured");
+  const signedParams = { ...params, api_key: apiKey, method };
+  const signature = Object.keys(signedParams)
+    .sort()
+    .map((key) => `${key}${signedParams[key]}`)
+    .join("");
+  signedParams.api_sig = createHash("md5").update(`${signature}${apiSecret}`).digest("hex");
+  const response = await lastfmLimiter.schedule(() =>
+    axios.post(LASTFM_API, new URLSearchParams({ ...signedParams, format: "json" }), {
+      timeout: LASTFM_TIMEOUT_MS,
+      httpsAgent: lastfmHttpsAgent,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      validateStatus: (status) => status >= 200 && status < 300,
+    }),
+  );
+  if (response.data?.error) {
+    throw new Error(response.data.message || `Last.fm request failed (${response.data.error})`);
+  }
+  return response.data;
+};
+
+export const lastfmGetSession = (token) =>
+  signedLastfmRequest("auth.getSession", { token: String(token || "").trim() });
+
+export const lastfmScrobble = (event, sessionKey) =>
+  signedLastfmRequest("track.scrobble", {
+    sk: sessionKey,
+    artist: event.artist,
+    track: event.title,
+    timestamp: Math.floor(Number(event.playedAt) / 1000),
+    ...(event.album ? { album: event.album } : {}),
+    ...(event.artistMbid ? { artist_mbid: event.artistMbid } : {}),
+    ...(event.trackMbid ? { mbid: event.trackMbid } : {}),
+    ...(event.durationMs ? { duration: Math.round(event.durationMs / 1000) } : {}),
+  });
 
 export async function lastfmRequest(method, params = {}, options = {}) {
   const apiKey = getLastfmApiKey();

--- a/backend/services/apiClients/listenbrainz.js
+++ b/backend/services/apiClients/listenbrainz.js
@@ -14,6 +14,18 @@ const LISTENBRAINZ_MAX_RETRIES = 2;
 const listenbrainzInflightRequests = new Map();
 const listenbrainzErrorLogAt = new Map();
 
+const normalizeListenbrainzBaseUrl = (baseUrl) => {
+  const candidate = String(baseUrl || "").trim().replace(/\/+$/, "") || LISTENBRAINZ_API;
+  try {
+    const parsed = new URL(candidate);
+    return ["http:", "https:"].includes(parsed.protocol) && parsed.host
+      ? candidate
+      : LISTENBRAINZ_API;
+  } catch {
+    return LISTENBRAINZ_API;
+  }
+};
+
 const listenbrainzWrite = async (baseUrl, path, { token, data } = {}) => {
   const response = await listenbrainzLimiter.schedule(() =>
     axios.post(`${String(baseUrl).replace(/\/+$/, "")}${path}`, data, {
@@ -25,9 +37,10 @@ const listenbrainzWrite = async (baseUrl, path, { token, data } = {}) => {
   return response.data;
 };
 
-export const listenbrainzValidateToken = async (token) => {
+export const listenbrainzValidateToken = async (token, baseUrl = LISTENBRAINZ_API) => {
+  const root = normalizeListenbrainzBaseUrl(baseUrl);
   const response = await listenbrainzLimiter.schedule(() =>
-    axios.get(`${LISTENBRAINZ_API}/1/validate-token`, {
+    axios.get(`${root}/1/validate-token`, {
       headers: { Authorization: `Token ${String(token || "").trim()}` },
       timeout: LISTENBRAINZ_TIMEOUT_MS,
       validateStatus: (status) => status >= 200 && status < 300,
@@ -37,10 +50,15 @@ export const listenbrainzValidateToken = async (token) => {
 };
 
 export const listenbrainzSubmit = async ({ token, baseUrl = LISTENBRAINZ_API, event }) => {
+  const root = normalizeListenbrainzBaseUrl(baseUrl);
+  const listenedAt = Math.floor(Number(event?.playedAt) / 1000);
+  if (!Number.isFinite(listenedAt) || listenedAt <= 0) {
+    throw new Error("listenbrainzSubmit requires a numeric playedAt timestamp");
+  }
   const payload = {
     listen_type: "single",
     payload: [{
-      listened_at: Math.floor(Number(event.playedAt) / 1000),
+      listened_at: listenedAt,
       track_metadata: {
         artist_name: event.artist,
         track_name: event.title,
@@ -55,7 +73,7 @@ export const listenbrainzSubmit = async ({ token, baseUrl = LISTENBRAINZ_API, ev
       },
     }],
   };
-  return listenbrainzWrite(`${String(baseUrl).replace(/\/+$/, "")}/1`, "/submit-listens", {
+  return listenbrainzWrite(`${root}/1`, "/submit-listens", {
     token,
     data: payload,
   });

--- a/backend/services/apiClients/listenbrainz.js
+++ b/backend/services/apiClients/listenbrainz.js
@@ -14,6 +14,53 @@ const LISTENBRAINZ_MAX_RETRIES = 2;
 const listenbrainzInflightRequests = new Map();
 const listenbrainzErrorLogAt = new Map();
 
+const listenbrainzWrite = async (baseUrl, path, { token, data } = {}) => {
+  const response = await listenbrainzLimiter.schedule(() =>
+    axios.post(`${String(baseUrl).replace(/\/+$/, "")}${path}`, data, {
+      headers: { Authorization: `Token ${String(token || "").trim()}` },
+      timeout: LISTENBRAINZ_TIMEOUT_MS,
+      validateStatus: (status) => status >= 200 && status < 300,
+    }),
+  );
+  return response.data;
+};
+
+export const listenbrainzValidateToken = async (token) => {
+  const response = await listenbrainzLimiter.schedule(() =>
+    axios.get(`${LISTENBRAINZ_API}/1/validate-token`, {
+      headers: { Authorization: `Token ${String(token || "").trim()}` },
+      timeout: LISTENBRAINZ_TIMEOUT_MS,
+      validateStatus: (status) => status >= 200 && status < 300,
+    }),
+  );
+  return response.data;
+};
+
+export const listenbrainzSubmit = async ({ token, baseUrl = LISTENBRAINZ_API, event }) => {
+  const payload = {
+    listen_type: "single",
+    payload: [{
+      listened_at: Math.floor(Number(event.playedAt) / 1000),
+      track_metadata: {
+        artist_name: event.artist,
+        track_name: event.title,
+        ...(event.album ? { release_name: event.album } : {}),
+        additional_info: {
+          submission_client: "Aurral",
+          duration_ms: event.durationMs || undefined,
+          recording_mbid: event.trackMbid || undefined,
+          release_mbid: event.albumMbid || undefined,
+          artist_mbids: event.artistMbid ? [event.artistMbid] : undefined,
+        },
+      },
+    }],
+  };
+  return listenbrainzWrite(`${String(baseUrl).replace(/\/+$/, "")}/1`, "/submit-listens", {
+    token,
+    data: payload,
+  });
+};
+
 export async function listenbrainzRequest(path, params = {}) {
   const cacheKey = `lb:${path}:${JSON.stringify(params)}`;
   const cached = listenbrainzCache.get(cacheKey);

--- a/backend/services/appRuntime.js
+++ b/backend/services/appRuntime.js
@@ -8,6 +8,7 @@ import {
 import { startSystemTaskWorker } from "./systemTaskWorker.js";
 import { startLibraryScanWorker } from "./libraryScanWorker.js";
 import { startNotificationOutboxWorker } from "./notificationOutboxWorker.js";
+import { startPlayEventOutboxWorker } from "./playEventOutboxWorker.js";
 import { startSlskdOrchestratorWorker } from "./slskdOrchestratorWorker.js";
 import { startDiscoveryRefreshWorker } from "./discoveryRefreshWorker.js";
 import { startDiscoveryPlaylistBuildWorker } from "./discoveryPlaylistBuildWorker.js";
@@ -33,6 +34,7 @@ const WORKER_STARTS = {
   "system-task": startSystemTaskWorker,
   "library-scan": startLibraryScanWorker,
   "_outbox:notifications": startNotificationOutboxWorker,
+  "_outbox:play-events": startPlayEventOutboxWorker,
   "slskd-pipeline": startSlskdOrchestratorWorker,
   "discovery-refresh": startDiscoveryRefreshWorker,
   "discovery-playlist-build": startDiscoveryPlaylistBuildWorker,

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -157,6 +157,7 @@ export const requestUserDiscoveryRefresh = (
   const operationId = enqueueDiscoveryUserRefreshJob({
     listenHistoryProfile: profile,
     feedbackUserId,
+    localOnly,
     requestedAt: Date.now(),
     reason: "manual",
   });

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -9,7 +9,6 @@ import {
 } from "../apiClients/index.js";
 import { logger } from "../logger.js";
 import {
-  getDefaultListenHistoryProfile,
   getListenHistoryCacheNamespace,
   getListenHistoryProfile,
   hasListenHistoryProfile,
@@ -65,35 +64,18 @@ import {
 } from "./persistence.js";
 import { buildTasteProfile, collectSeedTagsAndGenres } from "./tasteProfile.js";
 import { buildRecommendationsFromSeeds } from "./recommendations.js";
+import { getTopPlayedArtists } from "../playEventService.js";
 
 export { DISCOVERY_QUALITY_ENRICHED };
 
 const pendingUserDiscoveryProfiles = new Map();
 
-const hasListeningHistoryUsers = () => {
-  const defaultProfile = getDefaultListenHistoryProfile(dbOps.getSettings());
-  const globalNamespace = defaultProfile
-    ? getListenHistoryCacheNamespace(defaultProfile)
-    : null;
-  return userOps.getAllListeningHistoryUsers().some((user) => {
-    const profile = getListenHistoryProfile(user);
-    if (!hasListenHistoryProfile(profile)) return false;
-    if (globalNamespace && getListenHistoryCacheNamespace(profile) === globalNamespace) return false;
-    return true;
-  });
-};
-
 const collectListeningHistoryRefreshProfiles = () => {
-  const defaultProfile = getDefaultListenHistoryProfile(dbOps.getSettings());
-  const globalNamespace = defaultProfile
-    ? getListenHistoryCacheNamespace(defaultProfile)
-    : null;
   const profiles = new Map();
   for (const user of userOps.getAllListeningHistoryUsers()) {
     const profile = getListenHistoryProfile(user);
     const cacheNamespace = getListenHistoryCacheNamespace(profile);
     if (!cacheNamespace || !hasListenHistoryProfile(profile)) continue;
-    if (globalNamespace && cacheNamespace === globalNamespace) continue;
     profiles.set(cacheNamespace, {
       profile,
       feedbackUserId: user.id || null,
@@ -128,6 +110,7 @@ const enqueueListeningHistoryUserRefreshes = ({
       {
         listenHistoryProfile: entry.profile,
         feedbackUserId: entry.feedbackUserId || null,
+        localOnly: entry.localOnly === true,
         requestedAt: Date.now(),
         reason,
       },
@@ -143,7 +126,7 @@ const enqueueListeningHistoryUserRefreshes = ({
 
 export const requestUserDiscoveryRefresh = (
   listenHistoryProfile,
-  { feedbackUserId = null } = {},
+  { feedbackUserId = null, localOnly = false } = {},
 ) => {
   const profile = getListenHistoryProfile(listenHistoryProfile);
   const cacheNamespace = getListenHistoryCacheNamespace(profile);
@@ -154,11 +137,13 @@ export const requestUserDiscoveryRefresh = (
     pendingUserDiscoveryProfiles.set(cacheNamespace, {
       profile,
       feedbackUserId,
+      localOnly,
     });
     enqueueDiscoveryUserRefreshJob(
       {
         listenHistoryProfile: profile,
         feedbackUserId,
+        localOnly,
         requestedAt: Date.now(),
         reason: "global_refresh_in_progress",
       },
@@ -524,35 +509,6 @@ export const updateDiscoveryCache = async (options = {}) => {
     );
 
     const historyArtists = [];
-    const defaultListenHistoryProfile = getDefaultListenHistoryProfile(
-      dbOps.getSettings(),
-    );
-    const discoveryPeriod = getLastfmDiscoveryPeriod();
-    const listeningHistoryUsersConfigured = hasListeningHistoryUsers();
-    if (
-      defaultListenHistoryProfile &&
-      discoveryPeriod !== "none" &&
-      !listeningHistoryUsersConfigured
-    ) {
-      try {
-        const fetched = await fetchListenHistoryArtists(
-          defaultListenHistoryProfile,
-          discoveryPeriod,
-          lastfmHealth,
-        );
-        historyArtists.push(
-          ...fetched.map((artist) => ({
-            ...artist,
-            source: defaultListenHistoryProfile.listenHistoryProvider,
-          })),
-        );
-      } catch (error) {
-        logger.warn(
-          'discovery',
-          `[Discovery] Failed to load default listening history for ${defaultListenHistoryProfile.listenHistoryUsername}: ${error.message}`,
-        );
-      }
-    }
 
     const profileSampleSeedCount = selectDiscoverySeedSample(
       buildDiscoverySeedList({
@@ -887,7 +843,7 @@ export const updateUserDiscoveryCache = async (
   options = {},
 ) => {
   const { withHonkerLock } = await import("../honkerDb.js");
-  const { duringGlobalRefresh = false } = options;
+  const { duringGlobalRefresh = false, localOnly = false } = options;
   const profile = getListenHistoryProfile(listenHistoryProfile);
   const cacheNamespace = getListenHistoryCacheNamespace(profile);
   if (!cacheNamespace) return null;
@@ -911,11 +867,13 @@ export const updateUserDiscoveryCache = async (
     pendingUserDiscoveryProfiles.set(cacheNamespace, {
       profile,
       feedbackUserId: options.feedbackUserId || null,
+      localOnly,
     });
     enqueueDiscoveryUserRefreshJob(
       {
         listenHistoryProfile: profile,
         feedbackUserId: options.feedbackUserId || null,
+        localOnly,
         requestedAt: Date.now(),
         reason: "global_refresh_in_progress",
       },
@@ -949,7 +907,7 @@ export const updateUserDiscoveryCache = async (
     const discoveryPeriod = getLastfmDiscoveryPeriod();
     const historyArtists = [];
 
-    if (discoveryPeriod !== "none") {
+    if (!localOnly && discoveryPeriod !== "none") {
       logger.info(
         'discovery',
         `[Discovery] Fetching ${profile.listenHistoryProvider} top artists for ${profile.listenHistoryUsername} (period: ${discoveryPeriod})...`,
@@ -978,6 +936,15 @@ export const updateUserDiscoveryCache = async (
       }
     }
 
+    if (options.feedbackUserId) {
+      historyArtists.push(
+        ...getTopPlayedArtists(options.feedbackUserId, { limit: 50 }).map((artist) => ({
+          ...artist,
+          source: "local",
+        })),
+      );
+    }
+
     const recommendationRunStartedAt = new Date().toISOString();
     const discoveryRunId = createDiscoveryRunId();
     const feedback = options.feedbackUserId
@@ -989,7 +956,7 @@ export const updateUserDiscoveryCache = async (
     const globalTopTags = globalCache.topTags || [];
     const globalTopGenres = globalCache.topGenres || [];
 
-    if (globalPool.length === 0) {
+    if (globalPool.length === 0 && historyArtists.length === 0) {
       logger.info(
         'discovery',
         `[Discovery] Per-user refresh skipped for ${profile.listenHistoryUsername}: global pool is empty.`,
@@ -1006,9 +973,31 @@ export const updateUserDiscoveryCache = async (
       return null;
     }
 
-    let recommendationsArray = [];
-    recommendationsArray = mergeRetainedRecommendationPool({
-      freshRecommendations: recommendationsArray,
+    const personalSeeds = buildDiscoverySeedList({
+      libraryArtists: [],
+      historyArtists,
+    });
+    let freshRecommendations = [];
+    if (personalSeeds.length > 0) {
+      const rawRecommendations = await buildRecommendationsFromSeeds({
+        seeds: personalSeeds,
+        existingArtistKeys,
+        lastfmHealth,
+        profileTagWeights: new Map(),
+        seedTagMap: new Map(),
+        discoveryMode: getDiscoveryMode(),
+        includeCandidateTagHydration: false,
+        includeSecondHop: true,
+      });
+      freshRecommendations = await resolveRecommendationCandidates(
+        rawRecommendations,
+        existingArtistKeys,
+        40,
+        { resolveLimit: getDiscoveryRecommendationsPerRefresh() },
+      );
+    }
+    const recommendationsArray = mergeRetainedRecommendationPool({
+      freshRecommendations: freshRecommendations.length ? freshRecommendations : globalPool,
       existingRecommendations:
         dbOps.getDiscoveryCache(cacheNamespace).recommendations || [],
       existingArtistKeys,

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -749,6 +749,9 @@ export const updateDiscoveryCache = async (options = {}) => {
     discoveryCache.isUpdating = false;
     clearDiscoveryUpdateProgress();
 
+    const listeningHistoryUsersConfigured = userOps
+      .getAllListeningHistoryUsers()
+      .some((user) => hasListenHistoryProfile(getListenHistoryProfile(user)));
     if (listeningHistoryUsersConfigured) {
       emitDiscoveryDataUpdate(discoveryData, {
         progressMessage: "Discovery refresh completed",

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -18,6 +18,61 @@ const DISCOVERY_GLOBAL_REFRESH_LOCK = "discovery-global-refresh";
 
 let discoveryRefreshQueued = false;
 
+function isWorkerAlive(workerId) {
+  const match = /^aurral-(\d+)$/.exec(String(workerId || ""));
+  if (!match) return true;
+  try {
+    process.kill(Number(match[1]), 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+export function recoverDeadDiscoveryRefresh() {
+  const honker = getHonkerDb();
+  let liveRows;
+  let lockRows;
+  try {
+    liveRows = honker.query(`
+      SELECT id, worker_id
+      FROM _honker_live
+      WHERE queue = 'discovery-refresh'
+        AND state = 'processing'
+    `);
+    lockRows = honker.query(
+      "SELECT owner FROM _honker_locks WHERE name = ?",
+      [DISCOVERY_GLOBAL_REFRESH_LOCK],
+    );
+  } catch {
+    return false;
+  }
+
+  const deadJobs = liveRows.filter((row) => !isWorkerAlive(row.worker_id));
+  const deadLocks = lockRows.filter((row) => !isWorkerAlive(row.owner));
+  if (!deadJobs.length && !deadLocks.length) return false;
+
+  const queue = getDiscoveryRefreshQueue();
+  for (const row of deadJobs) {
+    try {
+      queue.cancel(row.id);
+    } catch {}
+  }
+  for (const row of deadLocks) {
+    const tx = honker.transaction();
+    try {
+      tx.query(
+        "SELECT honker_lock_release(?, ?)",
+        [DISCOVERY_GLOBAL_REFRESH_LOCK, row.owner],
+      );
+      tx.commit();
+    } catch {
+      try { tx.rollback(); } catch {}
+    }
+  }
+  return true;
+}
+
 function parseQueuedPayload(payload) {
   try {
     return JSON.parse(String(payload || "{}"));
@@ -121,6 +176,12 @@ export function enqueueDiscoveryRefresh(options = {}) {
   } = options;
   const cache = getDiscoveryCache();
 
+  if (!scheduleOnly && force && recoverDeadDiscoveryRefresh()) {
+    discoveryRefreshQueued = false;
+    cache.isUpdating = false;
+    clearDiscoveryUpdateProgress();
+  }
+
   if (!scheduleOnly) {
     if (isHonkerLockHeld(DISCOVERY_GLOBAL_REFRESH_LOCK)) {
       if (force) {
@@ -187,6 +248,7 @@ export async function enqueueDiscoveryRefreshIfNeeded(options = {}) {
 }
 
 export async function bootstrapDiscoveryRefresh() {
+  recoverDeadDiscoveryRefresh();
   const cache = getDiscoveryCache();
   if (
     !isHonkerLockHeld("discovery-global-refresh") &&

--- a/backend/services/discovery/userDiscovery.js
+++ b/backend/services/discovery/userDiscovery.js
@@ -23,7 +23,6 @@ import {
 import {
   getListenHistoryCacheNamespace,
   getListenHistoryProfile,
-  getDefaultListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
 import { enqueueDiscoveryRefresh } from "./refreshScheduler.js";
@@ -35,25 +34,28 @@ import {
   DISCOVERY_REVALIDATE_COOLDOWN_MS,
   getDiscoveryStaleMs,
 } from "../../routes/discovery/handlers/utils.js";
+import { getTopPlayedArtists } from "../playEventService.js";
 
 export async function getUserDiscovery(userId, limit = 50, offset = 0) {
   const hasLastfmKey = !!getLastfmApiKey();
   const libraryArtists = await libraryManager.getAllArtists();
 
   const reqUser = userOps.getUserById(userId);
-  const listenHistoryProfile = getListenHistoryProfile(reqUser || {});
+  const externalListenHistoryProfile = getListenHistoryProfile(reqUser || {});
+  const localHistoryArtists = getTopPlayedArtists(userId, { limit: 50 });
+  const localOnlyProfile = externalListenHistoryProfile.listenHistoryProvider === "local";
+  const hasExternalListenHistory =
+    !localOnlyProfile && hasListenHistoryProfile(externalListenHistoryProfile);
+  const hasLocalListenHistory = localOnlyProfile || localHistoryArtists.length > 0;
+  const listenHistoryProfile = hasExternalListenHistory
+    ? externalListenHistoryProfile
+    : hasLocalListenHistory
+      ? { listenHistoryProvider: "lastfm", listenHistoryUsername: `__aurral_local_${userId}` }
+      : externalListenHistoryProfile;
+  const localOnly = !hasExternalListenHistory && hasLocalListenHistory;
   const userCacheNamespace =
     getListenHistoryCacheNamespace(listenHistoryProfile);
-  const defaultProfile = getDefaultListenHistoryProfile(dbOps.getSettings());
-  const globalNamespace = defaultProfile
-    ? getListenHistoryCacheNamespace(defaultProfile)
-    : null;
-  const identityMatches = userCacheNamespace && globalNamespace && userCacheNamespace === globalNamespace;
-  const effectiveCacheNamespace = identityMatches
-    ? null
-    : hasLastfmKey
-      ? userCacheNamespace
-      : null;
+  const effectiveCacheNamespace = hasLastfmKey ? userCacheNamespace : null;
 
   if (
     hasListenHistoryProfile(listenHistoryProfile) &&
@@ -65,6 +67,7 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     if (staleness > staleMs) {
       requestUserDiscoveryRefresh(listenHistoryProfile, {
         feedbackUserId: userId || null,
+        localOnly,
       }).catch((err) => {
         logger.error("discovery", `On-demand refresh for ${listenHistoryProfile.listenHistoryProvider}:${listenHistoryProfile.listenHistoryUsername} failed`, { error: err.message });
       });
@@ -149,6 +152,19 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     recommendations: globalTop,
     feedback,
   });
+  const localBasedOn = localHistoryArtists.map((artist) => ({
+    name: artist.artistName,
+    id: artist.mbid,
+    source: "local",
+    profileBucket: null,
+  }));
+  const seenBasedOn = new Set((basedOn || []).map((artist) => `${artist.id || ""}:${artist.name || ""}`));
+  basedOn = [...(basedOn || []), ...localBasedOn.filter((artist) => {
+    const key = `${artist.id || ""}:${artist.name || ""}`;
+    if (seenBasedOn.has(key)) return false;
+    seenBasedOn.add(key);
+    return true;
+  })];
   fallbackGenres = (Array.isArray(fallbackGenres) ? fallbackGenres : []).map((section) => ({
     ...section,
     artists: filterBlockedArtistsForUser(userId || "global", section?.artists || []),

--- a/backend/services/discoveryUserRefreshWorker.js
+++ b/backend/services/discoveryUserRefreshWorker.js
@@ -22,6 +22,7 @@ async function processDiscoveryUserRefresh(payload = {}) {
   }
   await updateUserDiscoveryCache(profile, {
     feedbackUserId: payload?.feedbackUserId || null,
+    localOnly: payload?.localOnly === true,
   });
   return { refreshed: true };
 }

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -15,6 +15,7 @@ export const HONKER_QUEUE_NAMES = [
   "discovery-playlist-build",
   "discovery-user-refresh",
   "_outbox:notifications",
+  "_outbox:play-events",
 ];
 
 function resolveHonkerDbPath() {
@@ -26,6 +27,7 @@ function resolveHonkerDbPath() {
 let honkerDb = null;
 let openedHonkerDbPath = null;
 let notificationOutbox = null;
+let playEventOutbox = null;
 let honkerSchedulerStarted = false;
 let honkerSchedulerAbort = null;
 let honkerSchedulerPromise = null;
@@ -322,6 +324,30 @@ export function enqueueNotification(payload) {
     .catch((err) => { console.warn(err); });  return jobId;
 }
 
+export function getPlayEventOutbox() {
+  if (!playEventOutbox) {
+    playEventOutbox = getHonkerDb().outbox(
+      "play-events",
+      async (payload, job) => {
+        const { deliverPlayEvent } = await import("./playEventService.js");
+        const { withJobHeartbeat } = await import("./honkerWorkerRuntime.js");
+        const outbox = getPlayEventOutbox();
+        await withJobHeartbeat(job, outbox.queue, () => deliverPlayEvent(payload));
+      },
+      { visibilityTimeoutS: 120, maxAttempts: 5, baseBackoffS: 30 },
+    );
+  }
+  return playEventOutbox;
+}
+
+export function enqueuePlayEventDelivery(payload) {
+  const jobId = getPlayEventOutbox().enqueue(payload);
+  import("./playEventOutboxWorker.js")
+    .then(({ startPlayEventOutboxWorker }) => startPlayEventOutboxWorker())
+    .catch((err) => { console.warn(err); });
+  return jobId;
+}
+
 export function bootstrapHonkerSchedules() {
   const scheduler = getHonkerDb().scheduler();
   const canonicalByName = new Map(SCHEDULED_SYSTEM_TASKS.map((task) => [task.name, task]));
@@ -436,6 +462,7 @@ export function closeHonkerDb() {
     reset();
   }
   notificationOutbox = null;
+  playEventOutbox = null;
 }
 
 export function isHonkerLockHeld(name) {
@@ -553,6 +580,9 @@ export function sweepAllHonkerQueues() {
 export function getHonkerQueueByName(queueName) {
   if (queueName === "_outbox:notifications") {
     return getNotificationOutbox().queue;
+  }
+  if (queueName === "_outbox:play-events") {
+    return getPlayEventOutbox().queue;
   }
   return queueByName.get(queueName)?.getQueue() ?? null;
 }

--- a/backend/services/koitoClient.js
+++ b/backend/services/koitoClient.js
@@ -39,6 +39,11 @@ export function normalizeKoitoBaseUrl(baseUrl) {
   }
 }
 
+export function getKoitoListenBrainzBaseUrl(baseUrl) {
+  const normalized = normalizeKoitoBaseUrl(baseUrl);
+  return normalized ? `${normalized}/apis/listenbrainz` : "";
+}
+
 export function getKoitoPeriod(discoveryPeriod) {
   if (!discoveryPeriod || discoveryPeriod === "none") return null;
   return KOITO_PERIOD_BY_DISCOVERY_PERIOD[discoveryPeriod] || "month";

--- a/backend/services/listeningHistory.js
+++ b/backend/services/listeningHistory.js
@@ -1,4 +1,4 @@
-export const LISTEN_HISTORY_PROVIDERS = ["lastfm", "listenbrainz", "koito"];
+export const LISTEN_HISTORY_PROVIDERS = ["local", "lastfm", "listenbrainz", "koito"];
 export const DEFAULT_LISTEN_HISTORY_PROVIDER = "lastfm";
 
 const CACHE_PREFIX_BY_PROVIDER = {
@@ -58,7 +58,7 @@ export function getListenHistoryProfile(source = {}) {
 
   return {
     listenHistoryProvider: provider,
-    listenHistoryUsername: provider === "koito" ? null : username,
+    listenHistoryUsername: provider === "koito" || provider === "local" ? null : username,
     listenHistoryUrl: provider === "koito" ? url : null,
     lastfmUsername: provider === "lastfm" ? username : null,
   };
@@ -66,6 +66,7 @@ export function getListenHistoryProfile(source = {}) {
 
 export function hasListenHistoryProfile(profile) {
   const normalized = getListenHistoryProfile(profile);
+  if (normalized.listenHistoryProvider === "local") return true;
   if (normalized.listenHistoryProvider === "koito") {
     return !!normalized.listenHistoryUrl;
   }
@@ -84,6 +85,7 @@ export function listenHistoryProfilesEqual(a, b) {
 
 export function getListenHistoryCacheNamespace(profile) {
   const normalized = getListenHistoryProfile(profile);
+  if (normalized.listenHistoryProvider === "local") return null;
   if (normalized.listenHistoryProvider === "koito") {
     if (!normalized.listenHistoryUrl) return null;
     return `${CACHE_PREFIX_BY_PROVIDER.koito}:${normalized.listenHistoryUrl}`;
@@ -93,16 +95,7 @@ export function getListenHistoryCacheNamespace(profile) {
   return prefix ? `${prefix}:${normalized.listenHistoryUsername}` : null;
 }
 
-export function getDefaultListenHistoryProfile(settings) {
-  const username = String(settings?.integrations?.lastfm?.username || "").trim();
-  if (!username) return null;
-  return {
-    listenHistoryProvider: "lastfm",
-    listenHistoryUsername: username,
-  };
-}
-
-export function resolveListenHistorySettings(user = {}, settings = null) {
+export function resolveListenHistorySettings(user = {}) {
   const profile = getListenHistoryProfile(user);
   if (hasListenHistoryProfile(profile)) {
     return {
@@ -110,15 +103,6 @@ export function resolveListenHistorySettings(user = {}, settings = null) {
       listenHistoryUsername: profile.listenHistoryUsername,
       listenHistoryUrl: profile.listenHistoryUrl,
       lastfmUsername: profile.lastfmUsername,
-    };
-  }
-  const defaultProfile = settings ? getDefaultListenHistoryProfile(settings) : null;
-  if (defaultProfile) {
-    return {
-      listenHistoryProvider: defaultProfile.listenHistoryProvider,
-      listenHistoryUsername: defaultProfile.listenHistoryUsername,
-      listenHistoryUrl: null,
-      lastfmUsername: defaultProfile.listenHistoryUsername,
     };
   }
   return {

--- a/backend/services/playEventOutboxWorker.js
+++ b/backend/services/playEventOutboxWorker.js
@@ -1,0 +1,57 @@
+import { getPlayEventOutbox, getWorkerId } from "./honkerDb.js";
+import {
+  isHonkerShuttingDown,
+  markHonkerWorkerLoopEnded,
+  registerHonkerWorker,
+} from "./honkerWorkerRuntime.js";
+
+const WORKER_NAME = "play-event-outbox";
+let running = false;
+let stopRequested = false;
+let loopPromise = null;
+let abortController = null;
+
+async function runLoop() {
+  abortController = new AbortController();
+  try {
+    await getPlayEventOutbox().runWorker(getWorkerId(), {
+      idlePollS: 5,
+      signal: abortController.signal,
+    });
+  } catch (error) {
+    if (!stopRequested && !isHonkerShuttingDown()) {
+      console.error("[playEventOutboxWorker] loop error:", error);
+    }
+  } finally {
+    abortController = null;
+    running = false;
+    loopPromise = null;
+    const intentional = stopRequested;
+    stopRequested = false;
+    markHonkerWorkerLoopEnded(WORKER_NAME, startPlayEventOutboxWorker, { intentional });
+  }
+}
+
+export function startPlayEventOutboxWorker() {
+  if (running || isHonkerShuttingDown()) return;
+  running = true;
+  stopRequested = false;
+  loopPromise = runLoop();
+  return loopPromise;
+}
+
+export function stopPlayEventOutboxWorker() {
+  stopRequested = true;
+  abortController?.abort();
+  return loopPromise || Promise.resolve();
+}
+
+export function isPlayEventOutboxWorkerRunning() {
+  return running;
+}
+
+registerHonkerWorker(WORKER_NAME, {
+  start: startPlayEventOutboxWorker,
+  stop: stopPlayEventOutboxWorker,
+  isRunning: isPlayEventOutboxWorkerRunning,
+});

--- a/backend/services/playEventService.js
+++ b/backend/services/playEventService.js
@@ -63,7 +63,7 @@ export const recordPlayEvent = (userId, input = {}) => {
   const playedAt = Number.isFinite(playedAtValue)
     ? (playedAtValue < 10_000_000_000 ? Math.trunc(playedAtValue * 1000) : Math.trunc(playedAtValue))
     : Date.now();
-  const providers = new Set(Object.keys(scrobbleConnectionStore.getConnections(userId)));
+  const connections = scrobbleConnectionStore.getConnections(userId);
   const honker = getHonkerDb();
   const tx = honker.transaction();
   let eventId;
@@ -89,8 +89,13 @@ export const recordPlayEvent = (userId, input = {}) => {
       Date.now(),
     ]);
     eventId = rows[0]?.id;
-    for (const provider of providers) {
-      getPlayEventOutbox().enqueueTx(tx, { eventId, userId, provider });
+    for (const [provider, connection] of Object.entries(connections)) {
+      getPlayEventOutbox().enqueueTx(tx, {
+        eventId,
+        userId,
+        provider,
+        connectionRevision: connection.connectionRevision,
+      });
     }
     tx.commit();
   } catch (error) {
@@ -101,21 +106,21 @@ export const recordPlayEvent = (userId, input = {}) => {
   return event;
 };
 
-export const deliverPlayEvent = async ({ eventId, userId, provider }) => {
+export const deliverPlayEvent = async ({ eventId, userId, provider, connectionRevision }) => {
   const event = toPublicEvent(getEventStmt.get(eventId));
   const connection = scrobbleConnectionStore.getConnection(userId, provider);
-  if (!event) return;
-  if (provider === "lastfm" && connection) {
+  if (!event || !connection || !connectionRevision || connection.connectionRevision !== connectionRevision) return;
+  if (provider === "lastfm") {
     const { lastfmScrobble } = await import("./apiClients/lastfm.js");
     await lastfmScrobble(event, connection.token);
     return;
   }
-  if (provider === "listenbrainz" && connection) {
+  if (provider === "listenbrainz") {
     const { listenbrainzSubmit } = await import("./apiClients/listenbrainz.js");
     await listenbrainzSubmit({ token: connection.token, event });
     return;
   }
-  if (provider === "koito" && connection) {
+  if (provider === "koito") {
     const { listenbrainzSubmit } = await import("./apiClients/listenbrainz.js");
     await listenbrainzSubmit({
       token: connection.token,

--- a/backend/services/playEventService.js
+++ b/backend/services/playEventService.js
@@ -1,15 +1,8 @@
 import { db } from "../config/db-sqlite.js";
-import { logger } from "./logger.js";
-import { enqueuePlayEventDelivery } from "./honkerDb.js";
+import { getHonkerDb, getPlayEventOutbox } from "./honkerDb.js";
 import { scrobbleConnectionStore } from "./scrobbleConnectionStore.js";
-import { normalizeKoitoBaseUrl } from "./koitoClient.js";
+import { getKoitoListenBrainzBaseUrl } from "./koitoClient.js";
 
-const insertEventStmt = db.prepare(`
-  INSERT INTO play_events
-    (user_id, track_id, title, artist, album, artist_mbid, album_mbid, track_mbid,
-     duration_ms, played_at, source, created_at)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-`);
 const getEventStmt = db.prepare("SELECT * FROM play_events WHERE id = ?");
 const getHistoryStmt = db.prepare(
   "SELECT * FROM play_events WHERE user_id = ? ORDER BY played_at DESC, id DESC LIMIT ? OFFSET ?",
@@ -70,33 +63,41 @@ export const recordPlayEvent = (userId, input = {}) => {
   const playedAt = Number.isFinite(playedAtValue)
     ? (playedAtValue < 10_000_000_000 ? Math.trunc(playedAtValue * 1000) : Math.trunc(playedAtValue))
     : Date.now();
-  const result = insertEventStmt.run(
-    userId,
-    trackId,
-    title,
-    artist,
-    text(input.album, 500) || null,
-    text(input.artistMbid, 100) || null,
-    text(input.albumMbid, 100) || null,
-    text(input.trackMbid, 100) || null,
-    positiveInt(input.durationMs),
-    playedAt,
-    text(input.source, 50) || "unknown",
-    Date.now(),
-  );
-  const event = toPublicEvent(getEventStmt.get(result.lastInsertRowid));
   const providers = new Set(Object.keys(scrobbleConnectionStore.getConnections(userId)));
-  for (const provider of providers) {
-    try {
-      enqueuePlayEventDelivery({ eventId: event.id, userId, provider });
-    } catch (error) {
-      logger.warn("play-events", "Could not enqueue scrobble delivery", {
-        userId,
-        provider,
-        error: error?.message || String(error),
-      });
+  const honker = getHonkerDb();
+  const tx = honker.transaction();
+  let eventId;
+  try {
+    const rows = tx.query(`
+      INSERT INTO play_events
+        (user_id, track_id, title, artist, album, artist_mbid, album_mbid, track_mbid,
+         duration_ms, played_at, source, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      RETURNING id
+    `, [
+      userId,
+      trackId,
+      title,
+      artist,
+      text(input.album, 500) || null,
+      text(input.artistMbid, 100) || null,
+      text(input.albumMbid, 100) || null,
+      text(input.trackMbid, 100) || null,
+      positiveInt(input.durationMs),
+      playedAt,
+      text(input.source, 50) || "unknown",
+      Date.now(),
+    ]);
+    eventId = rows[0]?.id;
+    for (const provider of providers) {
+      getPlayEventOutbox().enqueueTx(tx, { eventId, userId, provider });
     }
+    tx.commit();
+  } catch (error) {
+    try { tx.rollback(); } catch {}
+    throw error;
   }
+  const event = toPublicEvent(getEventStmt.get(eventId));
   return event;
 };
 
@@ -118,7 +119,7 @@ export const deliverPlayEvent = async ({ eventId, userId, provider }) => {
     const { listenbrainzSubmit } = await import("./apiClients/listenbrainz.js");
     await listenbrainzSubmit({
       token: connection.token,
-      baseUrl: normalizeKoitoBaseUrl(connection.baseUrl || ""),
+      baseUrl: getKoitoListenBrainzBaseUrl(connection.baseUrl || ""),
       event,
     });
     return;

--- a/backend/services/playEventService.js
+++ b/backend/services/playEventService.js
@@ -1,0 +1,126 @@
+import { db } from "../config/db-sqlite.js";
+import { logger } from "./logger.js";
+import { enqueuePlayEventDelivery } from "./honkerDb.js";
+import { scrobbleConnectionStore } from "./scrobbleConnectionStore.js";
+import { normalizeKoitoBaseUrl } from "./koitoClient.js";
+
+const insertEventStmt = db.prepare(`
+  INSERT INTO play_events
+    (user_id, track_id, title, artist, album, artist_mbid, album_mbid, track_mbid,
+     duration_ms, played_at, source, created_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+const getEventStmt = db.prepare("SELECT * FROM play_events WHERE id = ?");
+const getHistoryStmt = db.prepare(
+  "SELECT * FROM play_events WHERE user_id = ? ORDER BY played_at DESC, id DESC LIMIT ? OFFSET ?",
+);
+const getArtistsStmt = db.prepare(`
+  SELECT artist, MAX(artist_mbid) AS artist_mbid, COUNT(*) AS play_count,
+         MAX(played_at) AS last_played_at
+  FROM play_events
+  WHERE user_id = ?
+  GROUP BY artist
+  ORDER BY play_count DESC, last_played_at DESC
+  LIMIT ?
+`);
+
+const text = (value, max = 500) => String(value || "").trim().slice(0, max);
+const positiveInt = (value, fallback = null) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+};
+
+const toPublicEvent = (row) => row && ({
+  id: row.id,
+  userId: row.user_id,
+  trackId: row.track_id,
+  title: row.title,
+  artist: row.artist,
+  album: row.album,
+  artistMbid: row.artist_mbid,
+  albumMbid: row.album_mbid,
+  trackMbid: row.track_mbid,
+  durationMs: row.duration_ms,
+  playedAt: row.played_at,
+  source: row.source,
+});
+
+export const getPlayHistory = (userId, { limit = 50, offset = 0 } = {}) => {
+  const safeLimit = Math.min(100, Math.max(1, positiveInt(limit, 50)));
+  const safeOffset = Math.max(0, positiveInt(offset, 0));
+  return getHistoryStmt.all(userId, safeLimit, safeOffset).map(toPublicEvent);
+};
+
+export const getTopPlayedArtists = (userId, { limit = 20 } = {}) => {
+  const safeLimit = Math.min(100, Math.max(1, positiveInt(limit, 20)));
+  return getArtistsStmt.all(userId, safeLimit).map((row) => ({
+    artistName: row.artist,
+    mbid: row.artist_mbid || null,
+    playcount: Number(row.play_count) || 0,
+    lastPlayedAt: Number(row.last_played_at) || null,
+  }));
+};
+
+export const recordPlayEvent = (userId, input = {}) => {
+  const trackId = text(input.trackId, 500);
+  const title = text(input.title, 500);
+  const artist = text(input.artist, 500);
+  if (!trackId || !title || !artist) throw new Error("trackId, title, and artist are required");
+  const playedAtValue = Number(input.playedAt);
+  const playedAt = Number.isFinite(playedAtValue)
+    ? (playedAtValue < 10_000_000_000 ? Math.trunc(playedAtValue * 1000) : Math.trunc(playedAtValue))
+    : Date.now();
+  const result = insertEventStmt.run(
+    userId,
+    trackId,
+    title,
+    artist,
+    text(input.album, 500) || null,
+    text(input.artistMbid, 100) || null,
+    text(input.albumMbid, 100) || null,
+    text(input.trackMbid, 100) || null,
+    positiveInt(input.durationMs),
+    playedAt,
+    text(input.source, 50) || "unknown",
+    Date.now(),
+  );
+  const event = toPublicEvent(getEventStmt.get(result.lastInsertRowid));
+  const providers = new Set(Object.keys(scrobbleConnectionStore.getConnections(userId)));
+  for (const provider of providers) {
+    try {
+      enqueuePlayEventDelivery({ eventId: event.id, userId, provider });
+    } catch (error) {
+      logger.warn("play-events", "Could not enqueue scrobble delivery", {
+        userId,
+        provider,
+        error: error?.message || String(error),
+      });
+    }
+  }
+  return event;
+};
+
+export const deliverPlayEvent = async ({ eventId, userId, provider }) => {
+  const event = toPublicEvent(getEventStmt.get(eventId));
+  const connection = scrobbleConnectionStore.getConnection(userId, provider);
+  if (!event) return;
+  if (provider === "lastfm" && connection) {
+    const { lastfmScrobble } = await import("./apiClients/lastfm.js");
+    await lastfmScrobble(event, connection.token);
+    return;
+  }
+  if (provider === "listenbrainz" && connection) {
+    const { listenbrainzSubmit } = await import("./apiClients/listenbrainz.js");
+    await listenbrainzSubmit({ token: connection.token, event });
+    return;
+  }
+  if (provider === "koito" && connection) {
+    const { listenbrainzSubmit } = await import("./apiClients/listenbrainz.js");
+    await listenbrainzSubmit({
+      token: connection.token,
+      baseUrl: normalizeKoitoBaseUrl(connection.baseUrl || ""),
+      event,
+    });
+    return;
+  }
+};

--- a/backend/services/scrobbleConnectionStore.js
+++ b/backend/services/scrobbleConnectionStore.js
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import { db, dbHelpers } from "../config/db-sqlite.js";
+import { decryptWithKey, encryptWithKey } from "../config/encryption.js";
+
+const SETTINGS_KEY = "scrobbleConnections";
+const PROVIDERS = new Set(["lastfm", "listenbrainz", "koito"]);
+const getSettingStmt = db.prepare("SELECT value FROM settings WHERE key = ?");
+const upsertSettingStmt = db.prepare(
+  "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+);
+const getEncryptionKey = () => {
+  const stored = getSettingStmt.get("_encryptionKey")?.value;
+  if (stored) return Buffer.from(stored, "base64");
+  const key = crypto.randomBytes(32);
+  upsertSettingStmt.run("_encryptionKey", key.toString("base64"));
+  return key;
+};
+
+const readStore = () => {
+  const parsed = dbHelpers.parseJSON(getSettingStmt.get(SETTINGS_KEY)?.value);
+  return parsed && typeof parsed === "object" ? parsed : {};
+};
+
+const writeStore = (store) => upsertSettingStmt.run(SETTINGS_KEY, dbHelpers.stringifyJSON(store));
+const userKey = (userId) => String(Math.trunc(Number(userId)));
+const encryptToken = (token) => encryptWithKey(String(token || ""), getEncryptionKey());
+const decryptToken = (token) => decryptWithKey(token, getEncryptionKey());
+
+export const getScrobbleEncryptionKey = getEncryptionKey;
+
+const normalize = (provider, raw) => {
+  if (!PROVIDERS.has(provider) || !raw || typeof raw !== "object") return null;
+  const token = decryptToken(raw.token);
+  if (!token) return null;
+  return {
+    provider,
+    token,
+    displayName: String(raw.displayName || "").trim() || null,
+    baseUrl: String(raw.baseUrl || "").trim() || null,
+    connectedAt: Number(raw.connectedAt) || null,
+  };
+};
+
+export const scrobbleConnectionStore = {
+  getConnection(userId, provider) {
+    const connection = normalize(provider, readStore()[userKey(userId)]?.[provider]);
+    return connection;
+  },
+
+  getConnections(userId) {
+    const raw = readStore()[userKey(userId)] || {};
+    return Object.fromEntries([...PROVIDERS].map((provider) => {
+      const connection = normalize(provider, raw[provider]);
+      return connection ? [provider, connection] : null;
+    }).filter(Boolean));
+  },
+
+  getPublicStatus(userId) {
+    return Object.fromEntries([...PROVIDERS].map((provider) => {
+      const connection = this.getConnection(userId, provider);
+      return [provider, connection
+        ? { connected: true, displayName: connection.displayName, connectedAt: connection.connectedAt }
+        : { connected: false, displayName: null, connectedAt: null }];
+    }));
+  },
+
+  saveConnection(userId, provider, { token, displayName = null, baseUrl = null } = {}) {
+    if (!PROVIDERS.has(provider)) throw new Error("Unsupported scrobble provider");
+    const safeToken = String(token || "").trim();
+    if (!safeToken) throw new Error("Scrobble token is required");
+    const store = readStore();
+    const key = userKey(userId);
+    store[key] = store[key] || {};
+    store[key][provider] = {
+      token: encryptToken(safeToken),
+      displayName: String(displayName || "").trim() || null,
+      baseUrl: String(baseUrl || "").trim() || null,
+      connectedAt: Date.now(),
+    };
+    writeStore(store);
+    return this.getConnection(userId, provider);
+  },
+
+  deleteConnection(userId, provider) {
+    const store = readStore();
+    const key = userKey(userId);
+    if (!store[key]?.[provider]) return false;
+    delete store[key][provider];
+    if (Object.keys(store[key]).length === 0) delete store[key];
+    writeStore(store);
+    return true;
+  },
+};

--- a/backend/services/scrobbleConnectionStore.js
+++ b/backend/services/scrobbleConnectionStore.js
@@ -5,14 +5,24 @@ import { decryptWithKey, encryptWithKey } from "../config/encryption.js";
 const SETTINGS_KEY = "scrobbleConnections";
 const PROVIDERS = new Set(["lastfm", "listenbrainz", "koito"]);
 const getSettingStmt = db.prepare("SELECT value FROM settings WHERE key = ?");
+const insertSettingStmt = db.prepare(
+  "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+);
 const upsertSettingStmt = db.prepare(
   "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
 );
-const getEncryptionKey = () => {
+const ensureEncryptionKey = db.transaction(() => {
   const stored = getSettingStmt.get("_encryptionKey")?.value;
-  if (stored) return Buffer.from(stored, "base64");
-  const key = crypto.randomBytes(32);
-  upsertSettingStmt.run("_encryptionKey", key.toString("base64"));
+  if (!stored) {
+    insertSettingStmt.run("_encryptionKey", crypto.randomBytes(32).toString("base64"));
+  }
+  const persisted = getSettingStmt.get("_encryptionKey")?.value;
+  if (!persisted) throw new Error("Scrobble encryption key could not be initialized");
+  return Buffer.from(persisted, "base64");
+});
+const getEncryptionKey = () => {
+  const key = ensureEncryptionKey();
+  if (key.length !== 32) throw new Error("Scrobble encryption key is invalid");
   return key;
 };
 
@@ -56,8 +66,9 @@ export const scrobbleConnectionStore = {
   },
 
   getPublicStatus(userId) {
+    const connections = this.getConnections(userId);
     return Object.fromEntries([...PROVIDERS].map((provider) => {
-      const connection = this.getConnection(userId, provider);
+      const connection = connections[provider];
       return [provider, connection
         ? { connected: true, displayName: connection.displayName, connectedAt: connection.connectedAt }
         : { connected: false, displayName: null, connectedAt: null }];

--- a/backend/services/scrobbleConnectionStore.js
+++ b/backend/services/scrobbleConnectionStore.js
@@ -45,6 +45,7 @@ const normalize = (provider, raw) => {
   return {
     provider,
     token,
+    connectionRevision: String(raw.connectionRevision || raw.connectedAt || "").trim() || null,
     displayName: String(raw.displayName || "").trim() || null,
     baseUrl: String(raw.baseUrl || "").trim() || null,
     connectedAt: Number(raw.connectedAt) || null,
@@ -84,6 +85,7 @@ export const scrobbleConnectionStore = {
     store[key] = store[key] || {};
     store[key][provider] = {
       token: encryptToken(safeToken),
+      connectionRevision: crypto.randomUUID(),
       displayName: String(displayName || "").trim() || null,
       baseUrl: String(baseUrl || "").trim() || null,
       connectedAt: Date.now(),

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -24,6 +24,7 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | Variable | Purpose |
 | -------- | ------- |
 | `TRUST_PROXY` | Set when Aurral is behind a reverse proxy. |
+| `AURRAL_PUBLIC_URL` | Canonical public origin for OAuth callbacks (for example, `https://aurral.example.com`). |
 | `AUTH_PROXY_ENABLED` | Enable reverse-proxy authentication. Default header `x-forwarded-user`. |
 | `AUTH_PROXY_HEADER` | Custom header that contains the authenticated username. |
 | `AUTH_PROXY_DOMAIN` | Origin of your forwardAuth login page (for example, `https://auth.example.com`). Aurral adds it to the `connect-src` content security policy so pages can reach your authentication origin. |

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -14,7 +14,8 @@ description: Common setup and runtime issues.
 - Make sure that Aurral can connect to Lidarr.
 - Make sure that Lidarr contains artists.
 - Add a Last.fm API key for better discovery.
-- Set your listening-history provider in **Profile** (Last.fm or ListenBrainz username, or Koito instance URL).
+- Set your listening-history provider in **Profile** (Local only, a Last.fm or ListenBrainz username,
+  or a Koito instance URL).
 - Run a manual refresh from **Settings > Discover**.
 
 ## Playlists do not download

--- a/docs/src/content/docs/integrations/koito.mdx
+++ b/docs/src/content/docs/integrations/koito.mdx
@@ -9,17 +9,22 @@ Aurral can use your Koito data for personalized discovery. You do not need Last.
 
 ## Per-user setup
 
-Each user must set a Koito instance URL:
+Each user must set a Koito instance URL and API key:
 
 1. Open **Profile > Listening history**.
 2. Select **Koito**.
 3. Enter a base URL that Aurral can reach.
+4. Open **Settings > Playback > Scrobbling > Koito**.
+5. Enter the Koito API key and select **Connect Koito**.
 
 For example, enter `https://koito.example.com:4110`.
 
 ![Aurral profile listening history](../../../assets/screenshots/profile-listening.webp)
 
 Aurral reads your top artists from the Koito chart API. Aurral uses these artists for recommendations and discover playlists.
+
+Aurral sends completed local plays to Koito through its ListenBrainz-compatible `submit-listens`
+endpoint. A provider outage does not remove local history.
 
 The Aurral server must be able to reach Koito.
 
@@ -34,7 +39,7 @@ The Aurral server must be able to reach Koito.
 | Provider     | Admin setup                        | User setup                  |
 | ------------ | ---------------------------------- | --------------------------- |
 | Last.fm      | API key in **Settings > Connect**  | Username in **Profile**     |
-| ListenBrainz | None                               | Username in **Profile**     |
-| Koito        | None                               | Instance URL in **Profile** |
+| ListenBrainz | None                               | Username in **Profile**; token in **Settings > Playback > Scrobbling** |
+| Koito        | None                               | Instance URL and history choice in **Profile**; API key in **Settings > Playback > Scrobbling** |
 
 Last.fm still supplies tags and similar-artist discovery when you configure an API key. Koito supplies listening-history context only.

--- a/docs/src/content/docs/integrations/lastfm.mdx
+++ b/docs/src/content/docs/integrations/lastfm.mdx
@@ -12,7 +12,8 @@ for recommendations and discovery data, and uses both values to connect Last.fm 
 
 ## Scrobbling
 
-Open **Settings > Playback > Scrobbling** and enable **Last.fm**.
+Open **Settings > Playback > Scrobbling**, enable **Last.fm**, select **Connect Last.fm account**,
+and complete the authorization in the Last.fm window.
 
 Aurral copies Navidrome's Last.fm flow directly: it uses the API key and API secret from
 **Settings > Connect**, then stores each user's Last.fm session key. Navidrome is not required.
@@ -26,6 +27,10 @@ Aurral combines local play events with external history when a user selects Last
 or Koito.
 
 Aurral records local plays from the built-in player and Subsonic clients before it contacts Last.fm. A Last.fm outage does not remove local history or stop playback.
+
+Local plays are queued before provider delivery. Delivery is at least once: temporary failures are
+retried, so a provider can receive a duplicate scrobble attempt. Aurral's local history is retained
+regardless of provider delivery results.
 
 ![Aurral profile listening history](../../../assets/screenshots/profile-listening.webp)
 

--- a/docs/src/content/docs/integrations/lastfm.mdx
+++ b/docs/src/content/docs/integrations/lastfm.mdx
@@ -5,13 +5,27 @@ description: Personalized discovery, tags, and listening history.
 
 You can use Aurral without Last.fm. A Last.fm API key improves recommendations, tags, and discover playlists.
 
-## Server setup
+## Recommendations
 
-Add your Last.fm API key in **Settings > Connect > Last.fm**.
+Add your Last.fm API key and API secret in **Settings > Connect > Last.fm**. Aurral uses the key
+for recommendations and discovery data, and uses both values to connect Last.fm scrobbling.
+
+## Scrobbling
+
+Open **Settings > Playback > Scrobbling** and enable **Last.fm**.
+
+Aurral copies Navidrome's Last.fm flow directly: it uses the API key and API secret from
+**Settings > Connect**, then stores each user's Last.fm session key. Navidrome is not required.
 
 ## Per-user listening history
 
-Each user sets a Last.fm username in **Profile**. Aurral uses the username to make personal recommendations.
+Each user selects a history source in **Profile**. Select **Last.fm** and enter a Last.fm username
+to read external history. Select **Local only** to use only Aurral play events.
+
+Aurral combines local play events with external history when a user selects Last.fm, ListenBrainz,
+or Koito.
+
+Aurral records local plays from the built-in player and Subsonic clients before it contacts Last.fm. A Last.fm outage does not remove local history or stop playback.
 
 ![Aurral profile listening history](../../../assets/screenshots/profile-listening.webp)
 
@@ -19,4 +33,5 @@ Each user sets a Last.fm username in **Profile**. Aurral uses the username to ma
 
 Admins set the refresh interval and discovery mode in **Settings > Discover**. The available modes are Safer, Balanced, and Deeper.
 
-If Last.fm is unavailable, Aurral can use ListenBrainz or [Koito](/integrations/koito/) listening history when users have them configured.
+If Last.fm is unavailable, Aurral can use ListenBrainz or [Koito](/integrations/koito/) history
+when the user selects that provider in **Profile**.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -19,7 +19,23 @@ Use the Aurral URL as the Feishin server URL. Set the server type to `Subsonic`.
 
 The native Subsonic responses include playlist artwork through `getPlaylists`, `getPlaylist`, and `getCoverArt`. They also expose genres from canonical artist, album, and track metadata through artist, album, song, and `getGenres` responses. The native path does not fetch metadata from a provider while browsing.
 
-Aurral accepts password authentication for every Aurral user. Token authentication is limited to the configured account because Aurral stores other user passwords as one-way hashes.
+## Submit play history
+
+Aurral reports `scrobble.view` submissions from Subsonic clients as local play events. The endpoint accepts repeated `id` and `time` parameters and follows the Subsonic `submission` flag. A successful submission records local history before Aurral delivers the play to any configured scrobbling provider.
+
+Aurral exposes `scrobblingEnabled=true` from `getuser.view`. This reports that the server supports the scrobble endpoint. It does not require a provider connection.
+
+The built-in Aurral player records completed library tracks through the same local play-event path. Aurral keeps local history when Last.fm, ListenBrainz, or Koito is unavailable.
+
+## Navidrome-compatible scrobbling
+
+Open **Settings > Playback > Scrobbling** to connect Last.fm or ListenBrainz. Aurral copies
+Navidrome's provider flows directly, so a Navidrome connection is not required for scrobbling.
+
+Aurral uses the Last.fm API key and API secret from **Settings > Connect > Last.fm**. It validates
+ListenBrainz tokens directly. Completed plays are submitted from Aurral to the selected provider.
+
+Navidrome remains an independent playback and playlist destination.
 
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
 

--- a/docs/src/content/docs/using/discover.mdx
+++ b/docs/src/content/docs/using/discover.mdx
@@ -52,7 +52,9 @@ You can add them to your Playlists library for downloads and playback.
 
 ## Per-user listening history
 
-Each user sets a listening-history provider in **Profile**. Enter a Last.fm username, ListenBrainz username, or Koito instance URL.
+Each user sets a listening-history provider in **Profile**. Select **Local only**, enter a Last.fm
+or ListenBrainz username, or enter a Koito instance URL. Aurral uses local play events for every
+profile and adds external history when the selected provider supplies it.
 
 Aurral uses this value to make personal recommendations on a shared instance.
 

--- a/frontend/src/contexts/AudioQueueProvider.jsx
+++ b/frontend/src/contexts/AudioQueueProvider.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "r
 import { useAudioPlayerContext } from "react-use-audio-player";
 import { getFormatLoadAttempts, getHowlerFormat, normalizeQueueTrack } from "../utils/audioQueue";
 import { AudioQueueContext } from "./audioQueueContext";
+import { recordPlayEvent } from "../utils/api/endpoints/auth";
 
 const SHARED_VOLUME_KEY = "aurral.preview.volume";
 const SHARED_VOLUME_EVENT = "aurral:shared-volume-change";
@@ -205,6 +206,20 @@ export function AudioQueueProvider({ children }) {
       onend: () => {
         const cur = stateRef.current;
         if (cur.currentIndex < 0) return;
+        if (track.recordHistory) {
+          recordPlayEvent({
+            trackId: track.id,
+            title: track.title,
+            artist: track.artist,
+            album: track.album,
+            artistMbid: track.artistMbid,
+            albumMbid: track.albumMbid,
+            trackMbid: track.trackMbid,
+            durationMs: track.durationMs,
+            playedAt: Date.now(),
+            source: "native-player",
+          }).catch(() => {});
+        }
 
         if (cur.repeatMode === "one") {
           loadedSignatureRef.current = null;

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -701,6 +701,9 @@ function LibraryPage() {
         quality: file?.quality || null,
         artistMbid: artist?.mbid || null,
         albumMbid: album?.mbid || album?.releaseGroupMbid || null,
+        trackMbid: track.mbid || track.trackMbid || null,
+        durationMs: Number(track.durationMs || file?.durationMs || 0) || null,
+        recordHistory: true,
         artwork: getAlbumCover(album),
       };
     },

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -63,6 +63,7 @@ export function SettingsAccountTab({
   }
 
   const profileSummary = (() => {
+    if (listenHistoryProvider === "local") return "Local only";
     if (listenHistoryProvider === "koito" && listenHistoryUrl) {
       return `Koito: ${listenHistoryUrl}`;
     }
@@ -150,8 +151,16 @@ export function SettingsAccountTab({
               <SettingsSelect
                 id="profile-history-provider"
                 value={listenHistoryProvider}
-                onChange={(e) => setListenHistoryProvider(e.target.value)}
+                onChange={(e) => {
+                  const provider = e.target.value;
+                  setListenHistoryProvider(provider);
+                  if (provider === "local") {
+                    setListenHistoryUsername("");
+                    setListenHistoryUrl("");
+                  }
+                }}
               >
+                <option value="local">Local only</option>
                 <option value="lastfm">Last.fm</option>
                 <option value="listenbrainz">ListenBrainz</option>
                 <option value="koito">Koito</option>
@@ -160,7 +169,14 @@ export function SettingsAccountTab({
                 Select the service that supplies your listening history for personalized discovery.
               </p>
             </div>
-            {listenHistoryProvider === "koito" ? (
+            {listenHistoryProvider === "local" ? (
+              <div className="profile-settings__field">
+                <p className="settings-page__hint">
+                  Use Aurral play events for personalized recommendations. Aurral will not read
+                  listening history from an external service.
+                </p>
+              </div>
+            ) : listenHistoryProvider === "koito" ? (
               <div className="profile-settings__field">
                 <label className="profile-settings__label" htmlFor="profile-history-url">
                   Koito URL
@@ -197,8 +213,8 @@ export function SettingsAccountTab({
                   onChange={(e) => setListenHistoryUsername(e.target.value)}
                 />
                 <p className="settings-page__hint">
-                  Connect Last.fm or ListenBrainz for personalized discovery recommendations. Admin
-                  API defaults are in{" "}
+                  Aurral uses the profile selected above for personalized discovery recommendations.
+                  Configure the Last.fm API key in{" "}
                   <Link to="/settings/connect" className="settings-page__link">
                     Settings → Connect
                   </Link>

--- a/frontend/src/pages/Settings/components/SettingsConnectTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsConnectTab.jsx
@@ -2,7 +2,6 @@ import { useState, useRef } from "react";
 import { testGotifyConnection } from "../../../utils/api/endpoints/settings.js";
 
 import { Plus, Trash2, GripVertical } from "lucide-react";
-import { Link } from "react-router-dom";
 import { SettingsInput, SettingsTextarea } from "./SettingsField";
 import { IntegrationCard, SettingsIntegrationModal } from "./SettingsIntegrationCards";
 import {
@@ -116,7 +115,6 @@ export function SettingsConnectTab({
       setTestingGotify(false);
     }
   };
-
   const addWebhook = () => {
     if (webhooks.length >= 5) return;
     updateWebhooks([...webhooks, { url: "", body: null, headers: [] }]);
@@ -192,9 +190,15 @@ export function SettingsConnectTab({
             />
             <IntegrationCard
               title="Last.fm"
-              subtitle="Listening history API"
+              subtitle="Recommendations and scrobbling"
               status={getConfiguredStatus(lastfmConfigured)}
-              meta={lastfm.username || "Admin default"}
+              meta={
+                lastfm.apiKey && lastfm.apiSecret
+                  ? "API key and secret configured"
+                  : lastfm.apiKey
+                    ? "API secret required for scrobbling"
+                    : "API key required"
+              }
               onClick={() => setActiveModal("lastfm")}
             />
             <IntegrationCard
@@ -547,13 +551,10 @@ export function SettingsConnectTab({
       {activeModal === "lastfm" && (
         <SettingsIntegrationModal title="Last.fm" onClose={() => setActiveModal(null)}>
           <SettingsModalIntro>
-            Admin default API key and username. Users can override listening history in{" "}
-            <Link to="/profile" className="settings-page__link">
-              Profile
-            </Link>
-            .
+            Aurral uses the API key for recommendations and discovery data. The API secret is also
+            required to connect a Last.fm account for scrobbling in Playback.
           </SettingsModalIntro>
-          <SettingsModalSection title="Credentials">
+          <SettingsModalSection title="API">
             <SettingsModalField label="API key">
               <SettingsInput
                 type="password"
@@ -563,13 +564,13 @@ export function SettingsConnectTab({
                 onChange={(e) => updateLastfm({ apiKey: e.target.value })}
               />
             </SettingsModalField>
-            <SettingsModalField label="Default username">
+            <SettingsModalField label="API secret">
               <SettingsInput
-                type="text"
-                placeholder="Your Last.fm username"
+                type="password"
+                placeholder="Last.fm API secret"
                 autoComplete="off"
-                value={lastfm.username || ""}
-                onChange={(e) => updateLastfm({ username: e.target.value })}
+                value={lastfm.apiSecret || ""}
+                onChange={(e) => updateLastfm({ apiSecret: e.target.value })}
               />
             </SettingsModalField>
           </SettingsModalSection>

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   startPlexAuth,
@@ -69,6 +69,7 @@ export function SettingsPlaybackSection({
   const [listenBrainzToken, setListenBrainzToken] = useState("");
   const [koitoToken, setKoitoToken] = useState("");
   const [koitoUrl, setKoitoUrl] = useState("");
+  const lastfmPollRef = useRef(null);
 
   const navidrome = settings.integrations?.navidrome || {};
   const plex = settings.integrations?.plex || {};
@@ -81,7 +82,11 @@ export function SettingsPlaybackSection({
   const refreshScrobbleStatus = () => getScrobbleStatus().then(setScrobbleStatus).catch(() => {});
 
   useEffect(() => {
-    getScrobbleStatus().then(setScrobbleStatus).catch(() => {});
+    refreshScrobbleStatus();
+    return () => {
+      if (lastfmPollRef.current) window.clearInterval(lastfmPollRef.current);
+      lastfmPollRef.current = null;
+    };
   }, []);
 
   const closeModal = () => {
@@ -300,6 +305,8 @@ export function SettingsPlaybackSection({
       return;
     }
     try {
+      if (lastfmPollRef.current) window.clearInterval(lastfmPollRef.current);
+      lastfmPollRef.current = null;
       const result = await getLastfmScrobbleLink();
       if (!result.authorizeUrl) {
         showError("Could not start Last.fm linking.");
@@ -314,9 +321,11 @@ export function SettingsPlaybackSection({
         showError("Allow popups to link Last.fm.");
         return;
       }
-      const timer = window.setInterval(() => {
-        if (popup.closed) {
-          window.clearInterval(timer);
+      const deadline = Date.now() + 3 * 60 * 1000;
+      lastfmPollRef.current = window.setInterval(() => {
+        if (popup.closed || Date.now() >= deadline) {
+          window.clearInterval(lastfmPollRef.current);
+          lastfmPollRef.current = null;
           refreshScrobbleStatus();
         }
       }, 500);

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   startPlexAuth,
   checkPlexAuth,
@@ -8,6 +9,13 @@ import {
   testPlaybackConnection,
   syncPlexNow,
 } from "../../../utils/api/endpoints/settings.js";
+import {
+  getLastfmScrobbleLink,
+  getScrobbleStatus,
+  linkKoito,
+  linkListenBrainz,
+  unlinkScrobbleProvider,
+} from "../../../utils/api/endpoints/auth.js";
 import { getConfiguredStatus } from "../utils/integrationStatus";
 
 import {
@@ -26,9 +34,12 @@ import {
 } from "./arr/SettingsArrLayout";
 import {
   SettingsModalActions,
+  SettingsModalCallout,
   SettingsModalField,
   SettingsModalIntro,
   SettingsModalSection,
+  SettingsModalToggle,
+  SettingsModalToggleGroup,
 } from "./SettingsModalLayout";
 import {
   pickBestPlexConnection,
@@ -54,6 +65,10 @@ export function SettingsPlaybackSection({
   const [libraryAccessCheck, setLibraryAccessCheck] = useState(null);
   const [plexPathPickerOpen, setPlexPathPickerOpen] = useState(false);
   const [plexLibraryPathPickerOpen, setPlexLibraryPathPickerOpen] = useState(false);
+  const [scrobbleStatus, setScrobbleStatus] = useState(null);
+  const [listenBrainzToken, setListenBrainzToken] = useState("");
+  const [koitoToken, setKoitoToken] = useState("");
+  const [koitoUrl, setKoitoUrl] = useState("");
 
   const navidrome = settings.integrations?.navidrome || {};
   const plex = settings.integrations?.plex || {};
@@ -62,6 +77,12 @@ export function SettingsPlaybackSection({
   const plexToken = plex.token;
   const pathMappings = Array.isArray(settings.pathMappings) ? settings.pathMappings : [];
   const plexLibraryMapping = pathMappings.find((entry) => entry?.source === "plex") || null;
+
+  const refreshScrobbleStatus = () => getScrobbleStatus().then(setScrobbleStatus).catch(() => {});
+
+  useEffect(() => {
+    getScrobbleStatus().then(setScrobbleStatus).catch(() => {});
+  }, []);
 
   const closeModal = () => {
     setActiveModal(null);
@@ -273,6 +294,84 @@ export function SettingsPlaybackSection({
     }
   };
 
+  const handleLastfmLink = async () => {
+    if (scrobbleStatus?.lastfm?.configured !== true) {
+      setActiveModal("lastfm");
+      return;
+    }
+    try {
+      const result = await getLastfmScrobbleLink();
+      if (!result.authorizeUrl) {
+        showError("Could not start Last.fm linking.");
+        return;
+      }
+      const popup = window.open(
+        result.authorizeUrl,
+        "aurral-lastfm-link",
+        "popup,width=600,height=700",
+      );
+      if (!popup) {
+        showError("Allow popups to link Last.fm.");
+        return;
+      }
+      const timer = window.setInterval(() => {
+        if (popup.closed) {
+          window.clearInterval(timer);
+          refreshScrobbleStatus();
+        }
+      }, 500);
+    } catch (error) {
+      showError(error.response?.data?.error || error.message || "Could not start Last.fm linking");
+    }
+  };
+
+  const handleListenBrainzLink = async () => {
+    try {
+      await linkListenBrainz(listenBrainzToken);
+      setListenBrainzToken("");
+      refreshScrobbleStatus();
+      showSuccess("ListenBrainz connected.");
+    } catch (error) {
+      showError(error.response?.data?.error || error.message || "Could not connect ListenBrainz");
+    }
+  };
+
+  const handleKoitoLink = async () => {
+    try {
+      await linkKoito(koitoToken, koitoUrl);
+      setKoitoToken("");
+      refreshScrobbleStatus();
+      showSuccess("Koito connected.");
+    } catch (error) {
+      showError(error.response?.data?.error || error.message || "Could not connect Koito");
+    }
+  };
+
+  const handleUnlink = async (provider) => {
+    try {
+      await unlinkScrobbleProvider(provider);
+      setActiveModal(null);
+      refreshScrobbleStatus();
+      showSuccess(
+        `${provider === "lastfm" ? "Last.fm" : provider === "listenbrainz" ? "ListenBrainz" : "Koito"} disconnected.`,
+      );
+    } catch (error) {
+      showError(error.response?.data?.error || error.message || "Could not disconnect provider");
+    }
+  };
+
+  const handleScrobbleToggle = (provider, enabled) => {
+    if (enabled) {
+      if (provider === "lastfm" && scrobbleStatus?.lastfm?.configured !== true) {
+        setActiveModal("lastfm");
+        return;
+      }
+      setActiveModal(provider);
+    } else {
+      void handleUnlink(provider);
+    }
+  };
+
   const handleSyncPlex = async () => {
     if (hasUnsavedChanges) {
       const saved = await handleSaveSettings?.();
@@ -328,6 +427,127 @@ export function SettingsPlaybackSection({
           />
         </SettingsArrCardGrid>
       </SettingsArrFieldSet>
+
+      <SettingsArrFieldSet legend="Scrobbling">
+        <div className="arr-info">
+          Send completed local plays to your connected listening services. Aurral uses the same
+          provider flows as Navidrome; a Navidrome connection is not required.
+        </div>
+        <SettingsModalToggleGroup>
+          {["lastfm", "listenbrainz", "koito"].map((provider) => {
+            const status = scrobbleStatus?.[provider];
+            const label = provider === "lastfm"
+              ? status?.displayName
+                ? `Last.fm — ${status.displayName}`
+                : "Last.fm"
+              : provider === "listenbrainz"
+                ? "ListenBrainz"
+                : "Koito";
+            return (
+              <SettingsModalToggle
+                key={provider}
+                label={label}
+                checked={status?.connected === true}
+                disabled={!status}
+                onChange={(event) => handleScrobbleToggle(provider, event.target.checked)}
+              />
+            );
+          })}
+        </SettingsModalToggleGroup>
+        {scrobbleStatus && scrobbleStatus.lastfm?.configured !== true ? (
+          <SettingsModalCallout>
+            Last.fm API key and secret are required before connecting an account. Add them in{" "}
+            <Link to="/settings/connect" className="settings-page__link">
+              Settings → Connect → Last.fm
+            </Link>
+            .
+          </SettingsModalCallout>
+        ) : null}
+      </SettingsArrFieldSet>
+
+      {activeModal === "lastfm" && (
+        <SettingsIntegrationModal title="Last.fm scrobbling" onClose={closeModal}>
+          <SettingsModalIntro>
+            Link the Last.fm account that receives completed local plays. Aurral runs the same
+            Last.fm flow Navidrome uses; Navidrome is not required.
+          </SettingsModalIntro>
+          {scrobbleStatus?.lastfm?.configured !== true ? (
+            <SettingsModalCallout>
+              Last.fm API key and secret are required first. Add them in{" "}
+              <Link to="/settings/connect" className="settings-page__link">
+                Settings → Connect → Last.fm
+              </Link>
+              .
+            </SettingsModalCallout>
+          ) : null}
+          <SettingsModalActions>
+            {scrobbleStatus?.lastfm?.configured === true ? (
+              <button type="button" className="arr-btn arr-btn--secondary" onClick={handleLastfmLink}>
+                {scrobbleStatus?.lastfm?.connected ? "Relink Last.fm" : "Connect Last.fm account"}
+              </button>
+            ) : null}
+            {scrobbleStatus?.lastfm?.connected ? (
+              <button type="button" className="arr-btn arr-btn--ghost" onClick={() => handleUnlink("lastfm")}>
+                Disconnect
+              </button>
+            ) : null}
+          </SettingsModalActions>
+        </SettingsIntegrationModal>
+      )}
+
+      {activeModal === "listenbrainz" && (
+        <SettingsIntegrationModal title="ListenBrainz scrobbling" onClose={closeModal}>
+          <SettingsModalIntro>
+            Enter a ListenBrainz user token. Aurral validates and stores it directly; Navidrome is
+            not required.
+          </SettingsModalIntro>
+          <SettingsModalSection title="Connection">
+            <SettingsModalField label="User token">
+              <SettingsInput
+                type="password"
+                placeholder="ListenBrainz user token"
+                autoComplete="off"
+                value={listenBrainzToken}
+                onChange={(event) => setListenBrainzToken(event.target.value)}
+              />
+            </SettingsModalField>
+          </SettingsModalSection>
+          <SettingsModalActions>
+            <button type="button" className="arr-btn arr-btn--secondary" disabled={!listenBrainzToken} onClick={handleListenBrainzLink}>
+              Connect ListenBrainz
+            </button>
+            {scrobbleStatus?.listenbrainz?.connected ? (
+              <button type="button" className="arr-btn arr-btn--ghost" onClick={() => handleUnlink("listenbrainz")}>
+                Disconnect
+              </button>
+            ) : null}
+          </SettingsModalActions>
+        </SettingsIntegrationModal>
+      )}
+
+      {activeModal === "koito" && (
+        <SettingsIntegrationModal title="Koito scrobbling" onClose={closeModal}>
+          <SettingsModalIntro>Koito accepts the ListenBrainz submission format and API key.</SettingsModalIntro>
+          <SettingsModalSection title="Connection">
+            <SettingsModalField label="Koito URL">
+              <SettingsInput type="url" placeholder="https://koito.example.com" value={koitoUrl} onChange={(event) => setKoitoUrl(event.target.value)} />
+            </SettingsModalField>
+            <SettingsModalField label="API key">
+              <SettingsInput type="password" placeholder="Koito API key" autoComplete="off" value={koitoToken} onChange={(event) => setKoitoToken(event.target.value)} />
+            </SettingsModalField>
+          </SettingsModalSection>
+          <SettingsModalActions>
+            <button type="button" className="arr-btn arr-btn--secondary" disabled={!koitoToken} onClick={handleKoitoLink}>
+              Connect Koito
+            </button>
+            {scrobbleStatus?.koito?.connected ? (
+              <button type="button" className="arr-btn arr-btn--ghost" onClick={() => handleUnlink("koito")}>
+                Disconnect
+              </button>
+            ) : null}
+          </SettingsModalActions>
+        </SettingsIntegrationModal>
+      )}
 
       {activeModal === "navidrome" && (
         <SettingsIntegrationModal

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -77,17 +77,6 @@ function getLocalBypassStatus(status) {
   }
 }
 
-function formatListenHistory(user) {
-  if (!user.listenHistoryUsername && !user.listenHistoryUrl) {
-    return "—";
-  }
-  if (user.listenHistoryProvider === "koito") {
-    return `Koito: ${user.listenHistoryUrl}`;
-  }
-  const provider = user.listenHistoryProvider === "listenbrainz" ? "ListenBrainz" : "Last.fm";
-  return `${provider}: ${user.listenHistoryUsername}`;
-}
-
 function formatPlexLink(user) {
   const plexLink = user.plexLink;
   if (plexLink?.connected) {
@@ -333,7 +322,6 @@ export function SettingsUsersTab({
                   <tr>
                     <th scope="col">Username</th>
                     <th scope="col">Role</th>
-                    <th scope="col">Listening history</th>
                     <th scope="col">Plex</th>
                     <th scope="col" className="arr-table__actions-head">
                       <span className="sr-only">Actions</span>
@@ -343,11 +331,11 @@ export function SettingsUsersTab({
                 <tbody>
                   {loadingUsers ? (
                     <tr className="arr-table__empty-row">
-                      <td colSpan={5}>Loading users…</td>
+                      <td colSpan={4}>Loading users…</td>
                     </tr>
                   ) : usersList.length === 0 ? (
                     <tr className="arr-table__empty-row">
-                      <td colSpan={5}>No users configured.</td>
+                      <td colSpan={4}>No users configured.</td>
                     </tr>
                   ) : (
                     usersList.map((user) => (
@@ -361,9 +349,6 @@ export function SettingsUsersTab({
                           >
                             {user.role}
                           </span>
-                        </td>
-                        <td>
-                          <span className="arr-table__path">{formatListenHistory(user)}</span>
                         </td>
                         <td>
                           <span className="arr-table__path">{formatPlexLink(user)}</span>

--- a/frontend/src/pages/Settings/hooks/useAccountSettings.js
+++ b/frontend/src/pages/Settings/hooks/useAccountSettings.js
@@ -122,7 +122,7 @@ export function useAccountSettings(authUser, showError) {
           updateMyListeningHistory(authUser.id, {
             listenHistoryProvider: saveDraft.provider,
             listenHistoryUsername:
-              saveDraft.provider === "koito" ? null : saveDraft.username || null,
+              ["koito", "local"].includes(saveDraft.provider) ? null : saveDraft.username || null,
             listenHistoryUrl: saveDraft.provider === "koito" ? saveDraft.url || null : null,
           }),
           updateMyLidarrPreferences({

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -58,7 +58,7 @@ const defaultSettings = {
     },
     lastfm: {
       apiKey: "",
-      username: "",
+      apiSecret: "",
       discoveryPeriod: "1month",
       discoveryAutoRefreshHours: 168,
       discoveryRecommendationsPerRefresh: 200,

--- a/frontend/src/pages/Settings/settingsTabsConfig.js
+++ b/frontend/src/pages/Settings/settingsTabsConfig.js
@@ -150,10 +150,11 @@ const SETTINGS_SEARCH_METADATA = {
     },
   },
   playback: {
-    sections: ["Playback Servers", "Cover Art", "Connection", "Account", "Aurral Library Path", "Main library (optional)", "Sync"],
+    sections: ["Playback Servers", "Scrobbling", "Cover Art", "Connection", "Account", "Aurral Library Path", "Main library (optional)", "Sync"],
     services: {
       Navidrome: "Subsonic music server",
       Plex: "Plexamp music server",
+      Scrobbling: "Last.fm ListenBrainz Koito completed plays",
     },
     fields: {
       "Server URL": "playback server address host connection",
@@ -166,13 +167,16 @@ const SETTINGS_SEARCH_METADATA = {
       "Include tracks from an existing library": "Plex main library",
       "Local path for this library (optional)": "Plex path mapping",
       Sync: "Navidrome scan playlists Plex refresh",
+      "Last.fm": "scrobbling OAuth account",
+      ListenBrainz: "scrobbling user token",
+      Koito: "scrobbling API key URL",
     },
   },
   connect: {
     sections: ["Connections", "Webhooks", "Notification Events", "Inbox"],
     services: {
       Gotify: "push notifications mobile alerts",
-      "Last.fm": "listening history API",
+      "Last.fm": "recommendations API key secret scrobbling",
       Ticketmaster: "local shows events",
       Inbox: "library updates releases shows news discoveries",
       Webhooks: "notifications HTTP callbacks",
@@ -180,8 +184,8 @@ const SETTINGS_SEARCH_METADATA = {
     fields: {
       "Server URL": "Gotify address host connection",
       "Application token": "Gotify credentials API",
-      "API key": "Last.fm credentials",
-      "Default username": "Last.fm account listening history",
+      "API key": "Last.fm recommendations and scrobbling credentials",
+      "API secret": "Last.fm scrobbling credentials",
       "Consumer key": "Ticketmaster API credentials",
       "Search radius (miles)": "local shows concerts distance",
       "Local discovery": "Ticketmaster shows concerts artists",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -90,7 +90,6 @@ export const normalizeSettings = (savedSettings) => {
       },
       lastfm: {
         apiKey: "",
-        username: "",
         discoveryPeriod: "1month",
         discoveryAutoRefreshHours: normalizedAutoRefreshHours,
         discoveryRecommendationsPerRefresh: normalizedRecommendationsPerRefresh,

--- a/frontend/src/utils/api/endpoints/auth.js
+++ b/frontend/src/utils/api/endpoints/auth.js
@@ -1,4 +1,4 @@
-import { getData, postData, patchData, deleteData, fetchInflightOnce, bootstrapInflight, lidarrCredentialParams } from "../core.js";
+import { getData, postData, putData, patchData, deleteData, fetchInflightOnce, bootstrapInflight, lidarrCredentialParams } from "../core.js";
 
 export const checkHealth = () => getData("/health");
 
@@ -96,6 +96,17 @@ export const changeMyPassword = async (currentPassword, newPassword) => {
 };
 
 export const getMyListeningHistory = () => getData("/users/me/listening-history");
+
+export const recordPlayEvent = (payload) => postData("/play-events", payload);
+
+export const getScrobbleStatus = () => getData("/scrobbling/status");
+export const getLastfmScrobbleLink = () => getData("/scrobbling/lastfm/link");
+export const linkListenBrainz = (token) =>
+  putData("/scrobbling/listenbrainz/link", { token });
+export const unlinkScrobbleProvider = (provider) =>
+  deleteData(`/scrobbling/${provider}/link`);
+export const linkKoito = (token, url) =>
+  putData("/scrobbling/koito/link", { token, url });
 
 export const getMyLidarrPreferences = () =>
   getData("/users/me/lidarr-preferences");

--- a/frontend/src/utils/audioQueue.js
+++ b/frontend/src/utils/audioQueue.js
@@ -67,6 +67,9 @@ export function normalizeQueueTrack(track, overrides = {}) {
     streamFormat: resolveTrackStreamFormat(track),
     quality: track?.quality ?? overrides.quality ?? null,
     finalPath: track?.finalPath ?? overrides.finalPath ?? null,
+    durationMs: track?.durationMs ?? overrides.durationMs ?? null,
+    recordHistory: track?.recordHistory === true || overrides.recordHistory === true,
+    trackMbid: track?.trackMbid ?? overrides.trackMbid ?? null,
     ...overrides,
   };
   return {
@@ -77,6 +80,8 @@ export function normalizeQueueTrack(track, overrides = {}) {
       String(
         merged.albumMbid ?? track?.albumMbid ?? track?.releaseGroupMbid ?? track?.albumId ?? "",
       ).trim() || null,
+    trackMbid: String(merged.trackMbid ?? "").trim() || null,
+    recordHistory: merged.recordHistory === true,
   };
 }
 
@@ -91,6 +96,9 @@ export function normalizeFlowTrack(track) {
     streamFormat: track.streamFormat,
     artistMbid: track.artistMbid,
     albumMbid: track.albumMbid,
+    trackMbid: track.trackMbid || track.mbid,
+    durationMs: track.durationMs,
+    recordHistory: true,
   });
 }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -64,6 +64,7 @@ export default defineConfig(({ mode }) => {
         "/api": {
           target: "http://localhost:3001",
           changeOrigin: true,
+          xfwd: true,
           secure: false,
           ws: true,
           timeout: 60000,
@@ -72,6 +73,7 @@ export default defineConfig(({ mode }) => {
         "/sso/callback": {
           target: "http://localhost:3001",
           changeOrigin: true,
+          xfwd: true,
           secure: false,
         },
         "/ws": {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -63,7 +63,7 @@ export default defineConfig(({ mode }) => {
       proxy: {
         "/api": {
           target: "http://localhost:3001",
-          changeOrigin: true,
+          changeOrigin: false,
           xfwd: true,
           secure: false,
           ws: true,


### PR DESCRIPTION
## Summary

Adds per-user local play history with discovery integration and support for scrobbling to Last.fm, ListenBrainz, and Koito. Adds playback settings, connection management, encrypted credentials, outbox delivery, and Subsonic scrobble handling.

## Linked issues

- None

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): listening history, scrobbling integrations, Subsonic API, discovery, settings UI, persistence
- Automated coverage: Existing listening-history tests updated; play-event recording and artist aggregation covered by `.tests/history/play-events.test.js`
- Manual steps and expected result: Configure Last.fm, ListenBrainz, or Koito under playback settings; connect the provider; play or scrobble tracks; verify local history, provider delivery, and discovery recommendations.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local-only listening history based on in-app playback.
  - Added play history and top-artist tracking.
  - Added scrobbling connections for Last.fm, ListenBrainz, and Koito.
  - Added controls to connect, disconnect, and view scrobbling status.
  - Added Subsonic play-event submissions.
- **Improvements**
  - Discover recommendations now incorporate local listening activity.
  - Local history is preserved during external-service outages.
  - Last.fm setup now uses an API secret instead of a username.
- **Documentation**
  - Updated guidance for local history and scrobbling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->