### PR TITLE
feat(library): split canonical library, playlists, and flows

### DIFF
--- a/.tests/frontend/library-track-navigation.test.js
+++ b/.tests/frontend/library-track-navigation.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findCanonicalArtistByName,
+  findCanonicalAlbumByName,
+} from "../../frontend/src/utils/libraryTrackNavigation.js";
+
+test("finds an imported artist when canonical metadata has no MBID", () => {
+  const artist = findCanonicalArtistByName(
+    [{ id: 906098, name: "Circle Jerks", mbid: null }],
+    "Circle Jerks",
+  );
+
+  assert.equal(artist?.id, 906098);
+});
+
+test("finds an imported album by title and artist when canonical metadata has no MBID", () => {
+  const album = findCanonicalAlbumByName(
+    [{ id: 906098, title: "Wild In The Streets", albumArtist: "Circle Jerks" }],
+    "Wild in the Streets",
+    "Circle Jerks",
+  );
+
+  assert.equal(album?.id, 906098);
+});

--- a/.tests/history/aurral-history.test.js
+++ b/.tests/history/aurral-history.test.js
@@ -14,7 +14,12 @@ const [isolatedState, { db }, historyModule] = await setupIsolatedBackend(
   "backend/services/aurralHistoryService.js",
 );
 
-const { upsertAurralHistory, getAurralHistoryRequests, recordTrackJobBlocked } = historyModule;
+const {
+  upsertAurralHistory,
+  getAurralHistoryRequests,
+  recordTrackJobBlocked,
+  recordTrackJobQueued,
+} = historyModule;
 const { downloadTracker } = await importFromRepo(
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
 );
@@ -166,6 +171,26 @@ test("getAurralHistoryRequests reconciles completed download jobs", async () => 
   assert.equal(entry?.status, "completed");
   assert.equal(entry?.statusLabel, "Downloaded");
   assert.equal(entry?.inQueue, false);
+});
+
+test("queued library track jobs appear in activity immediately", async () => {
+  const jobId = downloadTracker.addJob(
+    {
+      artistName: "Artist",
+      trackName: "Queued Song",
+      albumName: "Album",
+      trackMbid: "track-mbid",
+    },
+    "library",
+  );
+
+  recordTrackJobQueued(downloadTracker.getJob(jobId));
+
+  const entry = (await getAurralHistoryRequests()).find((item) => item.jobId === jobId);
+  assert.equal(entry?.status, "processing");
+  assert.equal(entry?.statusLabel, "Searching");
+  assert.equal(entry?.inQueue, true);
+  assert.equal(entry?.trackName, "Queued Song");
 });
 
 test("getAurralHistoryRequests fails stale active download history", async () => {

--- a/.tests/library/library-track-hydration.test.js
+++ b/.tests/library/library-track-hydration.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeAlbumMetadataTracks } from "../../frontend/src/utils/libraryTrackHydration.js";
+
+test("merges release metadata with owned album tracks in track order", () => {
+  const tracks = mergeAlbumMetadataTracks(
+    [
+      {
+        id: 9,
+        mbid: "owned-recording",
+        title: "Owned title",
+        trackNumber: 3,
+        available: true,
+        files: [{ available: true, durationMs: 180000 }],
+      },
+    ],
+    [
+      { mbid: "missing-one", title: "Missing one", position: 1, length: 123000 },
+      { mbid: "missing-two", title: "Missing two", position: 2, length: 124000 },
+      { mbid: "metadata-recording", title: "Owned title", position: 3, length: 180000 },
+    ],
+    {
+      id: 42,
+      title: "Album",
+      mbid: "album-mbid",
+      releaseGroupMbid: "release-group-mbid",
+    },
+    { id: 7, name: "Artist", mbid: "artist-mbid" },
+  );
+
+  assert.deepEqual(
+    tracks.map((track) => [track.trackNumber, track.title, track.available]),
+    [
+      [1, "Missing one", false],
+      [2, "Missing two", false],
+      [3, "Owned title", true],
+    ],
+  );
+  assert.equal(tracks[0].durationMs, 123000);
+  assert.deepEqual(tracks[0].albums, [{ albumId: 42, discNumber: 1, trackNumber: 1 }]);
+});

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -266,6 +266,58 @@ test("canonical album track pages keep the selected album relationship", () => {
   }
 });
 
+test("canonical album track pages include indexed tracks without media", () => {
+  const key = `query-album-missing-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({ identityKey: `${key}:artist`, name: "Partial Fixture" });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: artist.id,
+    title: "Partial Album",
+  });
+  const ownedTrack = upsertLibraryTrack({
+    identityKey: `${key}:owned-track`,
+    mbid: `${key}-owned`,
+    title: "Owned Track",
+    artistName: "Partial Fixture",
+  });
+  const missingTrack = upsertLibraryTrack({
+    identityKey: `${key}:missing-track`,
+    mbid: `${key}-missing`,
+    title: "Missing Track",
+    artistName: "Partial Fixture",
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: ownedTrack.id, trackNumber: 1 });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: missingTrack.id, trackNumber: 2 });
+  const ownedPath = `/tmp/${key}/owned.flac`;
+  upsertLibraryMediaFile({
+    trackId: ownedTrack.id,
+    albumId: album.id,
+    source: "aurral",
+    path: ownedPath,
+  });
+
+  try {
+    const page = getCanonicalLibraryPage({
+      source: "aurral",
+      kind: "tracks",
+      albumId: album.id,
+      page: 1,
+      pageSize: 10,
+    });
+    assert.deepEqual(page.items.map((track) => track.title), ["Owned Track", "Missing Track"]);
+    assert.equal(page.items[0].files.length, 1);
+    assert.deepEqual(page.items[1].files, []);
+    assert.equal(page.albums[0].trackCount, 2);
+    assert.equal(page.albums[0].availableTrackCount, 1);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(ownedPath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(ownedTrack.id, missingTrack.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("canonical library responses do not expose filesystem paths", () => {
   const response = toPublicLibrary({
     artists: [{ metadata: { path: "/music/private", tags: { genre: "rock" } } }],

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -285,6 +285,7 @@ test("canonical album track pages include indexed tracks without media", () => {
     mbid: `${key}-missing`,
     title: "Missing Track",
     artistName: "Partial Fixture",
+    metadata: { genres: ["Electronic"] },
   });
   linkLibraryAlbumTrack({ albumId: album.id, trackId: ownedTrack.id, trackNumber: 1 });
   linkLibraryAlbumTrack({ albumId: album.id, trackId: missingTrack.id, trackNumber: 2 });
@@ -309,6 +310,29 @@ test("canonical album track pages include indexed tracks without media", () => {
     assert.deepEqual(page.items[1].files, []);
     assert.equal(page.albums[0].trackCount, 2);
     assert.equal(page.albums[0].availableTrackCount, 1);
+
+    const filtered = getCanonicalLibraryPage({
+      kind: "tracks",
+      albumId: album.id,
+      page: 1,
+      pageSize: 10,
+      query: "missing",
+      genre: "electronic",
+      sort: "name",
+      direction: "desc",
+    });
+    assert.deepEqual(filtered.items.map((track) => track.title), ["Missing Track"]);
+
+    const artistScoped = getCanonicalLibraryPage({
+      kind: "tracks",
+      albumId: album.id,
+      artistId: artist.id,
+      page: 1,
+      pageSize: 10,
+      sort: "name",
+      direction: "desc",
+    });
+    assert.deepEqual(artistScoped.items.map((track) => track.title), ["Owned Track", "Missing Track"]);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path = ?").run(ownedPath);
     db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);

--- a/.tests/library/storage-health-playlist-path.test.js
+++ b/.tests/library/storage-health-playlist-path.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps }, { runStorageHealthCheck }] =
+  await setupIsolatedBackend(
+    "storage-health-playlist-path",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/services/storageHealthService.js",
+  );
+
+test.beforeEach(async () => {
+  await resetDatabase(db);
+  const downloadFolder = process.env.DOWNLOAD_FOLDER;
+  dbOps.updateSettings({
+    ...dbOps.getSettings(),
+    integrations: {},
+    pathMappings: [],
+    downloadFolderPath: downloadFolder,
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("does not report legacy playlist job paths as storage failures", async () => {
+  const result = await runStorageHealthCheck({ force: true });
+
+  assert.equal(result.sections.some((section) => section.id === "playlists"), false);
+  assert.equal(
+    result.sections
+      .find((section) => section.id === "downloads")
+      ?.steps.some((step) => step.id === "playlist-root"),
+    false,
+  );
+});

--- a/.tests/library/storage-health.test.js
+++ b/.tests/library/storage-health.test.js
@@ -63,92 +63,6 @@ test("runStorageHealthCheck passes when downloads folder is writable", async () 
   assert.equal(result.ok, true);
 });
 
-test("runStorageHealthCheck fails when completed playlist files are missing", async () => {
-  const { downloadTracker } = await importFromRepo(
-    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
-  );
-  const playlistRoot = resolvePlaylistRoot();
-  const missingPath = path.join(
-    playlistRoot,
-    "aurral-weekly-flow",
-    "health-playlist",
-    "Artist",
-    "Album",
-    "missing-track.flac",
-  );
-  const jobId = downloadTracker.addJob(
-    { artistName: "Artist", trackName: "Song" },
-    "health-playlist",
-  );
-  downloadTracker.setDone(jobId, missingPath, "Album");
-
-  const result = await runStorageHealthCheck();
-  const playlists = result.sections.find((section) => section.id === "playlists");
-  assert.ok(playlists);
-  assert.equal(playlists.status, "fail");
-  assert.equal(result.ok, false);
-});
-
-test("runStorageHealthCheck passes when completed playlist files exist", async () => {
-  const { downloadTracker } = await importFromRepo(
-    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
-  );
-  const playlistRoot = resolvePlaylistRoot();
-  const trackPath = path.join(
-    playlistRoot,
-    "aurral-weekly-flow",
-    "health-playlist-ok",
-    "Artist",
-    "Album",
-    "present-track.flac",
-  );
-  await fs.mkdir(path.dirname(trackPath), { recursive: true });
-  await fs.writeFile(trackPath, "audio");
-  const jobId = downloadTracker.addJob(
-    { artistName: "Artist", trackName: "Present" },
-    "health-playlist-ok",
-  );
-  downloadTracker.setDone(jobId, trackPath, "Album");
-
-  const result = await runStorageHealthCheck();
-  const playlists = result.sections.find((section) => section.id === "playlists");
-  assert.ok(playlists);
-  assert.equal(playlists.status, "pass");
-});
-
-test("runStorageHealthCheck warns when completed playlist files are empty", async () => {
-  const { downloadTracker } = await importFromRepo(
-    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
-  );
-  const playlistRoot = resolvePlaylistRoot();
-  const trackPath = path.join(
-    playlistRoot,
-    "aurral-weekly-flow",
-    "health-playlist-empty",
-    "Artist",
-    "Album",
-    "empty-track.flac",
-  );
-  await fs.mkdir(path.dirname(trackPath), { recursive: true });
-  await fs.writeFile(trackPath, "");
-  const jobId = downloadTracker.addJob(
-    { artistName: "Artist", trackName: "Empty" },
-    "health-playlist-empty",
-  );
-  downloadTracker.setDone(jobId, trackPath, "Album");
-
-  const result = await runStorageHealthCheck();
-  const playlists = result.sections.find((section) => section.id === "playlists");
-  assert.ok(playlists);
-  assert.equal(playlists.status, "warn");
-  assert.equal(
-    playlists.steps.some(
-      (step) => step.id === "tracked-nonempty" && step.status === "warn",
-    ),
-    true,
-  );
-});
-
 test("runStorageHealthCheck fails when a path mapping local folder is missing", async () => {
   dbOps.updateSettings({
     ...dbOps.getSettings(),
@@ -230,14 +144,6 @@ test("runStorageHealthCheck passes shared volume when dedicated browse roots exi
   const sharedMount = volume.steps.find((step) => step.id === "shared-mount");
   assert.ok(sharedMount);
   assert.equal(sharedMount.status, "pass");
-});
-
-test("runStorageHealthCheck skips playlist verification before any tracks complete", async () => {
-  const result = await runStorageHealthCheck({ force: true });
-  const playlists = result.sections.find((section) => section.id === "playlists");
-
-  assert.equal(playlists?.status, "skip");
-  assert.match(playlists?.skipReason || "", /no completed playlist tracks/i);
 });
 
 test("runStorageHealthCheck does not warn about preferred shared-root conventions", async () => {
@@ -366,6 +272,7 @@ test("slskd missing-path remediation points to slskd rather than a nonexistent A
 
 test("unrelated Navidrome libraries do not fail local storage health", async (t) => {
   const playlistLibrary = path.join(resolvePlaylistRoot(), "aurral-weekly-flow");
+  await fs.mkdir(playlistLibrary, { recursive: true });
   const server = await createMockHttpServer((request, response) => {
     response.writeHead(200, { "content-type": "application/json" });
     if (request.url?.startsWith("/rest/ping")) {
@@ -408,6 +315,7 @@ test("unrelated Navidrome libraries do not fail local storage health", async (t)
 
 test("Navidrome health does not compare reused Lidarr and Navidrome paths", async (t) => {
   const playlistLibrary = path.join(resolvePlaylistRoot(), "aurral-weekly-flow");
+  await fs.mkdir(playlistLibrary, { recursive: true });
   const lidarrRoot = path.join(isolatedState.baseDir, "lidarr-music");
   await fs.mkdir(lidarrRoot, { recursive: true });
   const server = await createMockHttpServer((request, response) => {

--- a/.tests/lidarr/album-lookup-route.test.js
+++ b/.tests/lidarr/album-lookup-route.test.js
@@ -186,3 +186,78 @@ test("canonical album lookup reports partial ownership and the complete track co
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
   }
 });
+
+test("canonical album lookup includes owned tracks after the first track page", async () => {
+  const key = `album-lookup-pagination-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "Paginated Lookup Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}-album`,
+    artistId: artist.id,
+    title: "Paginated Lookup Album",
+  });
+  const trackIds = [];
+  const ownedTrack = upsertLibraryTrack({
+    identityKey: `${key}:owned-track`,
+    mbid: `${key}-owned`,
+    title: "Track 101",
+    artistName: artist.name,
+  });
+  for (let index = 1; index <= 100; index += 1) {
+    const track = upsertLibraryTrack({
+      identityKey: `${key}:track-${index}`,
+      mbid: `${key}-track-${index}`,
+      title: `Track ${String(index).padStart(3, "0")}`,
+      artistName: artist.name,
+    });
+    trackIds.push(track.id);
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: index });
+  }
+  trackIds.push(ownedTrack.id);
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: ownedTrack.id, trackNumber: 101 });
+  const ownedPath = `/tmp/${key}/owned.flac`;
+  upsertLibraryMediaFile({
+    trackId: ownedTrack.id,
+    albumId: album.id,
+    source: "aurral",
+    path: ownedPath,
+  });
+
+  const routes = new Map();
+  registerMisc({
+    get() {},
+    post(path, handler) {
+      routes.set(path, handler);
+    },
+  });
+  let body;
+  const response = {
+    status() {
+      return this;
+    },
+    json(value) {
+      body = value;
+      return this;
+    },
+  };
+
+  try {
+    await routes.get("/albums/lookup/batch")(
+      { body: { mbids: [album.mbid] } },
+      response,
+    );
+    const result = body?.[album.mbid];
+    assert.equal(result?.trackCount, 101);
+    assert.equal(result?.trackFileCount, 1);
+    assert.deepEqual(result?.ownedTrackMbids, [ownedTrack.mbid]);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(ownedPath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare(`DELETE FROM library_tracks WHERE id IN (${trackIds.map(() => "?").join(",")})`).run(...trackIds);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});

--- a/.tests/lidarr/album-lookup-route.test.js
+++ b/.tests/lidarr/album-lookup-route.test.js
@@ -1,9 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { db } from "../../backend/config/db-sqlite.js";
 import { registerMisc } from "../../backend/routes/library/handlers/misc.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { logger } from "../../backend/services/logger.js";
+import {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} from "../../backend/services/libraryMediaStore.js";
 
 test("album batch lookup bypasses stale cache and unrelated broken albums", async () => {
   const routes = new Map();
@@ -17,6 +26,7 @@ test("album batch lookup bypasses stale cache and unrelated broken albums", asyn
   const originalIsConfigured = lidarrClient.isConfigured;
   const originalGetAlbumMbidIndex = lidarrClient.getAlbumMbidIndex;
   const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalGetTracks = libraryManager.getTracks;
   const originalWarn = logger.warn;
   let lookupOptions;
   let warning;
@@ -45,6 +55,7 @@ test("album batch lookup bypasses stale cache and unrelated broken albums", asyn
         }
       : undefined;
   };
+  libraryManager.getTracks = async () => [{ mbid: "owned-track", hasFile: true }];
   logger.warn = (category, message, data) => {
     warning = { category, message, data };
   };
@@ -71,6 +82,7 @@ test("album batch lookup bypasses stale cache and unrelated broken albums", asyn
     assert.equal(statusCode, 200);
     assert.equal(body?.["target-album"]?.inLibrary, true);
     assert.equal(body?.["target-album"]?.status, "monitored");
+    assert.deepEqual(body?.["target-album"]?.ownedTrackMbids, ["owned-track"]);
     assert.equal(lookupOptions?.forceRefresh, true);
     assert.deepEqual(warning, {
       category: "library",
@@ -94,6 +106,83 @@ test("album batch lookup bypasses stale cache and unrelated broken albums", asyn
     lidarrClient.isConfigured = originalIsConfigured;
     lidarrClient.getAlbumMbidIndex = originalGetAlbumMbidIndex;
     lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    libraryManager.getTracks = originalGetTracks;
     logger.warn = originalWarn;
+  }
+});
+
+test("canonical album lookup reports partial ownership and the complete track count", async () => {
+  const key = `album-lookup-partial-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: "11111111-1111-4111-8111-111111111111",
+    name: "Partial Lookup Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: "22222222-2222-4222-8222-222222222222",
+    artistId: artist.id,
+    title: "Partial Lookup Album",
+  });
+  const ownedTrack = upsertLibraryTrack({
+    identityKey: `${key}:owned-track`,
+    mbid: "33333333-3333-4333-8333-333333333333",
+    title: "Owned Track",
+    artistName: artist.name,
+  });
+  const missingTrack = upsertLibraryTrack({
+    identityKey: `${key}:missing-track`,
+    mbid: "44444444-4444-4444-8444-444444444444",
+    title: "Missing Track",
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: ownedTrack.id, trackNumber: 1 });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: missingTrack.id, trackNumber: 2 });
+  const ownedPath = `/tmp/${key}/owned.flac`;
+  upsertLibraryMediaFile({
+    trackId: ownedTrack.id,
+    albumId: album.id,
+    source: "aurral",
+    path: ownedPath,
+  });
+
+  const routes = new Map();
+  registerMisc({
+    get() {},
+    post(path, handler) {
+      routes.set(path, handler);
+    },
+  });
+  let statusCode = 200;
+  let body;
+  const response = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(value) {
+      body = value;
+      return this;
+    },
+  };
+
+  try {
+    await routes.get("/albums/lookup/batch")(
+      { body: { mbids: [album.mbid] } },
+      response,
+    );
+    const result = body?.[album.mbid];
+    assert.equal(statusCode, 200);
+    assert.equal(result?.status, "partial");
+    assert.equal(result?.trackCount, 2);
+    assert.equal(result?.trackFileCount, 1);
+    assert.equal(result?.percentOfTracks, 50);
+    assert.deepEqual(result?.ownedTrackMbids, [ownedTrack.mbid]);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(ownedPath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(ownedTrack.id, missingTrack.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
   }
 });

--- a/.tests/lidarr/album-lookup-route.test.js
+++ b/.tests/lidarr/album-lookup-route.test.js
@@ -6,6 +6,7 @@ import { registerMisc } from "../../backend/routes/library/handlers/misc.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { logger } from "../../backend/services/logger.js";
+import { invalidateCanonicalLibraryCache } from "../../backend/services/libraryQueryService.js";
 import {
   linkLibraryAlbumTrack,
   upsertLibraryAlbum,
@@ -259,5 +260,6 @@ test("canonical album lookup includes owned tracks after the first track page", 
     db.prepare(`DELETE FROM library_tracks WHERE id IN (${trackIds.map(() => "?").join(",")})`).run(...trackIds);
     db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    invalidateCanonicalLibraryCache();
   }
 });

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -160,7 +160,7 @@ test("retains a failed item and completes it safely on retry", async () => {
   assert.equal(third.migrated, 0);
 });
 
-test("does not reuse a same-name destination with different content", async () => {
+test("retains a same-size canonical destination with different content", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Collision" });
   const source = path.join(
     root,
@@ -170,11 +170,11 @@ test("does not reuse a same-name destination with different content", async () =
     "Album",
     "Track.flac",
   );
-  const existing = path.join(root, "Artist", "Album", "Track.mp3");
+  const existing = path.join(root, "Artist", "Album", "Track.flac");
   await fs.mkdir(path.dirname(source), { recursive: true });
   await fs.mkdir(path.dirname(existing), { recursive: true });
   await fs.writeFile(source, "source-content");
-  await fs.writeFile(existing, "different");
+  await fs.writeFile(existing, "target-content");
   const jobId = downloadTracker.addJob(
     { artistName: "Artist", albumName: "Album", trackName: "Track" },
     playlist.id,
@@ -188,10 +188,11 @@ test("does not reuse a same-name destination with different content", async () =
     },
   });
 
-  assert.equal(result.migrated, 1);
-  assert.equal(await fs.readFile(existing, "utf8"), "different");
-  assert.equal(await fs.readFile(path.join(root, "Artist", "Album", "Track.flac"), "utf8"), "source-content");
-  await assert.rejects(() => fs.access(source));
+  assert.equal(result.migrated, 0);
+  assert.equal(result.failed, 1);
+  assert.equal(result.status, "needs-review");
+  assert.equal(await fs.readFile(existing, "utf8"), "target-content");
+  assert.equal(await fs.readFile(source, "utf8"), "source-content");
 });
 
 test("retains partial and ambiguous files instead of guessing", async () => {

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -30,6 +30,7 @@ const root = process.env.WEEKLY_FLOW_FOLDER;
 test.beforeEach(async () => {
   await fs.rm(root, { recursive: true, force: true });
   resetDatabase(db);
+  downloadTracker.clearAll();
   dbOps.updateSettings({
     integrations: {},
     flows: [],
@@ -83,7 +84,13 @@ test("migrates permanent tracks, isolates active flows, and removes unkept flow 
     { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
     flow.id,
   );
-  downloadTracker.setDone(permanentJobId, permanentSource);
+  downloadTracker.setDone(permanentJobId, permanentSource, "Album", "/remote/Track.flac");
+  downloadTracker.updateQuality(permanentJobId, {
+    tier: "lossless",
+    format: "FLAC",
+    checkedAt: 123,
+  });
+  const permanentCompletedAt = downloadTracker.getJob(permanentJobId).completedAt;
   downloadTracker.setDone(flowJobId, flowSource);
 
   const result = await migrateAurralDownloadFolder({
@@ -96,7 +103,11 @@ test("migrates permanent tracks, isolates active flows, and removes unkept flow 
   assert.equal(result.migrated, 2);
   assert.equal(result.flowMigrated, 1);
   assert.equal(result.removed, 1);
-  assert.equal(downloadTracker.getJob(permanentJobId).finalPath, permanentDestination);
+  const permanentJob = downloadTracker.getJob(permanentJobId);
+  assert.equal(permanentJob.finalPath, permanentDestination);
+  assert.equal(permanentJob.externalPath, "/remote/Track.flac");
+  assert.equal(permanentJob.completedAt, permanentCompletedAt);
+  assert.equal(permanentJob.qualityTier, "lossless");
   assert.equal(downloadTracker.getJob(flowJobId).finalPath, flowDestination);
   await assert.doesNotReject(() => fs.access(permanentDestination));
   await assert.doesNotReject(() => fs.access(flowDestination));
@@ -149,6 +160,40 @@ test("retains a failed item and completes it safely on retry", async () => {
   assert.equal(third.migrated, 0);
 });
 
+test("does not reuse a same-name destination with different content", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Collision" });
+  const source = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Track.flac",
+  );
+  const existing = path.join(root, "Artist", "Album", "Track.mp3");
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.mkdir(path.dirname(existing), { recursive: true });
+  await fs.writeFile(source, "source-content");
+  await fs.writeFile(existing, "different");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Track" },
+    playlist.id,
+  );
+  downloadTracker.setDone(jobId, source);
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+    indexDestination: async ({ targetPath }) => {
+      assert.equal(targetPath, path.join(root, "Artist", "Album", "Track.flac"));
+    },
+  });
+
+  assert.equal(result.migrated, 1);
+  assert.equal(await fs.readFile(existing, "utf8"), "different");
+  assert.equal(await fs.readFile(path.join(root, "Artist", "Album", "Track.flac"), "utf8"), "source-content");
+  await assert.rejects(() => fs.access(source));
+});
+
 test("retains partial and ambiguous files instead of guessing", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Review" });
   const partial = path.join(
@@ -176,10 +221,20 @@ test("retains partial and ambiguous files instead of guessing", async () => {
 
   const result = await migrateAurralDownloadFolder({
     root,
+    metadataReader: async () => ({
+      common: {
+        albumartist: "Unknown Artist",
+        album: "Unknown Album",
+        title: "Unknown Track",
+      },
+    }),
   });
 
   assert.equal(result.retained, 2);
   assert.equal(result.status, "needs-review");
+  const state = dbOps.getJSONSetting("aurralDownloadFolderMigration");
+  assert.equal(state.items[partial].reason, "partial file");
+  assert.equal(state.items[ambiguous].reason, "ambiguous media identity");
   await assert.doesNotReject(() => fs.access(partial));
   await assert.doesNotReject(() => fs.access(ambiguous));
 });

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -1,0 +1,208 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs/promises";
+import path from "path";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [
+  isolatedState,
+  { db },
+  { dbOps },
+  { flowPlaylistConfig },
+  { downloadTracker },
+  { migrateAurralDownloadFolder },
+] = await setupIsolatedBackend(
+  "aurral-download-folder-migration",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
+  "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  "backend/services/aurralDownloadFolderMigration.js",
+);
+
+const root = process.env.WEEKLY_FLOW_FOLDER;
+
+test.beforeEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  resetDatabase(db);
+  dbOps.updateSettings({
+    integrations: {},
+    flows: [],
+    sharedPlaylists: [],
+    onboardingComplete: true,
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("migrates permanent tracks, isolates active flows, and removes unkept flow files", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Saved" });
+  const flow = flowPlaylistConfig.createFlow({ name: "Nightly", enabled: true });
+  const permanentSource = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Track.flac",
+  );
+  const flowSource = path.join(
+    root,
+    "aurral-weekly-flow",
+    flow.id,
+    "Artist",
+    "Album",
+    "Flow Track.flac",
+  );
+  const unkeptFlowSource = path.join(
+    root,
+    "aurral-weekly-flow",
+    flow.id,
+    "Artist",
+    "Album",
+    "Unkept.flac",
+  );
+  await Promise.all(
+    [permanentSource, flowSource, unkeptFlowSource].map(async (filePath) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, filePath);
+    }),
+  );
+  const permanentJobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Track" },
+    playlist.id,
+  );
+  const flowJobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
+    flow.id,
+  );
+  downloadTracker.setDone(permanentJobId, permanentSource);
+  downloadTracker.setDone(flowJobId, flowSource);
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+    indexDestination: async () => {},
+  });
+
+  const permanentDestination = path.join(root, "Artist", "Album", "Track.flac");
+  const flowDestination = path.join(root, ".flows", flow.id, "Artist", "Album", "Flow Track.flac");
+  assert.equal(result.migrated, 2);
+  assert.equal(result.flowMigrated, 1);
+  assert.equal(result.removed, 1);
+  assert.equal(downloadTracker.getJob(permanentJobId).finalPath, permanentDestination);
+  assert.equal(downloadTracker.getJob(flowJobId).finalPath, flowDestination);
+  await assert.doesNotReject(() => fs.access(permanentDestination));
+  await assert.doesNotReject(() => fs.access(flowDestination));
+  await assert.rejects(() => fs.access(permanentSource));
+  await assert.rejects(() => fs.access(flowSource));
+  await assert.rejects(() => fs.access(unkeptFlowSource));
+});
+
+test("retains a failed item and completes it safely on retry", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Retry" });
+  const source = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Retry.flac",
+  );
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "retry");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Retry" },
+    playlist.id,
+  );
+  downloadTracker.setDone(jobId, source);
+
+  let shouldFail = true;
+  let verifiedBeforeRemoval = false;
+  const indexDestination = async () => {
+    await fs.access(source);
+    await fs.access(path.join(root, "Artist", "Album", "Retry.flac"));
+    verifiedBeforeRemoval = true;
+    if (shouldFail) throw new Error("index unavailable");
+  };
+  const first = await migrateAurralDownloadFolder({ root, indexDestination });
+  assert.equal(first.failed, 1);
+  assert.equal(verifiedBeforeRemoval, true);
+  await assert.doesNotReject(() => fs.access(source));
+  await assert.doesNotReject(() => fs.access(path.join(root, "Artist", "Album", "Retry.flac")));
+
+  shouldFail = false;
+  const second = await migrateAurralDownloadFolder({ root, indexDestination });
+  assert.equal(second.migrated, 1);
+  assert.equal(downloadTracker.getJob(jobId).finalPath, path.join(root, "Artist", "Album", "Retry.flac"));
+  await assert.rejects(() => fs.access(source));
+
+  const third = await migrateAurralDownloadFolder({ root, indexDestination });
+  assert.equal(third.status, "complete");
+  assert.equal(third.scanned, 0);
+  assert.equal(third.migrated, 0);
+});
+
+test("retains partial and ambiguous files instead of guessing", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Review" });
+  const partial = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Partial.flac.part",
+  );
+  const ambiguous = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Unknown",
+    "Unknown",
+    "Ambiguous.flac",
+  );
+  await Promise.all(
+    [partial, ambiguous].map(async (filePath) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, "review");
+    }),
+  );
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+  });
+
+  assert.equal(result.retained, 2);
+  assert.equal(result.status, "needs-review");
+  await assert.doesNotReject(() => fs.access(partial));
+  await assert.doesNotReject(() => fs.access(ambiguous));
+});
+
+test("blocks migration when DL_FOLDER overlaps the Lidarr root", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Protected" });
+  const source = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Protected.flac",
+  );
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "protected");
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+    lidarrRoots: [root],
+  });
+
+  assert.equal(result.status, "blocked");
+  await assert.doesNotReject(() => fs.access(source));
+  await assert.rejects(() => fs.access(path.join(root, "Artist", "Album", "Protected.flac")));
+});

--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -95,8 +95,6 @@ test("approving a reviewed download commits it inside the managed playlist libra
   const payload = await response.json();
   const expectedPath = path.join(
     process.env.DOWNLOAD_FOLDER,
-    "aurral-weekly-flow",
-    playlistId,
     "Artist",
     "Album",
     "Track.flac",

--- a/.tests/weekly-flow/download-tracker.test.js
+++ b/.tests/weekly-flow/download-tracker.test.js
@@ -9,15 +9,17 @@ import {
   resetDatabase,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps }, trackerModule, qualityProfileService] = await setupIsolatedBackend(
+const [isolatedState, { db }, { dbOps }, trackerModule, qualityProfileService, workerModule] = await setupIsolatedBackend(
   "download-tracker",
   "backend/config/db-sqlite.js",
   "backend/db/helpers/index.js",
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
   "backend/services/qualityProfileService.js",
+  "backend/services/weeklyFlow/weeklyFlowWorker.js",
 );
 
 const { WeeklyFlowDownloadTracker } = trackerModule;
+const { WeeklyFlowWorker } = workerModule;
 
 test.beforeEach(async () => {
   await resetDatabase(db);
@@ -46,6 +48,19 @@ test("getNextPendingMatching skips future-dated retry jobs and returns ready wor
   );
 
   assert.equal(ready?.id, secondId);
+});
+
+test("worker does not select a job that is already active", () => {
+  const tracker = trackerModule.downloadTracker;
+  const worker = new WeeklyFlowWorker(isolatedState.baseDir);
+  const jobId = tracker.addJob(
+    { artistName: "Artist", trackName: "Library Song" },
+    "library",
+  );
+
+  assert.equal(worker._getNextReadyPendingJob()?.id, jobId);
+  worker.activeJobs.set(jobId, { promise: Promise.resolve() });
+  assert.equal(worker._getNextReadyPendingJob(), null);
 });
 
 test("persists enriched album context for slskd matching", () => {

--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -100,6 +100,42 @@ test("reuseTrackForPlaylist references a completed Aurral track path", async () 
   assert.equal(downloadTracker.getJob(result.jobId)?.finalPath, sourcePath);
 });
 
+test("library reuse does not cross album boundaries for the same track title", async () => {
+  const sourceTrack = {
+    artistName: "Amigo the Devil",
+    trackName: "Hell and You",
+    albumName: "Everything is Fine",
+    albumMbid: "everything-is-fine",
+    trackMbid: "everything-track",
+  };
+  const sourcePath = path.join(
+    weeklyFlowRoot,
+    "aurral-weekly-flow",
+    "source-playlist",
+    "Amigo the Devil",
+    "Everything is Fine",
+    "Hell and You.flac",
+  );
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.writeFile(sourcePath, "audio");
+  const sourceJobId = downloadTracker.addJob(sourceTrack, "source-playlist");
+  downloadTracker.setDone(sourceJobId, sourcePath, sourceTrack.albumName);
+
+  const result = await reuseTrackForPlaylist(
+    {
+      artistName: "Amigo the Devil",
+      trackName: "Hell and You",
+      albumName: "Volume 1",
+      albumMbid: "volume-1",
+      trackMbid: "volume-1-track",
+    },
+    "library",
+    { existingFileMode: "reuse", weeklyFlowRoot },
+  );
+
+  assert.equal(result.reused, false);
+});
+
 test("reuseTrackForPlaylist does not inspect sources when reuse is disabled", async () => {
   const result = await reuseTrackForPlaylist(
     { artistName: "Artist", trackName: "Song", albumName: "Album" },

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -25,7 +25,7 @@ import {
 } from "../services/discovery/index.js";
 import { getCachedArtistCount } from "../services/libraryManager.js";
 import { logger } from "../services/logger.js";
-import { PLAYLIST_LIBRARY_DIR, resolvePlaylistRoot } from "../services/playlistPaths.js";
+import { resolvePlaylistRoot } from "../services/playlistPaths.js";
 import { getFilesystemBrowseRoots } from "../services/downloadFolderConfig.js";
 import { dbOps } from "../db/helpers/index.js";
 import { db } from "../config/db-sqlite.js";
@@ -152,10 +152,6 @@ async function computeDiskSpacePayload(settings) {
     { location: dataDir, role: "App data" },
     { location: path.dirname(dbPath), role: "Database" },
     { location: downloadRoot, role: "Downloads" },
-    {
-      location: path.join(downloadRoot, PLAYLIST_LIBRARY_DIR),
-      role: "Playlist library",
-    },
     ...getFilesystemBrowseRoots().map((location) => ({
       location,
       role: "Browse root",

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -326,11 +326,12 @@ export function registerDownloads(router) {
     try {
       const canonical = getCanonicalLibrary({ source: "all", availableOnly: false });
       const alreadyOwned = canonical.tracks.some((candidate) => {
-        const sameMbid = track.trackMbid && candidate.mbid === track.trackMbid;
-        const sameDetails =
+        if (!candidate.files.some((file) => file.available)) return false;
+        if (track.trackMbid) return candidate.mbid === track.trackMbid;
+        return (
           candidate.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&
-          candidate.title?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase();
-        return (sameMbid || sameDetails) && candidate.files.some((file) => file.available);
+          candidate.title?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase()
+        );
       });
       if (alreadyOwned) return res.json({ success: true, alreadyOwned: true, queued: false });
 
@@ -339,7 +340,7 @@ export function registerDownloads(router) {
       );
       const existingJob = downloadTracker.getAll().find((job) => {
         if (job.playlistType !== "library" || job.status === "failed") return false;
-        if (track.trackMbid && job.trackMbid) return job.trackMbid === track.trackMbid;
+        if (track.trackMbid) return job.trackMbid === track.trackMbid;
         return (
           job.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&
           job.trackName?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase()

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -18,6 +18,11 @@ let allDownloadStatusesCache = {
   pending: null,
 };
 
+const invalidateActivityRequestsCache = () =>
+  import("../../requests.js")
+    .then(({ invalidateRequestsCache }) => invalidateRequestsCache())
+    .catch(() => {});
+
 export const getDownloadStatusesForAlbumIds = async (
   albumIdArrayInput,
   snapshot = null,
@@ -352,6 +357,7 @@ export function registerDownloads(router) {
             "../../../services/aurralHistoryService.js"
           );
           recordTrackJobQueued(existingJob);
+          await invalidateActivityRequestsCache();
         }
         return res.status(202).json({
           success: true,
@@ -398,6 +404,7 @@ export function registerDownloads(router) {
         "../../../services/aurralHistoryService.js"
       );
       recordTrackJobQueued(downloadTracker.getJob(jobId));
+      await invalidateActivityRequestsCache();
       await weeklyFlowWorker.start();
       return res.status(202).json({ success: true, queued: true, jobId });
     } catch (error) {

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -344,7 +344,9 @@ export function registerDownloads(router) {
         "../../../services/weeklyFlow/weeklyFlowDownloadTracker.js"
       );
       const existingJob = downloadTracker.getAll().find((job) => {
-        if (job.playlistType !== "library" || job.status === "failed") return false;
+        if (job.playlistType !== "library" || ["failed", "done"].includes(job.status)) {
+          return false;
+        }
         if (track.trackMbid) return job.trackMbid === track.trackMbid;
         return (
           job.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -8,6 +8,7 @@ import {
   albumHasTrackFiles,
 } from "../../../services/albumSearchState.js";
 import { logger } from "../../../services/logger.js";
+import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 
 const STALE_GRABBED_MS = 15 * 60 * 1000;
 const DOWNLOAD_STATUS_CACHE_MS = 5000;
@@ -303,6 +304,100 @@ export const getAllDownloadStatuses = async () => {
 };
 
 export function registerDownloads(router) {
+  router.post("/downloads/track", requireAuth, requirePermission("addAlbum"), async (req, res) => {
+    const body = req.body || {};
+    const track = {
+      artistName: String(body.artistName || "").trim(),
+      trackName: String(body.trackName || "").trim(),
+      albumName: String(body.albumName || "").trim() || null,
+      artistMbid: String(body.artistMbid || "").trim() || null,
+      albumMbid: String(body.albumMbid || "").trim() || null,
+      trackMbid: String(body.trackMbid || "").trim() || null,
+      releaseYear: String(body.releaseYear || "").trim() || null,
+      durationMs: body.durationMs,
+      trackNumber: body.trackNumber,
+      albumTrackCount: body.albumTrackCount,
+      albumTrackTitles: body.albumTrackTitles,
+    };
+    if (!track.artistName || !track.trackName) {
+      return res.status(400).json({ error: "artistName and trackName are required" });
+    }
+
+    try {
+      const canonical = getCanonicalLibrary({ source: "all", availableOnly: false });
+      const alreadyOwned = canonical.tracks.some((candidate) => {
+        const sameMbid = track.trackMbid && candidate.mbid === track.trackMbid;
+        const sameDetails =
+          candidate.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&
+          candidate.title?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase();
+        return (sameMbid || sameDetails) && candidate.files.some((file) => file.available);
+      });
+      if (alreadyOwned) return res.json({ success: true, alreadyOwned: true, queued: false });
+
+      const { downloadTracker } = await import(
+        "../../../services/weeklyFlow/weeklyFlowDownloadTracker.js"
+      );
+      const existingJob = downloadTracker.getAll().find((job) => {
+        if (job.playlistType !== "library" || job.status === "failed") return false;
+        if (track.trackMbid && job.trackMbid) return job.trackMbid === track.trackMbid;
+        return (
+          job.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&
+          job.trackName?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase()
+        );
+      });
+      if (existingJob) {
+        return res.status(202).json({
+          success: true,
+          queued: existingJob.status !== "done",
+          jobId: existingJob.id,
+          alreadyQueued: true,
+        });
+      }
+
+      const jobId = downloadTracker.addJob(track, "library");
+      if (!jobId) return res.status(400).json({ error: "Track details are incomplete" });
+
+      const { weeklyFlowWorker } = await import(
+        "../../../services/weeklyFlow/weeklyFlowWorker.js"
+      );
+      try {
+        const { normalizeExistingFileMode, reuseTrackForPlaylist } = await import(
+          "../../../services/weeklyFlow/weeklyFlowFileReuse.js"
+        );
+        const reuse = await reuseTrackForPlaylist(track, "library", {
+          existingFileMode: normalizeExistingFileMode(
+            weeklyFlowWorker.getWorkerSettings().existingFileMode,
+          ),
+          weeklyFlowRoot: weeklyFlowWorker.weeklyFlowRoot,
+          existingJobId: jobId,
+          targetPlaylistType: "library",
+          skipHistory: true,
+        });
+        if (reuse.reused) {
+          return res.status(202).json({
+            success: true,
+            queued: false,
+            reused: true,
+            jobId,
+          });
+        }
+      } catch (error) {
+        logger.warn("library", "Track reuse failed; leaving acquisition queued", {
+          error: error.message,
+        });
+      }
+
+      await weeklyFlowWorker.start();
+      return res.status(202).json({ success: true, queued: true, jobId });
+    } catch (error) {
+      logger.error("library", "Failed to queue track acquisition", error.message);
+      return res.status(500).json({
+        error: "Failed to queue track acquisition",
+        message: error.message,
+      });
+    }
+  });
+
   router.post("/downloads/album", requireAuth, requirePermission("addAlbum"), async (req, res) => {
     try {
       const { albumId } = req.body;

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -347,6 +347,12 @@ export function registerDownloads(router) {
         );
       });
       if (existingJob) {
+        if (existingJob.status !== "done") {
+          const { recordTrackJobQueued } = await import(
+            "../../../services/aurralHistoryService.js"
+          );
+          recordTrackJobQueued(existingJob);
+        }
         return res.status(202).json({
           success: true,
           queued: existingJob.status !== "done",
@@ -388,6 +394,10 @@ export function registerDownloads(router) {
         });
       }
 
+      const { recordTrackJobQueued } = await import(
+        "../../../services/aurralHistoryService.js"
+      );
+      recordTrackJobQueued(downloadTracker.getJob(jobId));
       await weeklyFlowWorker.start();
       return res.status(202).json({ success: true, queued: true, jobId });
     } catch (error) {

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -167,10 +167,26 @@ export function registerMisc(router) {
             pageSize: 100,
           });
           const albumStats = albumPage.albums[0];
-          const ownedTrackMbids = albumPage.tracks
-            .filter((track) => track.available && track.mbid)
-            .map((track) => String(track.mbid).trim())
-            .filter(Boolean);
+          const ownedTrackMbids = [];
+          let trackPage = albumPage;
+          while (trackPage) {
+            ownedTrackMbids.push(
+              ...trackPage.tracks
+                .filter((track) => track.available && track.mbid)
+                .map((track) => String(track.mbid).trim())
+                .filter(Boolean),
+            );
+            trackPage = trackPage.hasMore
+              ? getCanonicalLibraryPage({
+                  source: "all",
+                  availableOnly: false,
+                  kind: "tracks",
+                  albumId: album.id,
+                  page: trackPage.page + 1,
+                  pageSize: 100,
+                })
+              : null;
+          }
           results[foreignAlbumId] = canonicalAlbumResult(
             albumStats
               ? {

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -6,6 +6,7 @@ import { libraryManager } from "../../../services/libraryManager.js";
 import { normalizePercentOfTracks } from "../../../services/lidarrAlbumStats.js";
 import { logger } from "../../../services/logger.js";
 import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalLibraryPage } from "../../../services/libraryQueryService.js";
 
 const canonicalAlbumLookup = (albums, reference) =>
   albums.find((album) =>
@@ -14,22 +15,35 @@ const canonicalAlbumLookup = (albums, reference) =>
     ),
   );
 
-const canonicalAlbumResult = (album) => ({
+const canonicalAlbumResult = (album, ownedTrackMbids = []) => ({
   inLibrary: true,
   canonicalInLibrary: true,
   canonicalAlbumId: String(album.canonicalId ?? album.id),
   canonicalArtistId: String(album.artistId),
   libraryAlbumId: String(album.providerId ?? album.id),
   libraryArtistId: String(album.providerArtistId ?? album.artistId),
-  status: album.available ? "available" : "partial",
+  status:
+    Number(album.statistics?.trackCount || 0) > Number(album.statistics?.trackFileCount || 0)
+      ? "partial"
+      : album.available
+        ? "available"
+        : "partial",
   monitored: album.monitored,
   percentOfTracks: Number(album.statistics?.percentOfTracks || 0),
   sizeOnDisk: Number(album.statistics?.sizeOnDisk || 0),
   trackCount: Number(album.statistics?.trackCount || 0),
   trackFileCount: Number(album.statistics?.trackFileCount || 0),
+  ownedTrackMbids,
   albumName: String(album.albumName || album.title || "").trim(),
   releaseDate: String(album.releaseDate || "").trim(),
 });
+
+const ownedLidarrTrackMbids = (tracks) =>
+  (Array.isArray(tracks) ? tracks : [])
+    .filter((track) => track?.hasFile === true || track?.path || track?.trackFile?.path)
+    .map((track) => track?.mbid || track?.foreignRecordingId || track?.foreignTrackId)
+    .map((mbid) => String(mbid || "").trim())
+    .filter(Boolean);
 
 const toLibraryArtist = (artist) => ({
   ...artist,
@@ -143,7 +157,39 @@ export function registerMisc(router) {
       const results = {};
       for (const foreignAlbumId of wanted) {
         const album = canonicalAlbumLookup(canonicalAlbums, foreignAlbumId);
-        if (album) results[foreignAlbumId] = canonicalAlbumResult(album);
+        if (album) {
+          const albumPage = getCanonicalLibraryPage({
+            source: "all",
+            availableOnly: false,
+            kind: "tracks",
+            albumId: album.id,
+            page: 1,
+            pageSize: 100,
+          });
+          const albumStats = albumPage.albums[0];
+          const ownedTrackMbids = albumPage.tracks
+            .filter((track) => track.available && track.mbid)
+            .map((track) => String(track.mbid).trim())
+            .filter(Boolean);
+          results[foreignAlbumId] = canonicalAlbumResult(
+            albumStats
+              ? {
+                  ...album,
+                  available: albumStats.availableTrackCount > 0,
+                  statistics: {
+                    ...album.statistics,
+                    trackCount: albumStats.trackCount,
+                    trackFileCount: albumStats.availableTrackCount,
+                    percentOfTracks:
+                      albumStats.trackCount > 0
+                        ? (albumStats.availableTrackCount / albumStats.trackCount) * 100
+                        : 0,
+                  },
+                }
+              : album,
+            ownedTrackMbids,
+          );
+        }
       }
 
       const missing = wanted.filter((foreignAlbumId) => !results[foreignAlbumId]);
@@ -176,6 +222,8 @@ export function registerMisc(router) {
         const album = result.value;
         if (!album) continue;
 
+        const albumTracks = album.id ? await libraryManager.getTracks(album.id) : [];
+
         const percentOfTracks = normalizePercentOfTracks(album?.statistics?.percentOfTracks);
         const sizeOnDisk = Number(album?.statistics?.sizeOnDisk || 0);
         const trackCount = Number(album?.statistics?.trackCount || 0);
@@ -195,6 +243,7 @@ export function registerMisc(router) {
           sizeOnDisk,
           trackCount,
           trackFileCount,
+          ownedTrackMbids: ownedLidarrTrackMbids(albumTracks),
           albumName: String(album?.title || "").trim(),
           releaseDate: String(album?.releaseDate || "").trim(),
         };

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -18,7 +18,7 @@ import {
   getAccessibleSharedPlaylist,
 } from "./utils.js";
 import {
-  buildPlaylistDestination,
+  buildAurralTrackDestination,
   resolvePlaylistRoot,
 } from "../../../services/playlistPaths.js";
 import {
@@ -216,7 +216,9 @@ export function registerJobs(router) {
     const ext = path.extname(sourcePath).toLowerCase();
     const albumDir = sanitizePathPart(job.albumName, "Unknown Album");
     const artistDir = sanitizePathPart(job.artistName, "Unknown Artist");
-    const destination = buildPlaylistDestination(job.playlistType, artistDir, albumDir);
+    const destination = buildAurralTrackDestination(job.playlistType, artistDir, albumDir, {
+      ephemeral: Boolean(flowPlaylistConfig.getFlow(job.playlistType)),
+    });
     const finalDir = joinUnderRoot(playlistRoot, destination);
     const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".mp3"}`;
     const finalPath = path.join(finalDir, finalName);

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -1,3 +1,5 @@
+import { createReadStream, constants as fsConstants } from "fs";
+import { createHash } from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { parseFile } from "music-metadata";
@@ -185,10 +187,27 @@ async function collectLegacyFiles(rootPath, knownIds) {
   return [...new Set(files.map((filePath) => path.resolve(filePath)))].sort();
 }
 
-async function findExistingDestination(targetPath, sourceSize = null) {
+async function fileDigest(filePath) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function filesMatch(leftPath, rightPath) {
+  const [leftStat, rightStat] = await Promise.all([fs.stat(leftPath), fs.stat(rightPath)]);
+  if (!leftStat.isFile() || !rightStat.isFile() || leftStat.size !== rightStat.size) return false;
+  const [leftDigest, rightDigest] = await Promise.all([
+    fileDigest(leftPath),
+    fileDigest(rightPath),
+  ]);
+  return leftDigest === rightDigest;
+}
+
+async function findExistingDestination(targetPath, sourcePath) {
   const directory = path.dirname(targetPath);
   const baseName = path.basename(targetPath, path.extname(targetPath)).toLowerCase();
   const targetExtension = path.extname(targetPath).toLowerCase();
+  const sourceStat = await fs.stat(sourcePath);
   const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => []);
   const candidates = entries.filter(
     (entry) =>
@@ -203,17 +222,27 @@ async function findExistingDestination(targetPath, sourceSize = null) {
   );
   for (const entry of candidates) {
     const candidatePath = path.join(directory, entry.name);
-    if (sourceSize === null) return candidatePath;
     const stat = await fs.stat(candidatePath).catch(() => null);
-    if (stat?.isFile() && stat.size === sourceSize) return candidatePath;
+    if (
+      stat?.isFile() &&
+      stat.size === sourceStat.size &&
+      (await filesMatch(sourcePath, candidatePath))
+    ) {
+      return candidatePath;
+    }
   }
   return null;
 }
 
 async function copyWithoutRemovingSource(sourcePath, targetPath) {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
-  const sourceStat = await fs.stat(sourcePath);
-  const existing = await findExistingDestination(targetPath, sourceStat.size);
+  const targetStat = await fs.stat(targetPath).catch(() => null);
+  if (targetStat?.isFile()) {
+    if (await filesMatch(sourcePath, targetPath)) return targetPath;
+    throw new Error("Canonical destination conflicts with source content");
+  }
+  if (targetStat) throw new Error("Canonical destination is not a file");
+  const existing = await findExistingDestination(targetPath, sourcePath);
   if (existing) return existing;
   const temporary = path.join(
     path.dirname(targetPath),
@@ -228,7 +257,10 @@ async function copyWithoutRemovingSource(sourcePath, targetPath) {
     if (sourceStat.size !== temporaryStat.size) {
       throw new Error("Migration copy did not match source size");
     }
-    await fs.rename(temporary, targetPath);
+    await fs.copyFile(temporary, targetPath, fsConstants.COPYFILE_EXCL);
+    if (!(await filesMatch(sourcePath, targetPath))) {
+      throw new Error("Migration copy content did not match source");
+    }
     return targetPath;
   } finally {
     await fs.rm(temporary, { force: true }).catch(() => {});
@@ -471,7 +503,12 @@ export async function migrateAurralDownloadFolder(options = {}) {
       let committedPath = destination;
       const destinationStat = await fs.stat(destination).catch(() => null);
       const destinationMatches =
-        destinationStat?.isFile() && destinationStat.size === stat.size;
+        destinationStat?.isFile() &&
+        destinationStat.size === stat.size &&
+        (await filesMatch(sourcePath, destination));
+      if (destinationStat?.isFile() && !destinationMatches) {
+        throw new Error("Canonical destination conflicts with source content");
+      }
       if (
         !destinationMatches ||
         (previous.status !== "copied" && previous.status !== "indexed" && previous.status !== "referenced")

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -173,30 +173,47 @@ async function resolveJobSourcePath(finalPath, rootPath) {
 async function collectLegacyFiles(rootPath, knownIds) {
   const roots = LEGACY_PLAYLIST_ROOTS.map((name) => path.join(rootPath, name));
   for (const id of knownIds) roots.push(path.join(rootPath, id));
+  const resolvedRoot = path.resolve(rootPath);
   const files = [];
   for (const candidateRoot of [...new Set(roots)]) {
-    if (!isPathInsideRoot(candidateRoot, rootPath)) continue;
-    await walkFiles(candidateRoot, files);
+    const resolvedCandidate = path.resolve(candidateRoot);
+    if (resolvedCandidate === resolvedRoot || !isPathInsideRoot(resolvedCandidate, resolvedRoot)) {
+      continue;
+    }
+    await walkFiles(resolvedCandidate, files);
   }
   return [...new Set(files.map((filePath) => path.resolve(filePath)))].sort();
 }
 
-async function findExistingDestination(targetPath) {
+async function findExistingDestination(targetPath, sourceSize = null) {
   const directory = path.dirname(targetPath);
   const baseName = path.basename(targetPath, path.extname(targetPath)).toLowerCase();
+  const targetExtension = path.extname(targetPath).toLowerCase();
   const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => []);
-  const match = entries.find(
+  const candidates = entries.filter(
     (entry) =>
       entry.isFile() &&
       AUDIO_EXTENSIONS.has(path.extname(entry.name).toLowerCase()) &&
       path.basename(entry.name, path.extname(entry.name)).toLowerCase() === baseName,
   );
-  return match ? path.join(directory, match.name) : null;
+  candidates.sort(
+    (left, right) =>
+      Number(path.extname(right.name).toLowerCase() === targetExtension) -
+      Number(path.extname(left.name).toLowerCase() === targetExtension),
+  );
+  for (const entry of candidates) {
+    const candidatePath = path.join(directory, entry.name);
+    if (sourceSize === null) return candidatePath;
+    const stat = await fs.stat(candidatePath).catch(() => null);
+    if (stat?.isFile() && stat.size === sourceSize) return candidatePath;
+  }
+  return null;
 }
 
 async function copyWithoutRemovingSource(sourcePath, targetPath) {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
-  const existing = await findExistingDestination(targetPath);
+  const sourceStat = await fs.stat(sourcePath);
+  const existing = await findExistingDestination(targetPath, sourceStat.size);
   if (existing) return existing;
   const temporary = path.join(
     path.dirname(targetPath),
@@ -236,12 +253,7 @@ async function removeSource(sourcePath, rootPath) {
 
 function updateJobPaths(jobs, destination) {
   for (const job of jobs) {
-    downloadTracker.setDone(
-      job.id,
-      destination,
-      job.albumName || null,
-      job.externalPath || null,
-    );
+    downloadTracker.updateFinalPath(job.id, destination);
   }
 }
 
@@ -288,7 +300,7 @@ async function resolveIdentity(sourcePath, rootPath, playlistId, jobs, metadataR
 }
 
 async function defaultIndexDestination({ rootPath, targetPath, metadataReader }) {
-  await scanMusicRoot({ rootPath, source: "aurral", metadataReader });
+  await scanMusicRoot({ rootPath, source: "aurral", filePaths: [targetPath], metadataReader });
   const media = getLibraryMediaFile({ source: "aurral", path: targetPath });
   if (!media?.available) {
     throw new Error("Destination was not indexed as available Aurral media");
@@ -358,10 +370,11 @@ export async function migrateAurralDownloadFolder(options = {}) {
     ...flowPlaylistConfig.getSharedPlaylists().map((playlist) => String(playlist.id)),
   ]);
   const files = await collectLegacyFiles(rootPath, knownIds);
+  const fileSet = new Set(files);
   const jobsByPath = new Map();
   for (const job of jobs) {
     const sourcePath = await resolveJobSourcePath(job.finalPath, rootPath);
-    if (!sourcePath || !files.includes(sourcePath)) continue;
+    if (!sourcePath || !fileSet.has(sourcePath)) continue;
     const matches = jobsByPath.get(sourcePath) || [];
     matches.push(job);
     jobsByPath.set(sourcePath, matches);
@@ -456,12 +469,11 @@ export async function migrateAurralDownloadFolder(options = {}) {
 
     try {
       let committedPath = destination;
-      let destinationExists = false;
-      try {
-        destinationExists = (await fs.stat(destination)).isFile();
-      } catch {}
+      const destinationStat = await fs.stat(destination).catch(() => null);
+      const destinationMatches =
+        destinationStat?.isFile() && destinationStat.size === stat.size;
       if (
-        !destinationExists ||
+        !destinationMatches ||
         (previous.status !== "copied" && previous.status !== "indexed" && previous.status !== "referenced")
       ) {
         committedPath = await copyWithoutRemovingSource(sourcePath, destination);
@@ -522,7 +534,7 @@ export async function migrateAurralDownloadFolder(options = {}) {
   }
 
   for (const [sourcePath, item] of Object.entries(state.items)) {
-    if (item?.status !== "referenced" || files.includes(sourcePath)) continue;
+    if (item?.status !== "referenced" || fileSet.has(sourcePath)) continue;
     state.items[sourcePath] = { ...item, status: "complete", updatedAt: Date.now() };
   }
   state.status = result.failed || result.retained ? "needs-review" : "complete";

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -1,0 +1,541 @@
+import fs from "fs/promises";
+import path from "path";
+import { parseFile } from "music-metadata";
+import { dbOps, userOps } from "../db/helpers/index.js";
+import {
+  AUDIO_EXTENSIONS,
+  buildMetadataRecord,
+  scanMusicRoot,
+} from "./libraryFileScanner.js";
+import { getLibraryMediaFile } from "./libraryMediaStore.js";
+import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
+import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
+import {
+  PLAYLIST_LIBRARY_DIR,
+  buildAurralTrackDestination,
+  isPathInsideRoot,
+  remapLegacyPath,
+  resolvePlaylistRoot,
+} from "./playlistPaths.js";
+import { sanitizePathPart } from "./playlistDownloadUtils.js";
+
+export const AURRAL_DOWNLOAD_FOLDER_MIGRATION_VERSION = 1;
+export const AURRAL_DOWNLOAD_FOLDER_MIGRATION_SETTING = "aurralDownloadFolderMigration";
+
+const LEGACY_PLAYLIST_ROOTS = [PLAYLIST_LIBRARY_DIR, "aurral-playlists"];
+const PARTIAL_EXTENSIONS = new Set([
+  ".crdownload",
+  ".download",
+  ".part",
+  ".partial",
+  ".tmp",
+]);
+const UNKNOWN_IDENTITY_VALUES = new Set([
+  "unknown",
+  "unknown artist",
+  "unknown album",
+  "unknown track",
+]);
+
+const text = (value) => String(value || "").trim();
+
+function log(logger, method, message, details = null) {
+  const fn = logger?.[method];
+  if (typeof fn !== "function") return;
+  fn.call(logger, message, ...(details ? [details] : []));
+}
+
+function newMigrationState(rootPath) {
+  return {
+    version: AURRAL_DOWNLOAD_FOLDER_MIGRATION_VERSION,
+    rootPath,
+    status: "pending",
+    items: {},
+    updatedAt: Date.now(),
+  };
+}
+
+function loadMigrationState(rootPath) {
+  const stored = dbOps.getJSONSetting(AURRAL_DOWNLOAD_FOLDER_MIGRATION_SETTING);
+  if (
+    !stored ||
+    stored.version !== AURRAL_DOWNLOAD_FOLDER_MIGRATION_VERSION ||
+    path.resolve(String(stored.rootPath || "")) !== rootPath
+  ) {
+    return newMigrationState(rootPath);
+  }
+  return {
+    ...newMigrationState(rootPath),
+    ...stored,
+    items: stored.items && typeof stored.items === "object" ? stored.items : {},
+  };
+}
+
+function saveMigrationState(state) {
+  state.updatedAt = Date.now();
+  dbOps.setJSONSetting(AURRAL_DOWNLOAD_FOLDER_MIGRATION_SETTING, state);
+}
+
+function pathsOverlap(left, right) {
+  const a = path.resolve(left);
+  const b = path.resolve(right);
+  return a === b || a.startsWith(`${b}${path.sep}`) || b.startsWith(`${a}${path.sep}`);
+}
+
+function configuredLidarrRoots(options) {
+  if (Array.isArray(options.lidarrRoots)) return options.lidarrRoots.filter(Boolean);
+  const settings = dbOps.getSettings();
+  const users = typeof userOps.getAllUsers === "function" ? userOps.getAllUsers() : [];
+  return [
+    settings.rootFolderPath,
+    settings.integrations?.lidarr?.rootFolderPath,
+    ...users.map((user) => user.lidarrRootFolderPath),
+  ].filter(Boolean);
+}
+
+function isPartialFile(filePath, stat) {
+  const extension = path.extname(filePath).toLowerCase();
+  return stat.size <= 0 || PARTIAL_EXTENSIONS.has(extension) || path.basename(filePath).startsWith(".");
+}
+
+function isCandidateFile(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  return AUDIO_EXTENSIONS.has(extension) || PARTIAL_EXTENSIONS.has(extension);
+}
+
+function jobPlaylistId(job) {
+  return text(job?.playlistId || job?.playlistType);
+}
+
+async function walkFiles(rootPath, output = []) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootPath, { withFileTypes: true });
+  } catch {
+    return output;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const filePath = path.join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      await walkFiles(filePath, output);
+    } else if (entry.isFile() && isCandidateFile(filePath)) {
+      output.push(filePath);
+    }
+  }
+  return output;
+}
+
+function safePathPart(value) {
+  const result = sanitizePathPart(value, "");
+  return result && result !== "." && result !== ".." ? result : null;
+}
+
+function legacyPlaylistId(sourcePath, rootPath, knownIds) {
+  const relative = path.relative(rootPath, sourcePath).split(path.sep).filter(Boolean);
+  if (!relative.length) return null;
+  if (LEGACY_PLAYLIST_ROOTS.includes(relative[0])) return relative[1] || null;
+  return knownIds.has(relative[0]) ? relative[0] : null;
+}
+
+function pathIdentity(sourcePath, rootPath, playlistId, isLegacyRoot) {
+  const relative = path.relative(rootPath, sourcePath).split(path.sep).filter(Boolean);
+  const start = isLegacyRoot ? 2 : 1;
+  const parts = relative.slice(start);
+  if (parts.length !== 3) return null;
+  const fileName = parts.at(-1);
+  const title = path.basename(fileName, path.extname(fileName)).replace(/^\d+(?:[. _-]+|$)/, "").trim();
+  return {
+    playlistId,
+    artistName: parts.at(-3) || null,
+    albumName: parts.at(-2) || null,
+    trackName: title || null,
+  };
+}
+
+function isLegacyRootPath(sourcePath, rootPath) {
+  const relative = path.relative(rootPath, sourcePath).split(path.sep).filter(Boolean);
+  return LEGACY_PLAYLIST_ROOTS.includes(relative[0]);
+}
+
+async function resolveJobSourcePath(finalPath, rootPath) {
+  const raw = path.resolve(String(finalPath || ""));
+  const candidates = [...new Set([raw, remapLegacyPath(raw, rootPath)])];
+  for (const candidate of candidates) {
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {}
+  }
+  return null;
+}
+
+async function collectLegacyFiles(rootPath, knownIds) {
+  const roots = LEGACY_PLAYLIST_ROOTS.map((name) => path.join(rootPath, name));
+  for (const id of knownIds) roots.push(path.join(rootPath, id));
+  const files = [];
+  for (const candidateRoot of [...new Set(roots)]) {
+    if (!isPathInsideRoot(candidateRoot, rootPath)) continue;
+    await walkFiles(candidateRoot, files);
+  }
+  return [...new Set(files.map((filePath) => path.resolve(filePath)))].sort();
+}
+
+async function findExistingDestination(targetPath) {
+  const directory = path.dirname(targetPath);
+  const baseName = path.basename(targetPath, path.extname(targetPath)).toLowerCase();
+  const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => []);
+  const match = entries.find(
+    (entry) =>
+      entry.isFile() &&
+      AUDIO_EXTENSIONS.has(path.extname(entry.name).toLowerCase()) &&
+      path.basename(entry.name, path.extname(entry.name)).toLowerCase() === baseName,
+  );
+  return match ? path.join(directory, match.name) : null;
+}
+
+async function copyWithoutRemovingSource(sourcePath, targetPath) {
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  const existing = await findExistingDestination(targetPath);
+  if (existing) return existing;
+  const temporary = path.join(
+    path.dirname(targetPath),
+    `.aurral-migration-${process.pid}-${Date.now()}-${path.basename(targetPath)}.tmp`,
+  );
+  try {
+    await fs.copyFile(sourcePath, temporary);
+    const [sourceStat, temporaryStat] = await Promise.all([
+      fs.stat(sourcePath),
+      fs.stat(temporary),
+    ]);
+    if (sourceStat.size !== temporaryStat.size) {
+      throw new Error("Migration copy did not match source size");
+    }
+    await fs.rename(temporary, targetPath);
+    return targetPath;
+  } finally {
+    await fs.rm(temporary, { force: true }).catch(() => {});
+  }
+}
+
+async function removeSource(sourcePath, rootPath) {
+  if (!isPathInsideRoot(sourcePath, rootPath)) {
+    throw new Error("Migration source is outside the Aurral root");
+  }
+  await fs.rm(sourcePath, { force: true });
+  let current = path.dirname(sourcePath);
+  while (current !== rootPath && isPathInsideRoot(current, rootPath)) {
+    try {
+      await fs.rmdir(current);
+    } catch {
+      break;
+    }
+    current = path.dirname(current);
+  }
+}
+
+function updateJobPaths(jobs, destination) {
+  for (const job of jobs) {
+    downloadTracker.setDone(
+      job.id,
+      destination,
+      job.albumName || null,
+      job.externalPath || null,
+    );
+  }
+}
+
+async function resolveIdentity(sourcePath, rootPath, playlistId, jobs, metadataReader) {
+  const pathValues = pathIdentity(
+    sourcePath,
+    rootPath,
+    playlistId,
+    isLegacyRootPath(sourcePath, rootPath),
+  );
+  const completeJobs = jobs.filter((candidate) =>
+    [candidate.artistName, candidate.albumName, candidate.trackName].every((value) => text(value)),
+  );
+  const jobIdentities = new Set(
+    completeJobs
+      .map((candidate) => [candidate.artistName, candidate.albumName, candidate.trackName].map(text).join("\u0000")),
+  );
+  if (jobIdentities.size > 1) return null;
+  const job = completeJobs[0] || jobs[0] || null;
+  let metadataValues = null;
+  if (!job) {
+    const metadata = await metadataReader(sourcePath, { skipCovers: true });
+    metadataValues = buildMetadataRecord(metadata, sourcePath, rootPath);
+  }
+  const artistName = text(job?.artistName || metadataValues?.artistName || pathValues?.artistName);
+  const albumName = text(job?.albumName || metadataValues?.albumName || pathValues?.albumName);
+  const trackName = text(job?.trackName || metadataValues?.title || pathValues?.trackName);
+  if (!artistName || !albumName || !trackName) return null;
+  if (
+    [artistName, albumName, trackName].some((value) =>
+      UNKNOWN_IDENTITY_VALUES.has(value.toLowerCase()),
+    )
+  ) {
+    return null;
+  }
+  return {
+    artistName,
+    albumName,
+    trackName,
+    artistMbid: job?.artistMbid || metadataValues?.artistMbid || null,
+    albumMbid: job?.albumMbid || metadataValues?.albumMbid || null,
+    trackMbid: job?.trackMbid || metadataValues?.trackMbid || null,
+  };
+}
+
+async function defaultIndexDestination({ rootPath, targetPath, metadataReader }) {
+  await scanMusicRoot({ rootPath, source: "aurral", metadataReader });
+  const media = getLibraryMediaFile({ source: "aurral", path: targetPath });
+  if (!media?.available) {
+    throw new Error("Destination was not indexed as available Aurral media");
+  }
+  return media;
+}
+
+function itemState(state, sourcePath) {
+  return state.items[sourcePath] || {};
+}
+
+function retainItem(state, sourcePath, reason, logger) {
+  state.items[sourcePath] = {
+    ...itemState(state, sourcePath),
+    status: "retained",
+    reason,
+    updatedAt: Date.now(),
+  };
+  saveMigrationState(state);
+  log(logger, "warn", `[AurralMigration] Retained ${sourcePath}: ${reason}`);
+}
+
+function resolveOwnership(sourcePath, rootPath, jobs, knownIds) {
+  const pathPlaylistId = legacyPlaylistId(sourcePath, rootPath, knownIds);
+  const candidates = jobs
+    .map((job) => jobPlaylistId(job))
+    .filter(Boolean);
+  const playlistIds = [...new Set([...candidates, pathPlaylistId].filter(Boolean))];
+  const sharedId = playlistIds.find((id) => flowPlaylistConfig.getSharedPlaylist(id)) || null;
+  const flowId = playlistIds.find((id) => flowPlaylistConfig.getFlow(id)) || null;
+  const playlistId = sharedId || flowId || pathPlaylistId;
+  return {
+    playlistId,
+    sharedPlaylist: playlistId ? flowPlaylistConfig.getSharedPlaylist(playlistId) : null,
+    flow: !sharedId && flowId ? flowPlaylistConfig.getFlow(flowId) : null,
+  };
+}
+
+export async function migrateAurralDownloadFolder(options = {}) {
+  const rootPath = path.resolve(options.root || resolvePlaylistRoot());
+  const logger = options.logger || console;
+  const lidarrRoots = configuredLidarrRoots(options);
+  if (lidarrRoots.some((candidate) => pathsOverlap(rootPath, candidate))) {
+    const reason = "Aurral DL_FOLDER overlaps a configured Lidarr root";
+    log(logger, "error", `[AurralMigration] ${reason}`);
+    return { status: "blocked", rootPath, reason, scanned: 0, migrated: 0, removed: 0, retained: 0 };
+  }
+
+  const state = loadMigrationState(rootPath);
+  if (state.status === "complete") {
+    return {
+      status: "complete",
+      rootPath,
+      scanned: 0,
+      migrated: 0,
+      flowMigrated: 0,
+      removed: 0,
+      retained: 0,
+      failed: 0,
+      failures: [],
+    };
+  }
+  const jobs = downloadTracker.getAll().filter((job) => job?.status === "done");
+  const knownIds = new Set([
+    ...jobs.map(jobPlaylistId).filter(Boolean),
+    ...flowPlaylistConfig.getFlows().map((flow) => String(flow.id)),
+    ...flowPlaylistConfig.getSharedPlaylists().map((playlist) => String(playlist.id)),
+  ]);
+  const files = await collectLegacyFiles(rootPath, knownIds);
+  const jobsByPath = new Map();
+  for (const job of jobs) {
+    const sourcePath = await resolveJobSourcePath(job.finalPath, rootPath);
+    if (!sourcePath || !files.includes(sourcePath)) continue;
+    const matches = jobsByPath.get(sourcePath) || [];
+    matches.push(job);
+    jobsByPath.set(sourcePath, matches);
+  }
+
+  const metadataReader = options.metadataReader || parseFile;
+  const indexDestination = options.indexDestination || defaultIndexDestination;
+  const result = {
+    status: "complete",
+    rootPath,
+    scanned: files.length,
+    migrated: 0,
+    flowMigrated: 0,
+    removed: 0,
+    retained: 0,
+    failed: 0,
+    failures: [],
+  };
+
+  for (const sourcePath of files) {
+    const jobsForSource = jobsByPath.get(sourcePath) || [];
+    let stat;
+    try {
+      stat = await fs.stat(sourcePath);
+    } catch {
+      continue;
+    }
+    if (isPartialFile(sourcePath, stat)) {
+      retainItem(state, sourcePath, "partial file", logger);
+      result.retained += 1;
+      continue;
+    }
+
+    const { playlistId, flow, sharedPlaylist } = resolveOwnership(
+      sourcePath,
+      rootPath,
+      jobsForSource,
+      knownIds,
+    );
+    if (!playlistId || (!flow && !sharedPlaylist)) {
+      retainItem(state, sourcePath, "ambiguous playlist ownership", logger);
+      result.retained += 1;
+      continue;
+    }
+    if (flow && jobsForSource.length === 0) {
+      try {
+        await removeSource(sourcePath, rootPath);
+        state.items[sourcePath] = { status: "removed", reason: "unkept flow media", updatedAt: Date.now() };
+        saveMigrationState(state);
+        result.removed += 1;
+      } catch (error) {
+        retainItem(state, sourcePath, `could not remove unkept flow media: ${error.message}`, logger);
+        result.failed += 1;
+        result.failures.push({ sourcePath, reason: error.message });
+      }
+      continue;
+    }
+
+    let identity;
+    try {
+      identity = await resolveIdentity(sourcePath, rootPath, playlistId, jobsForSource, metadataReader);
+    } catch (error) {
+      retainItem(state, sourcePath, `could not resolve media identity: ${error.message}`, logger);
+      result.retained += 1;
+      continue;
+    }
+    if (!identity) {
+      retainItem(state, sourcePath, "ambiguous media identity", logger);
+      result.retained += 1;
+      continue;
+    }
+
+    const previous = itemState(state, sourcePath);
+    const artistDir = safePathPart(identity.artistName);
+    const albumDir = safePathPart(identity.albumName);
+    const trackName = safePathPart(identity.trackName);
+    if (!artistDir || !albumDir || !trackName) {
+      retainItem(state, sourcePath, "unsafe media identity", logger);
+      result.retained += 1;
+      continue;
+    }
+    const destination = previous.destination || path.resolve(
+      rootPath,
+      buildAurralTrackDestination(playlistId, artistDir, albumDir, { ephemeral: Boolean(flow) }),
+      `${trackName}${path.extname(sourcePath).toLowerCase() || ".mp3"}`,
+    );
+    if (!isPathInsideRoot(destination, rootPath)) {
+      retainItem(state, sourcePath, "destination escaped Aurral root", logger);
+      result.retained += 1;
+      continue;
+    }
+
+    try {
+      let committedPath = destination;
+      let destinationExists = false;
+      try {
+        destinationExists = (await fs.stat(destination)).isFile();
+      } catch {}
+      if (
+        !destinationExists ||
+        (previous.status !== "copied" && previous.status !== "indexed" && previous.status !== "referenced")
+      ) {
+        committedPath = await copyWithoutRemovingSource(sourcePath, destination);
+        state.items[sourcePath] = {
+          ...previous,
+          status: "copied",
+          destination: committedPath,
+          identity,
+          updatedAt: Date.now(),
+        };
+        saveMigrationState(state);
+      }
+      if (!flow) {
+        await indexDestination({
+          rootPath,
+          targetPath: committedPath,
+          identity,
+          jobs: jobsForSource,
+          metadataReader,
+        });
+      } else {
+        const destinationStat = await fs.stat(committedPath);
+        if (!destinationStat.isFile() || destinationStat.size !== stat.size) {
+          throw new Error("Flow destination verification failed");
+        }
+      }
+      state.items[sourcePath] = {
+        ...itemState(state, sourcePath),
+        status: "indexed",
+        destination: committedPath,
+        identity,
+        updatedAt: Date.now(),
+      };
+      saveMigrationState(state);
+      updateJobPaths(jobsForSource, committedPath);
+      state.items[sourcePath] = {
+        ...itemState(state, sourcePath),
+        status: "referenced",
+        updatedAt: Date.now(),
+      };
+      saveMigrationState(state);
+      if (path.resolve(sourcePath) !== path.resolve(committedPath)) {
+        await removeSource(sourcePath, rootPath);
+      }
+      state.items[sourcePath] = {
+        ...itemState(state, sourcePath),
+        status: "complete",
+        updatedAt: Date.now(),
+      };
+      saveMigrationState(state);
+      result.migrated += 1;
+      if (flow) result.flowMigrated += 1;
+    } catch (error) {
+      retainItem(state, sourcePath, `migration verification failed: ${error.message}`, logger);
+      result.failed += 1;
+      result.failures.push({ sourcePath, reason: error.message });
+    }
+  }
+
+  for (const [sourcePath, item] of Object.entries(state.items)) {
+    if (item?.status !== "referenced" || files.includes(sourcePath)) continue;
+    state.items[sourcePath] = { ...item, status: "complete", updatedAt: Date.now() };
+  }
+  state.status = result.failed || result.retained ? "needs-review" : "complete";
+  result.status = state.status;
+  state.lastResult = {
+    scanned: result.scanned,
+    migrated: result.migrated,
+    flowMigrated: result.flowMigrated,
+    removed: result.removed,
+    retained: result.retained,
+    failed: result.failed,
+    failures: result.failures,
+  };
+  saveMigrationState(state);
+  return result;
+}

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -800,6 +800,12 @@ export const recordTrackJobSearching = (job) =>
     title: `Searching ${resolveDownloadClientLabel(job?.downloadSource, job?.downloadClient)} for ${job?.trackName || "track"}`,
   });
 
+export const recordTrackJobQueued = (job) => {
+  const jobId = String(job?.id || "").trim();
+  if (!jobId || dbOps.getAurralHistoryById(stableId("track_download", jobId))) return null;
+  return recordTrackJobSearching(job);
+};
+
 export const recordTrackJobDownloading = (job) =>
   recordTrackJob(job, {
     status: "processing",

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -144,14 +144,29 @@ async function* walkAudioFiles(rootPath) {
 export async function scanMusicRoot({
   rootPath,
   source = "aurral",
+  filePaths = null,
   metadataReader = parseFile,
 } = {}) {
   const resolvedRoot = path.resolve(String(rootPath || ""));
   await fs.mkdir(resolvedRoot, { recursive: true });
+  const requestedFiles = Array.isArray(filePaths)
+    ? [...new Set(filePaths.map((filePath) => path.resolve(String(filePath || ""))))].filter(
+        (filePath) => {
+          const relative = path.relative(resolvedRoot, filePath);
+          return (
+            relative &&
+            !relative.startsWith("..") &&
+            !path.isAbsolute(relative) &&
+            AUDIO_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+          );
+        },
+      )
+    : null;
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   const scanResult = await withLibraryScan(source, resolvedRoot, (scanId) => {
     const run = async () => {
-      for await (const filePath of walkAudioFiles(resolvedRoot)) {
+      const files = requestedFiles || walkAudioFiles(resolvedRoot);
+      for await (const filePath of files) {
         result.filesSeen += 1;
         try {
           const [metadata, stat] = await Promise.all([
@@ -205,7 +220,7 @@ export async function scanMusicRoot({
           result.filesFailed += 1;
         }
       }
-      if (result.filesFailed === 0) markUnseenFilesUnavailable(scanId, source);
+      if (!requestedFiles && result.filesFailed === 0) markUnseenFilesUnavailable(scanId, source);
       return result;
     };
     return run();

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -286,3 +286,14 @@ export function getLibrarySnapshot() {
     files: db.prepare("SELECT * FROM library_media_files ORDER BY path").all(),
   };
 }
+
+export function getLibraryMediaFile({ source, path }) {
+  return db
+    .prepare(
+      `SELECT *
+       FROM library_media_files
+       WHERE source = ? AND path = ?
+       LIMIT 1`,
+    )
+    .get(normalizeText(source), normalizeText(path));
+}

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -526,7 +526,11 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) 
   return buildLibraryFromRows(rows);
 }
 
-function getAlbumTrackLibrary(albumId, sourceFilter) {
+function getAlbumTrackLibrary(
+  albumId,
+  sourceFilter,
+  { query = "", genre = "", sort = "album", direction = "asc", artistId = null } = {},
+) {
   const conditions = ["album.id = ?"];
   const parameters = [];
   const mediaConditions = [
@@ -538,6 +542,35 @@ function getAlbumTrackLibrary(albumId, sourceFilter) {
     parameters.push(sourceFilter);
   }
   parameters.push(Number(albumId));
+  if (artistId) {
+    conditions.push("artist.id = ?");
+    parameters.push(Number(artistId));
+  }
+  if (query) {
+    const pattern = `%${escapeLike(query)}%`;
+    conditions.push(`(${[
+      "track.title",
+      "track.artist_name",
+      "album.title",
+      "album.album_artist",
+      "artist.name",
+    ].map((field) => `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...["track.title", "track.artist_name", "album.title", "album.album_artist", "artist.name"]
+      .map(() => pattern));
+  }
+  if (genre) {
+    const predicate = genrePredicate(["artist", "album", "track"], genre);
+    conditions.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+  const orderDirection = direction === "desc" ? "DESC" : "ASC";
+  const orderBy = sort === "album"
+    ? "album_track.disc_number ASC, album_track.track_number ASC"
+    : sort === "newest"
+      ? recentMediaOrder("tracks", sourceFilter, false, direction)
+    : sort === "artist"
+      ? `artist.name COLLATE NOCASE ${orderDirection}, track.title COLLATE NOCASE ${orderDirection}`
+      : `track.title COLLATE NOCASE ${orderDirection}`;
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
@@ -546,20 +579,21 @@ function getAlbumTrackLibrary(albumId, sourceFilter) {
      JOIN library_artists AS artist ON artist.id = album.artist_id
      LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
      WHERE ${conditions.join(" AND ")}
-     ORDER BY album_track.disc_number, album_track.track_number,
-       track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+     ORDER BY ${orderBy}, album_track.disc_number, album_track.track_number,
+       media.path COLLATE NOCASE`,
   ).all(...parameters);
   return buildLibraryFromRows(rows);
 }
 
-function getAlbumTrackPage(albumId, sourceFilter, page, currentPageSize) {
-  const library = getAlbumTrackLibrary(albumId, sourceFilter);
-  const album = library.albums[0] || null;
+function getAlbumTrackPage(albumId, sourceFilter, page, currentPageSize, options = {}) {
+  const completeLibrary = getAlbumTrackLibrary(albumId, sourceFilter);
+  const library = getAlbumTrackLibrary(albumId, sourceFilter, options);
+  const album = completeLibrary.albums[0] || null;
   const artist = album
-    ? library.artists.find((candidate) => candidate.id === album.artistId) || null
+    ? completeLibrary.artists.find((candidate) => candidate.id === album.artistId) || null
     : null;
   const tracks = library.tracks;
-  const availableTrackCount = tracks.filter((track) => track.available).length;
+  const availableTrackCount = completeLibrary.tracks.filter((track) => track.available).length;
   const pageItems = tracks.slice((page - 1) * currentPageSize, page * currentPageSize);
   const albums = album
     ? [{
@@ -620,7 +654,7 @@ export function getCanonicalLibraryPage({
   pageSize: requestedPageSize = DEFAULT_PAGE_SIZE,
   query = "",
   genre = "",
-  sort = "name",
+  sort = null,
   direction = "asc",
   artistId = null,
   albumId = null,
@@ -633,6 +667,9 @@ export function getCanonicalLibraryPage({
   const normalizedQuery = text(query).toLocaleLowerCase();
   const normalizedGenre = text(genre);
   const normalizedDirection = text(direction).toLocaleLowerCase();
+  const normalizedSort =
+    text(sort).toLocaleLowerCase() ||
+    (normalizedKind === "tracks" && albumId ? "album" : "name");
   const currentPage = pageNumber(page);
   const currentPageSize = pageSize(requestedPageSize);
 
@@ -664,7 +701,13 @@ export function getCanonicalLibraryPage({
   }
 
   if (normalizedKind === "tracks" && albumId && availableOnly !== true) {
-    return getAlbumTrackPage(albumId, sourceFilter, currentPage, currentPageSize);
+    return getAlbumTrackPage(albumId, sourceFilter, currentPage, currentPageSize, {
+      query: normalizedQuery,
+      genre: normalizedGenre,
+      sort: normalizedSort,
+      direction: normalizedDirection,
+      artistId,
+    });
   }
 
   const queryDefinition = buildPageQuery({
@@ -673,7 +716,7 @@ export function getCanonicalLibraryPage({
     availableOnly,
     query: normalizedQuery,
     genre: normalizedGenre,
-    sort: text(sort).toLocaleLowerCase(),
+    sort: normalizedSort,
     direction: normalizedDirection,
     artistId,
     albumId,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -125,26 +125,34 @@ function buildLibraryFromRows(rows) {
       });
     }
 
-    if (!artist.sources.includes(row.media_source)) artist.sources.push(row.media_source);
-    if (!album.sources.includes(row.media_source)) album.sources.push(row.media_source);
-    if (!track.sources.includes(row.media_source)) track.sources.push(row.media_source);
+    if (row.media_id != null) {
+      if (row.media_source && !artist.sources.includes(row.media_source)) {
+        artist.sources.push(row.media_source);
+      }
+      if (row.media_source && !album.sources.includes(row.media_source)) {
+        album.sources.push(row.media_source);
+      }
+      if (row.media_source && !track.sources.includes(row.media_source)) {
+        track.sources.push(row.media_source);
+      }
 
-    const file = {
-      id: row.media_id,
-      source: row.media_source,
-      path: row.media_path,
-      format: row.media_format,
-      size: row.media_size,
-      mtimeMs: row.media_mtime_ms,
-      durationMs: row.media_duration_ms,
-      quality: parseJson(row.media_quality_json),
-      available: Boolean(row.media_available),
-    };
-    if (!track.files.some((entry) => entry.id === file.id)) track.files.push(file);
-    if (file.available) {
-      artist.available = true;
-      album.available = true;
-      track.available = true;
+      const file = {
+        id: row.media_id,
+        source: row.media_source,
+        path: row.media_path,
+        format: row.media_format,
+        size: row.media_size,
+        mtimeMs: row.media_mtime_ms,
+        durationMs: row.media_duration_ms,
+        quality: parseJson(row.media_quality_json),
+        available: Boolean(row.media_available),
+      };
+      if (!track.files.some((entry) => entry.id === file.id)) track.files.push(file);
+      if (file.available) {
+        artist.available = true;
+        album.available = true;
+        track.available = true;
+      }
     }
   }
 
@@ -518,23 +526,83 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) 
   return buildLibraryFromRows(rows);
 }
 
+function getAlbumTrackLibrary(albumId, sourceFilter) {
+  const conditions = ["album.id = ?"];
+  const parameters = [];
+  const mediaConditions = [
+    "media.track_id = track.id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  parameters.push(Number(albumId));
+  const rows = db.prepare(
+    `${CANONICAL_SELECT}
+     FROM library_tracks AS track
+     JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+     JOIN library_albums AS album ON album.id = album_track.album_id
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY album_track.disc_number, album_track.track_number,
+       track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+  ).all(...parameters);
+  return buildLibraryFromRows(rows);
+}
+
+function getAlbumTrackPage(albumId, sourceFilter, page, currentPageSize) {
+  const library = getAlbumTrackLibrary(albumId, sourceFilter);
+  const album = library.albums[0] || null;
+  const artist = album
+    ? library.artists.find((candidate) => candidate.id === album.artistId) || null
+    : null;
+  const tracks = library.tracks;
+  const availableTrackCount = tracks.filter((track) => track.available).length;
+  const pageItems = tracks.slice((page - 1) * currentPageSize, page * currentPageSize);
+  const albums = album
+    ? [{
+        ...album,
+        trackCount: tracks.length,
+        availableTrackCount,
+      }]
+    : [];
+  return {
+    kind: "tracks",
+    page,
+    pageSize: currentPageSize,
+    total: tracks.length,
+    hasMore: page * currentPageSize < tracks.length,
+    items: pageItems,
+    artists: artist ? [artist] : [],
+    albums,
+    tracks: pageItems,
+    genres: getCanonicalGenreStats({ sourceFilter, availableOnly: false }),
+  };
+}
+
 function getAlbumStats(albumIds, sourceFilter) {
   if (!albumIds.length) return new Map();
   const conditions = [`album_track.album_id IN (${albumIds.map(() => "?").join(",")})`];
-  const parameters = [...albumIds];
+  const parameters = [];
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
   if (sourceFilter) {
-    conditions.push("media.source = ?");
+    mediaConditions.push("media.source = ?");
     parameters.push(sourceFilter);
   }
+  parameters.push(...albumIds);
   const rows = db.prepare(
     `SELECT
        album_track.album_id AS album_id,
        COUNT(DISTINCT album_track.track_id) AS track_count,
        COUNT(DISTINCT CASE WHEN media.available = 1 THEN album_track.track_id END) AS available_track_count
      FROM library_album_tracks AS album_track
-     JOIN library_media_files AS media
-       ON media.track_id = album_track.track_id
-       AND ${albumMediaCondition("media", "album_track")}
+     LEFT JOIN library_media_files AS media
+       ON ${mediaConditions.join(" AND ")}
      WHERE ${conditions.join(" AND ")}
      GROUP BY album_track.album_id`,
   ).all(...parameters);
@@ -593,6 +661,10 @@ export function getCanonicalLibraryPage({
       tracks: [],
       genres: getCanonicalGenreStats({ sourceFilter, availableOnly }),
     };
+  }
+
+  if (normalizedKind === "tracks" && albumId && availableOnly !== true) {
+    return getAlbumTrackPage(albumId, sourceFilter, currentPage, currentPageSize);
   }
 
   const queryDefinition = buildPageQuery({

--- a/backend/services/playlistPaths.js
+++ b/backend/services/playlistPaths.js
@@ -8,6 +8,7 @@ import {
 import { commitImportToPlaylistLibrary } from "./playlistDownloadUtils.js";
 
 export const PLAYLIST_LIBRARY_DIR = "aurral-weekly-flow";
+export const AURRAL_FLOWS_DIR = ".flows";
 const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PREVIOUS_V2_LIBRARY_DIR = "aurral-playlists";
 const LEGACY_DOCKER_PLAYLIST_ROOT = "/app/downloads";
@@ -64,6 +65,17 @@ export function buildPlaylistDestination(playlistId, artistDir, albumDir) {
     String(artistDir || "Unknown Artist"),
     String(albumDir || "Unknown Album"),
   );
+}
+
+export function buildAurralTrackDestination(
+  playlistId,
+  artistDir,
+  albumDir,
+  { ephemeral = false } = {},
+) {
+  const destination = [String(artistDir || "Unknown Artist"), String(albumDir || "Unknown Album")];
+  if (ephemeral) destination.unshift(AURRAL_FLOWS_DIR, String(playlistId || ""));
+  return path.posix.join(...destination);
 }
 
 export function isPathInsideRoot(candidatePath, rootPath) {

--- a/backend/services/qualityProfileService.js
+++ b/backend/services/qualityProfileService.js
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import { parseFile } from "music-metadata";
 import { dbOps } from "../db/helpers/index.js";
-import { resolvePlaylistRoot, isPathInsideRoot, PLAYLIST_LIBRARY_DIR } from "./playlistPaths.js";
+import { resolvePlaylistRoot, isPathInsideRoot } from "./playlistPaths.js";
 import { getEnabledDownloadSources } from "./downloadSourceService.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import {
@@ -22,8 +22,7 @@ export function getQualityProfile() {
 
 export function isAurralOwnedPath(filePath) {
   if (!filePath) return false;
-  const libraryRoot = path.join(resolvePlaylistRoot(), PLAYLIST_LIBRARY_DIR);
-  return isPathInsideRoot(path.resolve(filePath), path.resolve(libraryRoot));
+  return isPathInsideRoot(path.resolve(filePath), path.resolve(resolvePlaylistRoot()));
 }
 
 export function decorateJobQuality(job, profile = getQualityProfile()) {

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -19,10 +19,6 @@ import {
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import { commitImportToPlaylistLibrary } from "./playlistDownloadUtils.js";
 import {
-  remapLegacyPath as remapLegacyWeeklyFlowPath,
-  resolvePlaylistRoot as resolveWeeklyFlowRoot,
-} from "./playlistPaths.js";
-import {
   getFilesystemBrowseRoots,
   resolveEnvDownloadFolder,
   getSuggestedDownloadFolderPath,
@@ -34,11 +30,10 @@ const STORAGE_HEALTH_CACHE_TTL_MS = Math.max(
   0,
   Math.floor(Number(process.env.AURRAL_STORAGE_HEALTH_CACHE_MS) || 60 * 1000),
 );
-const PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT = Math.max(
+const MEDIA_HEALTH_SAMPLE_LIMIT = Math.max(
   50,
-  Math.floor(Number(process.env.AURRAL_PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT) || 500),
+  Math.floor(Number(process.env.AURRAL_MEDIA_HEALTH_SAMPLE_LIMIT) || 500),
 );
-
 let storageHealthCache = null;
 let storageHealthCacheExpiresAt = 0;
 let storageHealthCacheKey = "";
@@ -233,7 +228,7 @@ function formatPathAccessDetail(reportedPath, readablePath) {
 async function runDownloadTransferProbe(sourceDir, targetRoot) {
   const probeId = `${process.pid}-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const sourcePath = path.join(sourceDir, `.aurral-transfer-${probeId}.tmp`);
-  const targetDir = path.join(targetRoot, PLAYLIST_LIBRARY_DIR, `.aurral-health-${probeId}`);
+  const targetDir = path.join(targetRoot, `.aurral-health-${probeId}`);
   const targetPath = path.join(targetDir, "transfer.tmp");
   const contents = `aurral transfer health probe ${probeId}\n`;
   let committedPath = null;
@@ -506,23 +501,6 @@ async function checkDownloadsSection() {
               : undefined,
         },
       ),
-    );
-  }
-
-  const playlistLibraryRoot = path.join(downloadFolder, PLAYLIST_LIBRARY_DIR);
-  try {
-    await fs.mkdir(playlistLibraryRoot, { recursive: true });
-    steps.push(
-      healthStep("playlist-root", "pass", "Playlist library folder is ready", {
-        detail: playlistLibraryRoot,
-      }),
-    );
-  } catch (error) {
-    steps.push(
-      healthStep("playlist-root", "fail", "Playlist library folder is ready", {
-        detail: playlistLibraryRoot,
-        fix: error?.message || "Could not create the Aurral playlist library folder.",
-      }),
     );
   }
 
@@ -856,7 +834,7 @@ async function checkNativePlaybackSection() {
     ]);
   }
 
-  const sample = tracks.slice(0, PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT);
+  const sample = tracks.slice(0, MEDIA_HEALTH_SAMPLE_LIMIT);
   const missing = [];
   for (const track of sample) {
     let readable = false;
@@ -968,97 +946,6 @@ async function checkPlexSection() {
   return buildSection("plex", "Plex playback", steps);
 }
 
-async function checkPlaylistFilesSection() {
-  const steps = [];
-  const weeklyFlowRoot = resolveWeeklyFlowRoot();
-  const totalDoneJobs = Number(downloadTracker.getStats()?.done || 0);
-  const doneJobs = downloadTracker.getDoneWithFinalPath(PLAYLIST_FILE_HEALTH_SAMPLE_LIMIT);
-
-  if (doneJobs.length === 0) {
-    return buildSection("playlists", "Playlist files", [], {
-      skipped: true,
-      skipReason: "No completed playlist tracks are available to verify yet.",
-    });
-  }
-
-  let totalMissing = 0;
-  let totalUnreadable = 0;
-  let totalEmpty = 0;
-  let sampleMissing = null;
-  let sampleUnreadable = null;
-  let sampleEmpty = null;
-  for (const job of doneJobs) {
-    const localPath = path.resolve(remapLegacyWeeklyFlowPath(job.finalPath, weeklyFlowRoot));
-    try {
-      const stat = await fs.stat(localPath);
-      if (!stat.isFile()) {
-        totalMissing += 1;
-        if (!sampleMissing) sampleMissing = localPath;
-        continue;
-      }
-      if (stat.size <= 0) {
-        totalEmpty += 1;
-        if (!sampleEmpty) sampleEmpty = localPath;
-      }
-      try {
-        await fs.access(localPath, fs.constants.R_OK);
-      } catch {
-        totalUnreadable += 1;
-        if (!sampleUnreadable) sampleUnreadable = localPath;
-      }
-    } catch {
-      totalMissing += 1;
-      if (!sampleMissing) sampleMissing = localPath;
-    }
-  }
-
-  if (totalMissing > 0) {
-    steps.push(
-      healthStep("tracked", "fail", "Completed playlist files are accessible", {
-        detail: `${totalMissing} of ${doneJobs.length} completed tracks are missing on disk`,
-        fix: sampleMissing
-          ? `Example missing path: ${sampleMissing}. Restore the missing file or fix the mount that should contain it, then update the affected playlist or flow.`
-          : "Restore the missing files or fix the mount that should contain them, then update the affected playlist or flow.",
-      }),
-    );
-    return buildSection("playlists", "Playlist files", steps);
-  }
-
-  if (totalUnreadable > 0) {
-    steps.push(
-      healthStep("tracked-readable", "fail", "Completed playlist files are readable", {
-        detail: `${totalUnreadable} of ${doneJobs.length} completed tracks cannot be read`,
-        fix: sampleUnreadable
-          ? `Example unreadable path: ${sampleUnreadable}. Check ownership, ACLs, and read permissions for the mounted folder.`
-          : "Check ownership, ACLs, and read permissions for the mounted folder.",
-      }),
-    );
-    return buildSection("playlists", "Playlist files", steps);
-  }
-
-  if (totalEmpty > 0) {
-    steps.push(
-      healthStep("tracked-nonempty", "warn", "Completed playlist files are non-empty", {
-        detail: `${totalEmpty} of ${doneJobs.length} completed tracks are zero bytes`,
-        fix: sampleEmpty
-          ? `Example empty path: ${sampleEmpty}. Re-run the affected flow, or remove and add the track again in the affected playlist, so Aurral replaces the empty file.`
-          : "Re-run the affected flow, or remove and add the tracks again in the affected playlist, so Aurral replaces empty files.",
-      }),
-    );
-  }
-
-  steps.push(
-    healthStep("tracked", "pass", "Completed playlist files are accessible", {
-      detail:
-        totalDoneJobs > doneJobs.length
-          ? `${doneJobs.length} of ${totalDoneJobs} completed tracks sampled`
-          : `${doneJobs.length} completed track${doneJobs.length === 1 ? "" : "s"} verified`,
-    }),
-  );
-
-  return buildSection("playlists", "Playlist files", steps);
-}
-
 async function buildStorageHealthCheck() {
   const volumeSection = await checkSharedVolumeSection();
   const downloadsSection = await checkDownloadsSection();
@@ -1075,7 +962,6 @@ async function buildStorageHealthCheck() {
     await checkSabnzbdSection(),
     await checkNavidromeSection(),
     await checkPlexSection(),
-    await checkPlaylistFilesSection(),
   ];
 
   const summary = summarizeResult(sections);

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -86,10 +86,23 @@ async function processSystemTask(payload = {}) {
         import("./weeklyFlow/weeklyFlowPlaylistManager.js"),
         import("./playlistDownloadUtils.js"),
       ]);
-      const result = await migrateAurralDownloadFolder();
+      let result = {
+        migrated: 0,
+        flowMigrated: 0,
+        removed: 0,
+        retained: 0,
+        failed: 0,
+      };
+      try {
+        result = await migrateAurralDownloadFolder();
+      } catch (error) {
+        console.error(`[Playlists] Aurral download folder migration failed: ${error.message}`);
+      }
+      const flowMigrated = result.flowMigrated || 0;
+      const permanentMigrated = (result.migrated || 0) - flowMigrated;
       if (result.migrated > 0 || result.removed > 0) {
         console.log(
-          `[Playlists] Migrated ${result.migrated} permanent track(s) and removed ${result.removed} unkept flow file(s)`,
+          `[Playlists] Migrated ${permanentMigrated} permanent track(s) and ${flowMigrated} flow track(s), and removed ${result.removed} unkept flow file(s)`,
         );
       }
       if (result.retained > 0 || result.failed > 0) {

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -76,23 +76,25 @@ async function processSystemTask(payload = {}) {
     }
     case "playlist-startup-migration": {
       const [
-        { migrateLegacyPaths, resolvePlaylistRoot },
+        { migrateAurralDownloadFolder },
         trackerModule,
         { playlistManager },
         { repairYtdlpMetadata },
       ] = await Promise.all([
-        import("./playlistPaths.js"),
+        import("./aurralDownloadFolderMigration.js"),
         import("./weeklyFlow/weeklyFlowDownloadTracker.js"),
         import("./weeklyFlow/weeklyFlowPlaylistManager.js"),
         import("./playlistDownloadUtils.js"),
       ]);
-      const result = await migrateLegacyPaths(
-        resolvePlaylistRoot(),
-        trackerModule.downloadTracker,
-      );
-      if (result.migrated > 0) {
+      const result = await migrateAurralDownloadFolder();
+      if (result.migrated > 0 || result.removed > 0) {
         console.log(
-          `[Playlists] Migrated ${result.migrated} legacy track paths to ${resolvePlaylistRoot()}`,
+          `[Playlists] Migrated ${result.migrated} permanent track(s) and removed ${result.removed} unkept flow file(s)`,
+        );
+      }
+      if (result.retained > 0 || result.failed > 0) {
+        console.warn(
+          `[Playlists] Retained ${result.retained} item(s) and failed ${result.failed} migration item(s) for review`,
         );
       }
       const metadataRepair = await repairYtdlpMetadata(

--- a/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
@@ -668,6 +668,14 @@ export class WeeklyFlowDownloadTracker {
     return changed;
   }
 
+  updateFinalPath(id, finalPath) {
+    const job = this.jobs.get(id);
+    if (!job || job.status !== "done") return false;
+    job.finalPath = finalPath;
+    this._update(job);
+    return true;
+  }
+
   updateMetadata(id, metadata = {}) {
     const job = this.jobs.get(id);
     if (!job || !metadata || typeof metadata !== "object") return false;
@@ -1017,6 +1025,7 @@ export class WeeklyFlowDownloadTracker {
       updatePlaylistTypeStmt.run(toId, toId, fromId);
       for (const job of this.jobs.values()) {
         if (job.playlistType === fromId) {
+          job.playlistId = toId;
           job.playlistType = toId;
           count += 1;
         }

--- a/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
@@ -2,7 +2,6 @@ import { randomUUID } from "crypto";
 import { db } from "../../config/db-sqlite.js";
 import { enqueuePipelineJob } from "../honkerDb.js";
 import { isAnyDownloadSourceConfigured } from "../downloadSourceService.js";
-import { buildPlaylistDestination } from "../playlistPaths.js";
 import {
   normalizePositiveInteger,
   normalizeStringList,
@@ -10,6 +9,10 @@ import {
   sanitizePathPart,
   stringifyStringListJson,
 } from "../playlistDownloadUtils.js";
+import {
+  buildAurralTrackDestination,
+} from "../playlistPaths.js";
+import { flowPlaylistConfig } from "./weeklyFlowPlaylistConfig.js";
 
 const parseDeniedSources = (raw) => {
   if (!raw) return [];
@@ -209,6 +212,7 @@ function buildPipelinePayload(job) {
   const playlistId = job.playlistId || job.playlistType;
   const artistDir = sanitizePathPart(job.artistName, "Unknown Artist");
   const albumDir = sanitizePathPart(job.albumName, "Unknown Album");
+  const ephemeral = Boolean(flowPlaylistConfig.getFlow(String(job.playlistType || "").trim()));
   return {
     phase: "search",
     jobId: job.id,
@@ -228,7 +232,7 @@ function buildPipelinePayload(job) {
       artistAliases: job.artistAliases || [],
     },
     attempt: 0,
-    destination: buildPlaylistDestination(playlistId, artistDir, albumDir),
+    destination: buildAurralTrackDestination(playlistId, artistDir, albumDir, { ephemeral }),
     upgrade: Boolean(job.upgradeForJobId),
     upgradeForJobId: job.upgradeForJobId || null,
     allowedSources: job.upgradeForJobId ? ["slskd", "usenet"] : null,

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -116,6 +116,22 @@ function isFlowPlaylistType(playlistType) {
   return Boolean(flowPlaylistConfig.getFlow(String(playlistType || "").trim()));
 }
 
+function tracksShareLibraryMembership(left, right) {
+  const leftTrackMbid = String(left?.trackMbid || "").trim();
+  const rightTrackMbid = String(right?.trackMbid || "").trim();
+  if (leftTrackMbid && rightTrackMbid && leftTrackMbid !== rightTrackMbid) return false;
+
+  const leftAlbumMbid = String(left?.albumMbid || "").trim();
+  const rightAlbumMbid = String(right?.albumMbid || "").trim();
+  if (leftAlbumMbid && rightAlbumMbid && leftAlbumMbid !== rightAlbumMbid) return false;
+
+  const leftAlbumName = normalizeText(left?.albumName);
+  const rightAlbumName = normalizeText(right?.albumName);
+  if (leftAlbumName && rightAlbumName && leftAlbumName !== rightAlbumName) return false;
+
+  return tracksShareMembership(left, right);
+}
+
 async function findAurralSource(track, options = {}) {
   const weeklyFlowRoot = path.resolve(options.weeklyFlowRoot || resolveWeeklyFlowRoot());
   const targetPlaylistType = String(options.targetPlaylistType || "").trim();
@@ -129,7 +145,10 @@ async function findAurralSource(track, options = {}) {
     if (!job || job.status !== "done") continue;
     if (excludeJobIds.has(String(job.id || ""))) continue;
     if (!job.finalPath || typeof job.finalPath !== "string") continue;
-    if (!tracksShareMembership(track, job)) continue;
+    const matches = targetPlaylistType === "library"
+      ? tracksShareLibraryMembership(track, job)
+      : tracksShareMembership(track, job);
+    if (!matches) continue;
     if (targetPlaylistType && String(job.playlistType || "") === targetPlaylistType) {
       continue;
     }
@@ -335,7 +354,7 @@ function rankAlbums(albums, track) {
   });
 }
 
-function findMatchingTrack(tracks, track) {
+function findMatchingTrack(tracks, track, strictAlbum = false) {
   const trackMbid = String(track?.trackMbid || "").trim();
   if (trackMbid) {
     const match = tracks.find(
@@ -345,6 +364,7 @@ function findMatchingTrack(tracks, track) {
         String(entry?.foreignTrackId || "").trim() === trackMbid,
     );
     if (match) return match;
+    if (strictAlbum) return null;
   }
   const trackKey = normalizeText(track?.trackName);
   if (!trackKey) return null;
@@ -353,7 +373,8 @@ function findMatchingTrack(tracks, track) {
   );
 }
 
-async function findLidarrSource(track) {
+async function findLidarrSource(track, options = {}) {
+  const strictAlbum = options.targetPlaylistType === "library";
   let artists = [];
   try {
     artists = await libraryManager.getAllArtists();
@@ -386,7 +407,21 @@ async function findLidarrSource(track) {
   }
 
   let foundTitleOnAnyAlbum = false;
-  for (const album of rankAlbums(Array.isArray(albums) ? albums : [], track)) {
+  const rankedAlbums = rankAlbums(Array.isArray(albums) ? albums : [], track);
+  const albumsToCheck = strictAlbum
+    ? rankedAlbums.filter((album) => {
+        const albumMbid = String(track?.albumMbid || "").trim();
+        if (albumMbid) {
+          return (
+            String(album?.mbid || "").trim() === albumMbid ||
+            String(album?.foreignAlbumId || "").trim() === albumMbid
+          );
+        }
+        const albumName = normalizeText(track?.albumName);
+        return !albumName || normalizeText(album?.albumName || album?.title) === albumName;
+      })
+    : rankedAlbums;
+  for (const album of albumsToCheck) {
     let tracks = [];
     try {
       tracks = await libraryManager.getTracks(album.id);
@@ -394,7 +429,11 @@ async function findLidarrSource(track) {
       console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr tracks:", error.message);
       continue;
     }
-    const matchedTrack = findMatchingTrack(Array.isArray(tracks) ? tracks : [], track);
+    const matchedTrack = findMatchingTrack(
+      Array.isArray(tracks) ? tracks : [],
+      track,
+      strictAlbum,
+    );
     if (!matchedTrack) continue;
     foundTitleOnAnyAlbum = true;
     if (matchedTrack.hasFile !== true || !matchedTrack.path) {
@@ -433,7 +472,7 @@ export async function resolveReusableTrackSource(track, options = {}) {
   }
   const aurralSource = await findAurralSource(track, options);
   if (aurralSource) return { source: aurralSource, reason: null };
-  const lidarrSource = await findLidarrSource(track);
+  const lidarrSource = await findLidarrSource(track, options);
   if (lidarrSource) return { source: lidarrSource, reason: null };
   return { source: null, reason: "No reusable Aurral or Lidarr file found" };
 }
@@ -443,7 +482,7 @@ export async function resolveRepairTrackSource(track, options = {}) {
   if (mode === "download") {
     return { source: null, reason: "Existing file reuse is disabled" };
   }
-  const lidarrSource = await findLidarrSource(track);
+  const lidarrSource = await findLidarrSource(track, options);
   if (lidarrSource) return { source: lidarrSource, reason: null };
   const aurralSource = await findAurralSource(track, options);
   if (aurralSource) return { source: aurralSource, reason: null };

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -6,8 +6,9 @@ import {
   tracksShareMembership,
 } from "./weeklyFlowPlaylistConfig.js";
 import { libraryManager } from "../libraryManager.js";
-import { commitImportToPlaylistLibrary } from "../playlistDownloadUtils.js";
+import { commitImportToPlaylistLibrary, sanitizePathPart } from "../playlistDownloadUtils.js";
 import {
+  AURRAL_FLOWS_DIR,
   isPathInsideRoot,
   PLAYLIST_LIBRARY_DIR,
   remapLegacyPath as remapLegacyWeeklyFlowPath,
@@ -165,24 +166,53 @@ function retargetJobsToPath(oldPath, newPath, weeklyFlowRoot, albumName = null) 
   }
 }
 
-export async function adoptFileIntoPlaylist(sourcePath, targetPlaylistType, weeklyFlowRoot) {
+export async function adoptFileIntoPlaylist(sourcePath, targetPlaylistType, weeklyFlowRoot, options = {}) {
   const safeTarget = String(targetPlaylistType || "").trim();
   const root = path.resolve(weeklyFlowRoot || resolveWeeklyFlowRoot());
   const resolvedSource = path.resolve(remapLegacyWeeklyFlowPath(sourcePath, root));
   if (!safeTarget || !(await fileExists(resolvedSource))) return null;
 
-  const targetRoot = path.resolve(root, PLAYLIST_LIBRARY_DIR, safeTarget);
-  if (isPathInsideRoot(resolvedSource, targetRoot)) return resolvedSource;
+  const knownFlow = isFlowPlaylistType(safeTarget);
+  const knownPlaylist = Boolean(flowPlaylistConfig.getSharedPlaylist(safeTarget));
+  const canonical = knownFlow || knownPlaylist;
+  const ephemeral = knownFlow;
+  const targetRoot = ephemeral
+    ? path.resolve(root, AURRAL_FLOWS_DIR, safeTarget)
+    : canonical
+      ? path.resolve(root)
+      : path.resolve(root, PLAYLIST_LIBRARY_DIR, safeTarget);
+  const legacySource = [PLAYLIST_LIBRARY_DIR, AURRAL_FLOWS_DIR].some((directory) =>
+    isPathInsideRoot(resolvedSource, path.resolve(root, directory)),
+  );
+  if (
+    (ephemeral && isPathInsideRoot(resolvedSource, targetRoot)) ||
+    (!ephemeral && !canonical && isPathInsideRoot(resolvedSource, targetRoot)) ||
+    (!ephemeral && canonical && !legacySource)
+  ) {
+    return resolvedSource;
+  }
 
   const sourcePlaylistId = parsePlaylistIdFromFinalPath(resolvedSource, root);
   const sourceRoot = sourcePlaylistId
-    ? path.resolve(root, PLAYLIST_LIBRARY_DIR, sourcePlaylistId)
+    ? path.resolve(
+        root,
+        resolvedSource.includes(`${path.sep}${AURRAL_FLOWS_DIR}${path.sep}`)
+          ? AURRAL_FLOWS_DIR
+          : PLAYLIST_LIBRARY_DIR,
+        sourcePlaylistId,
+      )
     : null;
   const relative =
     sourceRoot && isPathInsideRoot(resolvedSource, sourceRoot)
       ? path.relative(sourceRoot, resolvedSource)
       : path.basename(resolvedSource);
-  const destPath = path.join(targetRoot, relative);
+  const segments = relative.split(path.sep).filter(Boolean);
+  const artistDir = sanitizePathPart(options.track?.artistName || segments.at(-3), "Unknown Artist");
+  const albumDir = sanitizePathPart(options.track?.albumName || segments.at(-2), "Unknown Album");
+  const fileName = path.basename(resolvedSource);
+  const destPath = canonical
+    ? path.join(targetRoot, artistDir, albumDir, fileName)
+    : path.join(targetRoot, relative);
   const committed = await commitImportToPlaylistLibrary(resolvedSource, destPath);
   retargetJobsToPath(resolvedSource, committed, root);
   return path.resolve(committed);
@@ -193,13 +223,16 @@ export async function relocateSharedFilesBeforePlaylistRemoval(playlistType, opt
   const safePlaylistType = String(playlistType || "").trim();
   if (!safePlaylistType) return { relocated: 0 };
 
-  const removedDir = path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistType);
+  const removedDirs = [
+    path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistType),
+    path.resolve(weeklyFlowRoot, AURRAL_FLOWS_DIR, safePlaylistType),
+  ];
   const byPath = new Map();
   for (const job of downloadTracker.getAll()) {
     if (job?.status !== "done" || typeof job.finalPath !== "string") continue;
     if (String(job.playlistType || "") === safePlaylistType) continue;
     const finalPath = path.resolve(remapLegacyWeeklyFlowPath(job.finalPath, weeklyFlowRoot));
-    if (!isPathInsideRoot(finalPath, removedDir)) continue;
+    if (!removedDirs.some((removedDir) => isPathInsideRoot(finalPath, removedDir))) continue;
     if (!(await fileExists(finalPath))) continue;
     const list = byPath.get(finalPath) || [];
     list.push(job);
@@ -213,6 +246,7 @@ export async function relocateSharedFilesBeforePlaylistRemoval(playlistType, opt
       oldPath,
       survivor.playlistType,
       weeklyFlowRoot,
+      { track: survivor },
     );
     if (nextPath) relocated += 1;
   }
@@ -224,9 +258,16 @@ export async function removePlaylistFileIfUnshared(finalPath, playlistId, option
   const safePlaylistId = String(playlistId || "").trim();
   if (!safePlaylistId || typeof finalPath !== "string") return { action: "skipped" };
 
-  const playlistRoot = path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistId);
+  const playlistRoots = isFlowPlaylistType(safePlaylistId)
+    ? [path.resolve(weeklyFlowRoot, AURRAL_FLOWS_DIR, safePlaylistId)]
+    : flowPlaylistConfig.getSharedPlaylist(safePlaylistId)
+      ? [path.resolve(weeklyFlowRoot)]
+      : [path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistId)];
+  if (flowPlaylistConfig.getSharedPlaylist(safePlaylistId)) return { action: "skipped" };
   const resolved = path.resolve(remapLegacyWeeklyFlowPath(finalPath, weeklyFlowRoot));
-  if (!isPathInsideRoot(resolved, playlistRoot)) return { action: "skipped" };
+  if (!playlistRoots.some((playlistRoot) => isPathInsideRoot(resolved, playlistRoot))) {
+    return { action: "skipped" };
+  }
 
   const excludeJobIds = new Set(
     (Array.isArray(options.excludeJobIds) ? options.excludeJobIds : [])
@@ -482,7 +523,10 @@ export async function repairJobsUnderRemovedPlaylistDir(playlistType, options = 
     return { repaired: 0, requeued: 0, skipped: 0, changedPlaylistTypes: [] };
   }
 
-  const removedDir = path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistType);
+  const removedDirs = [
+    path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistType),
+    path.resolve(weeklyFlowRoot, AURRAL_FLOWS_DIR, safePlaylistType),
+  ];
   let repaired = 0;
   let requeued = 0;
   let skipped = 0;
@@ -491,7 +535,7 @@ export async function repairJobsUnderRemovedPlaylistDir(playlistType, options = 
   for (const job of downloadTracker.getAll()) {
     if (job?.status !== "done" || typeof job?.finalPath !== "string") continue;
     const finalPath = path.resolve(remapLegacyWeeklyFlowPath(job.finalPath, weeklyFlowRoot));
-    if (!isPathInsideRoot(finalPath, removedDir)) continue;
+    if (!removedDirs.some((removedDir) => isPathInsideRoot(finalPath, removedDir))) continue;
     if (await fileExists(finalPath)) continue;
 
     const result = await restoreCompletedTrack(job, {
@@ -531,12 +575,15 @@ export async function repairJobsUnderRemovedPlaylistDir(playlistType, options = 
 
 function parsePlaylistIdFromFinalPath(finalPath, weeklyFlowRoot) {
   const resolved = path.resolve(remapLegacyWeeklyFlowPath(finalPath, weeklyFlowRoot));
-  const marker = `${path.sep}${PLAYLIST_LIBRARY_DIR}${path.sep}`;
-  const markerIndex = resolved.indexOf(marker);
-  if (markerIndex < 0) return null;
-  const remainder = resolved.slice(markerIndex + marker.length);
-  const playlistId = remainder.split(path.sep)[0];
-  return playlistId || null;
+  for (const directory of [PLAYLIST_LIBRARY_DIR, AURRAL_FLOWS_DIR]) {
+    const marker = `${path.sep}${directory}${path.sep}`;
+    const markerIndex = resolved.indexOf(marker);
+    if (markerIndex < 0) continue;
+    const remainder = resolved.slice(markerIndex + marker.length);
+    const playlistId = remainder.split(path.sep)[0];
+    if (playlistId) return playlistId;
+  }
+  return null;
 }
 
 export async function repairOrphanedPlaylistTrackPaths(options = {}) {

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -10,6 +10,7 @@ import {
   writeGeneratedPlaylistArtwork,
 } from "../playlistArtworkGenerator.js";
 import {
+  AURRAL_FLOWS_DIR,
   PLAYLIST_LIBRARY_DIR,
   resolvePlaylistRoot,
 } from "../playlistPaths.js";
@@ -294,6 +295,10 @@ export class WeeklyFlowPlaylistManager {
           weeklyFlowRoot: this.weeklyFlowRoot,
         });
         await fs.rm(playlistDir, { recursive: true, force: true });
+        await fs.rm(path.join(this.weeklyFlowRoot, AURRAL_FLOWS_DIR, playlistType), {
+          recursive: true,
+          force: true,
+        });
         console.log(`[WeeklyFlowPlaylistManager] Deleted files for ${playlistType}`);
       } catch (error) {
         console.warn(

--- a/backend/services/weeklyFlow/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlow/weeklyFlowWorker.js
@@ -255,7 +255,10 @@ export class WeeklyFlowWorker {
   }
 
   _getNextReadyPendingJob(lastPlaylistType = null) {
-    return downloadTracker.getNextPendingMatching(() => true, lastPlaylistType);
+    return downloadTracker.getNextPendingMatching(
+      (job) => !this.activeJobs.has(job.id),
+      lastPlaylistType,
+    );
   }
 
   getWorkerSettings() {
@@ -691,6 +694,9 @@ export class WeeklyFlowWorker {
             console.error(`[WeeklyFlowWorker] Error processing job ${job.id}:`, error.message);
             this._recordPlaylistTerminalFailure(job.playlistType, job);
             downloadTracker.setFailed(job.id, error.message);
+            import("../aurralHistoryService.js")
+              .then(({ recordTrackJobFailed }) => recordTrackJobFailed(job, error.message))
+              .catch(() => {});
             await this.checkPlaylistComplete(job.playlistType);
           })
           .finally(() => {
@@ -801,7 +807,9 @@ export class WeeklyFlowWorker {
       if (!isAnyDownloadSourceConfigured()) {
         throw new Error(getDownloadSourceNotConfiguredMessage());
       }
-      downloadTracker.enqueueDownloadPipeline(job.id);
+      if (!downloadTracker.enqueueDownloadPipeline(job.id)) {
+        throw new Error("Failed to enqueue the download pipeline");
+      }
       return;
     } catch (error) {
       const cpuDelta = process.cpuUsage(perfStartCpu);

--- a/docs/src/content/docs/using/flows.mdx
+++ b/docs/src/content/docs/using/flows.mdx
@@ -3,7 +3,10 @@ title: Flows
 description: Schedule, source mix, focus, and flow generation behavior.
 ---
 
-Flows are dynamic playlists. They regenerate on their schedule and download files into Aurral's folder. Aurral can send them to Navidrome or Plex.
+Flows are dynamic discovery features. They regenerate on their schedule and
+download temporary files under `.flows` in the Aurral root. Aurral can send
+their playlist references to Navidrome or Plex without making the files part of
+the permanent Library.
 
 ![Aurral flow editor](../../../assets/screenshots/flow-editor.webp)
 

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -12,13 +12,16 @@ to see the overview and browse these sections:
 - **Tracks** shows playable tracks, artist and album links, and missing files.
 - **Album Artists** and **Artists** show the canonical artist records.
 - **Genres** links to the album list filtered by genre.
+- **Playlists** opens your static playlists. Flows have their own **Flows** section.
 
 Select a track or album to play it with Aurral's built-in player. Artists and
 albums open listening-first library pages with their tracks, playback controls,
 and favorites. Those pages link to the full Discover artist or release page
 when a canonical identifier is available. Tracks without an available file
-stay visible but cannot play. The page reports stale library data, partial or
-missing files, provider health problems, and empty results.
+stay visible but cannot play; missing album tracks are shown in a muted state.
+Use the track action menu to add a library track to a playlist. The page reports
+stale library data, partial or missing files, provider health problems, and empty
+results.
 
 Navidrome remains optional. Lidarr remains the library provider when it is
 configured.

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -23,6 +23,19 @@ missing files, provider health problems, and empty results.
 Navidrome remains optional. Lidarr remains the library provider when it is
 configured.
 
+## Aurral-owned storage
+
+Permanent Aurral tracks use the canonical `artist/album/track` layout under
+the configured Aurral download folder. Flow media is temporary and lives under
+`.flows`; it is not added to the canonical Library. Static playlist membership
+is stored by Aurral's Subsonic model, so deleting a playlist does not delete a
+canonical track.
+
+When upgrading from an older Aurral installation, the one-time migration moves
+legacy playlist-folder files into this layout. It resumes after a restart and
+keeps ambiguous, partial, or failed items for review. It never changes the
+Lidarr-owned root.
+
 ## When new files appear
 
 Aurral keeps the canonical library in its own database. It scans the Aurral
@@ -33,7 +46,7 @@ to them.
 When Lidarr imports a download, or a file changes in the Aurral root, Aurral's
 filesystem watcher queues a scan. The watcher waits briefly for a file move or
 rename to finish and ignores `_playlists`, `_staging`, `_fallback`, hidden
-folders, and `aurral-weekly-flow`.
+folders, `.flows`, and the legacy `aurral-weekly-flow` tree.
 
 When the scan completes, an open Library page reloads its canonical records
 automatically. The home page and **Newest** album or track sorting use the time

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -29,11 +29,12 @@ Use Search to find artists and albums. You can preview tracks, check library sta
 
 Library shows the artists in Lidarr. It includes search, sort controls, artwork, monitoring status, and artist pages.
 
-### Playlists
+### Playlists and Flows
 
 ![Aurral playlists](../../../assets/screenshots/playlists.webp)
 
-Playlists contains scheduled flows, Spotify imports, discover playlists, in-app playback, and download status.
+Library > Playlists contains static playlists, in-app playback, and their
+download status. Flows is a separate section for scheduled discovery mixes.
 
 Flows regenerate on a schedule. Static playlists keep fixed tracklists or synchronize with Spotify.
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -3,7 +3,8 @@ title: Playlists overview
 description: Flows, static imports, and how they differ.
 ---
 
-The **Playlists** page contains flows and imported playlists. Both types use the Aurral folder under `aurral-weekly-flow`.
+Static playlists appear under **Library > Playlists**. Flows appear separately
+under **Flows** because their downloaded media is temporary.
 
 Aurral does not write these files to your main music library.
 
@@ -34,13 +35,20 @@ Flows can expose a **Lidarr import URL** so Lidarr polls the current flow trackl
 
 ## Where files go
 
-Generated playlists go under your Downloads Folder path. Set this path in **Settings > Download Clients**. Usually, the path is:
+Static playlist membership is stored as canonical track references. Permanent
+Aurral tracks use the canonical `artist/album/track` layout under the configured
+Aurral download folder. Set this path in **Settings > Download Clients**.
+
+Flow media is temporary and lives under `.flows` below that root. Usually, the
+legacy playlist folder was:
 
 ```text
-/data/downloads/aurral/aurral-weekly-flow/<playlist-id>/
+/data/downloads/aurral/aurral-weekly-flow/
 ```
 
-Navidrome scans that tree, then Aurral creates playlists through the Subsonic API. Plex can index the track folders and create playlists for Plexamp.
+The one-time upgrade migration moves legacy Aurral files into the canonical
+layout and keeps the Lidarr-owned root unchanged. Navidrome and Plex can use
+the roots they are configured to scan.
 
 See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/) for playback setup.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -259,18 +259,27 @@ function AppContent() {
                       <Route path="/discover/playlists/:presetId" element={<DiscoverPlaylistDetailPage />} />
                       <Route path="/discover/playlists" element={<DiscoverPlaylistsPage />} />
                       <Route path="/discover/news" element={<NewsPage />} />
+                      <Route
+                        path="/library/playlists"
+                        element={
+                          <PermissionRoute permission="accessFlow">
+                            <FlowPage mode="playlists" />
+                          </PermissionRoute>
+                        }
+                      />
                       <Route path="/library/album/:albumId" element={<LibraryPage />} />
                       <Route path="/library/artist/:artistId" element={<LibraryPage />} />
                       <Route path="/library/:section?" element={<LibraryPage />} />
                       <Route
-                        path="/playlists"
+                        path="/flows"
                         element={
                           <PermissionRoute permission="accessFlow">
-                            <FlowPage />
+                            <FlowPage mode="flows" />
                           </PermissionRoute>
                         }
                       />
-                      <Route path="/flow" element={<Navigate to="/playlists" replace />} />
+                      <Route path="/playlists" element={<Navigate to="/library/playlists" replace />} />
+                      <Route path="/flow" element={<Navigate to="/flows" replace />} />
                       <Route path="/downloads" element={<Navigate to="/activity/queue" replace />} />
                       <Route path="/requests" element={<Navigate to="/activity/queue" replace />} />
                       <Route path="/history" element={<Navigate to="/activity/history" replace />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -200,8 +200,8 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
           ]
         : []),
       {
-        path: "/playlists",
-        label: "Playlists",
+        path: "/flows",
+        label: "Flows",
         icon: AudioWaveform,
         permission: "accessFlow",
       },

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -103,8 +103,11 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   const activeLibraryView = useMemo(() => {
     if (!isOnLibrary) return null;
     const segment = location.pathname.replace(/^\/library\/?/, "").split("/")[0];
-    return LIBRARY_VIEWS.some((view) => view.id === segment) ? segment : DEFAULT_LIBRARY_VIEW;
-  }, [isOnLibrary, location.pathname]);
+    const visibleViews = LIBRARY_VIEWS.filter(
+      (view) => !view.permission || user?.role === "admin" || !!user?.permissions?.[view.permission],
+    );
+    return visibleViews.some((view) => view.id === segment) ? segment : DEFAULT_LIBRARY_VIEW;
+  }, [isOnLibrary, location.pathname, user]);
 
   const activeActivityView = useMemo(() => {
     if (!isOnActivity) return null;
@@ -162,6 +165,9 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   );
 
   const navItems = useMemo(() => {
+    const libraryViews = LIBRARY_VIEWS.filter(
+      (view) => !view.permission || user?.role === "admin" || !!user?.permissions?.[view.permission],
+    );
     const items = [
       {
         path: "/discover",
@@ -175,7 +181,7 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
         label: "Library",
         icon: Library,
         section: "library",
-        subnav: LIBRARY_VIEWS,
+        subnav: libraryViews,
       },
       ...(ticketmasterConfigured
         ? [

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8073,7 +8073,7 @@ button.native-library-card__artist:focus-visible {
 }
 
 .native-library-track {
-  --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem 1.7rem;
+  --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem 1.7rem 1.7rem;
 
   display: grid;
   min-width: 44rem;
@@ -8222,6 +8222,34 @@ button.native-library-card__artist:focus-visible {
 .native-library-track__time.is-missing {
   color: var(--aurral-text-muted);
   font-size: 0.65rem;
+}
+
+.native-library-track__download {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+}
+
+.native-library-track__download:hover,
+.native-library-track__download:focus-visible {
+  color: var(--aurral-text);
+}
+
+.native-library-track__download:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.native-library-track__download svg {
+  width: 0.85rem;
+  height: 0.85rem;
 }
 
 .native-library-track__favorite {
@@ -8536,7 +8564,7 @@ button.native-library-genre-row:focus-visible {
   }
 
   .native-library-track {
-    --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem 1.7rem;
+    --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem 1.7rem 1.7rem;
 
     min-width: 32rem;
   }
@@ -8599,7 +8627,7 @@ button.native-library-genre-row:focus-visible {
   }
 
   .native-library-track {
-    --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem 1.7rem;
+    --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem 1.7rem 1.7rem;
 
     min-width: 0;
     gap: 0.4rem;
@@ -9885,14 +9913,14 @@ button.native-library-genre-row:focus-visible {
   display: flex;
   min-height: 0;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .flow-page__library-head {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding-inline: 0.375rem;
+  gap: 0.5rem;
+  padding-inline: 0.25rem;
 }
 
 .flow-page__library-collapse {
@@ -9928,7 +9956,7 @@ button.native-library-genre-row:focus-visible {
   min-width: 0;
   flex: 1;
   color: var(--aurral-text);
-  font-size: 1.125rem;
+  font-size: 1rem;
   font-weight: 800;
   line-height: 1.2;
 }
@@ -9945,8 +9973,8 @@ button.native-library-genre-row:focus-visible {
 
 .flow-page__library-create-btn {
   display: inline-flex;
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 2.25rem;
+  height: 2.25rem;
   align-items: center;
   justify-content: center;
   padding: 0;
@@ -9974,8 +10002,8 @@ button.native-library-genre-row:focus-visible {
 }
 
 .flow-page__library-create-icon {
-  width: 1.375rem;
-  height: 1.375rem;
+  width: 1.125rem;
+  height: 1.125rem;
   stroke-width: 2.75;
 }
 
@@ -10139,9 +10167,9 @@ button.native-library-genre-row:focus-visible {
   min-height: 0;
   flex: 1;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.125rem;
   overflow: auto;
-  padding: 0.375rem;
+  padding: 0.25rem;
   background: var(--aurral-surface);
   border-radius: var(--aurral-radius);
 }
@@ -10150,7 +10178,7 @@ button.native-library-genre-row:focus-visible {
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.25rem;
   padding: 0;
   background: transparent;
   color: inherit;
@@ -10164,8 +10192,8 @@ button.native-library-genre-row:focus-visible {
   min-width: 0;
   flex: 1;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.625rem;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
   border: 0;
   border-radius: var(--aurral-radius-sm);
   background: transparent;
@@ -10188,9 +10216,9 @@ button.native-library-genre-row:focus-visible {
   background: var(--aurral-surface-raised);
 }
 
-.flow-page__library-item-artwork {
-  width: 3rem;
-  height: 3rem;
+.flow-page__library-item .flow-page__library-item-artwork.flow-page__artwork {
+  width: 2.5rem;
+  height: 2.5rem;
 }
 
 .flow-page__library-item-body {
@@ -10216,7 +10244,7 @@ button.native-library-genre-row:focus-visible {
 
 .flow-page__library-item-type {
   color: var(--aurral-text-muted);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .flow-page__library-item-activity {
@@ -10233,7 +10261,7 @@ button.native-library-genre-row:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--aurral-text);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 700;
 }
 
@@ -10241,8 +10269,8 @@ button.native-library-genre-row:focus-visible {
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  gap: 0.375rem;
-  padding-right: 0.5rem;
+  gap: 0.25rem;
+  padding-right: 0.375rem;
 }
 
 .flow-page__library-item-meta {
@@ -10250,7 +10278,7 @@ button.native-library-genre-row:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--aurral-text-muted);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .flow-page__detail {
@@ -10263,6 +10291,78 @@ button.native-library-genre-row:focus-visible {
   padding: 1.25rem 1.5rem 1.5rem;
   background: var(--aurral-surface);
   border-radius: var(--aurral-radius);
+}
+
+.flow-page--playlists .flow-page__library-list {
+  padding: 0.125rem;
+  background: transparent;
+}
+
+.flow-page--playlists .flow-page__detail {
+  gap: 1.25rem;
+  padding: 0.5rem 1.25rem 1.5rem;
+  background: transparent;
+  border-radius: 0;
+}
+
+.flow-page--playlists .flow-page__detail-hero {
+  margin: 0;
+  padding: 0.75rem 0 1rem;
+  background: transparent;
+  border-bottom: 1px solid var(--aurral-border);
+  border-radius: 0;
+}
+
+.flow-page--playlists .flow-page__detail-artwork.flow-page__artwork {
+  width: 5rem;
+  height: 5rem;
+}
+
+.flow-page--playlists .flow-page__detail-title--hero {
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  letter-spacing: -0.04em;
+}
+
+.flow-page--playlists .flow-page__tracks {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+.flow-page--playlists .flow-page__tracks-toolbar {
+  padding: 0 0 0.625rem;
+}
+
+.flow-page--playlists .flow-page__tracks-toolbar .btn-accent {
+  background: var(--aurral-text);
+  color: var(--aurral-surface);
+}
+
+.flow-page--playlists .flow-page__tracks-table-head th {
+  padding: 0.45rem 0.75rem;
+}
+
+.flow-page--playlists .flow-page__tracks-table-row td {
+  padding: 0.4rem 0.75rem;
+}
+
+.flow-page--playlists .flow-page__tracks-table-artwork {
+  width: 3rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.flow-page--playlists .flow-page__tracks-table-artwork .flow-page__tracks-table-artwork-thumb {
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.2rem;
+}
+
+.flow-page--playlists .flow-page__tracks-table-duration {
+  width: 4.5rem;
+  color: var(--aurral-text-subtle);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .flow-page__detail--empty {
@@ -11295,6 +11395,26 @@ button.native-library-genre-row:focus-visible {
   padding: 0.5rem 0.25rem;
   text-align: center;
   vertical-align: middle;
+}
+
+.flow-page__tracks-table-artwork {
+  width: 3.35rem;
+  padding: 0.5rem;
+  vertical-align: middle;
+}
+
+.flow-page__tracks-table-artwork-thumb {
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.2rem;
+}
+
+.flow-page__tracks-table-duration {
+  width: 4.5rem;
+  color: var(--aurral-text-muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .flow-page__track-status-dot {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11706,7 +11706,8 @@ button.native-library-genre-row:focus-visible {
   background: var(--aurral-surface-hover);
 }
 
-.flow-page__tracks-artist-link {
+.flow-page__tracks-artist-link,
+.flow-page__tracks-album-link {
   display: block;
   width: 100%;
   max-width: 100%;
@@ -11718,7 +11719,8 @@ button.native-library-genre-row:focus-visible {
   transition: color 0.18s ease;
 }
 
-.flow-page__tracks-artist-link:hover {
+.flow-page__tracks-artist-link:hover,
+.flow-page__tracks-album-link:hover {
   color: var(--aurral-text);
   text-decoration: underline;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3091,7 +3091,8 @@ textarea {
 }
 
 .artist-menu-submenu:hover .artist-menu-submenu__panel,
-.artist-menu-submenu:focus-within .artist-menu-submenu__panel {
+.artist-menu-submenu:focus-within .artist-menu-submenu__panel,
+.artist-menu-submenu.is-open .artist-menu-submenu__panel {
   display: block;
 }
 
@@ -4639,7 +4640,7 @@ textarea {
   z-index: 50;
   width: 16rem;
   padding: 0.25rem;
-  overflow: hidden;
+  overflow: visible;
   background: var(--aurral-surface-popover);
   border-radius: var(--aurral-radius-sm);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8086,6 +8086,11 @@ button.native-library-card__artist:focus-visible {
   font-size: 0.74rem;
 }
 
+.native-library-track:has(.artist-playlist-menu) {
+  position: relative;
+  z-index: 1;
+}
+
 .native-library-track--heading {
   min-height: 2rem;
   border-bottom: 0;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3574,6 +3574,12 @@ textarea {
   white-space: nowrap;
 }
 
+.artist-track-title--owned {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .artist-track-subtitle {
   margin: 0.125rem 0 0;
   overflow: hidden;
@@ -8066,7 +8072,7 @@ button.native-library-card__artist:focus-visible {
 }
 
 .native-library-track {
-  --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem;
+  --native-library-track-columns: 2rem 2rem 2.35rem minmax(12rem, 1.4fr) minmax(8rem, 1fr) minmax(8rem, 1fr) 4.5rem 1.7rem 1.7rem;
 
   display: grid;
   min-width: 44rem;
@@ -8096,6 +8102,16 @@ button.native-library-card__artist:focus-visible {
 
 .native-library-track.is-active .native-library-track__title > span {
   color: var(--aurral-accent);
+}
+
+.native-library-track.is-missing {
+  color: var(--aurral-text-subtle);
+  opacity: 0.68;
+}
+
+.native-library-track.is-missing .native-library-track__title > span,
+.native-library-track.is-missing .native-library-track__link {
+  color: var(--aurral-text-muted);
 }
 
 .native-library-track__play,
@@ -8519,7 +8535,7 @@ button.native-library-genre-row:focus-visible {
   }
 
   .native-library-track {
-    --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem;
+    --native-library-track-columns: 2rem 2.2rem 2.35rem minmax(10rem, 1fr) 4.5rem 1.7rem 1.7rem;
 
     min-width: 32rem;
   }
@@ -8582,7 +8598,7 @@ button.native-library-genre-row:focus-visible {
   }
 
   .native-library-track {
-    --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem;
+    --native-library-track-columns: 1.8rem 2.15rem minmax(0, 1fr) 3.8rem 1.7rem 1.7rem;
 
     min-width: 0;
     gap: 0.4rem;

--- a/frontend/src/navigation/libraryNavConfig.js
+++ b/frontend/src/navigation/libraryNavConfig.js
@@ -7,5 +7,5 @@ export const LIBRARY_VIEWS = [
   { id: "album-artists", label: "Album Artists", path: "/library/album-artists" },
   { id: "artists", label: "Artists", path: "/library/artists" },
   { id: "genres", label: "Genres", path: "/library/genres" },
-  { id: "playlists", label: "Playlists", path: "/library/playlists" },
+  { id: "playlists", label: "Playlists", path: "/library/playlists", permission: "accessFlow" },
 ];

--- a/frontend/src/navigation/libraryNavConfig.js
+++ b/frontend/src/navigation/libraryNavConfig.js
@@ -7,4 +7,5 @@ export const LIBRARY_VIEWS = [
   { id: "album-artists", label: "Album Artists", path: "/library/album-artists" },
   { id: "artists", label: "Artists", path: "/library/artists" },
   { id: "genres", label: "Genres", path: "/library/genres" },
+  { id: "playlists", label: "Playlists", path: "/library/playlists" },
 ];

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -113,7 +113,7 @@ function ActivityPage() {
     }
 
     try {
-      const data = await getRequests({ refresh });
+      const data = await getRequests({ refresh: refresh || isListLikeView });
       setRequests((previous) => mergeActivityRequests(previous, data));
       setError(null);
     } catch {
@@ -126,7 +126,7 @@ function ActivityPage() {
         setLoading(false);
       }
     }
-  }, []);
+  }, [isListLikeView]);
 
   const refreshFromStatusEvent = useCallback(() => {
     if (document.hidden) return;

--- a/frontend/src/pages/ArtistDetails/ReleasePage.jsx
+++ b/frontend/src/pages/ArtistDetails/ReleasePage.jsx
@@ -5,6 +5,7 @@ import {
 } from "../../utils/api/endpoints/playlists.js";
 import {
   getDownloadStatus,
+  downloadTrackToLibrary,
   lookupAlbumsInLibraryBatch,
   requestAlbumFromSearch,
 } from "../../utils/api/endpoints/library.js";
@@ -120,6 +121,7 @@ function ReleasePage() {
     loadSharedPlaylists,
   } = useSharedPlaylists();
   const [playlistMenuSavingKey, setPlaylistMenuSavingKey] = useState("");
+  const [libraryTrackSavingKey, setLibraryTrackSavingKey] = useState("");
   const downloadStatusPollInFlightRef = useRef(false);
 
   const [heroColor, setHeroColor] = useState(null);
@@ -443,6 +445,32 @@ function ReleasePage() {
     [buildReleaseTrackPayload, saveTrackToPlaylist],
   );
 
+  const handleReleaseTrackAddToLibrary = useCallback(
+    async (track) => {
+      const payload = buildReleaseTrackPayload(track);
+      const savingKey = String(track?.id ?? track?.mbid ?? "");
+      setLibraryTrackSavingKey(savingKey);
+      try {
+        const result = await downloadTrackToLibrary(payload);
+        showSuccess(
+          result?.alreadyOwned
+            ? `${payload.trackName} is already in your library`
+            : `Added ${payload.trackName} to your library`,
+        );
+      } catch (err) {
+        showError(
+          err.response?.data?.message ||
+            err.response?.data?.error ||
+            err.message ||
+            "Failed to add track to library",
+        );
+      } finally {
+        setLibraryTrackSavingKey("");
+      }
+    },
+    [buildReleaseTrackPayload, showError, showSuccess],
+  );
+
   const handleAlbumAction = useCallback(async () => {
     if (!releaseMbid || requestingAlbum) return;
     setRequestingAlbum(true);
@@ -630,6 +658,10 @@ function ReleasePage() {
             label: releaseTitle,
           }}
           onAddTrackToPlaylist={handleReleaseTrackAdd}
+          onAddTrackToLibrary={handleReleaseTrackAddToLibrary}
+          libraryTrackSavingKey={libraryTrackSavingKey}
+          ownedTrackMbids={libraryInfo?.ownedTrackMbids}
+          albumComplete={isComplete}
           resolveMembershipTrack={buildReleaseTrackPayload}
           playlists={sharedPlaylists}
           playlistsLoading={playlistModalLoading}

--- a/frontend/src/pages/ArtistDetails/ReleasePage.jsx
+++ b/frontend/src/pages/ArtistDetails/ReleasePage.jsx
@@ -663,7 +663,6 @@ function ReleasePage() {
           onAddTrackToLibrary={handleReleaseTrackAddToLibrary}
           libraryTrackSavingKey={libraryTrackSavingKey}
           ownedTrackMbids={libraryInfo?.ownedTrackMbids}
-          albumComplete={isComplete}
           resolveMembershipTrack={buildReleaseTrackPayload}
           playlists={sharedPlaylists}
           playlistsLoading={playlistModalLoading}

--- a/frontend/src/pages/ArtistDetails/ReleasePage.jsx
+++ b/frontend/src/pages/ArtistDetails/ReleasePage.jsx
@@ -455,7 +455,9 @@ function ReleasePage() {
         showSuccess(
           result?.alreadyOwned
             ? `${payload.trackName} is already in your library`
-            : `Added ${payload.trackName} to your library`,
+            : result?.queued
+              ? `Queued ${payload.trackName} for your library`
+              : `Added ${payload.trackName} to your library`,
         );
       } catch (err) {
         showError(

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
@@ -20,7 +20,6 @@ export function ArtistDetailsReleaseTrackList({
   onAddTrackToLibrary,
   libraryTrackSavingKey,
   ownedTrackMbids = [],
-  albumComplete = false,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -156,8 +155,9 @@ export function ArtistDetailsReleaseTrackList({
                     .toString()
                     .padStart(2, "0")}`
                 : "";
-              const isOwned = ownedTrackSet.has(String(track.mbid || track.id || ""));
-              const showOwned = !albumComplete && isOwned;
+              const isOwned = [track.mbid, track.recordingId, track.id]
+                .filter(Boolean)
+                .some((identity) => ownedTrackSet.has(String(identity)));
               return (
                 <div
                   key={currentTrackId}
@@ -179,8 +179,8 @@ export function ArtistDetailsReleaseTrackList({
                   ) : (
                     <span />
                   )}
-                  <span className={`artist-track-title${showOwned ? " artist-track-title--owned" : ""}`}>
-                    {showOwned ? <SearchLibraryCheck size="discover" /> : null}
+                  <span className={`artist-track-title${isOwned ? " artist-track-title--owned" : ""}`}>
+                    {isOwned ? <SearchLibraryCheck size="discover" /> : null}
                     <span>{track.title || track.trackName || "Unknown Track"}</span>
                   </span>
                   {onAddTrackToPlaylist ? (

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { Loader } from "lucide-react";
+import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import { TrackPlayButton } from "./TrackPlayButton";
 import { TrackPlaylistMenu } from "./TrackPlaylistMenu";
 import { ArtistTrackListToolbar } from "./ArtistTrackListToolbar";
@@ -16,6 +17,10 @@ export function ArtistDetailsReleaseTrackList({
   artistMbid = "",
   playbackSource = null,
   onAddTrackToPlaylist,
+  onAddTrackToLibrary,
+  libraryTrackSavingKey,
+  ownedTrackMbids = [],
+  albumComplete = false,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -26,6 +31,7 @@ export function ArtistDetailsReleaseTrackList({
   highlightTrackId = null,
 }) {
   const rowRefs = useRef({});
+  const ownedTrackSet = new Set((Array.isArray(ownedTrackMbids) ? ownedTrackMbids : []).map(String));
   const normalizeTrack = useCallback(
     (track, index) =>
       normalizePreviewTrack(
@@ -150,6 +156,8 @@ export function ArtistDetailsReleaseTrackList({
                     .toString()
                     .padStart(2, "0")}`
                 : "";
+              const isOwned = ownedTrackSet.has(String(track.mbid || track.id || ""));
+              const showOwned = !albumComplete && isOwned;
               return (
                 <div
                   key={currentTrackId}
@@ -171,8 +179,9 @@ export function ArtistDetailsReleaseTrackList({
                   ) : (
                     <span />
                   )}
-                  <span className="artist-track-title">
-                    {track.title || track.trackName || "Unknown Track"}
+                  <span className={`artist-track-title${showOwned ? " artist-track-title--owned" : ""}`}>
+                    {showOwned ? <SearchLibraryCheck size="discover" /> : null}
+                    <span>{track.title || track.trackName || "Unknown Track"}</span>
                   </span>
                   {onAddTrackToPlaylist ? (
                     <TrackPlaylistMenu
@@ -185,6 +194,13 @@ export function ArtistDetailsReleaseTrackList({
                       error={playlistError}
                       defaultNewPlaylistName={getDefaultPlaylistName?.(track, release)}
                       onLoadPlaylists={onLoadPlaylists}
+                      triggerVariant="kebab"
+                      librarySaving={libraryTrackSavingKey === currentTrackId}
+                      onAddToLibrary={
+                        onAddTrackToLibrary && !isOwned
+                          ? () => onAddTrackToLibrary(track, release)
+                          : null
+                      }
                       onSelect={(target) => onAddTrackToPlaylist(track, release, target)}
                     />
                   ) : null}

--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState }
 import { ChevronRight, Loader, MoreHorizontal, Plus } from "lucide-react";
 import AddActionButton from "../../../components/AddActionButton";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
+import TooltipButton from "../../../components/TooltipButton";
 
 function normalizeTrackForSharedIdentity(track) {
   if (!track || typeof track !== "object" || Array.isArray(track)) {
@@ -331,12 +332,12 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
     <div className="artist-relative" ref={menuRef}>
       {showTrigger ? (
         isKebab || triggerVariant === "compact" ? (
-          <button
+          <TooltipButton
             ref={buttonRef}
             type="button"
             className={triggerClassName}
             onClick={handleOpen}
-            title={triggerLabel}
+            label={triggerLabel}
             aria-label={triggerLabel}
             aria-haspopup="menu"
             aria-expanded={open}
@@ -349,7 +350,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
             ) : (
               <TriggerIcon className="artist-icon-xs" />
             )}
-          </button>
+          </TooltipButton>
         ) : (
           <AddActionButton
             ref={buttonRef}
@@ -377,7 +378,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
             <>
               {onSelect ? (
                 <TrackPlaylistSubmenu
-                  label="+ Add to playlist"
+                  label="Add to playlist"
                   icon={Plus}
                   track={track}
                   playlists={playlists}
@@ -405,7 +406,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
                 >
                   <span className="artist-menu-item__main">
                     <Plus className="artist-icon-sm" />
-                    + Add to library
+                    Add to library
                   </span>
                 </button>
               ) : null}

--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { ChevronRight, Loader, Plus } from "lucide-react";
+import { ChevronRight, Loader, MoreHorizontal, Plus } from "lucide-react";
 import AddActionButton from "../../../components/AddActionButton";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 
@@ -236,6 +236,8 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
     triggerLabel = "Add to playlist",
     triggerVariant = "expand",
     icon: TriggerIcon = Plus,
+    onAddToLibrary,
+    librarySaving = false,
     onLoadPlaylists,
     onSelect,
     onOpenChange,
@@ -244,6 +246,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
   ref,
 ) {
   const [open, setOpen] = useState(false);
+  const [openSubmenu, setOpenSubmenu] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
@@ -253,10 +256,12 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
     const handlePointerDown = (event) => {
       if (menuRef.current?.contains(event.target)) return;
       setOpen(false);
+      setOpenSubmenu(false);
       onOpenChange?.(false);
     };
     const handleViewportChange = () => {
       setOpen(false);
+      setOpenSubmenu(false);
       onOpenChange?.(false);
     };
     document.addEventListener("pointerdown", handlePointerDown);
@@ -288,6 +293,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
 
   const closeMenu = () => {
     setOpen(false);
+    setOpenSubmenu(false);
     onOpenChange?.(false);
   };
 
@@ -311,6 +317,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
   };
 
   const showTrigger = triggerVariant !== "hidden";
+  const isKebab = triggerVariant === "kebab";
   const triggerClassName = `btn btn-secondary btn-icon btn-xs${open ? " btn-neutral-active" : ""}`;
   const menuClassName = [
     "artist-playlist-menu",
@@ -323,7 +330,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
   return (
     <div className="artist-relative" ref={menuRef}>
       {showTrigger ? (
-        triggerVariant === "compact" ? (
+        isKebab || triggerVariant === "compact" ? (
           <button
             ref={buttonRef}
             type="button"
@@ -337,6 +344,8 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
           >
             {saving ? (
               <Loader className="artist-icon-xs animate-spin" />
+            ) : isKebab ? (
+              <MoreHorizontal className="artist-icon-xs" />
             ) : (
               <TriggerIcon className="artist-icon-xs" />
             )}
@@ -364,16 +373,55 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
           }}
           onClick={(event) => event.stopPropagation()}
         >
-          <TrackPlaylistPickerContent
-            track={track}
-            playlists={playlists}
-            loading={loading}
-            saving={saving}
-            error={error}
-            defaultNewPlaylistName={defaultNewPlaylistName}
-            excludedPlaylistIds={excludedPlaylistIds}
-            onSelect={handleSelect}
-          />
+          {isKebab ? (
+            <>
+              {onSelect ? (
+                <TrackPlaylistSubmenu
+                  label="+ Add to playlist"
+                  icon={Plus}
+                  track={track}
+                  playlists={playlists}
+                  loading={loading}
+                  saving={saving}
+                  error={error}
+                  defaultNewPlaylistName={defaultNewPlaylistName}
+                  excludedPlaylistIds={excludedPlaylistIds}
+                  onSelect={onSelect}
+                  onClose={closeMenu}
+                  toggleOnClick
+                  isOpen={openSubmenu}
+                  onToggle={() => setOpenSubmenu((current) => !current)}
+                />
+              ) : null}
+              {onAddToLibrary ? (
+                <button
+                  type="button"
+                  className="artist-menu-item"
+                  onClick={async () => {
+                    await onAddToLibrary?.(track);
+                    closeMenu();
+                  }}
+                  disabled={saving || librarySaving || disabled}
+                >
+                  <span className="artist-menu-item__main">
+                    <Plus className="artist-icon-sm" />
+                    + Add to library
+                  </span>
+                </button>
+              ) : null}
+            </>
+          ) : (
+            <TrackPlaylistPickerContent
+              track={track}
+              playlists={playlists}
+              loading={loading}
+              saving={saving}
+              error={error}
+              defaultNewPlaylistName={defaultNewPlaylistName}
+              excludedPlaylistIds={excludedPlaylistIds}
+              onSelect={handleSelect}
+            />
+          )}
         </div>
       ) : null}
     </div>

--- a/frontend/src/pages/ArtistDetails/utils.js
+++ b/frontend/src/pages/ArtistDetails/utils.js
@@ -248,8 +248,10 @@ export const resolveReleaseLibraryDisplay = (libraryInfo, downloadStatus) => {
   const percent = Number(libraryInfo.percentOfTracks || 0);
   const sizeOnDisk = Number(libraryInfo.sizeOnDisk || 0);
   const trackFileCount = Number(libraryInfo.trackFileCount || 0);
+  const trackCount = Number(libraryInfo.trackCount || 0);
   const hasFiles = sizeOnDisk > 0 || trackFileCount > 0;
-  const isComplete = hasFiles;
+  const isComplete =
+    trackCount > 0 ? percent >= 100 || trackFileCount >= trackCount : hasFiles;
 
   if (isComplete) {
     return withAction({

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -19,9 +19,7 @@ import {
   uploadFlowArtwork,
   deleteFlowArtwork,
   generateFlowArtwork,
-  reSearchSharedPlaylistTrack,
   reSearchFlowTrack,
-  reSearchMissingSharedPlaylistTracks,
   searchTrackUpgrade,
   searchPlaylistUpgrades,
   syncSharedPlaylistImport,
@@ -42,6 +40,7 @@ import {
   isEditorialFlow,
 } from "./flows/flowStats";
 import { getPlaylistRunActivity } from "./flows/flowRunActivity";
+import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
 import {
   PlaylistLibraryItem,
   PlaylistDetailHero,
@@ -181,7 +180,6 @@ function FlowPage({ mode = "all" }) {
   const [applyingFlowNameId, setApplyingFlowNameId] = useState(null);
   const [applyingSharedPlaylistNameId, setApplyingSharedPlaylistNameId] = useState(null);
   const [reSearchingTrackIds, setReSearchingTrackIds] = useState({});
-  const [reSearchingMissingPlaylistId, setReSearchingMissingPlaylistId] = useState(null);
   const [searchingUpgradePlaylistId, setSearchingUpgradePlaylistId] = useState(null);
   const [syncingImportPlaylistId, setSyncingImportPlaylistId] = useState(null);
   const [updatingSyncIntervalPlaylistId, setUpdatingSyncIntervalPlaylistId] = useState(null);
@@ -189,6 +187,7 @@ function FlowPage({ mode = "all" }) {
   const [deletingTrackId, setDeletingTrackId] = useState(null);
   const [bulkActionLoading, setBulkActionLoading] = useState(false);
   const [selectedTracks, setSelectedTracks] = useState([]);
+  const [trackArtworkByAlbumMbid, setTrackArtworkByAlbumMbid] = useState({});
   const [selectedTracksLoading, setSelectedTracksLoading] = useState(false);
   const [selectedTracksError, setSelectedTracksError] = useState("");
   const [importModalOpen, setImportModalOpen] = useState(false);
@@ -595,6 +594,7 @@ function FlowPage({ mode = "all" }) {
   useEffect(() => {
     if (!selectedId) {
       setSelectedTracks([]);
+      setTrackArtworkByAlbumMbid({});
       setSelectedTracksLoading(false);
       setSelectedTracksError("");
       return;
@@ -605,6 +605,42 @@ function FlowPage({ mode = "all" }) {
     fetchFlowTracks(selectedId, { signal: controller.signal });
     return () => controller.abort();
   }, [selectedId, fetchFlowTracks]);
+
+  useEffect(() => {
+    if (selectedEntry?.kind !== "shared") {
+      setTrackArtworkByAlbumMbid({});
+      return undefined;
+    }
+    const items = selectedTracks
+      .map((track) => ({
+        mbid: track?.albumMbid,
+        artistName: track?.artistName,
+        albumTitle: track?.albumName,
+      }))
+      .filter((item) => item.mbid);
+    if (!items.length) {
+      setTrackArtworkByAlbumMbid({});
+      return undefined;
+    }
+    let cancelled = false;
+    getReleaseGroupCoversBatch(items)
+      .then((covers) => {
+        if (cancelled) return;
+        setTrackArtworkByAlbumMbid(
+          Object.fromEntries(
+            Object.entries(covers || {})
+              .map(([mbid, cover]) => [mbid, cover?.image || ""])
+              .filter(([, image]) => image),
+          ),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setTrackArtworkByAlbumMbid({});
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedEntry?.kind, selectedTracks]);
 
   const selectPlaylist = (entry) => {
     if (isMobileLayout && selectedId === entry.id && mobileShowDetail) {
@@ -962,14 +998,14 @@ function FlowPage({ mode = "all" }) {
     }
   };
 
-  const handleReSearchTrack = async (playlistId, track, isFlow = false) => {
+  const handleReSearchTrack = async (flowId, track) => {
     const jobId = track?.id;
-    if (!playlistId || !jobId || reSearchingTrackIds[jobId]) return;
+    if (!flowId || !jobId || reSearchingTrackIds[jobId]) return;
     setReSearchingTrackIds((prev) => ({
       ...prev,
       [jobId]: true,
     }));
-    if (track.status !== "done" && playlistId === selectedId) {
+    if (track.status !== "done" && flowId === selectedId) {
       setSelectedTracks((prev) =>
         prev.map((entry) =>
           entry?.id === jobId
@@ -985,21 +1021,18 @@ function FlowPage({ mode = "all" }) {
     }
     try {
       if (track.status === "done") {
-        const result = await searchTrackUpgrade(playlistId, jobId);
+        const result = await searchTrackUpgrade(flowId, jobId);
         showSuccess(
           result?.alreadyQueued
             ? `Upgrade search already queued for ${track.trackName}`
             : `Searching for an upgrade to ${track.trackName}`,
         );
-      } else if (isFlow) {
-        await reSearchFlowTrack(playlistId, jobId);
-        showSuccess(`Re-searching ${track.trackName}`);
       } else {
-        await reSearchSharedPlaylistTrack(playlistId, jobId);
+        await reSearchFlowTrack(flowId, jobId);
         showSuccess(`Re-searching ${track.trackName}`);
       }
       await fetchStatus();
-      await fetchFlowTracks(playlistId, { showSpinner: false });
+      await fetchFlowTracks(flowId, { showSpinner: false });
     } catch (err) {
       const message =
         err.response?.data?.message ||
@@ -1007,7 +1040,7 @@ function FlowPage({ mode = "all" }) {
         err.message ||
         "Failed to re-search track";
       showError(message);
-      await fetchFlowTracks(playlistId, { showSpinner: false });
+      await fetchFlowTracks(flowId, { showSpinner: false });
     } finally {
       setReSearchingTrackIds(({ [jobId]: _, ...prev }) => prev);
     }
@@ -1030,30 +1063,6 @@ function FlowPage({ mode = "all" }) {
       showError(getApiErrorMessage(err, "Failed to search for upgrades"));
     } finally {
       setSearchingUpgradePlaylistId(null);
-    }
-  };
-
-  const handleReSearchMissingSharedPlaylistTracks = async (playlistId) => {
-    if (!playlistId || reSearchingMissingPlaylistId) return;
-    setReSearchingMissingPlaylistId(playlistId);
-    try {
-      const result = await reSearchMissingSharedPlaylistTracks(playlistId);
-      showSuccess(
-        result?.requeued > 0
-          ? `Re-searching ${result.requeued} track${result.requeued !== 1 ? "s" : ""}`
-          : "No failed tracks to re-search",
-      );
-      await fetchStatus();
-      await fetchFlowTracks(playlistId, { showSpinner: false });
-    } catch (err) {
-      const message =
-        err.response?.data?.message ||
-        err.response?.data?.error ||
-        err.message ||
-        "Failed to re-search missing tracks";
-      showError(message);
-    } finally {
-      setReSearchingMissingPlaylistId(null);
     }
   };
 
@@ -1128,40 +1137,6 @@ function FlowPage({ mode = "all" }) {
     }
     if (failed.length > 0) {
       showError(`Failed to remove: ${failed.join(", ")}`);
-    }
-    setBulkActionLoading(false);
-    await fetchStatus();
-    await fetchFlowTracks(selectedPlaylist.id, { showSpinner: false });
-  };
-
-  const handleBulkReSearch = async (tracks) => {
-    if (!selectedPlaylist) return;
-    setBulkActionLoading(true);
-    let requeued = 0;
-    for (const track of tracks) {
-      if (!track?.id) continue;
-      const canReSearch = track.status === "done" || track.status === "failed";
-      if (!canReSearch || reSearchingTrackIds[track.id]) continue;
-      setReSearchingTrackIds((prev) => ({ ...prev, [track.id]: true }));
-      setSelectedTracks((prev) =>
-        prev.map((entry) =>
-          entry?.id === track.id
-            ? { ...entry, status: "pending", error: null, streamUrl: null }
-            : entry,
-        ),
-      );
-      try {
-        if (track.status === "done") {
-          await searchTrackUpgrade(selectedPlaylist.id, track.id);
-        } else {
-          await reSearchSharedPlaylistTrack(selectedPlaylist.id, track.id);
-        }
-        requeued++;
-      } catch {
-      }
-    }
-    if (requeued > 0) {
-      showSuccess(`Re-searching ${requeued} track${requeued !== 1 ? "s" : ""}`);
     }
     setBulkActionLoading(false);
     await fetchStatus();
@@ -1291,7 +1266,9 @@ function FlowPage({ mode = "all" }) {
     }
     return getSharedPlaylistTrackCount(selectedPlaylist, selectedStats, selectedTracks.length);
   })();
-  const selectedEntryTrackLabel = formatTrackCountLabel(selectedEntryTotalTracks, selectedStats);
+  const selectedEntryTrackLabel = selectedIsFlow
+    ? formatTrackCountLabel(selectedEntryTotalTracks, selectedStats)
+    : `${selectedEntryTotalTracks} ${selectedEntryTotalTracks === 1 ? "track" : "tracks"}`;
   const flowLastRunShort = selectedFlow ? formatFlowLastRunShort(selectedFlow.lastRunAt) : null;
   const flowNextRunShort =
     selectedFlow && flowEnabled && getPlaylistState(selectedFlow.id) !== "running"
@@ -1344,12 +1321,11 @@ function FlowPage({ mode = "all" }) {
     return count;
   };
   const getEntryActivityMessage = (entry) => {
-    if (!entry?.id) return null;
-    const isFlow = entry.kind === "flow";
+    if (!entry?.id || entry.kind !== "flow") return null;
     const activity = getPlaylistRunActivity({
       playlistId: entry.id,
-      kind: isFlow ? "flow" : "playlist",
-      enabled: isFlow ? entry.enabled === true : true,
+      kind: "flow",
+      enabled: entry.enabled === true,
       status,
       stats: getPlaylistStats(entry.id),
       rerunning: rerunningId === entry.id,
@@ -1515,38 +1491,6 @@ function FlowPage({ mode = "all" }) {
           <button
             type="button"
             className="artist-menu-item"
-            onClick={() =>
-              handleReSearchMissingSharedPlaylistTracks(selectedPlaylist.id)
-            }
-            disabled={reSearchingMissingPlaylistId === selectedPlaylist.id}
-          >
-            <span className="artist-menu-item__main">
-              {reSearchingMissingPlaylistId === selectedPlaylist.id ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
-              ) : (
-                <Search className="artist-icon-sm" />
-              )}
-              Re-search missing
-            </span>
-          </button>
-          <button
-            type="button"
-            className="artist-menu-item"
-            onClick={() => handleSearchPlaylistUpgrades(selectedPlaylist.id)}
-            disabled={searchingUpgradePlaylistId === selectedPlaylist.id}
-          >
-            <span className="artist-menu-item__main">
-              {searchingUpgradePlaylistId === selectedPlaylist.id ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
-              ) : (
-                <Search className="artist-icon-sm" />
-              )}
-              Search for upgrades
-            </span>
-          </button>
-          <button
-            type="button"
-            className="artist-menu-item"
             onClick={() => handleExportFlow(selectedPlaylist)}
           >
             <span className="artist-menu-item__main">
@@ -1593,7 +1537,6 @@ function FlowPage({ mode = "all" }) {
             allowBulkEdit={!selectedIsFlow}
             bulkActionLoading={bulkActionLoading}
             onBulkDelete={selectedIsFlow ? undefined : handleBulkDelete}
-            onBulkReSearch={selectedIsFlow ? undefined : handleBulkReSearch}
             onBulkAddToPlaylist={selectedIsFlow ? undefined : handleBulkAddToPlaylist}
             onBulkMoveToPlaylist={selectedIsFlow ? undefined : handleBulkMoveToPlaylist}
             playlists={sharedPlaylists}
@@ -1607,10 +1550,8 @@ function FlowPage({ mode = "all" }) {
             deletingTrackId={selectedIsFlow ? undefined : deletingTrackId}
             onReSearchTrack={
               selectedIsFlow
-                ? (track) => handleReSearchTrack(selectedFlow.id, track, true)
-                : selectedPlaylist
-                  ? (track) => handleReSearchTrack(selectedPlaylist.id, track)
-                  : undefined
+                ? (track) => handleReSearchTrack(selectedFlow.id, track)
+                : undefined
             }
             onDeleteTrack={
               selectedIsFlow || !selectedPlaylist
@@ -1624,6 +1565,12 @@ function FlowPage({ mode = "all" }) {
                 : (track, target) => handleMoveTrackToPlaylist(track, target, selectedPlaylist.id)
             }
             onNavigateArtist={handleNavigateArtist}
+            trackTitleLabel={selectedIsFlow ? "Song" : "Title"}
+            showTrackArtwork={!selectedIsFlow}
+            artworkByAlbumMbid={trackArtworkByAlbumMbid}
+            showDuration={!selectedIsFlow}
+            hideStatusColumn={!selectedIsFlow}
+            hideQualityColumn={!selectedIsFlow}
           />
         ) : null}
         {detailTab === "recipe" && selectedIsFlow && simpleDraft ? (
@@ -1752,7 +1699,7 @@ function FlowPage({ mode = "all" }) {
   ) : null;
 
   return (
-    <div className="flow-page">
+    <div className={`flow-page${mode === "playlists" ? " flow-page--playlists" : ""}`}>
       <div
         className={`flow-page__shell${!isMobileLayout && libraryCollapsed ? " flow-page__shell--library-collapsed" : ""}`}
       >

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -42,6 +42,10 @@ import {
 import { getPlaylistRunActivity } from "./flows/flowRunActivity";
 import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
 import {
+  lookupAlbumsInLibraryBatch,
+  lookupArtistInLibrary,
+} from "../utils/api/endpoints/library.js";
+import {
   PlaylistLibraryItem,
   PlaylistDetailHero,
   FlowDetailTabs,
@@ -1111,11 +1115,45 @@ function FlowPage({ mode = "all" }) {
     }
   };
 
-  const handleNavigateArtist = (track) => {
+  const handleNavigateArtist = async (track) => {
     if (!track?.artistMbid) return;
-    navigate(`/artist/${track.artistMbid}`, {
-      state: { artistName: track.artistName },
-    });
+    if (selectedIsFlow) {
+      navigate(`/artist/${track.artistMbid}`, {
+        state: { artistName: track.artistName },
+      });
+      return;
+    }
+    try {
+      const lookup = await lookupArtistInLibrary(track.artistMbid);
+      const canonicalId = lookup?.artist?.canonicalId;
+      if (canonicalId) {
+        navigate(`/library/artist/${encodeURIComponent(canonicalId)}`);
+      }
+    } catch {}
+  };
+
+  const handleNavigateAlbum = async (track) => {
+    if (!track?.albumMbid) return;
+    if (selectedIsFlow && track.artistMbid) {
+      navigate(`/artist/${track.artistMbid}/release/${track.albumMbid}`, {
+        state: {
+          artistName: track.artistName,
+          focusReleaseGroupMbid: track.albumMbid,
+          focusReleaseGroup: {
+            id: track.albumMbid,
+            title: track.albumName || "",
+          },
+        },
+      });
+      return;
+    }
+    try {
+      const lookup = await lookupAlbumsInLibraryBatch([track.albumMbid]);
+      const canonicalId = lookup?.[track.albumMbid]?.canonicalAlbumId;
+      if (canonicalId) {
+        navigate(`/library/album/${encodeURIComponent(canonicalId)}`);
+      }
+    } catch {}
   };
 
   const handleBulkDelete = async (tracks) => {
@@ -1565,6 +1603,7 @@ function FlowPage({ mode = "all" }) {
                 : (track, target) => handleMoveTrackToPlaylist(track, target, selectedPlaylist.id)
             }
             onNavigateArtist={handleNavigateArtist}
+            onNavigateAlbum={handleNavigateAlbum}
             trackTitleLabel={selectedIsFlow ? "Song" : "Title"}
             showTrackArtwork={!selectedIsFlow}
             artworkByAlbumMbid={trackArtworkByAlbumMbid}

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -140,8 +140,9 @@ function readLibrarySidebarCollapsed() {
   }
 }
 
-function FlowPage() {
-  useDocumentTitle("Playlists");
+function FlowPage({ mode = "all" }) {
+  const fixedLibraryFilter = mode === "flows" ? "flows" : mode === "playlists" ? "playlists" : null;
+  useDocumentTitle(mode === "flows" ? "Flows" : "Playlists");
   const navigate = useNavigate();
   const location = useLocation();
   const {
@@ -157,7 +158,7 @@ function FlowPage() {
   const [confirmDelete, setConfirmDelete] = useState(null);
   const [confirmDisable, setConfirmDisable] = useState(null);
   const [selectedId, setSelectedId] = useState(null);
-  const [libraryFilter, setLibraryFilter] = useState("all");
+  const [libraryFilter, setLibraryFilter] = useState(fixedLibraryFilter || "all");
   const [libraryCollapsed, setLibraryCollapsed] = useState(readLibrarySidebarCollapsed);
   const [detailTab, setDetailTab] = useState("tracks");
   const [mobileShowDetail, setMobileShowDetail] = useState(false);
@@ -201,6 +202,10 @@ function FlowPage() {
   const { showSuccess, showError } = useToast();
   const disabledFlowSources = status?.capabilities?.unavailableSources || {};
   const canCreateGeneratedFlow = Object.keys(disabledFlowSources).length === 0;
+
+  useEffect(() => {
+    if (fixedLibraryFilter) setLibraryFilter(fixedLibraryFilter);
+  }, [fixedLibraryFilter]);
 
   useEffect(() => {
     if (!selectedId || !status?.flows?.length) return;
@@ -523,15 +528,16 @@ function FlowPage() {
     return [...shared, ...generated];
   }, [sharedPlaylists, effectiveFlowList]);
 
+  const activeLibraryFilter = fixedLibraryFilter || libraryFilter;
   const filteredCollection = useMemo(() => {
-    if (libraryFilter === "playlists") {
+    if (activeLibraryFilter === "playlists") {
       return collection.filter((entry) => entry.kind === "shared");
     }
-    if (libraryFilter === "flows") {
+    if (activeLibraryFilter === "flows") {
       return collection.filter((entry) => entry.kind === "flow");
     }
     return collection;
-  }, [collection, libraryFilter]);
+  }, [activeLibraryFilter, collection]);
 
   const selectedEntry = useMemo(
     () => collection.find((entry) => entry.id === selectedId) || null,
@@ -1776,7 +1782,7 @@ function FlowPage() {
             >
               <LibrarySidebarToggleIcon collapsed={libraryCollapsed} />
             </button>
-            <h1 className="flow-page__library-title">Playlists</h1>
+            <h1 className="flow-page__library-title">{mode === "flows" ? "Flows" : "Playlists"}</h1>
             <FlowLibraryCreateMenu
               onImport={() => setImportModalOpen(true)}
               onNewPlaylist={handleOpenCreatePlaylist}
@@ -1784,38 +1790,43 @@ function FlowPage() {
               creatingPlaylist={creatingPlaylist}
               creatingFlow={creating}
               canCreateFlow={canCreateGeneratedFlow}
+              showPlaylists={mode !== "flows"}
+              showFlows={mode !== "playlists"}
+              showImport={mode !== "flows"}
               compact={libraryCollapsed}
             />
           </div>
-          <div
-            className="artist-segmented flow-page__library-filters"
-            role="group"
-            aria-label="Library filter"
-          >
-            {[
-              { id: "all", label: "All" },
-              { id: "playlists", label: "Playlists" },
-              { id: "flows", label: "Flows" },
-            ].map((filter) => {
-              const isActive = libraryFilter === filter.id;
-              return (
-                <button
-                  key={filter.id}
-                  type="button"
-                  className={`artist-segmented-button flow-page__library-filter${isActive ? " is-active" : ""}`}
-                  aria-pressed={isActive}
-                  onClick={() => setLibraryFilter(filter.id)}
-                >
-                  {filter.label}
-                </button>
-              );
-            })}
-          </div>
+          {!fixedLibraryFilter ? (
+            <div
+              className="artist-segmented flow-page__library-filters"
+              role="group"
+              aria-label="Library filter"
+            >
+              {[
+                { id: "all", label: "All" },
+                { id: "playlists", label: "Playlists" },
+                { id: "flows", label: "Flows" },
+              ].map((filter) => {
+                const isActive = libraryFilter === filter.id;
+                return (
+                  <button
+                    key={filter.id}
+                    type="button"
+                    className={`artist-segmented-button flow-page__library-filter${isActive ? " is-active" : ""}`}
+                    aria-pressed={isActive}
+                    onClick={() => setLibraryFilter(filter.id)}
+                  >
+                    {filter.label}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
           <div className="flow-page__library-list">
             {filteredCollection.length === 0 ? (
               <FlowEmptyState
                 canCreate={canCreateGeneratedFlow}
-                libraryFilter={libraryFilter}
+                libraryFilter={activeLibraryFilter}
                 variant={isMobileLayout ? "full" : "compact"}
                 onImport={() => setImportModalOpen(true)}
                 onNewPlaylist={handleOpenCreatePlaylist}
@@ -1883,7 +1894,7 @@ function FlowPage() {
               filteredCollection.length === 0 ? (
                 <FlowEmptyState
                   canCreate={canCreateGeneratedFlow}
-                  libraryFilter={libraryFilter}
+                  libraryFilter={activeLibraryFilter}
                   variant="full"
                   onImport={() => setImportModalOpen(true)}
                   onNewPlaylist={handleOpenCreatePlaylist}

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -42,9 +42,15 @@ import {
 import { getPlaylistRunActivity } from "./flows/flowRunActivity";
 import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
 import {
+  getCanonicalLibraryPage,
   lookupAlbumsInLibraryBatch,
   lookupArtistInLibrary,
 } from "../utils/api/endpoints/library.js";
+import {
+  canonicalLibraryId,
+  findCanonicalAlbumByName,
+  findCanonicalArtistByName,
+} from "../utils/libraryTrackNavigation.js";
 import {
   PlaylistLibraryItem,
   PlaylistDetailHero,
@@ -1123,13 +1129,25 @@ function FlowPage({ mode = "all" }) {
       });
       return;
     }
+    let canonicalId = null;
     try {
       const lookup = await lookupArtistInLibrary(track.artistMbid);
-      const canonicalId = lookup?.artist?.canonicalId;
-      if (canonicalId) {
-        navigate(`/library/artist/${encodeURIComponent(canonicalId)}`);
-      }
+      canonicalId = lookup?.artist?.canonicalId || null;
     } catch {}
+    if (!canonicalId && track.artistName) {
+      try {
+        const page = await getCanonicalLibraryPage({
+          kind: "artists",
+          page: 1,
+          pageSize: 100,
+          query: track.artistName,
+        });
+        canonicalId = canonicalLibraryId(
+          findCanonicalArtistByName(page?.items, track.artistName),
+        );
+      } catch {}
+    }
+    if (canonicalId) navigate(`/library/artist/${encodeURIComponent(canonicalId)}`);
   };
 
   const handleNavigateAlbum = async (track) => {
@@ -1147,13 +1165,25 @@ function FlowPage({ mode = "all" }) {
       });
       return;
     }
+    let canonicalId = null;
     try {
       const lookup = await lookupAlbumsInLibraryBatch([track.albumMbid]);
-      const canonicalId = lookup?.[track.albumMbid]?.canonicalAlbumId;
-      if (canonicalId) {
-        navigate(`/library/album/${encodeURIComponent(canonicalId)}`);
-      }
+      canonicalId = lookup?.[track.albumMbid]?.canonicalAlbumId || null;
     } catch {}
+    if (!canonicalId && track.albumName) {
+      try {
+        const page = await getCanonicalLibraryPage({
+          kind: "albums",
+          page: 1,
+          pageSize: 100,
+          query: track.albumName,
+        });
+        canonicalId = canonicalLibraryId(
+          findCanonicalAlbumByName(page?.items, track.albumName, track.artistName),
+        );
+      } catch {}
+    }
+    if (canonicalId) navigate(`/library/album/${encodeURIComponent(canonicalId)}`);
   };
 
   const handleBulkDelete = async (tracks) => {

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -35,6 +35,7 @@ import {
   getCanonicalLibraryPage,
   getLibraryRefreshStatus,
   getLibraryFavorites,
+  getRequests,
   downloadTrackToLibrary,
   requestLibraryRefresh,
   updateLibraryFavorites,
@@ -113,6 +114,49 @@ const formatLongDuration = (durationMs) => {
   return hours
     ? hours + "h " + (minutes % 60) + "m"
     : minutes + "m " + (seconds % 60) + "s";
+};
+
+const TRACK_DOWNLOAD_ACTIVE_STATUSES = new Set([
+  "submitting",
+  "pending",
+  "processing",
+  "searching",
+  "downloading",
+  "moving",
+  "blocked",
+  "completed",
+]);
+
+const trackDownloadActionLabel = (status) => ({
+  submitting: "Adding to search queue…",
+  pending: "Queued for search",
+  processing: "Searching for track…",
+  searching: "Searching for track…",
+  downloading: "Downloading track…",
+  moving: "Adding to library…",
+  blocked: "Needs review",
+  completed: "Downloaded; waiting for library refresh",
+  failed: "Retry download track",
+}[status] || "Download track");
+
+const activityDownloadStatus = (request) => {
+  if (request?.status === "failed") return "failed";
+  if (request?.status === "completed") return "completed";
+  if (request?.status === "blocked") return "blocked";
+  const label = text(request?.statusLabel).toLocaleLowerCase();
+  if (label.includes("download")) return "downloading";
+  if (label.includes("moving")) return "moving";
+  if (request?.status === "pending") return "pending";
+  return "searching";
+};
+
+const trackDownloadIdentity = (track, fallbackTitle = "") =>
+  String(track?.id || track?.mbid || track?.trackMbid || track?.title || fallbackTitle);
+
+const sameTrackText = (left, right) => {
+  const first = text(left).toLocaleLowerCase();
+  const second = text(right).toLocaleLowerCase();
+  return Boolean(first) && Boolean(second) && first === second;
 };
 
 const TOP_ARTIST_TRACK_LIMIT = 10;
@@ -245,7 +289,7 @@ function LibraryPage() {
   const albumTrackCacheRef = useRef(new Map());
   const refreshAttemptRef = useRef(0);
   const [playlistSavingKey, setPlaylistSavingKey] = useState("");
-  const [trackDownloadKey, setTrackDownloadKey] = useState("");
+  const [trackDownloadStates, setTrackDownloadStates] = useState({});
 
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
@@ -662,10 +706,24 @@ function LibraryPage() {
         showError("Track details are incomplete");
         return;
       }
-      const key = String(track?.id || track?.mbid || payload.trackMbid || payload.trackName);
-      setTrackDownloadKey(key);
+      const key = trackDownloadIdentity(track, payload.trackName);
+      setTrackDownloadStates((current) => ({
+        ...current,
+        [key]: { jobId: null, status: "submitting" },
+      }));
       try {
         const result = await downloadTrackToLibrary(payload);
+        if (result?.alreadyOwned) {
+          setTrackDownloadStates(({ [key]: _, ...rest }) => rest);
+        } else {
+          setTrackDownloadStates((current) => ({
+            ...current,
+            [key]: {
+              jobId: result?.jobId || null,
+              status: result?.reused ? "moving" : "searching",
+            },
+          }));
+        }
         showSuccess(
           result?.alreadyOwned
             ? `${payload.trackName} is already in your library`
@@ -674,14 +732,13 @@ function LibraryPage() {
               : `Added ${payload.trackName} to your library`,
         );
       } catch (requestError) {
+        setTrackDownloadStates(({ [key]: _, ...rest }) => rest);
         showError(
           requestError.response?.data?.message ||
             requestError.response?.data?.error ||
             requestError.message ||
             "Failed to add track to library",
         );
-      } finally {
-        setTrackDownloadKey("");
       }
     },
     [getAlbumForTrack, getArtistForAlbum, isPreviewLibrary, showError, showSuccess],
@@ -886,6 +943,95 @@ function LibraryPage() {
     if (!libraryAlbum || isPreviewLibrary) return;
     loadAlbumTracks(libraryAlbum).catch(() => {});
   }, [isPreviewLibrary, libraryAlbum, loadAlbumTracks]);
+
+  useEffect(() => {
+    if (!libraryAlbum || isPreviewLibrary) return undefined;
+    const tracks = getAlbumTracks(libraryAlbum);
+    if (!tracks.length) return undefined;
+    let cancelled = false;
+
+    getRequests()
+      .then((requests) => {
+        if (cancelled) return;
+        const activeRequests = (Array.isArray(requests) ? requests : []).filter(
+          (request) =>
+            request?.kind === "track_download" &&
+            request?.playlistId === "library" &&
+            ["pending", "processing", "blocked"].includes(request?.status),
+        );
+        const nextStates = {};
+        for (const track of tracks) {
+          if (firstAvailableFile(track)) continue;
+          const request = activeRequests.find(
+            (candidate) =>
+              sameTrackText(candidate.trackName, track.title) &&
+              sameTrackText(candidate.artistName, track.artistName || libraryAlbum.albumArtist) &&
+              (!candidate.albumName || sameTrackText(candidate.albumName, libraryAlbum.title)),
+          );
+          if (request?.jobId) {
+            nextStates[trackDownloadIdentity(track)] = {
+              jobId: request.jobId,
+              status: activityDownloadStatus(request),
+            };
+          }
+        }
+        setTrackDownloadStates((current) => {
+          const next = { ...current };
+          for (const track of tracks) {
+            const key = trackDownloadIdentity(track);
+            if (nextStates[key]) next[key] = nextStates[key];
+            else if (next[key]?.status !== "submitting") delete next[key];
+          }
+          return next;
+        });
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getAlbumTracks, isPreviewLibrary, libraryAlbum, library.tracks]);
+
+  useEffect(() => {
+    const hasPollingState = Object.values(trackDownloadStates).some(
+      (state) => state?.jobId && state.status !== "completed" && TRACK_DOWNLOAD_ACTIVE_STATUSES.has(state.status),
+    );
+    if (!hasPollingState) return undefined;
+    let cancelled = false;
+    const sync = async () => {
+      try {
+        const requests = await getRequests();
+        if (cancelled) return;
+        const requestsByJobId = new Map(
+          (Array.isArray(requests) ? requests : [])
+            .filter((request) => request?.jobId)
+            .map((request) => [String(request.jobId), request]),
+        );
+        setTrackDownloadStates((current) => {
+          let changed = false;
+          const next = { ...current };
+          Object.entries(current).forEach(([key, state]) => {
+            if (!state?.jobId) return;
+            const request = requestsByJobId.get(String(state.jobId));
+            if (!request) return;
+            const status = activityDownloadStatus(request);
+            if (status !== state.status) {
+              next[key] = { ...state, status };
+              changed = true;
+            }
+          });
+          return changed ? next : current;
+        });
+      } catch {}
+    };
+    sync();
+    const interval = setInterval(sync, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [trackDownloadStates]);
+
   useDocumentTitle(
     isDetail
       ? libraryAlbum?.title || libraryArtist?.name || "Library"
@@ -1176,7 +1322,10 @@ function LibraryPage() {
         const album = getAlbumForTrack(track);
         const artist = getArtistForAlbum(album);
         const file = firstAvailableFile(track);
-        const downloadKey = String(track?.id || track?.mbid || track?.trackMbid || track?.title || "");
+        const downloadKey = trackDownloadIdentity(track);
+        const downloadState = trackDownloadStates[downloadKey];
+        const downloadPending = TRACK_DOWNLOAD_ACTIVE_STATUSES.has(downloadState?.status);
+        const downloadLabel = trackDownloadActionLabel(downloadState?.status);
         const active =
           String(currentTrack?.id) === String(track.id) &&
           matchesSource(librarySource);
@@ -1264,11 +1413,11 @@ function LibraryPage() {
               <TooltipButton
                 className="native-library-track__download"
                 onClick={() => downloadMissingTrack(track)}
-                disabled={trackDownloadKey === downloadKey}
-                label="Download track"
-                aria-label="Download track"
+                disabled={downloadPending}
+                label={downloadLabel}
+                aria-label={downloadLabel}
               >
-                {trackDownloadKey === downloadKey ? (
+                {downloadPending ? (
                   <RefreshCw className="animate-spin" aria-hidden="true" />
                 ) : (
                   <Download aria-hidden="true" />

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -950,7 +950,7 @@ function LibraryPage() {
     if (!tracks.length) return undefined;
     let cancelled = false;
 
-    getRequests()
+    getRequests({ refresh: true })
       .then((requests) => {
         if (cancelled) return;
         const activeRequests = (Array.isArray(requests) ? requests : []).filter(
@@ -1000,7 +1000,7 @@ function LibraryPage() {
     let cancelled = false;
     const sync = async () => {
       try {
-        const requests = await getRequests();
+        const requests = await getRequests({ refresh: true });
         if (cancelled) return;
         const requestsByJobId = new Map(
           (Array.isArray(requests) ? requests : [])

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -26,7 +26,10 @@ import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useSharedPlaylists } from "../hooks/useSharedPlaylists";
 import { useDiscoverNavigation } from "../hooks/useDiscoverNavigation";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
-import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
+import {
+  getReleaseGroupCoversBatch,
+  getReleaseGroupTracks,
+} from "../utils/api/endpoints/artists.js";
 import {
   clearCanonicalLibraryPageCache,
   getCanonicalLibraryPage,
@@ -41,6 +44,7 @@ import {
   createSharedPlaylist,
 } from "../utils/api/endpoints/playlists.js";
 import { buildAuthenticatedApiUrl } from "../utils/api/core.js";
+import { mergeAlbumMetadataTracks } from "../utils/libraryTrackHydration.js";
 import { navigateToLibraryAlbum } from "../utils/searchNavigation";
 import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { libraryPreviewData, libraryPreviewFavorites } from "./libraryPreviewData";
@@ -511,7 +515,27 @@ function LibraryPage() {
       page: 1,
       pageSize,
     });
-    const tracks = Array.isArray(page?.items) ? page.items : [];
+    const ownedTracks = Array.isArray(page?.items) ? page.items : [];
+    let tracks = ownedTracks;
+    const pageArtist = page?.artists?.[0] || null;
+    const releaseGroupMbid = album?.releaseGroupMbid || null;
+    if (releaseGroupMbid) {
+      try {
+        const metadataTracks = await getReleaseGroupTracks(releaseGroupMbid, {
+          artistMbid: album?.artistMbid || pageArtist?.mbid || "",
+          artistName:
+            album?.artistName || pageArtist?.name || album?.albumArtist || "",
+          albumTitle: album?.title || album?.albumName || "",
+          releaseDate: album?.releaseDate || "",
+        });
+        tracks = mergeAlbumMetadataTracks(
+          ownedTracks,
+          metadataTracks,
+          album,
+          pageArtist,
+        );
+      } catch {}
+    }
     albumTrackCacheRef.current.set(cacheKey, tracks);
     setLibrary((current) => {
       const merge = (kind) => [
@@ -523,7 +547,15 @@ function LibraryPage() {
       return {
         ...current,
         artists: merge("artists"),
-        albums: merge("albums"),
+        albums: merge("albums").map((entity) =>
+          String(entity.id) === String(album.id)
+            ? {
+                ...entity,
+                trackCount: tracks.length,
+                availableTrackCount: tracks.filter((track) => firstAvailableFile(track)).length,
+              }
+            : entity,
+        ),
         tracks: merge("tracks"),
       };
     });
@@ -849,6 +881,11 @@ function LibraryPage() {
   const homeTracks = ownedLibraryTracks.slice(0, 12);
   const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
   const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
+
+  useEffect(() => {
+    if (!libraryAlbum || isPreviewLibrary) return;
+    loadAlbumTracks(libraryAlbum).catch(() => {});
+  }, [isPreviewLibrary, libraryAlbum, loadAlbumTracks]);
   useDocumentTitle(
     isDetail
       ? libraryAlbum?.title || libraryArtist?.name || "Library"

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   ArrowUpZA,
+  Download,
   ExternalLink,
   Grid3X3,
   Heart,
@@ -31,6 +32,7 @@ import {
   getCanonicalLibraryPage,
   getLibraryRefreshStatus,
   getLibraryFavorites,
+  downloadTrackToLibrary,
   requestLibraryRefresh,
   updateLibraryFavorites,
 } from "../utils/api/endpoints/library.js";
@@ -77,6 +79,17 @@ const favoriteId = (kind, entity) =>
 
 const firstAvailableFile = (track) =>
   (track?.files || []).find((file) => file.available) || null;
+
+const trackDurationMs = (track) => {
+  const fileDurationMs = (track?.files || []).find((file) => Number(file?.durationMs) > 0)
+    ?.durationMs;
+  if (fileDurationMs != null) return fileDurationMs;
+  if (Number(track?.durationMs) > 0) return track.durationMs;
+  const metadataDurationMs = Number(track?.metadata?.durationMs);
+  if (metadataDurationMs > 0) return metadataDurationMs;
+  const metadataDurationSeconds = Number(track?.metadata?.duration);
+  return metadataDurationSeconds > 0 ? Math.round(metadataDurationSeconds * 1000) : null;
+};
 
 const formatDuration = (durationMs) => {
   const seconds = Math.max(0, Math.floor(Number(durationMs || 0) / 1000));
@@ -228,6 +241,7 @@ function LibraryPage() {
   const albumTrackCacheRef = useRef(new Map());
   const refreshAttemptRef = useRef(0);
   const [playlistSavingKey, setPlaylistSavingKey] = useState("");
+  const [trackDownloadKey, setTrackDownloadKey] = useState("");
 
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
@@ -349,6 +363,7 @@ function LibraryPage() {
               artistId: routeArtistId,
               page: 1,
               pageSize,
+              availableOnly: true,
             }),
           ])
       : section === "favorites"
@@ -366,6 +381,7 @@ function LibraryPage() {
               page: 1,
               pageSize: 12,
               sort: "newest",
+              availableOnly: true,
             }),
           ])
         : getCanonicalLibraryPage({
@@ -376,6 +392,7 @@ function LibraryPage() {
             genre: selectedGenre,
             sort: sortMode,
             direction: sortDirection,
+            availableOnly: tab === "tracks",
           });
 
     const favoritesRequest = Promise.resolve(null);
@@ -544,7 +561,7 @@ function LibraryPage() {
         albumMbid: album?.mbid || album?.releaseGroupMbid || "",
         trackMbid: track?.mbid || "",
         releaseYear: yearOf(album?.releaseDate),
-        durationMs: firstAvailableFile(track)?.durationMs || track?.durationMs,
+        durationMs: trackDurationMs(track),
       });
       if (!payload.artistName || !payload.trackName) {
         showError("Track details are incomplete");
@@ -594,6 +611,50 @@ function LibraryPage() {
     ],
   );
 
+  const downloadMissingTrack = useCallback(
+    async (track) => {
+      if (!track || firstAvailableFile(track) || isPreviewLibrary) return;
+      const album = getAlbumForTrack(track);
+      const artist = getArtistForAlbum(album);
+      const payload = {
+        artistName: artist?.name || track?.artistName || "",
+        trackName: track?.title || track?.trackName || "",
+        albumName: album?.title || track?.albumName || "",
+        artistMbid: artist?.mbid || track?.artistMbid || "",
+        albumMbid: album?.mbid || album?.releaseGroupMbid || track?.albumMbid || "",
+        trackMbid: track?.mbid || track?.trackMbid || "",
+        releaseYear: yearOf(album?.releaseDate),
+        durationMs: trackDurationMs(track),
+      };
+      if (!payload.artistName || !payload.trackName) {
+        showError("Track details are incomplete");
+        return;
+      }
+      const key = String(track?.id || track?.mbid || payload.trackMbid || payload.trackName);
+      setTrackDownloadKey(key);
+      try {
+        const result = await downloadTrackToLibrary(payload);
+        showSuccess(
+          result?.alreadyOwned
+            ? `${payload.trackName} is already in your library`
+            : result?.queued
+              ? `Queued ${payload.trackName} for your library`
+              : `Added ${payload.trackName} to your library`,
+        );
+      } catch (requestError) {
+        showError(
+          requestError.response?.data?.message ||
+            requestError.response?.data?.error ||
+            requestError.message ||
+            "Failed to add track to library",
+        );
+      } finally {
+        setTrackDownloadKey("");
+      }
+    },
+    [getAlbumForTrack, getArtistForAlbum, isPreviewLibrary, showError, showSuccess],
+  );
+
   const albumAvailability = useCallback(
     (album) => {
       const tracks = getAlbumTracks(album);
@@ -627,9 +688,14 @@ function LibraryPage() {
     [getArtistForAlbum, library.albums, normalizedQuery, selectedGenre],
   );
 
+  const ownedLibraryTracks = useMemo(
+    () => library.tracks.filter((track) => firstAvailableFile(track)),
+    [library.tracks],
+  );
+
   const filteredTracks = useMemo(
     () =>
-      library.tracks.filter((track) => {
+      ownedLibraryTracks.filter((track) => {
         const album = getAlbumForTrack(track);
         const artist = getArtistForAlbum(album);
         return (
@@ -644,7 +710,7 @@ function LibraryPage() {
           )
         );
       }),
-    [getAlbumForTrack, getArtistForAlbum, library.tracks, normalizedQuery, selectedGenre],
+    [getAlbumForTrack, getArtistForAlbum, normalizedQuery, ownedLibraryTracks, selectedGenre],
   );
 
   const genreStats = useMemo(() => {
@@ -661,11 +727,11 @@ function LibraryPage() {
     library.albums.forEach((album) =>
       metadataGenres(album).forEach((genre) => add(genre, "albums")),
     );
-    library.tracks.forEach((track) =>
+    ownedLibraryTracks.forEach((track) =>
       metadataGenres(track).forEach((genre) => add(genre, "tracks")),
     );
     return [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
-  }, [library.albums, library.artists, library.genres, library.tracks]);
+  }, [library.albums, library.artists, library.genres, ownedLibraryTracks]);
 
   const visibleGenreStats = useMemo(
     () =>
@@ -701,7 +767,7 @@ function LibraryPage() {
 
   const favoriteTracks = useMemo(
     () =>
-      library.tracks.filter((track) => {
+      ownedLibraryTracks.filter((track) => {
         const album = getAlbumForTrack(track);
         const artist = getArtistForAlbum(album);
         return (
@@ -716,7 +782,7 @@ function LibraryPage() {
           )
         );
       }),
-    [favoriteIds, getAlbumForTrack, getArtistForAlbum, library.tracks, normalizedQuery],
+    [favoriteIds, getAlbumForTrack, getArtistForAlbum, normalizedQuery, ownedLibraryTracks],
   );
 
   const sortedArtists = useMemo(() => {
@@ -780,7 +846,7 @@ function LibraryPage() {
         .slice(0, 12),
     [genreStats],
   );
-  const homeTracks = library.tracks.slice(0, 12);
+  const homeTracks = ownedLibraryTracks.slice(0, 12);
   const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
   const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
   useDocumentTitle(
@@ -993,7 +1059,7 @@ function LibraryPage() {
     favoriteArtists.length + favoriteAlbums.length + favoriteTracks.length;
   const activeCount =
     section === "home"
-      ? pageData?.total ?? library.albums.length + library.tracks.length
+          ? pageData?.total ?? library.albums.length + ownedLibraryTracks.length
       : section === "favorites"
         ? favoriteCount
         : pageData?.kind === tab
@@ -1029,13 +1095,13 @@ function LibraryPage() {
     if (section === "albums") return sortedAlbums.flatMap(getAlbumTracks);
     if (section === "tracks") return sortedTracks;
     if (section === "genres" && selectedGenre) return filteredTracks;
-    return library.tracks;
+      return ownedLibraryTracks;
   }, [
     favoriteTracks,
     filteredTracks,
     getAlbumTracks,
     libraryAlbum,
-    library.tracks,
+    ownedLibraryTracks,
     section,
     selectedGenre,
     sortedAlbums,
@@ -1073,6 +1139,7 @@ function LibraryPage() {
         const album = getAlbumForTrack(track);
         const artist = getArtistForAlbum(album);
         const file = firstAvailableFile(track);
+        const downloadKey = String(track?.id || track?.mbid || track?.trackMbid || track?.title || "");
         const active =
           String(currentTrack?.id) === String(track.id) &&
           matchesSource(librarySource);
@@ -1088,19 +1155,23 @@ function LibraryPage() {
             key={track.id}
             role="listitem"
           >
-            <TooltipButton
-              className="native-library-track__play"
-              onClick={() => playTrack(track, tracks)}
-              disabled={!file || (active && isLoading)}
-              label={(active && isPlaying ? "Pause " : "Play ") + track.title}
-              aria-label={(active && isPlaying ? "Pause " : "Play ") + track.title}
-            >
-              {active && isPlaying ? (
-                <span aria-hidden="true">Ⅱ</span>
-              ) : (
-                <Play aria-hidden="true" fill="currentColor" />
-              )}
-            </TooltipButton>
+            {file ? (
+              <TooltipButton
+                className="native-library-track__play"
+                onClick={() => playTrack(track, tracks)}
+                disabled={active && isLoading}
+                label={(active && isPlaying ? "Pause " : "Play ") + track.title}
+                aria-label={(active && isPlaying ? "Pause " : "Play ") + track.title}
+              >
+                {active && isPlaying ? (
+                  <span aria-hidden="true">Ⅱ</span>
+                ) : (
+                  <Play aria-hidden="true" fill="currentColor" />
+                )}
+              </TooltipButton>
+            ) : (
+              <span aria-hidden="true" />
+            )}
             <span className="native-library-track__number" aria-hidden="true">
               {index + 1}
             </span>
@@ -1150,8 +1221,25 @@ function LibraryPage() {
               <span className="native-library-track__link native-library-track__album">{albumName}</span>
             )}
             <span className={"native-library-track__time" + (!file ? " is-missing" : "")}>
-              {file ? formatDuration(file.durationMs) : "Unavailable"}
+              {formatDuration(trackDurationMs(track)) || "Unavailable"}
             </span>
+            {!file ? (
+              <TooltipButton
+                className="native-library-track__download"
+                onClick={() => downloadMissingTrack(track)}
+                disabled={trackDownloadKey === downloadKey}
+                label="Download track"
+                aria-label="Download track"
+              >
+                {trackDownloadKey === downloadKey ? (
+                  <RefreshCw className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Download aria-hidden="true" />
+                )}
+              </TooltipButton>
+            ) : (
+              <span />
+            )}
             <TrackPlaylistMenu
               track={track}
               playlists={sharedPlaylists}
@@ -1334,7 +1422,7 @@ function LibraryPage() {
       )}
       {homeTracks.length > 0 && (
         <section className="native-library-section">
-          {renderSectionHeader("Tracks", library.tracks.length, "/library/tracks")}
+          {renderSectionHeader("Tracks", ownedLibraryTracks.length, "/library/tracks")}
           {renderTrackList(homeTracks, "Library tracks")}
         </section>
       )}
@@ -1653,7 +1741,7 @@ function LibraryPage() {
       : 0;
   const pageCount =
     section === "home"
-      ? pageData?.total ?? library.albums.length + library.tracks.length
+      ? pageData?.total ?? library.albums.length + ownedLibraryTracks.length
       : activeCount;
   const showToolbar = section !== "home";
   const hasActiveFilters = Boolean(selectedGenre);

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -22,6 +22,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { useAudioQueue } from "../contexts/audioQueueContext";
 import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import { useSharedPlaylists } from "../hooks/useSharedPlaylists";
 import { useDiscoverNavigation } from "../hooks/useDiscoverNavigation";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
 import { getReleaseGroupCoversBatch } from "../utils/api/endpoints/artists.js";
@@ -33,10 +34,19 @@ import {
   requestLibraryRefresh,
   updateLibraryFavorites,
 } from "../utils/api/endpoints/library.js";
+import {
+  addSharedPlaylistTracks,
+  createSharedPlaylist,
+} from "../utils/api/endpoints/playlists.js";
 import { buildAuthenticatedApiUrl } from "../utils/api/core.js";
 import { navigateToLibraryAlbum } from "../utils/searchNavigation";
 import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { libraryPreviewData, libraryPreviewFavorites } from "./libraryPreviewData";
+import { TrackPlaylistMenu } from "./ArtistDetails/components/TrackPlaylistMenu";
+import {
+  buildSharedPlaylistTrackPayload,
+  reserveUniquePlaylistName,
+} from "./ArtistDetails/utils";
 
 const LIBRARY_VIEW_IDS = new Set(LIBRARY_VIEWS.map((view) => view.id));
 
@@ -187,6 +197,14 @@ function LibraryPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { bootstrap } = useAuth();
   const { showError, showSuccess } = useToast();
+  const {
+    sharedPlaylists,
+    setSharedPlaylists,
+    playlistsLoading,
+    playlistsError,
+    setPlaylistsError,
+    loadSharedPlaylists,
+  } = useSharedPlaylists();
   const { playQueue, currentTrack, isPlaying, isLoading, togglePlayPause, matchesSource } =
     useAudioQueue();
   const [library, setLibrary] = useState({ artists: [], albums: [], tracks: [], genres: [] });
@@ -209,6 +227,7 @@ function LibraryPage() {
   const [pageData, setPageData] = useState(null);
   const albumTrackCacheRef = useRef(new Map());
   const refreshAttemptRef = useRef(0);
+  const [playlistSavingKey, setPlaylistSavingKey] = useState("");
 
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
@@ -502,6 +521,77 @@ function LibraryPage() {
   const getArtistForAlbum = useCallback(
     (album) => (album ? artistsById.get(String(album.artistId)) : null),
     [artistsById],
+  );
+
+  const getDefaultTrackPlaylistName = useCallback(
+    (track) =>
+      reserveUniquePlaylistName(
+        sharedPlaylists,
+        `${getArtistForAlbum(getAlbumForTrack(track))?.name || track?.artistName || "Artist"} Picks`,
+      ),
+    [getAlbumForTrack, getArtistForAlbum, sharedPlaylists],
+  );
+
+  const addLibraryTrackToPlaylist = useCallback(
+    async (track, target) => {
+      const album = getAlbumForTrack(track);
+      const artist = getArtistForAlbum(album);
+      const payload = buildSharedPlaylistTrackPayload({
+        artistName: artist?.name || track?.artistName || "",
+        trackName: track?.title || "",
+        albumName: album?.title || "",
+        artistMbid: artist?.mbid || "",
+        albumMbid: album?.mbid || album?.releaseGroupMbid || "",
+        trackMbid: track?.mbid || "",
+        releaseYear: yearOf(album?.releaseDate),
+        durationMs: firstAvailableFile(track)?.durationMs || track?.durationMs,
+      });
+      if (!payload.artistName || !payload.trackName) {
+        showError("Track details are incomplete");
+        return;
+      }
+      const key = String(track?.id || "");
+      setPlaylistSavingKey(key);
+      setPlaylistsError("");
+      try {
+        if (target?.mode === "new") {
+          const name =
+            String(target?.name || "").trim() ||
+            getDefaultTrackPlaylistName(track);
+          await createSharedPlaylist({ name, tracks: [payload] });
+          showSuccess(`Track saved to ${name}`);
+        } else {
+          const playlist = sharedPlaylists.find(
+            (candidate) => candidate.id === target?.playlistId,
+          );
+          await addSharedPlaylistTracks(target?.playlistId, { tracks: [payload] });
+          showSuccess(`Track added to ${playlist?.name || "playlist"}`);
+        }
+        const nextPlaylists = await loadSharedPlaylists();
+        if (nextPlaylists) setSharedPlaylists(nextPlaylists);
+      } catch (requestError) {
+        const message =
+          requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          "Failed to save track to playlist";
+        setPlaylistsError(message);
+        showError(message);
+      } finally {
+        setPlaylistSavingKey("");
+      }
+    },
+    [
+      getAlbumForTrack,
+      getArtistForAlbum,
+      getDefaultTrackPlaylistName,
+      loadSharedPlaylists,
+      setPlaylistsError,
+      setSharedPlaylists,
+      sharedPlaylists,
+      showError,
+      showSuccess,
+    ],
   );
 
   const albumAvailability = useCallback(
@@ -976,6 +1066,7 @@ function LibraryPage() {
         <span>Album</span>
         <span className="native-library-track__time">Time</span>
         <span />
+        <span />
       </div>
       <div role="list" aria-label={label}>
         {tracks.map((track, index) => {
@@ -989,7 +1080,11 @@ function LibraryPage() {
         const albumName = album?.title || "Unknown Album";
         return (
           <div
-            className={"native-library-track" + (active ? " is-active" : "")}
+            className={
+              "native-library-track" +
+              (active ? " is-active" : "") +
+              (file ? "" : " is-missing")
+            }
             key={track.id}
             role="listitem"
           >
@@ -1057,6 +1152,17 @@ function LibraryPage() {
             <span className={"native-library-track__time" + (!file ? " is-missing" : "")}>
               {file ? formatDuration(file.durationMs) : "Unavailable"}
             </span>
+            <TrackPlaylistMenu
+              track={track}
+              playlists={sharedPlaylists}
+              loading={playlistsLoading}
+              saving={playlistSavingKey === String(track.id)}
+              error={playlistsError}
+              defaultNewPlaylistName={getDefaultTrackPlaylistName(track)}
+              onLoadPlaylists={loadSharedPlaylists}
+              triggerVariant="compact"
+              onSelect={(target) => addLibraryTrackToPlaylist(track, target)}
+            />
             <FavoriteButton
               className="native-library-track__favorite"
               active={favoriteIds.has(favoriteId("song", track))}

--- a/frontend/src/pages/Settings/components/SettingsStorageSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsStorageSection.jsx
@@ -189,7 +189,9 @@ export function SettingsStorageHealthSection({
     <>
       <SettingsArrFieldSet
         legend="Storage health"
-        actions={
+      >
+        <div className="settings-storage-health__toolbar">
+          <p className="arr-form-help">Checks configured library, download, and playback paths.</p>
           <button
             type="button"
             className="arr-btn"
@@ -199,10 +201,8 @@ export function SettingsStorageHealthSection({
             <RefreshCw className={`artist-icon-sm${checkingHealth ? " animate-spin" : ""}`} />
             {checkingHealth ? "Checking…" : "Run checks"}
           </button>
-        }
-      >
+        </div>
         <StorageHealthSummary result={healthResult} loading={checkingHealth} />
-        <p className="arr-form-help">Checks configured library, download, and playback paths.</p>
         <StorageHealthDashboard result={healthResult} loading={checkingHealth} showSummary={false} />
       </SettingsArrFieldSet>
 

--- a/frontend/src/pages/Settings/settingsArr.css
+++ b/frontend/src/pages/Settings/settingsArr.css
@@ -651,6 +651,18 @@
   display: block;
 }
 
+.settings-storage-health__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.settings-storage-health__toolbar .arr-form-help {
+  margin: 0;
+}
+
 .arr-health__loading {
   margin: 0;
   color: var(--arr-text-muted);
@@ -2228,6 +2240,11 @@
     position: static;
     flex-wrap: wrap;
     margin: -0.25rem 0.75rem 0.625rem;
+  }
+
+  .settings-storage-health__toolbar {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .settings-arr__toolbar {

--- a/frontend/src/pages/flows/FlowPlaylistUI.jsx
+++ b/frontend/src/pages/flows/FlowPlaylistUI.jsx
@@ -198,7 +198,10 @@ export function PlaylistLibraryItem({
     entry.kind === "flow"
       ? getFlowDisplayTrackCount(entry, stats)
       : getSharedPlaylistTrackCount(entry, stats);
-  const trackLabel = formatTrackCountLabel(trackCount, stats);
+  const trackLabel =
+    entry.kind === "flow"
+      ? formatTrackCountLabel(trackCount, stats)
+      : `${trackCount} ${trackCount === 1 ? "track" : "tracks"}`;
   const baseTypeLabel =
     entry.kind === "flow" ? (entry.enabled === true ? "Flow" : "Flow draft") : "Playlist";
   const showOwner =

--- a/frontend/src/pages/flows/FlowPlaylistUI.jsx
+++ b/frontend/src/pages/flows/FlowPlaylistUI.jsx
@@ -60,6 +60,9 @@ export function FlowLibraryCreateMenu({
   creatingPlaylist = false,
   creatingFlow = false,
   canCreateFlow = true,
+  showPlaylists = true,
+  showFlows = true,
+  showImport = true,
   compact = false,
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -73,7 +76,7 @@ export function FlowLibraryCreateMenu({
         type="button"
         className="flow-page__library-create-btn"
         onClick={() => setIsOpen((prev) => !prev)}
-        aria-label="Create playlist or flow"
+        aria-label={showFlows ? "Create playlist or flow" : "Create playlist"}
         aria-expanded={isOpen}
         aria-haspopup="menu"
       >
@@ -88,9 +91,12 @@ export function FlowLibraryCreateMenu({
             aria-label="Close menu"
           />
           <div className="flow-page__library-create-menu" role="menu" aria-label="Create and import">
-            <p className="flow-page__library-create-menu-label">Create</p>
-            <div className="flow-page__library-create-primary">
-              <button
+            {showPlaylists || showFlows ? (
+              <p className="flow-page__library-create-menu-label">Create</p>
+            ) : null}
+            {showPlaylists || (showFlows && canCreateFlow) ? (
+              <div className="flow-page__library-create-primary">
+              {showPlaylists ? <button
                 type="button"
                 role="menuitem"
                 className="flow-page__library-create-action flow-page__library-create-action--playlist"
@@ -111,8 +117,8 @@ export function FlowLibraryCreateMenu({
                     Curate and play your own track list
                   </span>
                 </span>
-              </button>
-              {canCreateFlow ? (
+              </button> : null}
+              {showFlows && canCreateFlow ? (
                 <button
                   type="button"
                   role="menuitem"
@@ -139,11 +145,12 @@ export function FlowLibraryCreateMenu({
                   </span>
                 </button>
               ) : null}
-            </div>
-            <p className="flow-page__library-create-menu-label flow-page__library-create-menu-label--import">
+              </div>
+            ) : null}
+            {showImport ? <p className="flow-page__library-create-menu-label flow-page__library-create-menu-label--import">
               Import
-            </p>
-            <div className="flow-page__library-create-primary">
+            </p> : null}
+            {showImport ? <div className="flow-page__library-create-primary">
               <button
                 type="button"
                 role="menuitem"
@@ -166,7 +173,7 @@ export function FlowLibraryCreateMenu({
                   </span>
                 </span>
               </button>
-            </div>
+            </div> : null}
           </div>
         </>
       ) : null}

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -18,6 +18,7 @@ import { Link } from "react-router-dom";
 import { useAudioQueue } from "../../../contexts/audioQueueContext";
 import { normalizeFlowTrack } from "../../../utils/audioQueue";
 import { TrackPlaylistMenu, TrackPlaylistSubmenu } from "../../ArtistDetails/components/TrackPlaylistMenu";
+import { PlaylistArtworkThumb } from "./PlaylistArtworkThumb.jsx";
 
 function getTrackStatusMeta(status) {
   switch (String(status || "").toLowerCase()) {
@@ -53,6 +54,12 @@ function getTrackQualityMeta(track) {
     external: "External",
   }[track.qualityState] || "");
   return { label, state };
+}
+
+function formatTrackDuration(durationMs) {
+  const seconds = Math.max(0, Math.floor(Number(durationMs || 0) / 1000));
+  if (!seconds) return "—";
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
 function BulkPlaylistAction({
@@ -445,6 +452,10 @@ export function FlowTracksPanel({
   onReSearchTrack,
   playbackSource = null,
   showPlaybackControls = true,
+  trackTitleLabel = "Song",
+  showTrackArtwork = false,
+  artworkByAlbumMbid = {},
+  showDuration = false,
   hideAlbumColumn = false,
   hideStatusColumn = false,
   hideQualityColumn = false,
@@ -761,8 +772,11 @@ export function FlowTracksPanel({
                     className="flow-page__tracks-table-index"
                   />
                 )}
+                {showTrackArtwork ? (
+                  <th className="flow-page__tracks-table-artwork" aria-hidden="true" />
+                ) : null}
                 <FlowTracksSortHeader
-                  label="Song"
+                  label={trackTitleLabel}
                   sortKey="song"
                   activeSortKey={sortKey}
                   sortDirection={sortDirection}
@@ -787,6 +801,11 @@ export function FlowTracksPanel({
                     className="flow-page__tracks-table-album"
                   />
                 )}
+                {showDuration ? (
+                  <th className="flow-page__tracks-table-duration" scope="col">
+                    Time
+                  </th>
+                ) : null}
                 {hideStatusColumn ? null : (
                   <FlowTracksSortHeader
                     label={<span className="sr-only">Status</span>}
@@ -834,6 +853,11 @@ export function FlowTracksPanel({
                 const isDeleting = deletingTrackId === track.id;
                 const isCurrent = track.id === currentTrackId && isCurrentPlaying;
                 const quality = hideQualityColumn ? null : getTrackQualityMeta(track);
+                const artworkUrl =
+                  track.artworkUrl ||
+                  track.coverUrl ||
+                  artworkByAlbumMbid[String(track.albumMbid || "")] ||
+                  "";
                 return (
                   <tr
                     key={track.id}
@@ -882,6 +906,15 @@ export function FlowTracksPanel({
                         trackDisplayNumber
                       )}
                     </td>
+                    {showTrackArtwork ? (
+                      <td className="flow-page__tracks-table-artwork">
+                        <PlaylistArtworkThumb
+                          artworkUrl={artworkUrl}
+                          name={track.albumName || track.trackName}
+                          className="flow-page__tracks-table-artwork-thumb"
+                        />
+                      </td>
+                    ) : null}
                     <td
                       className="flow-page__tracks-table-song"
                       title={track.trackName}
@@ -918,6 +951,11 @@ export function FlowTracksPanel({
                         </span>
                       </td>
                     )}
+                    {showDuration ? (
+                      <td className="flow-page__tracks-table-duration">
+                        {formatTrackDuration(track.durationMs)}
+                      </td>
+                    ) : null}
                     {hideStatusColumn ? null : (
                       <td className="flow-page__tracks-table-status-cell">
                         <TrackStatusDot status={track.status} />

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -449,6 +449,7 @@ export function FlowTracksPanel({
   onAddTrackToPlaylist,
   onMoveTrackToPlaylist,
   onNavigateArtist,
+  onNavigateAlbum,
   onReSearchTrack,
   playbackSource = null,
   showPlaybackControls = true,
@@ -946,9 +947,19 @@ export function FlowTracksPanel({
                         className="flow-page__tracks-table-album"
                         title={track.albumName || "Unknown Album"}
                       >
-                        <span className="flow-page__tracks-table-cell-text">
-                          {track.albumName || "Unknown Album"}
-                        </span>
+                        {track.albumMbid && typeof onNavigateAlbum === "function" ? (
+                          <button
+                            type="button"
+                            onClick={() => onNavigateAlbum(track)}
+                            className="flow-page__tracks-album-link"
+                          >
+                            {track.albumName || "Unknown Album"}
+                          </button>
+                        ) : (
+                          <span className="flow-page__tracks-table-cell-text">
+                            {track.albumName || "Unknown Album"}
+                          </span>
+                        )}
                       </td>
                     )}
                     {showDuration ? (

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -250,6 +250,9 @@ export const downloadAlbum = (artistId, albumId, options = {}) =>
     artistName: options.artistName,
   });
 
+export const downloadTrackToLibrary = (track) =>
+  postData("/library/downloads/track", track);
+
 export const triggerAlbumSearch = (albumId) =>
   postData("/library/downloads/album/search", {
     albumId,

--- a/frontend/src/utils/libraryTrackHydration.js
+++ b/frontend/src/utils/libraryTrackHydration.js
@@ -1,0 +1,81 @@
+const text = (value) => String(value || "").trim();
+
+const trackNumberOf = (track) =>
+  Number(
+    track?.trackNumber ||
+      track?.position ||
+      track?.albums?.[0]?.trackNumber ||
+      0,
+  );
+
+const titleKey = (track) => text(track?.title || track?.trackName).toLocaleLowerCase();
+
+const metadataDuration = (track) => {
+  const duration = Number(track?.length ?? track?.durationMs ?? track?.duration ?? 0);
+  return duration > 0 ? duration : null;
+};
+
+export function mergeAlbumMetadataTracks(
+  ownedTracks,
+  metadataTracks,
+  album,
+  artist = null,
+) {
+  const owned = Array.isArray(ownedTracks) ? ownedTracks : [];
+  const metadata = Array.isArray(metadataTracks) ? metadataTracks : [];
+  const usedOwned = new Set();
+  const albumMbid = album?.mbid || album?.releaseGroupMbid || null;
+  const artistName = artist?.name || album?.artistName || album?.albumArtist || "";
+  const artistMbid = artist?.mbid || album?.artistMbid || null;
+
+  const findOwned = (entry) => {
+    const mbid = text(entry?.mbid || entry?.id);
+    const number = trackNumberOf(entry);
+    const title = titleKey(entry);
+    const candidates = owned.filter((track) => !usedOwned.has(track));
+    return (
+      candidates.find((track) => mbid && text(track?.mbid) === mbid) ||
+      candidates.find((track) => number > 0 && trackNumberOf(track) === number) ||
+      candidates.find((track) => title && titleKey(track) === title) ||
+      null
+    );
+  };
+
+  const tracks = metadata.map((entry, index) => {
+    const number = trackNumberOf(entry) || index + 1;
+    const existing = findOwned(entry);
+    if (existing) {
+      usedOwned.add(existing);
+      return existing;
+    }
+
+    const mbid = text(entry?.mbid || entry?.id) || null;
+    return {
+      id: `metadata:${album?.id || "album"}:${mbid || number}`,
+      mbid,
+      title: text(entry?.title || entry?.trackName) || "Unknown Track",
+      trackName: text(entry?.trackName || entry?.title) || "Unknown Track",
+      artistName,
+      artistMbid,
+      albumName: album?.title || album?.albumName || "Unknown Album",
+      albumMbid,
+      albumId: album?.id,
+      trackNumber: number,
+      durationMs: metadataDuration(entry),
+      metadata: metadataDuration(entry) ? { durationMs: metadataDuration(entry) } : {},
+      albums: [{ albumId: album?.id, discNumber: 1, trackNumber: number }],
+      files: [],
+      sources: [],
+      available: false,
+    };
+  });
+
+  owned.forEach((track) => {
+    if (!usedOwned.has(track)) tracks.push(track);
+  });
+
+  return tracks.sort((left, right) => {
+    const numberDifference = trackNumberOf(left) - trackNumberOf(right);
+    return numberDifference || titleKey(left).localeCompare(titleKey(right));
+  });
+}

--- a/frontend/src/utils/libraryTrackNavigation.js
+++ b/frontend/src/utils/libraryTrackNavigation.js
@@ -1,0 +1,26 @@
+const normalizeName = (value) => String(value || "").trim().toLocaleLowerCase();
+
+export const canonicalLibraryId = (entry) => entry?.canonicalId ?? entry?.id ?? null;
+
+export function findCanonicalArtistByName(artists, artistName) {
+  const target = normalizeName(artistName);
+  if (!target) return null;
+  return (
+    (Array.isArray(artists) ? artists : []).find(
+      (artist) => normalizeName(artist?.name || artist?.artistName) === target,
+    ) || null
+  );
+}
+
+export function findCanonicalAlbumByName(albums, albumName, artistName) {
+  const targetAlbum = normalizeName(albumName);
+  const targetArtist = normalizeName(artistName);
+  if (!targetAlbum) return null;
+  return (
+    (Array.isArray(albums) ? albums : []).find(
+      (album) =>
+        normalizeName(album?.title || album?.albumName) === targetAlbum &&
+        (!targetArtist || normalizeName(album?.albumArtist || album?.artistName) === targetArtist),
+    ) || null
+  );
+}


### PR DESCRIPTION
## Problem

Aurral downloads and playlist-oriented media need a canonical library model without losing existing files, playlist membership, or temporary Flow behavior.

## Solution

- Migrate existing Aurral `DL_FOLDER` content safely to canonical `artist/album/track` paths.
- Keep static playlist references separate from temporary Flow media under `.flows`.
- Preserve source files until each destination is written, indexed, and verified; retain ambiguous or partial items for review.
- Show complete album tracklists in Library with missing tracks muted.
- Mark owned tracks in partial Discovery albums.
- Add track kebab actions for playlists and direct library acquisition.
- Add playlist actions to Library tracks and separate Library > Playlists from Flows.
- Keep Lidarr-owned roots isolated.

## Verification

- `npm test` (611 passing)
- `npm run test:integration` (50 passing)
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- Focused migration, canonical album, scanner, and ownership tests

Provider-backed download coverage remains outside this change because it requires a configured upstream account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable migration of existing downloads with verification, retries, and safe handling of incomplete or ambiguous files.
  * Added temporary Flow media alongside canonical library storage.
  * Added options to save individual tracks to the library or playlists.
  * Added separate navigation for Playlists and Flows.
  * Added album track availability, ownership indicators, and improved pagination.

* **Bug Fixes**
  * Improved file reuse, repair, cleanup, and playlist reset behavior.
  * Prevents migration when download and library folders overlap.
  * Improved handling and display of missing library tracks.

* **Documentation**
  * Documented storage layouts, Flow media, playlist membership, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->