### PR TITLE
feat(library): add item actions and wanted activity views

### DIFF
--- a/.tests/frontend/activity-missing.test.js
+++ b/.tests/frontend/activity-missing.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isCutoffUnmetAurralJob,
+  isMissingAurralJob,
+  sortMissingJobs,
+} from "../../frontend/src/pages/activity/activityMissingUtils.js";
+
+test("missing activity includes failed Aurral jobs but not upgrades", () => {
+  assert.equal(isMissingAurralJob({ status: "failed" }), true);
+  assert.equal(isMissingAurralJob({ status: "failed", upgradeForJobId: "job-1" }), false);
+  assert.equal(isMissingAurralJob({ status: "done" }), false);
+});
+
+test("cutoff activity includes owned files below the preferred quality", () => {
+  assert.equal(
+    isCutoffUnmetAurralJob({ status: "done", qualityOwned: true, qualityState: "upgrade" }),
+    true,
+  );
+  assert.equal(
+    isCutoffUnmetAurralJob({ status: "done", qualityOwned: true, qualityState: "preferred" }),
+    false,
+  );
+  assert.equal(
+    isCutoffUnmetAurralJob({ status: "done", qualityOwned: false, qualityState: "upgrade" }),
+    false,
+  );
+});
+
+test("missing activity sorts newest operations first", () => {
+  assert.ok(
+    sortMissingJobs({ createdAt: 20, trackName: "A" }, { createdAt: 10, trackName: "B" }) < 0,
+  );
+});

--- a/.tests/frontend/activity-missing.test.js
+++ b/.tests/frontend/activity-missing.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   isCutoffUnmetAurralJob,
+  getMissingJobKey,
   isMissingAurralJob,
   sortMissingJobs,
 } from "../../frontend/src/pages/activity/activityMissingUtils.js";
@@ -32,4 +33,8 @@ test("missing activity sorts newest operations first", () => {
   assert.ok(
     sortMissingJobs({ createdAt: 20, trackName: "A" }, { createdAt: 10, trackName: "B" }) < 0,
   );
+  assert.ok(
+    sortMissingJobs({ createdAt: 10, trackName: "A" }, { createdAt: 10, trackName: "B" }) < 0,
+  );
+  assert.equal(getMissingJobKey({ id: "job-42" }), "job-42");
 });

--- a/.tests/frontend/activity-nav.test.js
+++ b/.tests/frontend/activity-nav.test.js
@@ -6,12 +6,14 @@ import {
   matchesActivityView,
   normalizeActivityView,
   buildActivityPath,
+  buildWantedPath,
 } from "../../frontend/src/navigation/activityNavConfig.js";
 
 test("normalizeActivityView falls back to queue", () => {
   assert.equal(normalizeActivityView(undefined), "queue");
   assert.equal(normalizeActivityView("bogus"), "queue");
-  assert.equal(normalizeActivityView("review"), "review");
+  assert.equal(normalizeActivityView("review"), "queue");
+  assert.equal(normalizeActivityView("missing"), "missing");
 });
 
 test("buildActivityPath normalizes invalid views", () => {
@@ -19,15 +21,19 @@ test("buildActivityPath normalizes invalid views", () => {
   assert.equal(buildActivityPath("nope"), "/activity/queue");
 });
 
-test("blocked items with inQueue only appear in review", () => {
+test("wanted links share one page route", () => {
+  assert.equal(buildWantedPath("missing"), "/activity/missing");
+  assert.equal(buildWantedPath("cutoff"), "/activity/missing?tab=cutoff");
+});
+
+test("blocked items with inQueue appear in the combined queue", () => {
   const blocked = {
     status: "blocked",
     inQueue: true,
     kind: "track_download",
   };
-  assert.equal(isActivityQueueItem(blocked), false);
-  assert.equal(matchesActivityView(blocked, "queue"), false);
-  assert.equal(matchesActivityView(blocked, "review"), true);
+  assert.equal(isActivityQueueItem(blocked), true);
+  assert.equal(matchesActivityView(blocked, "queue"), true);
   assert.equal(matchesActivityView(blocked, "history"), false);
 });
 
@@ -36,6 +42,11 @@ test("processing items appear in queue not history", () => {
   assert.equal(matchesActivityView(active, "queue"), true);
   assert.equal(matchesActivityView(active, "review"), false);
   assert.equal(matchesActivityView(active, "history"), false);
+});
+
+test("missing is a separate operation view", () => {
+  const failed = { status: "failed", inQueue: false };
+  assert.equal(matchesActivityView(failed, "missing"), false);
 });
 
 test("completed items appear in history", () => {

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -54,6 +54,9 @@ test("canonical track reads remove nested filesystem paths", async () => {
 
     const routes = new Map();
     registerTracks({
+      delete(routePath, ...handlers) {
+        routes.set(routePath, handlers.at(-1));
+      },
       get(routePath, ...handlers) {
         routes.set(routePath, handlers.at(-1));
       },

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -55,12 +55,37 @@ test("canonical track reads remove nested filesystem paths", async () => {
     const routes = new Map();
     registerTracks({
       delete(routePath, ...handlers) {
-        routes.set(routePath, handlers.at(-1));
+        routes.set(routePath, async (req, res) => {
+          let index = 0;
+          const next = () => {
+            const handler = handlers[index++];
+            return handler ? handler(req, res, next) : undefined;
+          };
+          return next();
+        });
       },
       get(routePath, ...handlers) {
         routes.set(routePath, handlers.at(-1));
       },
     });
+
+    let deleteStatus;
+    let deleteBody;
+    await routes.get("/tracks/:id")(
+      { params: { id: "703" }, user: { role: "user", permissions: {} } },
+      {
+        status(code) {
+          deleteStatus = code;
+          return this;
+        },
+        json(value) {
+          deleteBody = value;
+          return this;
+        },
+      },
+    );
+    assert.equal(deleteStatus, 403);
+    assert.equal(deleteBody.message, "Permission required: deleteTrack or deleteAlbum");
 
     let body;
     await routes.get("/tracks")(

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Aurral is the Lidarr companion for self-hosted music discovery. Best-in-class re
 - **Search**: Find artists and albums, preview tracks, and add to Lidarr with your defaults.
 - **Library**: Browse and search artists already in Lidarr.
 - **Playlists**: Run scheduled flows, adopt discover playlists like Release Radar, import spotify playlists, and convert flows to fixed tracklists.
-- **Activity**: Queue, review, and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, and Aurral playlist jobs.
+- **Activity**: Queue and history for Lidarr requests, yt-dlp / slskd / Usenet downloads, plus Wanted actions for Aurral playlist jobs.
 - **Integrations**: Lidarr, Last.fm, ListenBrainz, Koito, yt-dlp, slskd, SABnzbd/NZBGet, Navidrome, Plex, Ticketmaster, Gotify, and webhooks.
 - **Playback**: Stream through API-synced Navidrome or Plex/Plexamp playlists from a dedicated download folder.
 - **Multi-user**: Per-user profiles, discovery layout, permissions, local auth, LAN auto-login, reverse-proxy SSO, and native OIDC.

--- a/backend/db/helpers/users.js
+++ b/backend/db/helpers/users.js
@@ -36,6 +36,7 @@ const DEFAULT_PERMISSIONS = {
   changeMonitoring: false,
   deleteArtist: false,
   deleteAlbum: false,
+  deleteTrack: false,
 };
 
 export const userOps = {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -244,6 +244,7 @@ function buildPermissions(role, permissions) {
       changeMonitoring: true,
       deleteArtist: true,
       deleteAlbum: true,
+      deleteTrack: true,
     };
   }
   return {
@@ -572,6 +573,7 @@ function legacyAuth(username, password) {
       changeMonitoring: true,
       deleteArtist: true,
       deleteAlbum: true,
+      deleteTrack: true,
     },
   };
 }

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -33,7 +33,7 @@ const requireTrackDeletion = (req, res, next) => {
   }
   return res.status(403).json({
     error: "Forbidden",
-    message: "Permission required: deleteTrack",
+    message: "Permission required: deleteTrack or deleteAlbum",
   });
 };
 

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -2,6 +2,7 @@ import { libraryManager } from "../../../services/libraryManager.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { noCache } from "../../../middleware/cache.js";
 import { verifyTokenAuth } from "../../../middleware/auth.js";
+import { requireAuth, requirePermission } from "../../../middleware/requirePermission.js";
 import { getAlbumTracksByAlbumMbid } from "../../../services/providers/brainzmashProvider.js";
 import { enrichTracksWithDeezerPreviews } from "../../../services/apiClients/index.js";
 import fsp from "fs/promises";
@@ -27,6 +28,31 @@ const canReadAudioFile = async (filePath) => {
 };
 
 export function registerTracks(router) {
+  if (typeof router.delete === "function") {
+    router.delete(
+      "/tracks/:id",
+      requireAuth,
+      requirePermission("deleteAlbum"),
+      async (req, res) => {
+        try {
+          const result = await libraryManager.deleteTrack(req.params.id);
+          if (!result?.success) {
+            return res.status(503).json({
+              error: result?.error || "Failed to delete track",
+              message: result?.error || "Failed to delete track",
+            });
+          }
+          return res.json({ success: true, message: "Track deleted successfully" });
+        } catch (error) {
+          return res.status(500).json({
+            error: "Failed to delete track",
+            message: error.message,
+          });
+        }
+      },
+    );
+  }
+
   router.get("/playback-queue", cacheMiddleware(120), async (req, res) => {
     try {
       const tracks = await libraryManager.getPlaybackQueue();

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -1,8 +1,8 @@
 import { libraryManager } from "../../../services/libraryManager.js";
 import { cacheMiddleware } from "../../../middleware/cache.js";
 import { noCache } from "../../../middleware/cache.js";
-import { verifyTokenAuth } from "../../../middleware/auth.js";
-import { requireAuth, requirePermission } from "../../../middleware/requirePermission.js";
+import { hasPermission, verifyTokenAuth } from "../../../middleware/auth.js";
+import { requireAuth } from "../../../middleware/requirePermission.js";
 import { getAlbumTracksByAlbumMbid } from "../../../services/providers/brainzmashProvider.js";
 import { enrichTracksWithDeezerPreviews } from "../../../services/apiClients/index.js";
 import fsp from "fs/promises";
@@ -27,31 +27,53 @@ const canReadAudioFile = async (filePath) => {
   }
 };
 
+const requireTrackDeletion = (req, res, next) => {
+  if (hasPermission(req.user, "deleteTrack") || hasPermission(req.user, "deleteAlbum")) {
+    return next();
+  }
+  return res.status(403).json({
+    error: "Forbidden",
+    message: "Permission required: deleteTrack",
+  });
+};
+
 export function registerTracks(router) {
-  if (typeof router.delete === "function") {
-    router.delete(
-      "/tracks/:id",
-      requireAuth,
-      requirePermission("deleteAlbum"),
-      async (req, res) => {
-        try {
-          const result = await libraryManager.deleteTrack(req.params.id);
-          if (!result?.success) {
-            return res.status(503).json({
-              error: result?.error || "Failed to delete track",
-              message: result?.error || "Failed to delete track",
+  router.delete(
+    "/tracks/:id",
+    requireAuth,
+    requireTrackDeletion,
+    async (req, res) => {
+      try {
+        const result = await libraryManager.deleteTrack(req.params.id);
+        if (!result?.success) {
+          if (result?.code === "not_found") {
+            return res.status(404).json({
+              error: "Track not found",
+              message: "The track or its file no longer exists.",
             });
           }
-          return res.json({ success: true, message: "Track deleted successfully" });
-        } catch (error) {
+          if (result?.code === "lidarr_unavailable") {
+            return res.status(503).json({
+              error: "Lidarr unavailable",
+              message: "Lidarr is not available. Try again later.",
+            });
+          }
+          logger.error("library", `Track deletion failed: ${String(result?.error || "Unknown error")}`);
           return res.status(500).json({
             error: "Failed to delete track",
-            message: error.message,
+            message: "Failed to delete track",
           });
         }
-      },
-    );
-  }
+        return res.json({ success: true, message: "Track deleted successfully" });
+      } catch (error) {
+        logger.error("library", `Track deletion threw: ${error.message}`);
+        return res.status(500).json({
+          error: "Failed to delete track",
+          message: "Failed to delete track",
+        });
+      }
+    },
+  );
 
   router.get("/playback-queue", cacheMiddleware(120), async (req, res) => {
     try {

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -29,6 +29,12 @@ const buildArtist = (artist, albums) => {
     sortName: artist.sortName,
     addedAt: null,
     monitored: Boolean(artist.metadata?.monitored),
+    monitorOption:
+      artist.metadata?.monitorOption ||
+      artist.metadata?.addOptions?.monitor ||
+      artist.metadata?.monitor ||
+      "none",
+    addOptions: artist.metadata?.addOptions || null,
     statistics: {
       albumCount: artistAlbums.length,
       trackCount,

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -2,6 +2,10 @@ import path from "path";
 import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
+import {
+  getCanonicalLibrary,
+  invalidateCanonicalLibraryCache,
+} from "./libraryQueryService.js";
 const normalizeTypeName = (value) =>
   String(value || "")
     .toLowerCase()
@@ -1511,6 +1515,49 @@ export class LibraryManager {
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete album from Lidarr: ${error.message}`);      return { success: false, error: error.message };
+    }
+  }
+
+  async deleteTrack(id) {
+    const lidarr = await getLidarrClient();
+    if (!lidarr || !lidarr.isConfigured()) {
+      return { success: false, error: "Lidarr is not configured" };
+    }
+    try {
+      const library = getCanonicalLibrary({ source: "lidarr", availableOnly: false });
+      const track = library.tracks.find((entry) => String(entry.id) === String(id));
+      if (!track) return { success: false, error: "Track not found" };
+
+      const metadata = track.metadata || {};
+      let trackFileId = Number(
+        metadata.trackFileId || metadata.trackFile?.id || metadata.file?.id,
+      );
+      if (!Number.isFinite(trackFileId)) {
+        const album = library.albums.find((entry) =>
+          track.albums.some((relation) => String(relation.albumId) === String(entry.id)),
+        );
+        const lidarrAlbumId = Number(album?.metadata?.id);
+        if (Number.isFinite(lidarrAlbumId)) {
+          const lidarrTracks = await lidarr.getTracksByAlbumId(lidarrAlbumId);
+          const match = lidarrTracks.find((entry) =>
+            [entry.id, entry.foreignRecordingId, entry.foreignTrackId].some(
+              (candidate) =>
+                String(candidate ?? "") === String(metadata.id ?? track.mbid ?? ""),
+            ),
+          );
+          trackFileId = Number(match?.trackFileId);
+        }
+      }
+      if (!Number.isFinite(trackFileId)) {
+        return { success: false, error: "Track file not found in Lidarr" };
+      }
+
+      await lidarr.deleteTrackFile(trackFileId);
+      invalidateCanonicalLibraryCache();
+      return { success: true };
+    } catch (error) {
+      logger.error('library', `[LibraryManager] Failed to delete track file: ${error.message}`);
+      return { success: false, error: error.message };
     }
   }
 

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1521,20 +1521,21 @@ export class LibraryManager {
   async deleteTrack(id) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      return { success: false, error: "Lidarr is not configured" };
+      return { success: false, code: "lidarr_unavailable", error: "Lidarr is not configured" };
     }
     try {
       const library = getCanonicalLibrary({ source: "lidarr", availableOnly: false });
       const track = library.tracks.find((entry) => String(entry.id) === String(id));
-      if (!track) return { success: false, error: "Track not found" };
+      if (!track) return { success: false, code: "not_found", error: "Track not found" };
 
       const metadata = track.metadata || {};
       let trackFileId = Number(
         metadata.trackFileId || metadata.trackFile?.id || metadata.file?.id,
       );
       if (!Number.isFinite(trackFileId)) {
+        const trackAlbums = Array.isArray(track.albums) ? track.albums : [];
         const album = library.albums.find((entry) =>
-          track.albums.some((relation) => String(relation.albumId) === String(entry.id)),
+          trackAlbums.some((relation) => String(relation.albumId) === String(entry.id)),
         );
         const lidarrAlbumId = Number(album?.metadata?.id);
         if (Number.isFinite(lidarrAlbumId)) {
@@ -1549,7 +1550,11 @@ export class LibraryManager {
         }
       }
       if (!Number.isFinite(trackFileId)) {
-        return { success: false, error: "Track file not found in Lidarr" };
+        return {
+          success: false,
+          code: "not_found",
+          error: "Track file not found in Lidarr",
+        };
       }
 
       await lidarr.deleteTrackFile(trackFileId);
@@ -1557,7 +1562,13 @@ export class LibraryManager {
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete track file: ${error.message}`);
-      return { success: false, error: error.message };
+      const status = error?.response?.status;
+      const code = status === 404
+        ? "not_found"
+        : !error?.response || status >= 500
+          ? "lidarr_unavailable"
+          : "failed";
+      return { success: false, code, error: error.message };
     }
   }
 

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1433,6 +1433,12 @@ export class LidarrClient {
     return this.request(`/album/${albumId}${query}`, "DELETE");
   }
 
+  async deleteTrackFile(trackFileId) {
+    const result = await this.request(`/trackfile/${trackFileId}`, "DELETE");
+    this._albumCache.clear();
+    return result;
+  }
+
   async getQualityProfiles(skipConfigUpdate = false) {
     return this.request("/qualityprofile", "GET", null, skipConfigUpdate);
   }

--- a/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
@@ -68,6 +68,18 @@ function collectPlaylistTrackIdentities(playlist) {
   return identities;
 }
 
+function collectPlaylistTrackEntries(playlist) {
+  const playlistId = String(playlist?.id || "");
+  if (!playlistId) return [];
+  return downloadTracker
+    .getByPlaylistType(playlistId)
+    .map((job) => ({
+      id: job.id,
+      identity: buildSharedTrackIdentity(job),
+    }))
+    .filter((entry) => entry.identity);
+}
+
 function buildOwnerMap(flows, sharedPlaylists) {
   const ownerIds = new Set();
   for (const item of [
@@ -120,6 +132,7 @@ export function getWeeklyFlowStatusSnapshot({
       createdAt: playlist.createdAt,
       trackCount: jobTotal > 0 ? jobTotal : playlist.trackCount,
       trackIdentities: collectPlaylistTrackIdentities(playlist),
+      trackEntries: collectPlaylistTrackEntries(playlist),
       importSource: playlist.importSource
         ? {
             provider: playlist.importSource.provider,

--- a/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
@@ -73,11 +73,21 @@ function collectPlaylistTrackEntries(playlist) {
   if (!playlistId) return [];
   return downloadTracker
     .getByPlaylistType(playlistId)
+    .filter((job) =>
+      [
+        job?.artistName,
+        job?.trackName,
+        job?.albumName,
+        job?.artistMbid,
+        job?.albumMbid,
+        job?.trackMbid,
+        job?.releaseYear,
+      ].some((value) => String(value ?? "").trim()),
+    )
     .map((job) => ({
       id: job.id,
       identity: buildSharedTrackIdentity(job),
-    }))
-    .filter((entry) => entry.identity);
+    }));
 }
 
 function buildOwnerMap(flows, sharedPlaylists) {

--- a/docs/src/content/docs/integrations/usenet.mdx
+++ b/docs/src/content/docs/integrations/usenet.mdx
@@ -73,13 +73,13 @@ If NZBGet runs on Windows and reports host paths, mount the parent folder into A
 
 Then, add a path mapping under **Settings > Download Clients > Remote Path Mappings**.
 
-Aurral can find a track with an incorrect duration. Aurral retains this track under **Activity > Review**.
+Aurral can find a track with an incorrect duration. Aurral retains this track under **Activity > Queue**.
 
 You can preview, approve, or deny the track.
 
 ## Quality and upgrades
 
-Use **Settings > Download Clients > Quality Profile** to set acceptable quality tiers and the preferred cutoff. Aurral reads the completed audio file before it accepts the quality. A quality rejection does not go to Review.
+Use **Settings > Download Clients > Quality Profile** to set acceptable quality tiers and the preferred cutoff. Aurral reads the completed audio file before it accepts the quality. A quality rejection does not go to Queue review.
 
 Usenet can supply both missing tracks and upgrades. Upgrade searches follow the normal source priority and have a lower queue priority than missing-track downloads. See [Playlists: Track upgrades](/using/playlists/#track-upgrades).
 

--- a/docs/src/content/docs/integrations/ytdlp.mdx
+++ b/docs/src/content/docs/integrations/ytdlp.mdx
@@ -37,7 +37,7 @@ Aurral also applies the global Quality Profile. It rejects the final file if its
 
 After validation, Aurral writes the playlist's title, artist, album, album artist, year, and track number into the audio file. This metadata lets tag-based libraries such as Navidrome organize yt-dlp downloads correctly.
 
-When a downloaded file matches the requested track but its duration differs significantly, Aurral retains it under **Activity > Review** for preview, approval, or denial.
+When a downloaded file matches the requested track but its duration differs significantly, Aurral retains it under **Activity > Queue** for preview, approval, or denial.
 
 Audio from YouTube is usually lossy. Prefer slskd or Usenet when you want higher quality.
 

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -3,23 +3,35 @@ title: Activity
 description: Track active downloads, Lidarr requests, and Aurral playlist jobs.
 ---
 
-Activity replaces the older Requests and Downloads views. It has three tabs:
+Activity replaces the older Requests and Downloads views. It has two views:
 
-- **Queue**: album requests and downloads in progress
-- **Review**: downloaded tracks that need your approval
+- **Queue**: album requests, downloads in progress, and tracks waiting for review
 - **History**: completed, denied, and failed events
+
+The **Wanted** section combines Aurral-owned tracks that need another search with
+files that do not meet the configured quality cutoff.
+
+Use the **Missing** and **Cutoff unmet** links under **Wanted** to switch between
+those two filters.
 
 ![Aurral activity timeline](../../../assets/screenshots/history.webp)
 
-Use **Queue** to see active downloads and processes.
+Use **Queue** to see active downloads and processes. Review items stay in this list because they are queued for your decision.
 
-Use **Review** when you must listen to a track before import. Use **History** to see completed and failed events.
+Use the review controls in **Queue** when you must listen to a track before import. Use **History** to see completed and failed events.
 
 Each review row shows the requested track, artist, album, and remote file path. It also shows the match scores and duration.
 
 Aurral keeps a possible match for review if the duration is not correct. It does not immediately try another source.
 
 When an album request fails in Lidarr, you can retry the search from History when the entry supports it.
+
+Use the search action on a Wanted row to re-search a failed Aurral operation or
+search for a quality upgrade. These actions apply across flows and static
+playlists.
+
+Use the info action on any activity or Wanted row to inspect the operation
+details without leaving the page.
 
 Album requests store the requester. Activity can show the requester, and external tools can filter requests by user.
 

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -44,7 +44,7 @@ Flows regenerate on a schedule. Static playlists keep fixed tracklists or synchr
 
 Activity shows active Lidarr requests, download client activity, and Aurral playlist jobs.
 
-The History tab shows completed and failed events.
+Queue combines active work with tracks waiting for review. History shows completed and failed events. Wanted shows Aurral-owned tracks that need another search or a quality upgrade.
 
 ### Blocklist
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -79,7 +79,7 @@ The default profile accepts all tiers and uses **FLAC standard** as the cutoff.
 
 Aurral can use search-result names and bitrate data to order candidates. Aurral does not trust that data for final admission. It reads the downloaded file and rejects it when the format, bitrate, sample rate, or bit depth does not match an enabled tier.
 
-An unknown final quality is not valid. A quality rejection does not go to **Activity > Review**. Review stays for track identity and duration decisions.
+An unknown final quality is not valid. A quality rejection does not go to **Activity > Queue**. Queue review stays for track identity and duration decisions.
 
 The **Quality** column on the Playlists page shows the measured tier and its profile state. It labels a file reused from Lidarr as **Lidarr**.
 

--- a/frontend/src/components/LibraryItemMenu.jsx
+++ b/frontend/src/components/LibraryItemMenu.jsx
@@ -1,0 +1,308 @@
+import { createPortal } from "react-dom";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from "react";
+import { ChevronRight, Loader2, MoreVertical } from "lucide-react";
+import TooltipButton from "./TooltipButton";
+
+let activeMenuCloser = null;
+
+export function LibraryItemSubmenu({
+  label,
+  icon: Icon,
+  items = [],
+  isOpen = false,
+  onToggle,
+  onClose,
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState("");
+  const open = typeof onToggle === "function" ? isOpen : internalOpen;
+
+  const handleAction = async (event, item) => {
+    event.stopPropagation();
+    if (item.disabled || pendingAction) return;
+    setPendingAction(item.id);
+    try {
+      await item.onSelect?.();
+      onClose?.();
+    } finally {
+      setPendingAction("");
+    }
+  };
+
+  return (
+    <div className={`artist-menu-submenu${open ? " is-open" : ""}`}>
+      <button
+        type="button"
+        className="artist-menu-item artist-menu-submenu__trigger"
+        role="menuitem"
+        aria-expanded={open}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (onToggle) onToggle();
+          else setInternalOpen((value) => !value);
+        }}
+      >
+        <span className="artist-menu-item__main">
+          {Icon ? <Icon className="artist-icon-sm" /> : null}
+          {label}
+        </span>
+        <ChevronRight
+          className={`artist-icon-sm${open ? " artist-chevron--open" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      <div className="artist-menu-submenu__panel">
+        {items.map((item) => {
+          const ItemIcon = item.icon;
+          const isPending = pendingAction === item.id;
+          return (
+            <button
+              type="button"
+              role="menuitem"
+              className={`artist-menu-item${item.danger ? " artist-menu-item--danger" : ""}${item.selected ? " is-selected" : ""}`}
+              key={item.id}
+              onClick={(event) => handleAction(event, item)}
+              disabled={item.disabled || !!pendingAction}
+              aria-pressed={item.selected || undefined}
+            >
+              <span className="artist-menu-item__main">
+                {isPending ? (
+                  <Loader2 className="artist-icon-sm animate-spin" />
+                ) : ItemIcon ? (
+                  <ItemIcon className="artist-icon-sm" />
+                ) : null}
+                {item.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
+  {
+    label,
+    items = [],
+    additionalItemsAfter = "",
+    renderAdditionalItems,
+    onMenuOpen,
+  },
+  ref,
+) {
+  const [open, setOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState("");
+  const [anchor, setAnchor] = useState(null);
+  const [position, setPosition] = useState(null);
+  const [submenuSide, setSubmenuSide] = useState("right");
+  const menuRootRef = useRef(null);
+  const menuRef = useRef(null);
+  const triggerRef = useRef(null);
+  const closeMenuRef = useRef(null);
+
+  const closeMenu = useCallback((restoreFocus = true) => {
+    setOpen(false);
+    setAnchor(null);
+    setPosition(null);
+    setSubmenuSide("right");
+    setPendingAction("");
+    if (activeMenuCloser === closeMenuRef.current) activeMenuCloser = null;
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => triggerRef.current?.focus());
+    }
+  }, []);
+  closeMenuRef.current = closeMenu;
+
+  const openMenu = useCallback(
+    (nextAnchor) => {
+      activeMenuCloser?.();
+      activeMenuCloser = () => closeMenu(false);
+      setAnchor(nextAnchor);
+      setSubmenuSide("right");
+      setPosition({
+        left: nextAnchor.kind === "context" ? nextAnchor.x : nextAnchor.right,
+        top: nextAnchor.kind === "context" ? nextAnchor.y : nextAnchor.bottom,
+      });
+      setOpen(true);
+      onMenuOpen?.();
+    },
+    [closeMenu, onMenuOpen],
+  );
+
+  const openFromTrigger = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    openMenu({ kind: "trigger", top: rect.top, right: rect.right, bottom: rect.bottom });
+  }, [openMenu]);
+
+  const openAt = useCallback(
+    (x, y) => openMenu({ kind: "context", x, y }),
+    [openMenu],
+  );
+
+  useImperativeHandle(ref, () => ({ openAt, close: closeMenu }), [closeMenu, openAt]);
+
+  useEffect(() => {
+    const target = menuRootRef.current?.closest("[data-library-menu-target]");
+    if (!target) return undefined;
+    const handleContextMenu = (event) => {
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      openAt(event.clientX, event.clientY);
+    };
+    target.addEventListener("contextmenu", handleContextMenu);
+    return () => target.removeEventListener("contextmenu", handleContextMenu);
+  }, [openAt]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handlePointerDown = (event) => {
+      if (
+        menuRootRef.current?.contains(event.target) ||
+        menuRef.current?.contains(event.target)
+      ) {
+        return;
+      }
+      closeMenu(false);
+    };
+    const handleEscape = (event) => {
+      if (event.key === "Escape") closeMenu();
+    };
+    const closeOnViewportChange = () => closeMenu(false);
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    window.addEventListener("resize", closeOnViewportChange);
+    window.addEventListener("scroll", closeOnViewportChange, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+      window.removeEventListener("resize", closeOnViewportChange);
+      window.removeEventListener("scroll", closeOnViewportChange, true);
+    };
+  }, [closeMenu, open]);
+
+  useEffect(() => {
+    return () => {
+      if (activeMenuCloser === closeMenuRef.current) activeMenuCloser = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    menuRef.current?.querySelector("button:not(:disabled)")?.focus();
+  }, [open]);
+
+  const updatePosition = useCallback(() => {
+    const menu = menuRef.current;
+    if (!menu || !anchor) return;
+    const edge = 8;
+    const gap = 8;
+    const width = menu.offsetWidth;
+    const height = menu.offsetHeight;
+    let left = anchor.kind === "context" ? anchor.x : anchor.right - width;
+    let top = anchor.kind === "context" ? anchor.y : anchor.bottom + gap;
+
+    if (anchor.kind === "trigger" && top + height > window.innerHeight - edge) {
+      top = anchor.top - height - gap;
+    }
+    left = Math.min(Math.max(edge, left), Math.max(edge, window.innerWidth - width - edge));
+    top = Math.min(Math.max(edge, top), Math.max(edge, window.innerHeight - height - edge));
+    const submenuWidth = 256;
+    const submenuGap = 8;
+    const rightSpace = window.innerWidth - left - width - edge;
+    const leftSpace = left - edge;
+    const nextSubmenuSide =
+      rightSpace >= submenuWidth + submenuGap || rightSpace >= leftSpace ? "right" : "left";
+    setSubmenuSide(nextSubmenuSide);
+    setPosition((current) =>
+      current?.left === left && current?.top === top ? current : { left, top },
+    );
+  }, [anchor]);
+
+  useLayoutEffect(() => {
+    if (open) updatePosition();
+  }, [open, updatePosition]);
+
+  const handleAction = async (event, item) => {
+    event.stopPropagation();
+    if (item.disabled || pendingAction) return;
+    setPendingAction(item.id);
+    try {
+      await item.onSelect?.(event);
+      closeMenu();
+    } finally {
+      setPendingAction("");
+    }
+  };
+
+  const renderItems = () => (
+    <>
+      {items.map((item) => {
+        const Icon = item.icon;
+        const isPending = pendingAction === item.id;
+        return (
+          <div key={item.id}>
+            {item.separatorBefore ? <div className="native-library-item-menu__separator" /> : null}
+            <button
+              type="button"
+              role="menuitem"
+              className={`artist-menu-item${item.danger ? " artist-menu-item--danger" : ""}${item.selected ? " is-selected" : ""}`}
+              onClick={(event) => handleAction(event, item)}
+              disabled={item.disabled || !!pendingAction}
+              aria-pressed={item.selected || undefined}
+            >
+              <span className="artist-menu-item__main">
+                {isPending ? (
+                  <Loader2 className="artist-icon-sm animate-spin" />
+                ) : Icon ? (
+                  <Icon className="artist-icon-sm" />
+                ) : null}
+                {item.label}
+              </span>
+            </button>
+            {item.id === additionalItemsAfter && renderAdditionalItems?.({ closeMenu })}
+          </div>
+        );
+      })}
+      {!items.some((item) => item.id === additionalItemsAfter)
+        ? renderAdditionalItems?.({ closeMenu })
+        : null}
+    </>
+  );
+
+  return (
+    <div className="native-library-item-menu" ref={menuRootRef}>
+      <TooltipButton
+        ref={triggerRef}
+        className={`native-library-item-menu__trigger${open ? " is-open" : ""}`}
+        label={`${label} options`}
+        aria-label={`${label} options`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (open) closeMenu();
+          else openFromTrigger();
+        }}
+      >
+        <MoreVertical aria-hidden="true" />
+      </TooltipButton>
+      {open && position
+        ? createPortal(
+            <div
+              ref={menuRef}
+              className={`native-library-item-menu__panel${submenuSide === "left" ? " is-submenu-left" : ""}`}
+              role="menu"
+              aria-label={`${label} actions`}
+              style={{ left: position.left, top: position.top }}
+              onClick={(event) => event.stopPropagation()}
+            >
+              {renderItems()}
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+});

--- a/frontend/src/components/LibraryItemMenu.jsx
+++ b/frontend/src/components/LibraryItemMenu.jsx
@@ -24,6 +24,7 @@ export function LibraryItemSubmenu({
     try {
       await item.onSelect?.();
       onClose?.();
+    } catch {
     } finally {
       setPendingAction("");
     }
@@ -103,16 +104,19 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
   const registeredCloserRef = useRef(null);
 
   const closeMenu = useCallback((restoreFocus = true) => {
+    const registeredCloser = registeredCloserRef.current;
+    const ownsActiveMenu =
+      registeredCloser !== null && activeMenuCloser === registeredCloser;
     setOpen(false);
     setAnchor(null);
     setPosition(null);
     setSubmenuSide("right");
     setPendingAction("");
-    if (activeMenuCloser === registeredCloserRef.current) {
+    if (ownsActiveMenu) {
       activeMenuCloser = null;
       registeredCloserRef.current = null;
     }
-    if (restoreFocus) {
+    if (restoreFocus && ownsActiveMenu) {
       window.requestAnimationFrame(() => triggerRef.current?.focus());
     }
   }, []);

--- a/frontend/src/components/LibraryItemMenu.jsx
+++ b/frontend/src/components/LibraryItemMenu.jsx
@@ -55,15 +55,16 @@ export function LibraryItemSubmenu({
         {items.map((item) => {
           const ItemIcon = item.icon;
           const isPending = pendingAction === item.id;
+          const isToggle = typeof item.selected === "boolean";
           return (
             <button
               type="button"
-              role="menuitem"
+              role={isToggle ? "menuitemcheckbox" : "menuitem"}
               className={`artist-menu-item${item.danger ? " artist-menu-item--danger" : ""}${item.selected ? " is-selected" : ""}`}
               key={item.id}
               onClick={(event) => handleAction(event, item)}
               disabled={item.disabled || !!pendingAction}
-              aria-pressed={item.selected || undefined}
+              aria-checked={isToggle ? item.selected : undefined}
             >
               <span className="artist-menu-item__main">
                 {isPending ? (
@@ -99,7 +100,7 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
   const menuRootRef = useRef(null);
   const menuRef = useRef(null);
   const triggerRef = useRef(null);
-  const closeMenuRef = useRef(null);
+  const registeredCloserRef = useRef(null);
 
   const closeMenu = useCallback((restoreFocus = true) => {
     setOpen(false);
@@ -107,17 +108,21 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
     setPosition(null);
     setSubmenuSide("right");
     setPendingAction("");
-    if (activeMenuCloser === closeMenuRef.current) activeMenuCloser = null;
+    if (activeMenuCloser === registeredCloserRef.current) {
+      activeMenuCloser = null;
+      registeredCloserRef.current = null;
+    }
     if (restoreFocus) {
       window.requestAnimationFrame(() => triggerRef.current?.focus());
     }
   }, []);
-  closeMenuRef.current = closeMenu;
 
   const openMenu = useCallback(
     (nextAnchor) => {
       activeMenuCloser?.();
-      activeMenuCloser = () => closeMenu(false);
+      const closer = () => closeMenu(false);
+      registeredCloserRef.current = closer;
+      activeMenuCloser = closer;
       setAnchor(nextAnchor);
       setSubmenuSide("right");
       setPosition({
@@ -184,7 +189,10 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
 
   useEffect(() => {
     return () => {
-      if (activeMenuCloser === closeMenuRef.current) activeMenuCloser = null;
+      if (activeMenuCloser === registeredCloserRef.current) {
+        activeMenuCloser = null;
+        registeredCloserRef.current = null;
+      }
     };
   }, []);
 
@@ -230,8 +238,9 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
     setPendingAction(item.id);
     try {
       await item.onSelect?.(event);
-      closeMenu();
+    } catch {
     } finally {
+      closeMenu();
       setPendingAction("");
     }
   };
@@ -241,16 +250,17 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
       {items.map((item) => {
         const Icon = item.icon;
         const isPending = pendingAction === item.id;
+        const isToggle = typeof item.selected === "boolean";
         return (
           <div key={item.id}>
             {item.separatorBefore ? <div className="native-library-item-menu__separator" /> : null}
             <button
               type="button"
-              role="menuitem"
+              role={isToggle ? "menuitemcheckbox" : "menuitem"}
               className={`artist-menu-item${item.danger ? " artist-menu-item--danger" : ""}${item.selected ? " is-selected" : ""}`}
               onClick={(event) => handleAction(event, item)}
               disabled={item.disabled || !!pendingAction}
-              aria-pressed={item.selected || undefined}
+              aria-checked={isToggle ? item.selected : undefined}
             >
               <span className="artist-menu-item__main">
                 {isPending ? (

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   Activity,
   AudioWaveform,
+  AlertTriangle,
   Ban,
   Library,
   Newspaper,
@@ -19,6 +20,8 @@ import {
   ACTIVITY_VIEWS,
   DEFAULT_ACTIVITY_VIEW,
   buildActivityPath,
+  buildWantedPath,
+  WANTED_VIEWS,
 } from "../navigation/activityNavConfig";
 import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { useDiscoverRecent } from "../contexts/DiscoverRecentProvider";
@@ -80,8 +83,10 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   const isOnLibrary = location.pathname === "/library" || location.pathname.startsWith("/library/");
   const isOnShows = location.pathname.startsWith("/shows");
   const isOnNews = location.pathname.startsWith("/discover/news");
+  const isOnWanted = location.pathname.startsWith("/activity/missing");
   const isOnActivity =
-    location.pathname.startsWith("/activity") || location.pathname.startsWith("/history");
+    !isOnWanted &&
+    (location.pathname.startsWith("/activity") || location.pathname.startsWith("/history"));
 
   const settingsTabs = useMemo(() => {
     if (!canAccessSettings) return [];
@@ -122,6 +127,11 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
     return segment || DEFAULT_ACTIVITY_VIEW;
   }, [isOnActivity, location.pathname]);
 
+  const activeWantedView = useMemo(() => {
+    if (!isOnWanted) return null;
+    return new URLSearchParams(location.search).get("tab") === "cutoff" ? "cutoff" : "missing";
+  }, [isOnWanted, location.search]);
+
   const positionSidebarTooltip = useCallback((event) => {
     const link = event.currentTarget;
     const rect = link.getBoundingClientRect();
@@ -158,10 +168,11 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
       if (item.section === "shows") return isOnShows;
       if (item.section === "news") return isOnNews;
       if (item.section === "activity") return isOnActivity;
+      if (item.section === "wanted") return isOnWanted;
       if (item.path === "/discover" && location.pathname === "/") return true;
       return location.pathname === item.path;
     },
-    [isDiscoverSectionActive, isOnActivity, isOnLibrary, isOnNews, isOnShows, location.pathname],
+    [isDiscoverSectionActive, isOnActivity, isOnLibrary, isOnNews, isOnShows, isOnWanted, location.pathname],
   );
 
   const navItems = useMemo(() => {
@@ -217,7 +228,15 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
         label: "Activity",
         icon: Activity,
         section: "activity",
-        subnav: ACTIVITY_VIEWS,
+        subnav: ACTIVITY_VIEWS.filter((view) => view.id !== "missing"),
+      },
+      {
+        path: buildWantedPath(),
+        label: "Wanted",
+        icon: AlertTriangle,
+        section: "wanted",
+        subnav: WANTED_VIEWS,
+        permission: "accessFlow",
       },
       { path: "/blocklist", label: "Blocklist", icon: Ban },
     ];
@@ -301,7 +320,7 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
             (item.section === "activity"
               ? buildActivityPath(entry.id)
               : `${item.basePath}/${entry.id}`);
-          const showReviewAlert = item.section === "activity" && entry.id === "review" && hasReviewAlert;
+          const showReviewAlert = item.section === "activity" && entry.id === "queue" && hasReviewAlert;
           return (
             <Link
               key={entry.id}
@@ -393,11 +412,13 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
                   ? discoverRecentPages.find((entry) => entry.path === activeDiscoverRecentPath)?.id
                   : item.section === "library"
                     ? activeLibraryView
-                    : item.section === "shows"
-                      ? activeShowsFilter
-                      : item.section === "activity"
-                        ? activeActivityView
-                        : null;
+                      : item.section === "shows"
+                        ? activeShowsFilter
+                        : item.section === "activity"
+                          ? activeActivityView
+                          : item.section === "wanted"
+                            ? activeWantedView
+                          : null;
 
               return (
                 <div key={item.path} className={getNavGroupClassName(item, active)}>

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -65,6 +65,7 @@ export const AuthProvider = ({ children }) => {
               changeMonitoring: true,
               deleteArtist: true,
               deleteAlbum: true,
+              deleteTrack: true,
             },
           },
         );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8947,21 +8947,6 @@ button.native-library-genre-row:focus-visible {
   transition: background-color 0.16s ease;
 }
 
-.activity-row.is-clickable {
-  cursor: pointer;
-}
-
-.activity-row.is-clickable:hover,
-.activity-row.is-clickable:focus-within,
-.activity-row.is-clickable:focus-visible {
-  background: var(--aurral-surface-hover);
-}
-
-.activity-row:focus-visible {
-  outline: 2px solid var(--aurral-ring);
-  outline-offset: -2px;
-}
-
 .activity-row__status {
   display: inline-flex;
   width: 1.75rem;
@@ -9005,6 +8990,26 @@ button.native-library-genre-row:focus-visible {
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.activity-row__title-button {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.activity-row__title-button:focus-visible {
+  outline: 2px solid var(--aurral-ring);
+  outline-offset: 2px;
 }
 
 .activity-row__meta,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7839,6 +7839,94 @@ textarea {
   position: relative;
 }
 
+.native-library-item-menu {
+  position: relative;
+  z-index: 4;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.native-library-card__cover-wrap > .native-library-item-menu {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.45rem;
+}
+
+.native-library-item-menu__trigger {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--aurral-border-strong);
+  border-radius: var(--aurral-radius-sm);
+  background: var(--aurral-surface);
+  color: var(--aurral-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.native-library-card__cover-wrap:hover .native-library-item-menu__trigger,
+.native-library-card:focus-within .native-library-item-menu__trigger,
+.native-library-track:hover .native-library-item-menu__trigger,
+.native-library-track:focus-within .native-library-item-menu__trigger,
+.flow-page__tracks-table-row:hover .native-library-item-menu__trigger,
+.flow-page__tracks-table-row:focus-within .native-library-item-menu__trigger,
+.native-library-item-menu__trigger:focus-visible,
+.native-library-item-menu__trigger.is-open {
+  opacity: 1;
+}
+
+.native-library-item-menu__trigger:hover,
+.native-library-item-menu__trigger:focus-visible,
+.native-library-item-menu__trigger.is-open {
+  background: var(--aurral-surface-hover);
+  color: var(--aurral-text);
+}
+
+.native-library-item-menu__trigger svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.native-library-item-menu__panel {
+  position: fixed;
+  z-index: 80;
+  width: min(15rem, calc(100vw - 1rem));
+  max-height: calc(100vh - 1rem);
+  overflow: visible;
+  padding: 0.25rem;
+  border-radius: var(--aurral-radius-sm);
+}
+
+.native-library-item-menu__panel .artist-menu-item.is-selected {
+  background: var(--aurral-surface-selected);
+  color: var(--aurral-text);
+}
+
+.native-library-item-menu__separator {
+  height: 1px;
+  margin: 0.25rem 0.5rem;
+  background: var(--aurral-border);
+}
+
+.native-library-item-menu__panel .artist-menu-submenu__panel {
+  right: auto;
+  left: calc(100% + 0.5rem);
+}
+
+.native-library-item-menu__panel.is-submenu-left .artist-menu-submenu__panel {
+  right: calc(100% + 0.5rem);
+  left: auto;
+}
+
+.native-library-item-menu__panel :focus-visible {
+  outline: 2px solid var(--aurral-ring);
+  outline-offset: -2px;
+}
+
 .native-library-card__cover {
   display: block;
   width: 100%;
@@ -8084,11 +8172,6 @@ button.native-library-card__artist:focus-visible {
   padding: 0.3rem 0.45rem;
   color: var(--aurral-text-muted);
   font-size: 0.74rem;
-}
-
-.native-library-track:has(.artist-playlist-menu) {
-  position: relative;
-  z-index: 1;
 }
 
 .native-library-track--heading {
@@ -8479,6 +8562,10 @@ button.native-library-genre-row:focus-visible {
   opacity: 1;
 }
 
+.native-library-detail__actions .native-library-item-menu__trigger {
+  opacity: 1;
+}
+
 .native-library-detail__discover {
   display: inline-flex;
   align-items: center;
@@ -8541,9 +8628,11 @@ button.native-library-genre-row:focus-visible {
   .native-library-icon-button,
   .native-library-title-play,
   .native-library-page-play,
-  .native-library-state__action {
+  .native-library-state__action,
+  .native-library-item-menu__trigger {
     min-width: 2.75rem;
     min-height: 2.75rem;
+    opacity: 1;
   }
 
   .native-library-favorite,
@@ -8744,303 +8833,355 @@ button.native-library-genre-row:focus-visible {
   }
 }
 
-.requests-page {
+.activity-page {
   padding-bottom: 1.5rem;
   color: var(--aurral-text);
   animation: fade-in 0.2s ease-out;
 }
 
-.requests-page__header {
+.activity-page__header {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  min-height: 2.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.activity-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 2.35rem;
+  gap: 0.75rem;
+  margin: 0 0 0.45rem;
+}
+
+.activity-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.activity-toolbar__filter {
+  display: flex;
+  width: min(20rem, 45vw);
+  min-width: 8rem;
+  height: 2rem;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0 0.55rem;
+  border: 1px solid var(--aurral-border);
+  border-radius: var(--aurral-radius-sm);
+  color: var(--aurral-text-subtle);
+}
+
+.activity-toolbar__filter:focus-within {
+  border-color: var(--aurral-border-strong);
+}
+
+.activity-toolbar__filter > svg {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex: 0 0 auto;
+}
+
+.activity-toolbar__filter input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--aurral-text);
+  font: inherit;
+  font-size: 0.76rem;
+}
+
+.activity-toolbar__filter .btn {
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0.25rem;
+}
+
+.activity-toolbar__filter .btn svg {
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.activity-page__error {
   margin-bottom: 1rem;
 }
 
-.requests-page__error {
-  margin-bottom: 1.5rem;
+.activity-page__loading {
+  display: flex;
+  min-height: 8rem;
+  align-items: center;
+  justify-content: center;
 }
 
-.requests-page__retry-button,
-.requests-page__empty-action {
-  margin-top: 1.25rem;
+.activity-list {
+  min-width: 0;
 }
 
-.requests-page__list {
-  display: grid;
-  gap: 0.125rem;
-  overflow: hidden;
-}
-
-.requests-page__date-group {
-  margin: 1rem 0 0.375rem;
-  padding: 0 0.5rem;
-  color: var(--aurral-text-muted);
-  font-size: 0.6875rem;
+.activity-list__date-group {
+  margin: 1rem 0 0.3rem;
+  color: var(--aurral-text-subtle);
+  font-size: 0.65rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.requests-page__date-group:first-child {
-  margin-top: 0;
+.activity-list__date-group:first-child {
+  margin-top: 0.25rem;
 }
 
-.requests-page__row {
-  position: relative;
+.activity-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: 1.75rem minmax(0, 1fr) minmax(5rem, auto) auto auto;
   align-items: center;
-  gap: 0.625rem;
-  min-height: 2.75rem;
-  padding: 0.5rem 0.75rem 0.5rem 0.875rem;
-  background: var(--aurral-surface);
-  transition: background-color 0.18s ease;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0.35rem 0.25rem;
+  border-bottom: 1px solid var(--aurral-border);
+  color: var(--aurral-text);
+  transition: background-color 0.16s ease;
 }
 
-.requests-page__row::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 3px;
-  background: var(--aurral-border-strong);
-}
-
-.requests-page__row--alt {
-  background: var(--aurral-surface-raised);
-}
-
-.requests-page__row.is-clickable {
+.activity-row.is-clickable {
   cursor: pointer;
 }
 
-.requests-page__row.is-clickable:hover {
-  background: var(--aurral-surface-popover);
+.activity-row.is-clickable:hover,
+.activity-row.is-clickable:focus-within,
+.activity-row.is-clickable:focus-visible {
+  background: var(--aurral-surface-hover);
 }
 
-.requests-page__actions {
-  display: flex;
+.activity-row:focus-visible {
+  outline: 2px solid var(--aurral-ring);
+  outline-offset: -2px;
+}
+
+.activity-row__status {
+  display: inline-flex;
+  width: 1.75rem;
+  height: 1.75rem;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: center;
+  color: var(--aurral-text-subtle);
 }
 
-.requests-page__action {
-  width: 2rem;
-  height: 2rem;
+.activity-row__status svg {
+  width: 1rem;
+  height: 1rem;
 }
 
-.requests-page__details {
+.activity-row__status--success {
+  color: var(--aurral-success);
+}
+
+.activity-row__status--failed {
+  color: var(--aurral-danger);
+}
+
+.activity-row__status--review {
+  color: var(--aurral-review);
+}
+
+.activity-row__status--pending {
+  color: var(--aurral-warning);
+}
+
+.activity-row__details {
   min-width: 0;
-  flex: 1;
 }
 
-.requests-page__row--review {
-  align-items: flex-start;
-  min-height: 0;
-  padding-top: 0.625rem;
-  padding-bottom: 0.625rem;
-}
-
-.requests-page__item-title {
+.activity-row__title {
   margin: 0;
-  min-width: 0;
   overflow: hidden;
   color: var(--aurral-text);
   font-size: 0.875rem;
-  font-weight: 700;
-  line-height: 1.25;
+  font-weight: 650;
+  line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.requests-page__meta {
-  display: flex;
-  align-items: center;
-  gap: 0.3125rem;
-  margin-top: 0.1875rem;
-  min-width: 0;
+.activity-row__meta,
+.activity-row__hint {
+  margin: 0.12rem 0 0;
+  overflow: hidden;
   color: var(--aurral-text-muted);
-  font-size: 0.6875rem;
-  line-height: 1.2;
-}
-
-.requests-page__review-lines {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1875rem;
-  margin-top: 0.1875rem;
-  min-width: 0;
-}
-
-.requests-page__review-lines .requests-page__meta {
-  margin-top: 0;
-}
-
-.requests-page__review-path,
-.requests-page__review-reason {
-  min-width: 0;
-  color: var(--aurral-text-subtle);
-  font-size: 0.6875rem;
-  line-height: 1.35;
-  overflow-wrap: anywhere;
-}
-
-.requests-page__review-reason {
-  color: var(--aurral-text-muted);
-}
-
-.requests-page__meta-time {
-  flex-shrink: 0;
-  color: var(--aurral-text-subtle);
-  font-variant-numeric: tabular-nums;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.requests-page__meta-separator {
-  flex-shrink: 0;
+.activity-row__hint {
   color: var(--aurral-text-subtle);
 }
 
-.requests-page__status {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  gap: 0.375rem;
+.activity-row__status-label,
+.activity-row__time {
+  color: var(--aurral-text-subtle);
+  font-size: 0.7rem;
+  white-space: nowrap;
 }
 
-.requests-page__badge {
-  display: inline-flex;
+.activity-row__time {
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-row__actions {
+  display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.125rem 0.375rem;
-  border-radius: var(--aurral-radius-sm);
-  font-size: 0.625rem;
+  justify-content: flex-end;
+  gap: 0.1rem;
+  min-width: 2rem;
+  opacity: 0;
+  transition: opacity 0.16s ease;
+}
+
+.activity-row:hover .activity-row__actions,
+.activity-row:focus-within .activity-row__actions {
+  opacity: 1;
+}
+
+.activity-row__actions .native-library-icon-button {
+  width: 2rem;
+  height: 2rem;
+}
+
+.activity-row__error {
+  max-width: 10rem;
+  overflow: hidden;
+  color: var(--aurral-danger);
+  font-size: 0.7rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-list__load-more {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0 0.25rem;
+}
+
+.activity-page__missing {
+  min-width: 0;
+}
+
+.activity-info-modal {
+  max-width: 42rem;
+  max-height: min(42rem, calc(100vh - 2rem));
+  overflow: auto;
+}
+
+.activity-info-modal__eyebrow {
+  margin: 0 0 0.25rem;
+  color: var(--aurral-text-subtle);
+  font-size: 0.68rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.requests-page__badge--active {
-  background: var(--aurral-surface-raised);
+.activity-info-modal__rows {
+  margin: 0;
+}
+
+.activity-info-modal__row {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.35fr) minmax(0, 1fr);
+  gap: 1rem;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--aurral-border);
+}
+
+.activity-info-modal__row:last-child {
+  border-bottom: 0;
+}
+
+.activity-info-modal__row dt,
+.activity-info-modal__row dd {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.activity-info-modal__row dt {
   color: var(--aurral-text-muted);
 }
 
-.requests-page__badge--success {
-  background: var(--aurral-surface-raised);
-  color: var(--aurral-success);
+.activity-info-modal__row dd {
+  min-width: 0;
+  color: var(--aurral-text);
+  overflow-wrap: anywhere;
 }
 
-.requests-page__badge--failed {
-  background: var(--aurral-surface-raised);
-  color: var(--aurral-danger);
-}
+@media (pointer: coarse) {
+  .activity-row__actions,
+  .activity-row__actions .native-library-icon-button {
+    opacity: 1;
+  }
 
-.requests-page__badge--pending {
-  background: var(--aurral-surface-raised);
-  color: var(--aurral-warning);
-}
-
-.requests-page__badge--review {
-  background: var(--aurral-surface-raised);
-  color: var(--aurral-review);
-}
-
-.requests-page__inline-error {
-  max-width: 8rem;
-  color: var(--aurral-danger);
-  font-size: 0.6875rem;
-  font-weight: 600;
-  line-height: 1.2;
-}
-
-.requests-page__load-more {
-  display: flex;
-  justify-content: center;
-  padding: 1.5rem 0 0.5rem;
+  .activity-row__actions .native-library-icon-button,
+  .activity-toolbar .native-library-icon-button {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
 }
 
 @media (max-width: 767px) {
-  .requests-page__header {
-    margin-bottom: 0.75rem;
+  .activity-page__header {
+    min-height: 2rem;
+    margin-bottom: 0.25rem;
   }
 
-  .requests-page__list {
-    gap: 0;
-    border-radius: var(--aurral-radius-sm);
+  .activity-toolbar__filter {
+    width: min(100%, 20rem);
   }
 
-  .requests-page__date-group {
-    margin: 0.75rem 0 0.25rem;
-    padding: 0 0.625rem;
-    font-size: 0.625rem;
-  }
-
-  .requests-page__row {
+  .activity-row {
+    grid-template-columns: 1.75rem minmax(0, 1fr) auto;
+    align-items: start;
     gap: 0.5rem;
-    min-height: 0;
-    padding: 0.625rem 0.625rem 0.625rem 0.75rem;
+    min-height: 3rem;
+    padding: 0.55rem 0;
   }
 
-  .requests-page__row::before {
-    width: 2px;
+  .activity-row__status {
+    margin-top: 0.05rem;
   }
 
-  .requests-page__row--alt {
-    background: var(--aurral-surface);
+  .activity-row__status-label {
+    display: none;
   }
 
-  .requests-page__item-title {
+  .activity-row__time {
+    padding-top: 0.15rem;
+    font-size: 0.65rem;
+  }
+
+  .activity-row__actions {
+    grid-column: 2 / -1;
+    justify-content: flex-start;
+    margin-top: 0.1rem;
+  }
+
+  .activity-row__title {
     font-size: 0.8125rem;
-    font-weight: 600;
-    white-space: nowrap;
-    text-overflow: ellipsis;
   }
 
-  .requests-page__meta {
-    margin-top: 0.125rem;
-    font-size: 0.625rem;
+  .activity-row__meta,
+  .activity-row__hint {
+    font-size: 0.65rem;
   }
 
-  .requests-page__review-path,
-  .requests-page__review-reason {
-    font-size: 0.625rem;
-  }
-
-  .requests-page__row--review .requests-page__status {
-    padding-top: 0;
-  }
-
-  .requests-page__meta .artist-truncate {
-    min-width: 0;
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .requests-page__status {
-    align-self: flex-start;
-    padding-top: 0.0625rem;
-  }
-
-  .requests-page__badge {
-    gap: 0;
-    padding: 0.25rem;
-    font-size: 0;
-    letter-spacing: 0;
-    line-height: 0;
-  }
-
-  .requests-page__badge .artist-icon-xs {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .requests-page__action {
-    width: 1.75rem;
-    height: 1.75rem;
+  .activity-info-modal__row {
+    grid-template-columns: minmax(5.5rem, 0.45fr) minmax(0, 1fr);
+    gap: 0.75rem;
   }
 }
 
@@ -10556,17 +10697,6 @@ button.native-library-genre-row:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-}
-
-.flow-page__track-menu {
-  position: relative;
-  display: inline-flex;
-}
-
-.flow-page__track-menu-dropdown {
-  min-width: 13.5rem;
-  width: auto;
-  overflow: visible;
 }
 
 .flow-page__detail-panel {
@@ -12388,38 +12518,35 @@ button.native-library-genre-row:focus-visible {
     pointer-events: auto;
   }
 
-  .flow-page__track-menu-dropdown {
-    width: min(16rem, calc(100vw - 1.5rem));
-  }
-
-  .flow-page__track-menu-dropdown .artist-menu-submenu {
+  .native-library-item-menu__panel .artist-menu-submenu {
     position: static;
   }
 
-  .flow-page__track-menu-dropdown .artist-menu-submenu__panel {
+  .native-library-item-menu__panel .artist-menu-submenu__panel {
     position: static;
     width: 100%;
+    margin-inline: 0;
     margin-top: 0.125rem;
     padding-top: 0.125rem;
     background: transparent;
     border-top: 1px solid var(--aurral-surface);
   }
 
-  .flow-page__track-menu-dropdown .artist-menu-submenu:hover .artist-menu-submenu__panel,
-  .flow-page__track-menu-dropdown .artist-menu-submenu:focus-within .artist-menu-submenu__panel {
+  .native-library-item-menu__panel .artist-menu-submenu:hover .artist-menu-submenu__panel,
+  .native-library-item-menu__panel .artist-menu-submenu:focus-within .artist-menu-submenu__panel {
     display: none;
   }
 
-  .flow-page__track-menu-dropdown .artist-menu-submenu.is-open .artist-menu-submenu__panel {
+  .native-library-item-menu__panel .artist-menu-submenu.is-open .artist-menu-submenu__panel {
     display: block;
   }
 
-  .flow-page__track-menu-dropdown .artist-menu-submenu.is-open .artist-menu-submenu__trigger {
+  .native-library-item-menu__panel .artist-menu-submenu.is-open .artist-menu-submenu__trigger {
     background-color: var(--aurral-surface-hover);
     color: var(--aurral-text);
   }
 
-  .flow-page__track-menu-dropdown
+  .native-library-item-menu__panel
     .artist-menu-submenu.is-open
     .artist-menu-submenu__trigger
     .artist-chevron--open {
@@ -13991,6 +14118,7 @@ button.native-library-genre-row:focus-visible {
 .artist-floating-menu,
 .artist-options-menu,
 .artist-options-menu--discover,
+.native-library-item-menu__panel,
 .artist-playlist-menu,
 .artist-nearby-zip-editor:not(.artist-nearby-zip-editor--menu),
 .flow-page__library-create-menu,
@@ -14104,6 +14232,7 @@ button.native-library-genre-row:focus-visible {
   .artist-floating-menu,
   .artist-options-menu,
   .artist-options-menu--discover,
+  .native-library-item-menu__panel,
   .artist-playlist-menu,
   .artist-nearby-zip-editor:not(.artist-nearby-zip-editor--menu),
   .flow-page__library-create-menu,

--- a/frontend/src/navigation/activityNavConfig.js
+++ b/frontend/src/navigation/activityNavConfig.js
@@ -1,7 +1,12 @@
 export const ACTIVITY_VIEWS = [
   { id: "queue", label: "Queue" },
-  { id: "review", label: "Review" },
   { id: "history", label: "History" },
+  { id: "missing", label: "Missing" },
+];
+
+export const WANTED_VIEWS = [
+  { id: "missing", label: "Missing", path: "/activity/missing" },
+  { id: "cutoff", label: "Cutoff unmet", path: "/activity/missing?tab=cutoff" },
 ];
 
 export const DEFAULT_ACTIVITY_VIEW = "queue";
@@ -12,8 +17,8 @@ export function normalizeActivityView(view) {
 }
 
 export function isActivityQueueItem(request) {
-  if (request?.status === "blocked") return false;
   return (
+    request?.status === "blocked" ||
     request?.inQueue === true ||
     request?.status === "processing" ||
     request?.status === "pending"
@@ -22,11 +27,16 @@ export function isActivityQueueItem(request) {
 
 export function matchesActivityView(request, view) {
   if (view === "queue") return isActivityQueueItem(request);
-  if (view === "review") return request?.status === "blocked";
+  if (view === "review") return false;
+  if (view === "missing") return false;
   return !isActivityQueueItem(request) && request?.status !== "blocked";
 }
 
 export function buildActivityPath(view) {
   const nextView = normalizeActivityView(view);
   return `/activity/${nextView}`;
+}
+
+export function buildWantedPath(view = "missing") {
+  return WANTED_VIEWS.find((entry) => entry.id === view)?.path || WANTED_VIEWS[0].path;
 }

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -4,7 +4,6 @@ import { approveBlockedJob, denyBlockedJob, getStagingStreamUrl } from "../utils
 import { useAudioQueue } from "../contexts/audioQueueContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAuth } from "../contexts/AuthContext";
-import { useFlowWorkerActivity } from "./flows/useFlowWorkerActivity";
 import { useWebSocketChannel } from "../hooks/useWebSocket";
 import { getActivityPollIntervalMs } from "../utils/requestScheduling.js";
 import { PageSectionMobileNav } from "../components/PageSectionMobileNav";
@@ -21,19 +20,17 @@ import {
   mergeActivityRequests,
 } from "./activity/activityListUtils";
 import ActivityRequestRow from "./activity/ActivityRequestRow";
+import ActivityToolbar from "./activity/ActivityToolbar";
+import ActivityMissingPage from "./activity/ActivityMissingPage";
+import ActivityInfoModal from "./activity/ActivityInfoModal";
 
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { Loader, AlertCircle, Music } from "lucide-react";
 const ACTIVITY_PAGE_SIZE = 25;
 
 const QUEUE_EMPTY_STATE = {
-  title: "Queue is empty",
-  message: "Active album requests and downloads will appear here.",
-};
-
-const REVIEW_EMPTY_STATE = {
-  title: "No tracks to review",
-  message: "Downloaded tracks that need your approval will appear here.",
+  title: "Nothing queued",
+  message: "Active requests, downloads, and tracks waiting for review will appear here.",
 };
 
 const HISTORY_EMPTY_STATE = {
@@ -43,10 +40,10 @@ const HISTORY_EMPTY_STATE = {
 
 function ActivityPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { view: viewParam } = useParams();
   const { user } = useAuth();
   const hasFlowAccess = user?.role === "admin" || !!user?.permissions?.accessFlow;
-  const { hasReview: hasReviewAlert } = useFlowWorkerActivity({ enabled: hasFlowAccess });
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -55,27 +52,52 @@ function ActivityPage() {
   const [approvingJobId, setApprovingJobId] = useState(null);
   const [denyingJobId, setDenyingJobId] = useState(null);
   const [jobErrors, setJobErrors] = useState({});
+  const [filterValue, setFilterValue] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [infoRequest, setInfoRequest] = useState(null);
   const fetchRequestsInFlightRef = useRef(false);
 
   const { playTrack, currentTrack, isPlaying, togglePlayPause } = useAudioQueue();
 
   const activeView = normalizeActivityView(viewParam);
   const isQueueView = activeView === "queue";
-  const isReviewView = activeView === "review";
   const isHistoryView = activeView === "history";
-  const isListLikeView = isQueueView || isReviewView;
+  const isMissingView = activeView === "missing";
+  const isCutoffView = new URLSearchParams(location.search).get("tab") === "cutoff";
+  const isListLikeView = isQueueView;
   const shouldRedirectView = viewParam && normalizeActivityView(viewParam) !== viewParam;
-
+  const activeViewLabel = isMissingView
+    ? isCutoffView ? "Cutoff unmet" : "Missing"
+    : ACTIVITY_VIEWS.find((entry) => entry.id === activeView)?.label || "Activity";
   useDocumentTitle(
-    isQueueView ? "Queue - Activity"
-    : isReviewView ? "Review - Activity"
+    isQueueView ? "Queued - Activity"
     : isHistoryView ? "History - Activity"
+    : isMissingView ? `${isCutoffView ? "Cutoff unmet" : "Missing"} - Wanted`
     : "Activity",
   );
 
   const filteredRequests = useMemo(
-    () => requests.filter((request) => matchesActivityView(request, activeView)),
-    [requests, activeView],
+    () => {
+      const query = filterValue.trim().toLocaleLowerCase();
+      return requests.filter((request) => {
+        if (!matchesActivityView(request, activeView)) return false;
+        if (!query) return true;
+        return [
+          request.title,
+          request.name,
+          request.trackName,
+          request.albumName,
+          request.artistName,
+          request.subtitle,
+          request.statusLabel,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLocaleLowerCase()
+          .includes(query);
+      });
+    },
+    [activeView, filterValue, requests],
   );
 
   const sortedRequests = useMemo(
@@ -129,9 +151,9 @@ function ActivityPage() {
   }, [isListLikeView]);
 
   const refreshFromStatusEvent = useCallback(() => {
-    if (document.hidden) return;
+    if (document.hidden || isMissingView) return;
     fetchRequests({ silent: true, refresh: true });
-  }, [fetchRequests]);
+  }, [fetchRequests, isMissingView]);
 
   const { isConnected: downloadsWsConnected } = useWebSocketChannel(
     "downloads",
@@ -149,6 +171,7 @@ function ActivityPage() {
   const activityWsConnected = downloadsWsConnected && (!hasFlowAccess || playlistsWsConnected);
 
   useEffect(() => {
+    if (isMissingView) return undefined;
     fetchRequests();
 
     const handleFocus = () => {
@@ -168,9 +191,10 @@ function ActivityPage() {
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [fetchRequests]);
+  }, [fetchRequests, isMissingView]);
 
   useEffect(() => {
+    if (isMissingView) return undefined;
     const intervalMs = getActivityPollIntervalMs({
       isConnected: activityWsConnected,
       isListLikeView,
@@ -180,7 +204,7 @@ function ActivityPage() {
       fetchRequests({ silent: true });
     }, intervalMs);
     return () => clearInterval(interval);
-  }, [activityWsConnected, isListLikeView, fetchRequests]);
+  }, [activityWsConnected, isListLikeView, isMissingView, fetchRequests]);
 
   const navigateToArtist = useCallback(
     (request, isAlbum, artistMbid, artistName, displayName) => {
@@ -315,34 +339,24 @@ function ActivityPage() {
     [navigate, navigateToArtist],
   );
 
-  const emptyState = isQueueView
-    ? QUEUE_EMPTY_STATE
-    : isReviewView
-      ? REVIEW_EMPTY_STATE
-      : HISTORY_EMPTY_STATE;
+  const emptyState = isQueueView ? QUEUE_EMPTY_STATE : HISTORY_EMPTY_STATE;
 
-  const activitySections = useMemo(
-    () =>
-      ACTIVITY_VIEWS.map((entry) => ({
-        id: entry.id,
-        label:
-          entry.id === "review" && hasReviewAlert ? `${entry.label} (needs review)` : entry.label,
-      })),
-    [hasReviewAlert],
-  );
+  const activitySections = ACTIVITY_VIEWS;
 
   const pageHeader = (
     <>
-      <header className="requests-page__header">
-        <h1 className="page-title">Activity</h1>
+      <header className="activity-page__header">
+        <h1 className="page-title">{activeViewLabel}</h1>
       </header>
-      <PageSectionMobileNav
-        sections={activitySections}
-        activeId={activeView}
-        label="Activity"
-        getSectionPath={buildActivityPath}
-        selectId="activity-view-select"
-      />
+      {!isMissingView ? (
+        <PageSectionMobileNav
+          sections={activitySections.filter((entry) => entry.id !== "missing")}
+          activeId={activeView}
+          label="Activity"
+          getSectionPath={buildActivityPath}
+          selectId="activity-view-select"
+        />
+      ) : null}
     </>
   );
 
@@ -354,10 +368,32 @@ function ActivityPage() {
     return <Navigate to={buildActivityPath(activeView)} replace />;
   }
 
+  if (isMissingView) {
+    return (
+      <div className="activity-page">
+        {pageHeader}
+        <ActivityMissingPage />
+      </div>
+    );
+  }
+
   if (loading) {
     return (
-      <div className="requests-page">
+      <div className="activity-page">
         {pageHeader}
+        <ActivityToolbar
+          filterValue={filterValue}
+          onFilterChange={setFilterValue}
+          onRefresh={async () => {
+            setRefreshing(true);
+            try {
+              await fetchRequests({ silent: true, refresh: true });
+            } finally {
+              setRefreshing(false);
+            }
+          }}
+          refreshing={refreshing}
+        />
         <div className="artist-loading">
           <Loader className="artist-spinner artist-spinner--large animate-spin" />
         </div>
@@ -366,18 +402,31 @@ function ActivityPage() {
   }
 
   return (
-    <div className="requests-page">
+    <div className="activity-page">
       {pageHeader}
+      <ActivityToolbar
+        filterValue={filterValue}
+        onFilterChange={setFilterValue}
+        onRefresh={async () => {
+          setRefreshing(true);
+          try {
+            await fetchRequests({ silent: true, refresh: true });
+          } finally {
+            setRefreshing(false);
+          }
+        }}
+        refreshing={refreshing}
+      />
 
       {error && (
-        <div className="artist-error-panel requests-page__error" role="alert">
+        <div className="artist-error-panel activity-page__error" role="alert">
           <AlertCircle className="artist-error-icon" aria-hidden="true" />
           <h2 className="artist-error-title">Unable to load activity</h2>
           <p className="artist-error-copy">{error}</p>
           <button
             type="button"
             onClick={() => fetchRequests()}
-            className="btn btn-secondary btn--bold btn-min-h requests-page__retry-button"
+            className="btn btn-secondary btn--bold btn-min-h"
           >
             Try Again
           </button>
@@ -396,7 +445,7 @@ function ActivityPage() {
               <button
                 type="button"
                 onClick={() => navigate("/")}
-                className="btn btn-primary btn--bold btn-min-h requests-page__empty-action"
+                className="btn btn-primary btn--bold btn-min-h"
               >
                 Start Discovering
               </button>
@@ -404,13 +453,12 @@ function ActivityPage() {
           </div>
         )
       ) : (
-        <div className="requests-page__list">
+        <div className="activity-list">
           {(() => {
-            let rowIndex = 0;
             return listEntries.map((entry) => {
               if (entry.type === "date") {
                 return (
-                  <div key={entry.key} className="requests-page__date-group">
+                  <div key={entry.key} className="activity-list__date-group">
                     {entry.label}
                   </div>
                 );
@@ -419,7 +467,6 @@ function ActivityPage() {
                 <ActivityRequestRow
                   key={entry.key}
                   request={entry.request}
-                  rowIndex={rowIndex}
                   reSearchingAlbumIds={reSearchingAlbumIds}
                   approvingJobId={approvingJobId}
                   denyingJobId={denyingJobId}
@@ -431,14 +478,14 @@ function ActivityPage() {
                   onApprove={handleApproveBlockedJob}
                   onDeny={handleDenyBlockedJob}
                   onPreview={handleReviewPreview}
+                  onInfo={setInfoRequest}
                 />
               );
-              rowIndex += 1;
               return row;
             });
           })()}
           {hasMoreItems && (
-            <div className="requests-page__load-more">
+            <div className="activity-list__load-more">
               <button
                 type="button"
                 onClick={() => setVisibleCount((count) => count + ACTIVITY_PAGE_SIZE)}
@@ -450,6 +497,7 @@ function ActivityPage() {
           )}
         </div>
       )}
+      <ActivityInfoModal item={infoRequest} onClose={() => setInfoRequest(null)} />
     </div>
   );
 }

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -104,6 +104,7 @@ function ActivityPage() {
     () => [...filteredRequests].sort(compareActivityRequests),
     [filteredRequests],
   );
+  const hasActivityFilter = filterValue.trim().length > 0;
 
   const visibleRequests = useMemo(
     () => sortedRequests.slice(0, visibleCount),
@@ -149,6 +150,15 @@ function ActivityPage() {
       }
     }
   }, [isListLikeView]);
+
+  const handleManualRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await fetchRequests({ silent: true, refresh: true });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [fetchRequests]);
 
   const refreshFromStatusEvent = useCallback(() => {
     if (document.hidden || isMissingView) return;
@@ -384,14 +394,7 @@ function ActivityPage() {
         <ActivityToolbar
           filterValue={filterValue}
           onFilterChange={setFilterValue}
-          onRefresh={async () => {
-            setRefreshing(true);
-            try {
-              await fetchRequests({ silent: true, refresh: true });
-            } finally {
-              setRefreshing(false);
-            }
-          }}
+          onRefresh={handleManualRefresh}
           refreshing={refreshing}
         />
         <div className="artist-loading">
@@ -407,14 +410,7 @@ function ActivityPage() {
       <ActivityToolbar
         filterValue={filterValue}
         onFilterChange={setFilterValue}
-        onRefresh={async () => {
-          setRefreshing(true);
-          try {
-            await fetchRequests({ silent: true, refresh: true });
-          } finally {
-            setRefreshing(false);
-          }
-        }}
+        onRefresh={handleManualRefresh}
         refreshing={refreshing}
       />
 
@@ -439,9 +435,15 @@ function ActivityPage() {
             <div className="search-empty-panel__icon" aria-hidden="true">
               <Music className="artist-icon-lg" />
             </div>
-            <h2 className="search-empty-panel__title">{emptyState.title}</h2>
-            <p className="search-empty-panel__message">{emptyState.message}</p>
-            {isQueueView && (
+            <h2 className="search-empty-panel__title">
+              {hasActivityFilter ? "No matches" : emptyState.title}
+            </h2>
+            <p className="search-empty-panel__message">
+              {hasActivityFilter
+                ? "No activity matches the current filter."
+                : emptyState.message}
+            </p>
+            {isQueueView && !hasActivityFilter && (
               <button
                 type="button"
                 onClick={() => navigate("/")}

--- a/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
@@ -1,0 +1,49 @@
+import { useId } from "react";
+import { Loader } from "lucide-react";
+import { useModalDialog } from "../../../hooks/useModalDialog.js";
+
+export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting }) {
+  const titleId = useId();
+  const { dialogRef } = useModalDialog({
+    open: show,
+    onClose: onCancel,
+    closeDisabled: Boolean(deleting),
+  });
+
+  if (!show) return null;
+  return (
+    <div className="artist-modal-backdrop">
+      <div
+        ref={dialogRef}
+        className="artist-modal"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <h3 id={titleId} className="artist-modal__title">
+          Delete Track File
+        </h3>
+        <p className="artist-modal__copy">
+          Delete <strong>{title || "this track"}</strong> from the library? This permanently
+          removes the audio file from disk.
+        </p>
+        <div className="artist-modal__actions">
+          <button onClick={onCancel} disabled={deleting} className="btn btn-secondary">
+            Cancel
+          </button>
+          <button onClick={onConfirm} disabled={deleting} className="btn btn-danger">
+            {deleting ? (
+              <>
+                <Loader className="artist-icon-sm animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              "Delete Track"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { ChevronRight, Loader, MoreHorizontal, Plus } from "lucide-react";
+import { ChevronRight, Loader, MoreHorizontal, Plus, Trash2 } from "lucide-react";
 import AddActionButton from "../../../components/AddActionButton";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import TooltipButton from "../../../components/TooltipButton";
@@ -219,6 +219,77 @@ export function TrackPlaylistSubmenu({
           excludedPlaylistIds={excludedPlaylistIds}
           onSelect={handleSelect}
         />
+      </div>
+    </div>
+  );
+}
+
+export function TrackPlaylistRemoveSubmenu({
+  track = null,
+  playlists = [],
+  saving = false,
+  error = "",
+  onSelect,
+  onClose,
+  toggleOnClick = false,
+  isOpen = false,
+  onToggle,
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const submenuOpen = typeof onToggle === "function" ? isOpen : internalOpen;
+  const removablePlaylists = playlists
+    .map((playlist) => {
+      const entry = (Array.isArray(playlist?.trackEntries) ? playlist.trackEntries : []).find(
+        (candidate) => trackMatchesStoredIdentity(candidate?.identity, track),
+      );
+      return entry ? { playlist, jobId: entry.id } : null;
+    })
+    .filter(Boolean);
+
+  if (!removablePlaylists.length) return null;
+
+  const handleSelect = async (playlistId, jobId) => {
+    await onSelect?.({ playlistId, jobId });
+    onClose?.();
+  };
+
+  return (
+    <div className={`artist-menu-submenu${toggleOnClick && submenuOpen ? " is-open" : ""}`}>
+      <button
+        type="button"
+        className="artist-menu-item artist-menu-submenu__trigger"
+        role="menuitem"
+        aria-expanded={toggleOnClick ? submenuOpen : undefined}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (toggleOnClick) {
+            if (onToggle) onToggle();
+            else setInternalOpen((value) => !value);
+          }
+        }}
+      >
+        <span className="artist-menu-item__main">
+          <Trash2 className="artist-icon-sm" />
+          Remove from playlist
+        </span>
+        <ChevronRight
+          className={`artist-icon-sm${toggleOnClick && submenuOpen ? " artist-chevron--open" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      <div className="artist-menu-submenu__panel">
+        {removablePlaylists.map(({ playlist, jobId }) => (
+          <button
+            type="button"
+            className="artist-menu-item artist-menu-item--danger"
+            key={playlist.id}
+            onClick={() => handleSelect(playlist.id, jobId)}
+            disabled={saving}
+          >
+            {playlist.name}
+          </button>
+        ))}
+        {error ? <div className="artist-error-text">{error}</div> : null}
       </div>
     </div>
   );

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -11,13 +11,18 @@ import {
   Heart,
   List,
   ListFilter,
+  Pause,
   Play,
+  Radio,
   RefreshCw,
   Search,
+  Trash2,
+  UserRound,
   X,
 } from "lucide-react";
 
 import ArtistImage from "../components/ArtistImage";
+import { LibraryItemMenu, LibraryItemSubmenu } from "../components/LibraryItemMenu";
 import TooltipButton from "../components/TooltipButton";
 import { useAuth } from "../contexts/AuthContext";
 import { useAudioQueue } from "../contexts/audioQueueContext";
@@ -32,24 +37,35 @@ import {
 } from "../utils/api/endpoints/artists.js";
 import {
   clearCanonicalLibraryPageCache,
+  deleteAlbumFromLibrary,
+  deleteArtistFromLibrary,
+  deleteTrackFromLibrary,
   getCanonicalLibraryPage,
   getLibraryRefreshStatus,
   getLibraryFavorites,
   getRequests,
   downloadTrackToLibrary,
   requestLibraryRefresh,
+  updateLibraryArtist,
   updateLibraryFavorites,
 } from "../utils/api/endpoints/library.js";
 import {
   addSharedPlaylistTracks,
   createSharedPlaylist,
+  deleteSharedPlaylistTrack,
 } from "../utils/api/endpoints/playlists.js";
 import { buildAuthenticatedApiUrl } from "../utils/api/core.js";
 import { mergeAlbumMetadataTracks } from "../utils/libraryTrackHydration.js";
 import { navigateToLibraryAlbum } from "../utils/searchNavigation";
 import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { libraryPreviewData, libraryPreviewFavorites } from "./libraryPreviewData";
-import { TrackPlaylistMenu } from "./ArtistDetails/components/TrackPlaylistMenu";
+import {
+  TrackPlaylistRemoveSubmenu,
+  TrackPlaylistSubmenu,
+} from "./ArtistDetails/components/TrackPlaylistMenu";
+import { DeleteAlbumModal } from "./ArtistDetails/components/DeleteAlbumModal";
+import { DeleteArtistModal } from "./ArtistDetails/components/DeleteArtistModal";
+import { DeleteTrackModal } from "./ArtistDetails/components/DeleteTrackModal";
 import {
   buildSharedPlaylistTrackPayload,
   reserveUniquePlaylistName,
@@ -256,7 +272,7 @@ function LibraryPage() {
     artistId: routeArtistId,
   } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { bootstrap } = useAuth();
+  const { bootstrap, hasPermission } = useAuth();
   const { showError, showSuccess } = useToast();
   const {
     sharedPlaylists,
@@ -290,6 +306,9 @@ function LibraryPage() {
   const refreshAttemptRef = useRef(0);
   const [playlistSavingKey, setPlaylistSavingKey] = useState("");
   const [trackDownloadStates, setTrackDownloadStates] = useState({});
+  const [libraryRemoval, setLibraryRemoval] = useState(null);
+  const [deleteFiles, setDeleteFiles] = useState(false);
+  const [deletingLibraryEntity, setDeletingLibraryEntity] = useState(false);
 
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
@@ -686,6 +705,191 @@ function LibraryPage() {
       showSuccess,
     ],
   );
+
+  const removeLibraryTrackFromPlaylist = useCallback(
+    async (track, target) => {
+      if (!target?.playlistId || !target?.jobId) return;
+      const key = String(track?.id || "");
+      setPlaylistSavingKey(key);
+      setPlaylistsError("");
+      try {
+        await deleteSharedPlaylistTrack(target.playlistId, target.jobId);
+        showSuccess(`Removed ${track?.title || "track"} from playlist`);
+        const nextPlaylists = await loadSharedPlaylists();
+        if (nextPlaylists) setSharedPlaylists(nextPlaylists);
+      } catch (requestError) {
+        const message =
+          requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          "Failed to remove track from playlist";
+        setPlaylistsError(message);
+        showError(message);
+      } finally {
+        setPlaylistSavingKey("");
+      }
+    },
+    [loadSharedPlaylists, setPlaylistsError, setSharedPlaylists, showError, showSuccess],
+  );
+
+  const canDeleteArtist = hasPermission("deleteArtist");
+  const canDeleteAlbum = hasPermission("deleteAlbum");
+  const canChangeMonitoring = hasPermission("changeMonitoring");
+
+  const openLibraryRemoval = useCallback((kind, entity) => {
+    setDeleteFiles(false);
+    setLibraryRemoval({ kind, entity });
+  }, []);
+
+  const removeLocalLibraryEntity = useCallback((removal) => {
+    if (!removal?.entity) return;
+    const entityId = String(removal.entity.id);
+    setLibrary((current) => {
+      if (removal.kind === "artist") {
+        const removedAlbumIds = new Set(
+          current.albums
+            .filter((album) => String(album.artistId) === entityId)
+            .map((album) => String(album.id)),
+        );
+        return {
+          ...current,
+          artists: current.artists.filter((artist) => String(artist.id) !== entityId),
+          albums: current.albums.filter((album) => !removedAlbumIds.has(String(album.id))),
+          tracks: current.tracks.filter(
+            (track) =>
+              String(track.artistId) !== entityId &&
+              !removedAlbumIds.has(String(track.albumId)) &&
+              !(track.albums || []).some((relation) => removedAlbumIds.has(String(relation.albumId))),
+          ),
+        };
+      }
+      if (removal.kind === "album") {
+        return {
+          ...current,
+          albums: current.albums.filter((album) => String(album.id) !== entityId),
+          tracks: current.tracks.filter(
+            (track) =>
+              String(track.albumId) !== entityId &&
+              !(track.albums || []).some((relation) => String(relation.albumId) === entityId),
+          ),
+        };
+      }
+      return {
+        ...current,
+        tracks: current.tracks.filter((track) => String(track.id) !== entityId),
+      };
+    });
+    clearCanonicalLibraryPageCache();
+    albumTrackCacheRef.current.clear();
+  }, []);
+
+  const handleLibraryRemovalConfirm = useCallback(async () => {
+    if (!libraryRemoval?.entity || deletingLibraryEntity) return;
+    const removal = libraryRemoval;
+    const entity = removal.entity;
+    setDeletingLibraryEntity(true);
+    try {
+      if (!isPreviewLibrary) {
+        if (removal.kind === "artist") {
+          await deleteArtistFromLibrary(entity.mbid, deleteFiles);
+        } else if (removal.kind === "album") {
+          await deleteAlbumFromLibrary(entity.providerId || entity.id, deleteFiles);
+        } else {
+          await deleteTrackFromLibrary(entity.id);
+        }
+      }
+      removeLocalLibraryEntity(removal);
+      setLibraryRemoval(null);
+      showSuccess(
+        removal.kind === "artist"
+          ? "Artist removed from library"
+          : removal.kind === "album"
+            ? "Album removed from library"
+            : "Track deleted",
+      );
+      if (
+        (removal.kind === "artist" && String(routeArtistId) === String(entity.id)) ||
+        (removal.kind === "album" && String(routeAlbumId) === String(entity.id))
+      ) {
+        navigate(
+          removal.kind === "artist"
+            ? "/library/artists" + previewQuery
+            : "/library/albums" + previewQuery,
+        );
+      }
+    } catch (requestError) {
+      showError(
+        requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          "Failed to update library",
+      );
+    } finally {
+      setDeletingLibraryEntity(false);
+    }
+  }, [
+    deleteFiles,
+    deletingLibraryEntity,
+    isPreviewLibrary,
+    libraryRemoval,
+    navigate,
+    previewQuery,
+    removeLocalLibraryEntity,
+    routeAlbumId,
+    routeArtistId,
+    showError,
+    showSuccess,
+  ]);
+
+  const updateArtistMonitoring = useCallback(
+    async (artist, monitorOption) => {
+      if (!artist?.mbid || !canChangeMonitoring) return;
+      try {
+        if (!isPreviewLibrary) {
+          await updateLibraryArtist(artist.mbid, {
+            monitored: true,
+            monitorOption,
+            addOptions: { ...(artist.addOptions || {}), monitor: monitorOption },
+          });
+        }
+        setLibrary((current) => ({
+          ...current,
+          artists: current.artists.map((entry) =>
+            String(entry.id) === String(artist.id)
+              ? { ...entry, monitored: true, monitorOption }
+              : entry,
+          ),
+        }));
+        showSuccess(`Artist monitoring set to ${monitorOption}`);
+      } catch (requestError) {
+        showError(
+          requestError.response?.data?.message ||
+            requestError.response?.data?.error ||
+            requestError.message ||
+            "Failed to update artist monitoring",
+        );
+      }
+    },
+    [canChangeMonitoring, isPreviewLibrary, showError, showSuccess],
+  );
+
+  const artistMonitorItems = (artist) => {
+    const currentOption = artist?.monitorOption || artist?.addOptions?.monitor || "none";
+    return [
+      ["none", "None (artist only)"],
+      ["existing", "Existing albums"],
+      ["all", "All albums"],
+      ["future", "Future albums"],
+      ["missing", "Missing albums"],
+      ["latest", "Latest album"],
+      ["first", "First album"],
+    ].map(([value, label]) => ({
+      id: value,
+      label,
+      selected: currentOption === value,
+      onSelect: () => updateArtistMonitoring(artist, value),
+    }));
+  };
 
   const downloadMissingTrack = useCallback(
     async (track) => {
@@ -1319,28 +1523,92 @@ function LibraryPage() {
       </div>
       <div role="list" aria-label={label}>
         {tracks.map((track, index) => {
-        const album = getAlbumForTrack(track);
-        const artist = getArtistForAlbum(album);
-        const file = firstAvailableFile(track);
-        const downloadKey = trackDownloadIdentity(track);
-        const downloadState = trackDownloadStates[downloadKey];
-        const downloadPending = TRACK_DOWNLOAD_ACTIVE_STATUSES.has(downloadState?.status);
-        const downloadLabel = trackDownloadActionLabel(downloadState?.status);
-        const active =
-          String(currentTrack?.id) === String(track.id) &&
-          matchesSource(librarySource);
-        const artistName = artist?.name || track.artistName || "Unknown Artist";
-        const albumName = album?.title || "Unknown Album";
-        return (
-          <div
-            className={
-              "native-library-track" +
-              (active ? " is-active" : "") +
-              (file ? "" : " is-missing")
-            }
-            key={track.id}
-            role="listitem"
-          >
+          const album = getAlbumForTrack(track);
+          const artist = getArtistForAlbum(album);
+          const file = firstAvailableFile(track);
+          const downloadKey = trackDownloadIdentity(track);
+          const downloadState = trackDownloadStates[downloadKey];
+          const downloadPending = TRACK_DOWNLOAD_ACTIVE_STATUSES.has(downloadState?.status);
+          const downloadLabel = trackDownloadActionLabel(downloadState?.status);
+          const active =
+            String(currentTrack?.id) === String(track.id) &&
+            matchesSource(librarySource);
+          const artistName = artist?.name || track.artistName || "Unknown Artist";
+          const albumName = album?.title || "Unknown Album";
+          const isFavorite = favoriteIds.has(favoriteId("song", track));
+          const trackMenuItems = [
+            {
+              id: "play",
+              label: active && isPlaying ? "Pause" : "Play",
+              icon: active && isPlaying ? Pause : Play,
+              onSelect: () => playTrack(track, tracks),
+              disabled: !file || (active && isLoading),
+            },
+            {
+              id: "favorite",
+              label: isFavorite ? "Remove from favorites" : "Add to favorites",
+              icon: Heart,
+              selected: isFavorite,
+              separatorBefore: true,
+              onSelect: () => toggleFavorite("song", track),
+            },
+            ...(!file
+              ? [
+                  {
+                    id: "download",
+                    label: downloadLabel,
+                    icon: Download,
+                    separatorBefore: true,
+                    onSelect: () => downloadMissingTrack(track),
+                    disabled: isPreviewLibrary || downloadPending,
+                  },
+                ]
+              : []),
+            ...(album
+              ? [
+                  {
+                    id: "album",
+                    label: "Go to album",
+                    icon: ExternalLink,
+                    separatorBefore: true,
+                    onSelect: () => handleAlbumOpen(album),
+                  },
+                ]
+              : []),
+            ...(artist
+              ? [
+                  {
+                    id: "artist",
+                    label: "Go to artist",
+                    icon: UserRound,
+                    onSelect: () => handleArtistOpen(artist),
+                  },
+                ]
+              : []),
+            ...(file && canDeleteAlbum
+              ? [
+                  {
+                    id: "delete",
+                    label: "Delete track file",
+                    icon: Trash2,
+                    danger: true,
+                    separatorBefore: true,
+                    onSelect: () => openLibraryRemoval("track", track),
+                  },
+                ]
+              : []),
+          ];
+          return (
+            <div
+              className={
+                "native-library-track" +
+                (active ? " is-active" : "") +
+                (file ? "" : " is-missing")
+              }
+              data-library-menu-target
+              key={track.id}
+              role="listitem"
+            >
             {file ? (
               <TooltipButton
                 className="native-library-track__play"
@@ -1426,16 +1694,36 @@ function LibraryPage() {
             ) : (
               <span />
             )}
-            <TrackPlaylistMenu
-              track={track}
-              playlists={sharedPlaylists}
-              loading={playlistsLoading}
-              saving={playlistSavingKey === String(track.id)}
-              error={playlistsError}
-              defaultNewPlaylistName={getDefaultTrackPlaylistName(track)}
-              onLoadPlaylists={loadSharedPlaylists}
-              triggerVariant="compact"
-              onSelect={(target) => addLibraryTrackToPlaylist(track, target)}
+            <LibraryItemMenu
+              label={track.title || "Track"}
+              items={trackMenuItems}
+              additionalItemsAfter="play"
+              onMenuOpen={loadSharedPlaylists}
+              renderAdditionalItems={({ closeMenu }) => (
+                <>
+                  <div className="native-library-item-menu__separator" />
+                  <TrackPlaylistSubmenu
+                    label="Add to playlist"
+                    track={track}
+                    playlists={sharedPlaylists}
+                    loading={playlistsLoading}
+                    saving={playlistSavingKey === String(track.id)}
+                    error={playlistsError}
+                    defaultNewPlaylistName={getDefaultTrackPlaylistName(track)}
+                    onSelect={(target) => addLibraryTrackToPlaylist(track, target)}
+                    onClose={closeMenu}
+                  />
+                  <TrackPlaylistRemoveSubmenu
+                    track={track}
+                    playlists={sharedPlaylists}
+                    saving={playlistSavingKey === String(track.id)}
+                    error={playlistsError}
+                    onSelect={(target) => removeLibraryTrackFromPlaylist(track, target)}
+                    onClose={closeMenu}
+                    toggleOnClick
+                  />
+                </>
+              )}
             />
             <FavoriteButton
               className="native-library-track__favorite"
@@ -1444,58 +1732,120 @@ function LibraryPage() {
               label={track.title || "track"}
               onClick={() => toggleFavorite("song", track)}
             />
-          </div>
+            </div>
           );
         })}
       </div>
     </div>
   );
 
-  const renderArtistCard = (artist) => (
-    <article className="native-library-card native-library-card--artist" key={artist.id}>
-      <button
-        type="button"
-        className="native-library-card__cover native-library-card__cover--round"
-        onClick={() => handleArtistOpen(artist)}
-        aria-label={"Open " + (artist.name || "artist")}
+  const renderArtistCard = (artist) => {
+    const isFavorite = favoriteIds.has(favoriteId("artist", artist));
+    return (
+      <article
+        className="native-library-card native-library-card--artist"
+        data-library-menu-target
+        key={artist.id}
       >
-        {artist.mbid ? (
-          <ArtistImage
-            mbid={artist.mbid}
-            artistName={artist.name}
-            alt={artist.name || ""}
-            className="native-library-artist-image"
-            showLoading={false}
-            enablePreviewPlayback={false}
-            isInLibrary
-          />
-        ) : (
-          <Cover label={artist.name} round />
-        )}
-      </button>
-      <div className="native-library-card__body">
-        <div className="native-library-card__title-row">
+        <div className="native-library-card__cover-wrap">
           <button
             type="button"
-            className="native-library-card__title"
+            className="native-library-card__cover native-library-card__cover--round"
             onClick={() => handleArtistOpen(artist)}
-            title={artist.name}
+            aria-label={"Open " + (artist.name || "artist")}
           >
-            {artist.name || "Unknown Artist"}
+            {artist.mbid ? (
+              <ArtistImage
+                mbid={artist.mbid}
+                artistName={artist.name}
+                alt={artist.name || ""}
+                className="native-library-artist-image"
+                showLoading={false}
+                enablePreviewPlayback={false}
+                isInLibrary
+              />
+            ) : (
+              <Cover label={artist.name} round />
+            )}
           </button>
-          <FavoriteButton
-            active={favoriteIds.has(favoriteId("artist", artist))}
-            pending={Boolean(pendingFavorite)}
-            label={artist.name || "artist"}
-            onClick={() => toggleFavorite("artist", artist)}
+          <LibraryItemMenu
+            label={artist.name || "Artist"}
+            items={[
+              {
+                id: "open",
+                label: "Open artist",
+                icon: UserRound,
+                onSelect: () => handleArtistOpen(artist),
+              },
+              {
+                id: "favorite",
+                label: isFavorite ? "Remove from favorites" : "Add to favorites",
+                icon: Heart,
+                selected: isFavorite,
+                separatorBefore: true,
+                onSelect: () => toggleFavorite("artist", artist),
+              },
+              ...(canDeleteArtist && artist.mbid
+                ? [
+                    {
+                      id: "delete",
+                      label: "Remove from library",
+                      icon: Trash2,
+                      danger: true,
+                      separatorBefore: true,
+                      onSelect: () => openLibraryRemoval("artist", artist),
+                    },
+                  ]
+                : []),
+              {
+                id: "discover",
+                label: "Explore in Discover",
+                icon: ExternalLink,
+                separatorBefore: true,
+                onSelect: () => handleDiscoverArtistOpen(artist),
+                disabled: !artist.mbid,
+              },
+            ]}
+            additionalItemsAfter="favorite"
+            renderAdditionalItems={({ closeMenu }) =>
+              canChangeMonitoring && artist.mbid ? (
+                <>
+                  <div className="native-library-item-menu__separator" />
+                  <LibraryItemSubmenu
+                    label="Monitoring"
+                    icon={Radio}
+                    items={artistMonitorItems(artist)}
+                    onClose={closeMenu}
+                  />
+                </>
+              ) : null
+            }
           />
         </div>
-        <span className="native-library-card__meta">
-          {artist.albumIds?.length || 0} album{artist.albumIds?.length === 1 ? "" : "s"}
-        </span>
-      </div>
-    </article>
-  );
+        <div className="native-library-card__body">
+          <div className="native-library-card__title-row">
+            <button
+              type="button"
+              className="native-library-card__title"
+              onClick={() => handleArtistOpen(artist)}
+              title={artist.name}
+            >
+              {artist.name || "Unknown Artist"}
+            </button>
+            <FavoriteButton
+              active={isFavorite}
+              pending={Boolean(pendingFavorite)}
+              label={artist.name || "artist"}
+              onClick={() => toggleFavorite("artist", artist)}
+            />
+          </div>
+          <span className="native-library-card__meta">
+            {artist.albumIds?.length || 0} album{artist.albumIds?.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </article>
+    );
+  };
 
   const renderAlbumCard = (album) => {
     const artist = getArtistForAlbum(album);
@@ -1507,8 +1857,9 @@ function LibraryPage() {
         : (yearOf(album.releaseDate) ? yearOf(album.releaseDate) + " · " : "") +
           (availability.total || 0) +
           " tracks";
+    const isFavorite = favoriteIds.has(favoriteId("album", album));
     return (
-      <article className="native-library-card" key={album.id}>
+      <article className="native-library-card" data-library-menu-target key={album.id}>
         <div className="native-library-card__cover-wrap">
           <button
             type="button"
@@ -1527,6 +1878,63 @@ function LibraryPage() {
           >
             <Play aria-hidden="true" fill="currentColor" />
           </TooltipButton>
+          <LibraryItemMenu
+            label={album.title || "Album"}
+            items={[
+              {
+                id: "play",
+                label: "Play album",
+                icon: Play,
+                onSelect: () => playAlbum(album),
+                disabled: !albumTracks.length && !album.trackCount && !album.trackIds?.length,
+              },
+              {
+                id: "open",
+                label: "Open album",
+                icon: ExternalLink,
+                onSelect: () => handleAlbumOpen(album),
+              },
+              {
+                id: "favorite",
+                label: isFavorite ? "Remove from favorites" : "Add to favorites",
+                icon: Heart,
+                selected: isFavorite,
+                separatorBefore: true,
+                onSelect: () => toggleFavorite("album", album),
+              },
+              ...(artist
+                ? [
+                    {
+                      id: "artist",
+                      label: "Go to artist",
+                      icon: UserRound,
+                      separatorBefore: true,
+                      onSelect: () => handleArtistOpen(artist),
+                    },
+                  ]
+                : []),
+              ...(canDeleteAlbum && album.providerId
+                ? [
+                    {
+                      id: "delete",
+                      label: "Remove from library",
+                      icon: Trash2,
+                      danger: true,
+                      separatorBefore: true,
+                      onSelect: () => openLibraryRemoval("album", album),
+                    },
+                  ]
+                : []),
+              {
+                id: "discover",
+                label: "Explore in Discover",
+                icon: ExternalLink,
+                separatorBefore: true,
+                onSelect: () => handleDiscoverAlbumOpen(album),
+                disabled: !artist?.mbid || !(album.releaseGroupMbid || album.mbid),
+              },
+            ]}
+          />
         </div>
         <div className="native-library-card__body">
           <div className="native-library-card__title-row">
@@ -1539,7 +1947,7 @@ function LibraryPage() {
               {album.title || "Unknown Album"}
             </button>
             <FavoriteButton
-              active={favoriteIds.has(favoriteId("album", album))}
+              active={isFavorite}
               pending={Boolean(pendingFavorite)}
               label={album.title || "album"}
               onClick={() => toggleFavorite("album", album)}
@@ -1693,7 +2101,7 @@ function LibraryPage() {
     );
     return (
       <section className="native-library-detail">
-        <div className="native-library-detail__hero">
+        <div className="native-library-detail__hero" data-library-menu-target>
           <div className="native-library-detail__cover">
             <Cover src={getAlbumCover(libraryAlbum)} label={libraryAlbum.title} />
           </div>
@@ -1731,6 +2139,59 @@ function LibraryPage() {
                 label={libraryAlbum.title || "album"}
                 onClick={() => toggleFavorite("album", libraryAlbum)}
               />
+              <LibraryItemMenu
+                label={libraryAlbum.title || "Album"}
+                items={[
+                  {
+                    id: "play",
+                    label: "Play album",
+                    icon: Play,
+                    onSelect: () => playTracks(albumTracks),
+                    disabled: !albumTracks.some((track) => firstAvailableFile(track)),
+                  },
+                  {
+                    id: "favorite",
+                    label: favoriteIds.has(favoriteId("album", libraryAlbum))
+                      ? "Remove from favorites"
+                      : "Add to favorites",
+                    icon: Heart,
+                    selected: favoriteIds.has(favoriteId("album", libraryAlbum)),
+                    separatorBefore: true,
+                    onSelect: () => toggleFavorite("album", libraryAlbum),
+                  },
+                  ...(canDeleteAlbum && libraryAlbum.providerId
+                    ? [
+                        {
+                          id: "delete",
+                          label: "Remove from library",
+                          icon: Trash2,
+                          danger: true,
+                          separatorBefore: true,
+                          onSelect: () => openLibraryRemoval("album", libraryAlbum),
+                        },
+                      ]
+                    : []),
+                  ...(artist
+                    ? [
+                        {
+                          id: "artist",
+                          label: "Go to artist",
+                          icon: UserRound,
+                          separatorBefore: true,
+                          onSelect: () => handleArtistOpen(artist),
+                        },
+                      ]
+                    : []),
+                  {
+                    id: "discover",
+                    label: "Explore in Discover",
+                    icon: ExternalLink,
+                    separatorBefore: true,
+                    onSelect: () => handleDiscoverAlbumOpen(libraryAlbum),
+                    disabled: !artist?.mbid || !(libraryAlbum.releaseGroupMbid || libraryAlbum.mbid),
+                  },
+                ]}
+              />
               {artist?.mbid && (libraryAlbum.releaseGroupMbid || libraryAlbum.mbid) && (
                 <button
                   type="button"
@@ -1763,7 +2224,10 @@ function LibraryPage() {
     const artistTopTracks = topArtistTracks(artistTracks, albumsById);
     return (
       <section className="native-library-detail">
-        <div className="native-library-detail__hero native-library-detail__hero--artist">
+        <div
+          className="native-library-detail__hero native-library-detail__hero--artist"
+          data-library-menu-target
+        >
           <div className="native-library-detail__cover">
             {libraryArtist.mbid ? (
               <ArtistImage
@@ -1799,6 +2263,62 @@ function LibraryPage() {
                 pending={Boolean(pendingFavorite)}
                 label={libraryArtist.name || "artist"}
                 onClick={() => toggleFavorite("artist", libraryArtist)}
+              />
+              <LibraryItemMenu
+                label={libraryArtist.name || "Artist"}
+                items={[
+                  {
+                    id: "play",
+                    label: "Play artist",
+                    icon: Play,
+                    onSelect: () => playTracks(artistTracks),
+                    disabled: !artistTracks.some((track) => firstAvailableFile(track)),
+                  },
+                  {
+                    id: "favorite",
+                    label: favoriteIds.has(favoriteId("artist", libraryArtist))
+                      ? "Remove from favorites"
+                      : "Add to favorites",
+                    icon: Heart,
+                    selected: favoriteIds.has(favoriteId("artist", libraryArtist)),
+                    separatorBefore: true,
+                    onSelect: () => toggleFavorite("artist", libraryArtist),
+                  },
+                  ...(canDeleteArtist && libraryArtist.mbid
+                    ? [
+                        {
+                          id: "delete",
+                          label: "Remove from library",
+                          icon: Trash2,
+                          danger: true,
+                          separatorBefore: true,
+                          onSelect: () => openLibraryRemoval("artist", libraryArtist),
+                        },
+                      ]
+                    : []),
+                  {
+                    id: "discover",
+                    label: "Explore in Discover",
+                    icon: ExternalLink,
+                    separatorBefore: true,
+                    onSelect: () => handleDiscoverArtistOpen(libraryArtist),
+                    disabled: !libraryArtist.mbid,
+                  },
+                ]}
+                additionalItemsAfter="favorite"
+                renderAdditionalItems={({ closeMenu }) =>
+                  canChangeMonitoring && libraryArtist.mbid ? (
+                    <>
+                      <div className="native-library-item-menu__separator" />
+                      <LibraryItemSubmenu
+                        label="Monitoring"
+                        icon={Radio}
+                        items={artistMonitorItems(libraryArtist)}
+                        onClose={closeMenu}
+                      />
+                    </>
+                  ) : null
+                }
               />
               {libraryArtist.mbid && (
                 <button
@@ -1841,6 +2361,37 @@ function LibraryPage() {
   const renderLibraryDetail = () =>
     libraryAlbum ? renderLibraryAlbumDetail() : renderLibraryArtistDetail();
 
+  const renderLibraryModals = () => (
+    <>
+      <DeleteArtistModal
+        show={libraryRemoval?.kind === "artist"}
+        artistName={libraryRemoval?.entity?.name}
+        libraryArtistName={libraryRemoval?.entity?.artistName}
+        deleteFiles={deleteFiles}
+        onDeleteFilesChange={setDeleteFiles}
+        onCancel={() => setLibraryRemoval(null)}
+        onConfirm={handleLibraryRemovalConfirm}
+        deleting={deletingLibraryEntity}
+      />
+      <DeleteAlbumModal
+        show={libraryRemoval?.kind === "album"}
+        title={libraryRemoval?.entity?.title || libraryRemoval?.entity?.albumName}
+        deleteFiles={deleteFiles}
+        onDeleteFilesChange={setDeleteFiles}
+        onCancel={() => setLibraryRemoval(null)}
+        onConfirm={handleLibraryRemovalConfirm}
+        removing={deletingLibraryEntity}
+      />
+      <DeleteTrackModal
+        show={libraryRemoval?.kind === "track"}
+        title={libraryRemoval?.entity?.title || libraryRemoval?.entity?.trackName}
+        onCancel={() => setLibraryRemoval(null)}
+        onConfirm={handleLibraryRemovalConfirm}
+        deleting={deletingLibraryEntity}
+      />
+    </>
+  );
+
   const providerWarning = bootstrap?.lidarr?.circuitOpen === true;
   const renderStatus = () => (
     <>
@@ -1874,6 +2425,7 @@ function LibraryPage() {
   if (isDetail) {
     return (
       <main className="library-page native-library-page">
+        {renderLibraryModals()}
         {renderStatus()}
         {!loading && !error && !libraryAlbum && !libraryArtist && (
           <EmptyState title="Not found" message="This library item is no longer indexed." />
@@ -1934,6 +2486,7 @@ function LibraryPage() {
 
   return (
     <main className="library-page native-library-page">
+      {renderLibraryModals()}
       <header className={`native-library-header${section === "home" ? " native-library-header--home" : ""}`}>
         <div className="native-library-title-row">
           <div className="native-library-title">

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -734,6 +734,7 @@ function LibraryPage() {
 
   const canDeleteArtist = hasPermission("deleteArtist");
   const canDeleteAlbum = hasPermission("deleteAlbum");
+  const canDeleteTrack = hasPermission("deleteTrack") || canDeleteAlbum;
   const canChangeMonitoring = hasPermission("changeMonitoring");
 
   const openLibraryRemoval = useCallback((kind, entity) => {
@@ -1585,7 +1586,7 @@ function LibraryPage() {
                   },
                 ]
               : []),
-            ...(file && canDeleteAlbum
+            ...(file && canDeleteTrack
               ? [
                   {
                     id: "delete",

--- a/frontend/src/pages/Settings/constants.js
+++ b/frontend/src/pages/Settings/constants.js
@@ -18,6 +18,7 @@ export const GRANULAR_PERMISSIONS = {
   changeMonitoring: false,
   deleteArtist: false,
   deleteAlbum: false,
+  deleteTrack: false,
 };
 
 export const granularPerms = [
@@ -27,4 +28,5 @@ export const granularPerms = [
   { key: "changeMonitoring", label: "Change artist monitoring" },
   { key: "deleteArtist", label: "Delete artists" },
   { key: "deleteAlbum", label: "Delete albums" },
+  { key: "deleteTrack", label: "Delete tracks" },
 ];

--- a/frontend/src/pages/activity/ActivityInfoModal.jsx
+++ b/frontend/src/pages/activity/ActivityInfoModal.jsx
@@ -1,0 +1,119 @@
+import { useId } from "react";
+import { X } from "lucide-react";
+import TooltipButton from "../../components/TooltipButton";
+import { useModalDialog } from "../../hooks/useModalDialog.js";
+import { formatDateTime } from "../../utils/dateTime.js";
+
+const text = (value) => String(value ?? "").trim();
+
+const formatTimestamp = (value) => {
+  if (value == null || value === "") return "";
+  const raw = text(value);
+  const date = new Date(/^-?\d+(\.\d+)?$/.test(raw) ? Number(raw) : value);
+  if (Number.isNaN(date.getTime())) return "";
+  return formatDateTime(date, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+const formatSource = (item) => {
+  const source = text(item.downloadSource || item.downloadClient || item.source);
+  if (!source) return "";
+  return source === "lidarr" ? "Lidarr" : source === "aurral" ? "Aurral" : source;
+};
+
+const formatKind = (kind) => {
+  const labels = {
+    album_requested: "Album request",
+    track_download: "Track download",
+    track_reused_aurral: "Reused track",
+    track_reused_lidarr: "Reused track",
+  };
+  return labels[kind] || text(kind).replace(/[_-]+/g, " ");
+};
+
+const formatQualityState = (state) => {
+  const labels = {
+    "below-floor": "Below floor",
+    upgrade: "Upgrade available",
+    preferred: "Preferred",
+    external: "External file",
+  };
+  return labels[state] || text(state);
+};
+
+function getRows(item) {
+  const requester = item.requestedBy?.username || item.requestedBy?.id;
+  const operation = item.playlistName || item.playlistId || item.playlistType;
+  const details = item.error || item.subtitle;
+  const id = item.jobId || item.id;
+  return [
+    ["Status", item.statusLabel || item.status],
+    ["Type", formatKind(item.kind)],
+    ["Artist", item.artistName],
+    ["Album", item.albumName],
+    ["Track", item.trackName],
+    ["Operation", operation],
+    ["Source", formatSource(item)],
+    ["Quality", item.qualityLabel],
+    ["Quality state", formatQualityState(item.qualityState)],
+    ["Requested", formatTimestamp(item.requestedAt || item.createdAt)],
+    ["Requester", requester],
+    ["Source file", item.sourceFilename],
+    ["Details", details],
+    ["ID", id],
+  ].filter(([, value]) => text(value));
+}
+
+export default function ActivityInfoModal({ item, onClose }) {
+  const titleId = useId();
+  const { dialogRef, handleBackdropClick } = useModalDialog({
+    open: Boolean(item),
+    onClose,
+  });
+
+  if (!item) return null;
+
+  const title = text(item.trackName || item.albumName || item.title) || "Activity details";
+  const status = text(item.statusLabel || item.status);
+  const rows = getRows(item);
+
+  return (
+    <div className="artist-modal-backdrop" onClick={handleBackdropClick}>
+      <section
+        ref={dialogRef}
+        className="artist-modal activity-info-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <div className="artist-modal__header">
+          <div>
+            {status ? <p className="activity-info-modal__eyebrow">{status}</p> : null}
+            <h2 id={titleId} className="artist-modal__title">{title}</h2>
+          </div>
+          <TooltipButton
+            className="btn btn-ghost btn-icon-square"
+            onClick={onClose}
+            label="Close details"
+          >
+            <X className="artist-icon-md" aria-hidden="true" />
+          </TooltipButton>
+        </div>
+        <dl className="activity-info-modal__rows">
+          {rows.map(([label, value]) => (
+            <div className="activity-info-modal__row" key={label}>
+              <dt>{label}</dt>
+              <dd>{text(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -150,6 +150,7 @@ export default function ActivityMissingPage() {
   const activeTab = searchParams.get("tab") === "cutoff" ? "cutoff" : "missing";
   const showingCutoff = activeTab === "cutoff";
   const filterPlaceholder = showingCutoff ? "Filter cutoff unmet" : "Filter missing tracks";
+  const hasFilter = filterValue.trim().length > 0;
 
   useEffect(() => {
     setVisibleCount(WANTED_PAGE_SIZE);
@@ -166,13 +167,26 @@ export default function ActivityMissingPage() {
           .filter((job) => job?.upgradeForJobId && ["pending", "downloading"].includes(job.status))
           .map((job) => String(job.upgradeForJobId)),
       );
-      setJobs(
-        (Array.isArray(allJobs) ? allJobs : [])
+      const nextJobs = (Array.isArray(allJobs) ? allJobs : [])
           .filter((job) => isMissingAurralJob(job) || isCutoffUnmetAurralJob(job))
           .map((job) => ({ ...job, upgradeQueued: upgradeJobIds.has(String(job.id)) }))
-          .sort(sortMissingJobs),
-      );
-      setActionStates({});
+          .sort(sortMissingJobs);
+      setJobs(nextJobs);
+      const jobsByKey = new Map(nextJobs.map((job) => [getMissingJobKey(job), job]));
+      setActionStates((current) => {
+        const next = {};
+        for (const [id, state] of Object.entries(current)) {
+          if (state === "working") {
+            next[id] = state;
+            continue;
+          }
+          if (jobsByKey.get(id)?.upgradeQueued) next[id] = "queued";
+        }
+        for (const job of nextJobs) {
+          if (job.upgradeQueued) next[getMissingJobKey(job)] = "queued";
+        }
+        return next;
+      });
       setPlaylistInfo(toPlaylistInfo(status));
     } catch (requestError) {
       setError(
@@ -219,6 +233,11 @@ export default function ActivityMissingPage() {
           : reSearchFlowTrack;
         await reSearch(job.playlistType, job.id);
         setJobs((current) => current.filter((entry) => getMissingJobKey(entry) !== id));
+        setActionStates((current) => {
+          const next = { ...current };
+          delete next[id];
+          return next;
+        });
         showSuccess(`Re-searching ${job.trackName || "track"}`);
       } else {
         await searchTrackUpgrade(job.playlistType, job.id);
@@ -283,12 +302,18 @@ export default function ActivityMissingPage() {
             <CheckCircle2 className="artist-icon-lg" />
           </div>
           <h2 className="search-empty-panel__title">
-            {showingCutoff ? "No cutoff gaps" : "No missing tracks"}
+            {hasFilter
+              ? "No tracks match your filter"
+              : showingCutoff
+                ? "No cutoff gaps"
+                : "No missing tracks"}
           </h2>
           <p className="search-empty-panel__message">
-            {showingCutoff
-              ? "Every Aurral-owned file currently meets the configured quality cutoff."
-              : "Every Aurral operation currently has a track available or in progress."}
+            {hasFilter
+              ? `${showingCutoff ? "No cutoff-unmet" : "No missing"} tracks match your filter.`
+              : showingCutoff
+                ? "Every Aurral-owned file currently meets the configured quality cutoff."
+                : "Every Aurral operation currently has a track available or in progress."}
           </p>
         </div>
       ) : null}

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  ArrowUpCircle,
+  CheckCircle2,
+  Info,
+  Loader,
+  RotateCcw,
+  Search,
+} from "lucide-react";
+import TooltipButton from "../../components/TooltipButton";
+import { useToast } from "../../contexts/ToastContext";
+import { formatDateTime } from "../../utils/dateTime.js";
+import { useSearchParams } from "react-router-dom";
+import {
+  getAllFlowJobs,
+  getFlowStatus,
+  reSearchFlowTrack,
+  reSearchSharedPlaylistTrack,
+  searchTrackUpgrade,
+} from "../../utils/api/endpoints/playlists.js";
+import ActivityToolbar from "./ActivityToolbar";
+import ActivityInfoModal from "./ActivityInfoModal";
+import {
+  getMissingJobKey,
+  isCutoffUnmetAurralJob,
+  isMissingAurralJob,
+  sortMissingJobs,
+} from "./activityMissingUtils.js";
+
+const toPlaylistInfo = (status) => {
+  const entries = [
+    ...(Array.isArray(status?.flows) ? status.flows : []).map((entry) => ({
+      ...entry,
+      kind: "flow",
+    })),
+    ...(Array.isArray(status?.sharedPlaylists) ? status.sharedPlaylists : []).map((entry) => ({
+      ...entry,
+      kind: "playlist",
+    })),
+  ];
+  return new Map(entries.map((entry) => [String(entry.id), entry]));
+};
+
+const formatJobDate = (value) => {
+  const date = new Date(Number(value));
+  if (Number.isNaN(date.getTime())) return "";
+  return formatDateTime(date, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+function MissingJobRow({ job, playlist, actionState, onAction, onInfo }) {
+  const isMissing = isMissingAurralJob(job);
+  const isWorking = actionState === "working";
+  const isQueued = actionState === "queued";
+  const operationLabel = playlist?.name || "Aurral operation";
+  const meta = [job.artistName, job.albumName].filter(Boolean).join(" · ") || operationLabel;
+  const hint = isMissing
+    ? job.error || operationLabel
+    : `${job.qualityLabel || "Unknown quality"} · ${
+        job.qualityState === "below-floor" ? "Below cutoff" : "Upgrade available"
+      }`;
+  const statusLabel = isMissing ? "Missing" : isQueued ? "Upgrade queued" : "Cutoff unmet";
+  const StatusIcon = isMissing ? AlertCircle : ArrowUpCircle;
+
+  return (
+    <article className="activity-row">
+      <span
+        className={`activity-row__status activity-row__status--${isMissing ? "failed" : "pending"}`}
+        title={statusLabel}
+        aria-label={statusLabel}
+      >
+        <StatusIcon aria-hidden="true" />
+      </span>
+      <div className="activity-row__details">
+        <h2 className="activity-row__title" title={job.trackName || "Unknown track"}>
+          {job.trackName || "Unknown track"}
+        </h2>
+        <p className="activity-row__meta" title={meta}>
+          {meta}
+        </p>
+        <p className="activity-row__hint" title={job.error || hint}>
+          {hint}
+        </p>
+      </div>
+      <span className="activity-row__status-label">{statusLabel}</span>
+      <time className="activity-row__time" dateTime={job.createdAt ? new Date(Number(job.createdAt)).toISOString() : undefined}>
+        {formatJobDate(job.createdAt)}
+      </time>
+      <div className="activity-row__actions">
+        <TooltipButton
+          className="native-library-icon-button"
+          onClick={() => onAction(job)}
+          disabled={isWorking || isQueued}
+          label={
+            isWorking
+              ? "Queuing search"
+              : isMissing
+                ? "Re-search track"
+                : isQueued
+                  ? "Upgrade queued"
+                  : "Search for upgrade"
+          }
+        >
+          {isWorking ? (
+            <Loader className="animate-spin" aria-hidden="true" />
+          ) : isMissing ? (
+            <RotateCcw aria-hidden="true" />
+          ) : (
+            <Search aria-hidden="true" />
+          )}
+        </TooltipButton>
+        <TooltipButton
+          className="native-library-icon-button"
+          onClick={() => onInfo({ ...job, playlistName: operationLabel })}
+          label={`Show ${job.trackName || "track"} details`}
+        >
+          <Info aria-hidden="true" />
+        </TooltipButton>
+      </div>
+    </article>
+  );
+}
+
+export default function ActivityMissingPage() {
+  const [searchParams] = useSearchParams();
+  const { showError, showSuccess } = useToast();
+  const [jobs, setJobs] = useState([]);
+  const [playlistInfo, setPlaylistInfo] = useState(new Map());
+  const [infoJob, setInfoJob] = useState(null);
+  const [actionStates, setActionStates] = useState({});
+  const [filterValue, setFilterValue] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState("");
+  const activeTab = searchParams.get("tab") === "cutoff" ? "cutoff" : "missing";
+  const showingCutoff = activeTab === "cutoff";
+  const filterPlaceholder = showingCutoff ? "Filter cutoff unmet" : "Filter missing tracks";
+
+  const loadJobs = useCallback(async ({ silent = false } = {}) => {
+    if (silent) setRefreshing(true);
+    else setLoading(true);
+    setError("");
+    try {
+      const [allJobs, status] = await Promise.all([getAllFlowJobs(), getFlowStatus()]);
+      const upgradeJobIds = new Set(
+        (Array.isArray(allJobs) ? allJobs : [])
+          .filter((job) => job?.upgradeForJobId && ["pending", "downloading"].includes(job.status))
+          .map((job) => String(job.upgradeForJobId)),
+      );
+      setJobs(
+        (Array.isArray(allJobs) ? allJobs : [])
+          .filter((job) => isMissingAurralJob(job) || isCutoffUnmetAurralJob(job))
+          .map((job) => ({ ...job, upgradeQueued: upgradeJobIds.has(String(job.id)) }))
+          .sort(sortMissingJobs),
+      );
+      setActionStates({});
+      setPlaylistInfo(toPlaylistInfo(status));
+    } catch (requestError) {
+      setError(
+          requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          "Failed to load wanted tracks",
+      );
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadJobs();
+  }, [loadJobs]);
+
+  const visibleJobs = useMemo(() => {
+    const query = filterValue.trim().toLocaleLowerCase();
+    return jobs.filter((job) => {
+      if (showingCutoff ? !isCutoffUnmetAurralJob(job) : !isMissingAurralJob(job)) return false;
+      if (!query) return true;
+      return [job.trackName, job.artistName, job.albumName, job.error]
+        .filter(Boolean)
+        .join(" ")
+        .toLocaleLowerCase()
+        .includes(query);
+    });
+  }, [filterValue, jobs, showingCutoff]);
+
+  const handleAction = async (job) => {
+    const id = getMissingJobKey(job);
+    if (!id || actionStates[id]) return;
+    const isMissing = isMissingAurralJob(job);
+    setActionStates((current) => ({ ...current, [id]: "working" }));
+    try {
+      if (isMissing) {
+        const playlist = playlistInfo.get(String(job.playlistType));
+        const reSearch = playlist?.kind === "playlist"
+          ? reSearchSharedPlaylistTrack
+          : reSearchFlowTrack;
+        await reSearch(job.playlistType, job.id);
+        setJobs((current) => current.filter((entry) => getMissingJobKey(entry) !== id));
+        showSuccess(`Re-searching ${job.trackName || "track"}`);
+      } else {
+        await searchTrackUpgrade(job.playlistType, job.id);
+        setActionStates((current) => ({ ...current, [id]: "queued" }));
+        showSuccess(`Upgrade search queued for ${job.trackName || "track"}`);
+      }
+    } catch (requestError) {
+      setActionStates((current) => {
+        const next = { ...current };
+        delete next[id];
+        return next;
+      });
+      showError(
+        requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          (isMissing ? "Failed to re-search track" : "Failed to search for an upgrade"),
+      );
+    }
+  };
+
+  if (loading) {
+    return (
+      <div>
+        <ActivityToolbar
+          filterValue={filterValue}
+          onFilterChange={setFilterValue}
+          onRefresh={() => loadJobs({ silent: true })}
+          refreshing={refreshing}
+          placeholder={filterPlaceholder}
+        />
+        <div className="activity-page__loading">
+          <Loader className="artist-spinner artist-spinner--large animate-spin" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="activity-page__missing" aria-label="Wanted tracks">
+      <ActivityToolbar
+        filterValue={filterValue}
+        onFilterChange={setFilterValue}
+        onRefresh={() => loadJobs({ silent: true })}
+        refreshing={refreshing}
+        placeholder={filterPlaceholder}
+      />
+      {error ? (
+        <div className="artist-error-panel" role="alert">
+          <AlertCircle className="artist-error-icon" aria-hidden="true" />
+          <h2 className="artist-error-title">Unable to load wanted tracks</h2>
+          <p className="artist-error-copy">{error}</p>
+          <button type="button" className="btn btn-secondary btn--bold" onClick={() => loadJobs()}>
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {!error && visibleJobs.length === 0 ? (
+        <div className="search-empty-panel">
+          <div className="search-empty-panel__icon" aria-hidden="true">
+            <CheckCircle2 className="artist-icon-lg" />
+          </div>
+          <h2 className="search-empty-panel__title">
+            {showingCutoff ? "No cutoff gaps" : "No missing tracks"}
+          </h2>
+          <p className="search-empty-panel__message">
+            {showingCutoff
+              ? "Every Aurral-owned file currently meets the configured quality cutoff."
+              : "Every Aurral operation currently has a track available or in progress."}
+          </p>
+        </div>
+      ) : null}
+
+      {!error && visibleJobs.length > 0 ? (
+        <div className="activity-list">
+          {visibleJobs.map((job) => (
+            <MissingJobRow
+              key={getMissingJobKey(job)}
+              job={job}
+              playlist={playlistInfo.get(String(job.playlistType))}
+              actionState={actionStates[getMissingJobKey(job)] || (job.upgradeQueued ? "queued" : "")}
+              onAction={handleAction}
+              onInfo={setInfoJob}
+            />
+          ))}
+        </div>
+      ) : null}
+      <ActivityInfoModal item={infoJob} onClose={() => setInfoJob(null)} />
+    </section>
+  );
+}

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -28,6 +28,8 @@ import {
   sortMissingJobs,
 } from "./activityMissingUtils.js";
 
+const WANTED_PAGE_SIZE = 25;
+
 const toPlaylistInfo = (status) => {
   const entries = [
     ...(Array.isArray(status?.flows) ? status.flows : []).map((entry) => ({
@@ -42,9 +44,16 @@ const toPlaylistInfo = (status) => {
   return new Map(entries.map((entry) => [String(entry.id), entry]));
 };
 
+const toJobDate = (value) => {
+  if (value == null || (typeof value === "string" && !value.trim())) return null;
+  const numericValue = Number(value);
+  const date = new Date(Number.isFinite(numericValue) ? numericValue : value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 const formatJobDate = (value) => {
-  const date = new Date(Number(value));
-  if (Number.isNaN(date.getTime())) return "";
+  const date = toJobDate(value);
+  if (!date) return "";
   return formatDateTime(date, {
     month: "short",
     day: "numeric",
@@ -88,7 +97,7 @@ function MissingJobRow({ job, playlist, actionState, onAction, onInfo }) {
         </p>
       </div>
       <span className="activity-row__status-label">{statusLabel}</span>
-      <time className="activity-row__time" dateTime={job.createdAt ? new Date(Number(job.createdAt)).toISOString() : undefined}>
+      <time className="activity-row__time" dateTime={toJobDate(job.createdAt)?.toISOString()}>
         {formatJobDate(job.createdAt)}
       </time>
       <div className="activity-row__actions">
@@ -136,10 +145,15 @@ export default function ActivityMissingPage() {
   const [filterValue, setFilterValue] = useState("");
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(WANTED_PAGE_SIZE);
   const [error, setError] = useState("");
   const activeTab = searchParams.get("tab") === "cutoff" ? "cutoff" : "missing";
   const showingCutoff = activeTab === "cutoff";
   const filterPlaceholder = showingCutoff ? "Filter cutoff unmet" : "Filter missing tracks";
+
+  useEffect(() => {
+    setVisibleCount(WANTED_PAGE_SIZE);
+  }, [activeTab]);
 
   const loadJobs = useCallback(async ({ silent = false } = {}) => {
     if (silent) setRefreshing(true);
@@ -189,6 +203,8 @@ export default function ActivityMissingPage() {
         .includes(query);
     });
   }, [filterValue, jobs, showingCutoff]);
+  const pagedJobs = visibleJobs.slice(0, visibleCount);
+  const hasMoreJobs = visibleCount < visibleJobs.length;
 
   const handleAction = async (job) => {
     const id = getMissingJobKey(job);
@@ -279,7 +295,7 @@ export default function ActivityMissingPage() {
 
       {!error && visibleJobs.length > 0 ? (
         <div className="activity-list">
-          {visibleJobs.map((job) => (
+          {pagedJobs.map((job) => (
             <MissingJobRow
               key={getMissingJobKey(job)}
               job={job}
@@ -289,6 +305,17 @@ export default function ActivityMissingPage() {
               onInfo={setInfoJob}
             />
           ))}
+          {hasMoreJobs ? (
+            <div className="activity-list__load-more">
+              <button
+                type="button"
+                className="btn btn-secondary btn--bold btn-min-h"
+                onClick={() => setVisibleCount((count) => count + WANTED_PAGE_SIZE)}
+              >
+                Load more
+              </button>
+            </div>
+          ) : null}
         </div>
       ) : null}
       <ActivityInfoModal item={infoJob} onClose={() => setInfoJob(null)} />

--- a/frontend/src/pages/activity/ActivityRequestRow.jsx
+++ b/frontend/src/pages/activity/ActivityRequestRow.jsx
@@ -117,18 +117,7 @@ export default function ActivityRequestRow({
   };
 
   return (
-    <article
-      className={`activity-row${canNavigate ? " is-clickable" : ""}`}
-      onClick={navigate}
-      onKeyDown={(event) => {
-        if (canNavigate && (event.key === "Enter" || event.key === " ")) {
-          event.preventDefault();
-          navigate();
-        }
-      }}
-      tabIndex={canNavigate ? 0 : undefined}
-      aria-label={canNavigate ? `Open ${rowLabel}` : undefined}
-    >
+    <article className="activity-row">
       <span
         className={`activity-row__status activity-row__status--${status.tone}`}
         title={status.label}
@@ -137,8 +126,20 @@ export default function ActivityRequestRow({
         <StatusIcon className={status.spinning ? "animate-spin" : ""} aria-hidden="true" />
       </span>
       <div className="activity-row__details">
-        <h2 className="activity-row__title" title={displayTitle}>
-          {displayTitle}
+        <h2 className="activity-row__title">
+          {canNavigate ? (
+            <button
+              type="button"
+              className="activity-row__title-button"
+              title={displayTitle}
+              aria-label={`Open ${rowLabel}`}
+              onClick={navigate}
+            >
+              {displayTitle}
+            </button>
+          ) : (
+            displayTitle
+          )}
         </h2>
         <p className="activity-row__meta" title={displayMeta}>
           {displayMeta}
@@ -153,6 +154,7 @@ export default function ActivityRequestRow({
             {request.sourceFilename}
           </p>
         ) : null}
+        {jobError ? <span className="activity-row__error" role="alert">{jobError}</span> : null}
       </div>
       <span className="activity-row__status-label">{status.label}</span>
       <time className="activity-row__time" dateTime={request.requestedAt || undefined}>
@@ -186,7 +188,6 @@ export default function ActivityRequestRow({
             </TooltipButton>
           </>
         ) : null}
-        {jobError ? <span className="activity-row__error" role="alert">{jobError}</span> : null}
         {canReSearch ? (
           <TooltipButton
             className="native-library-icon-button"

--- a/frontend/src/pages/activity/ActivityRequestRow.jsx
+++ b/frontend/src/pages/activity/ActivityRequestRow.jsx
@@ -1,64 +1,59 @@
 import {
-  Loader,
-  Clock,
-  CheckCircle2,
   AlertCircle,
+  CheckCircle2,
+  Clock,
+  Eye,
+  Info,
+  Loader,
+  Pause,
+  Play,
   RotateCcw,
   XCircle,
-  Play,
-  Pause,
-  Eye,
 } from "lucide-react";
+import TooltipButton from "../../components/TooltipButton";
 import { formatReviewReasonSummary, formatTimelineTime } from "./activityListUtils";
 
-function RequestStatusBadge({ request }) {
+function getStatusMeta(request) {
   if (request.status === "completed" || request.status === "available") {
-    return (
-      <span className="requests-page__badge requests-page__badge--success">
-        <CheckCircle2 className="artist-icon-xs" />
-        {request.statusLabel || "Done"}
-      </span>
-    );
+    return { icon: CheckCircle2, label: request.statusLabel || "Done", tone: "success" };
   }
-
   if (request.status === "failed") {
-    return (
-      <span className="requests-page__badge requests-page__badge--failed">
-        <AlertCircle className="artist-icon-xs" />
-        {request.statusLabel || "Failed"}
-      </span>
-    );
+    return { icon: AlertCircle, label: request.statusLabel || "Failed", tone: "failed" };
   }
-
   if (request.status === "blocked") {
-    return (
-      <span className="requests-page__badge requests-page__badge--review">
-        <Eye className="artist-icon-xs" />
-        {request.statusLabel || "Review"}
-      </span>
-    );
+    return { icon: Eye, label: request.statusLabel || "Needs review", tone: "review" };
   }
-
   if (request.status === "processing" || request.status === "pending") {
-    return (
-      <span className="requests-page__badge requests-page__badge--active">
-        <Loader className="artist-icon-xs animate-spin" />
-        {request.statusLabel || "In progress"}
-      </span>
-    );
+    return {
+      icon: Loader,
+      label: request.statusLabel || "In progress",
+      tone: "active",
+      spinning: true,
+    };
   }
+  return { icon: Clock, label: request.statusLabel || "Requested", tone: "pending" };
+}
 
+function getRequestTitle(request) {
   return (
-    <span className="requests-page__badge requests-page__badge--pending">
-      <Clock className="artist-icon-xs" />
-      {request.statusLabel || "Requested"}
-    </span>
+    String(request.trackName || "").trim() ||
+    String(request.albumName || "").trim() ||
+    String(request.name || "").trim() ||
+    String(request.title || "").trim() ||
+    "Activity"
   );
+}
+
+function getRequestMeta(request, title) {
+  const artist = String(request.artistName || "").trim();
+  const album = String(request.albumName || "").trim();
+  const isTrack = Boolean(request.trackName);
+  const values = [artist, isTrack && album !== title ? album : null].filter(Boolean);
+  return values.join(" · ") || String(request.subtitle || "").trim() || "Aurral activity";
 }
 
 export default function ActivityRequestRow({
   request,
-  rowIndex = 0,
   reSearchingAlbumIds,
   approvingJobId,
   denyingJobId,
@@ -70,6 +65,7 @@ export default function ActivityRequestRow({
   onApprove,
   onDeny,
   onPreview,
+  onInfo,
 }) {
   const isSlskd = request.source === "slskd";
   const isUsenet = request.source === "nzbget" || request.source === "sabnzbd";
@@ -79,38 +75,21 @@ export default function ActivityRequestRow({
   const isAurral = request.source === "aurral" && !isTrackDownload;
   const isActivity = request.type === "activity";
   const isAlbum = request.type === "album";
-  const usesTitleSubtitle = isTrackDownload || isAurral || isActivity;
   const isBlockedTrack =
     request.kind === "track_download" && request.status === "blocked" && !!request.jobId;
   const trackName =
     String(request.trackName || "").trim() ||
     request.title?.replace(/^Review needed for /, "") ||
     "track";
-  const displayName = isBlockedTrack
-    ? trackName
-    : usesTitleSubtitle
-      ? request.title
-      : isAlbum
-        ? request.albumName
-        : request.name;
-  const rowArtistName = request.artistName || null;
-  const rowAlbumName = String(request.albumName || "").trim() || null;
-  const requesterName = String(request.requestedBy?.username || "").trim() || null;
-  const metaLine = usesTitleSubtitle ? request.subtitle || null : rowArtistName;
-  const reviewReasonSummary = isBlockedTrack
-    ? formatReviewReasonSummary(request.subtitle)
-    : null;
-  const displayMetaLine = isBlockedTrack
-    ? null
-    : [metaLine, requesterName].filter(Boolean).join(" · ");
-  const reviewIdentityLine = isBlockedTrack
-    ? [rowArtistName, rowAlbumName, requesterName].filter(Boolean).join(" · ")
-    : null;
+  const displayTitle = getRequestTitle(request);
+  const displayMeta = getRequestMeta(request, displayTitle);
   const artistMbid = isAlbum ? request.artistMbid : request.mbid;
   const canNavigate =
     ((isSlskd || isUsenet || isYtdlp) && request.playlistId) ||
     ((isAurral || isActivity) && request.href) ||
     (artistMbid && artistMbid !== "null" && artistMbid !== "undefined");
+  const status = getStatusMeta(request);
+  const StatusIcon = status.icon;
   const timelineTime = formatTimelineTime(request.requestedAt);
   const canReSearch =
     request.canReSearch === true && request.albumId && !reSearchingAlbumIds[request.albumId];
@@ -119,160 +98,112 @@ export default function ActivityRequestRow({
   const isDenying = denyingJobId === request.jobId;
   const isThisPlaying = currentTrack?.id === String(request.jobId) && isPlaying;
   const jobError = jobErrors[request.jobId];
-  const displayRequest =
-    isReSearching && request.status === "failed"
-      ? {
-          ...request,
-          status: "processing",
-          statusLabel: "Searching",
-        }
-      : request;
+  const reviewReasonSummary = isBlockedTrack
+    ? formatReviewReasonSummary(request.subtitle)
+    : null;
+  const rowLabel = `${displayTitle}${displayMeta ? `, ${displayMeta}` : ""}`;
+
+  const navigate = () => {
+    if (!canNavigate) return;
+    onNavigate(request, {
+      isSlskd,
+      isUsenet,
+      isAurral,
+      isAlbum,
+      artistMbid,
+      artistName: request.artistName || null,
+      displayName: displayTitle,
+    });
+  };
 
   return (
     <article
-      className={`requests-page__row${rowIndex % 2 === 1 ? " requests-page__row--alt" : ""}${canNavigate ? " is-clickable" : ""}${isBlockedTrack ? " requests-page__row--review" : ""}`}
-      onClick={() => {
-        if (!canNavigate) return;
-        onNavigate(request, {
-          isSlskd,
-          isUsenet,
-          isAurral,
-          isAlbum,
-          artistMbid,
-          artistName: rowArtistName,
-          displayName,
-        });
+      className={`activity-row${canNavigate ? " is-clickable" : ""}`}
+      onClick={navigate}
+      onKeyDown={(event) => {
+        if (canNavigate && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          navigate();
+        }
       }}
+      tabIndex={canNavigate ? 0 : undefined}
+      aria-label={canNavigate ? `Open ${rowLabel}` : undefined}
     >
-      <div className="requests-page__details">
-        <h3 className="requests-page__item-title" title={displayName}>
-          {displayName}
-        </h3>
-        {isBlockedTrack ? (
-          <div className="requests-page__review-lines">
-            {(timelineTime || reviewIdentityLine) && (
-              <div className="requests-page__meta">
-                {timelineTime && (
-                  <time className="requests-page__meta-time" dateTime={request.requestedAt}>
-                    {timelineTime}
-                  </time>
-                )}
-                {timelineTime && reviewIdentityLine && (
-                  <span className="requests-page__meta-separator" aria-hidden="true">
-                    ·
-                  </span>
-                )}
-                {reviewIdentityLine && (
-                  <span className="artist-truncate" title={reviewIdentityLine}>
-                    {reviewIdentityLine}
-                  </span>
-                )}
-              </div>
-            )}
-            {request.sourceFilename && (
-              <div className="requests-page__review-path" title={request.sourceFilename}>
-                {request.sourceFilename}
-              </div>
-            )}
-            {reviewReasonSummary && (
-              <div className="requests-page__review-reason" title={request.subtitle || reviewReasonSummary}>
-                {reviewReasonSummary}
-              </div>
-            )}
-          </div>
-        ) : (
-          (timelineTime || displayMetaLine) && (
-            <div className="requests-page__meta">
-              {timelineTime && (
-                <time className="requests-page__meta-time" dateTime={request.requestedAt}>
-                  {timelineTime}
-                </time>
-              )}
-              {timelineTime && displayMetaLine && (
-                <span className="requests-page__meta-separator" aria-hidden="true">
-                  ·
-                </span>
-              )}
-              {displayMetaLine && (
-                <span className="artist-truncate" title={displayMetaLine}>
-                  {displayMetaLine}
-                </span>
-              )}
-            </div>
-          )
-        )}
+      <span
+        className={`activity-row__status activity-row__status--${status.tone}`}
+        title={status.label}
+        aria-label={status.label}
+      >
+        <StatusIcon className={status.spinning ? "animate-spin" : ""} aria-hidden="true" />
+      </span>
+      <div className="activity-row__details">
+        <h2 className="activity-row__title" title={displayTitle}>
+          {displayTitle}
+        </h2>
+        <p className="activity-row__meta" title={displayMeta}>
+          {displayMeta}
+        </p>
+        {reviewReasonSummary ? (
+          <p className="activity-row__hint" title={request.subtitle || reviewReasonSummary}>
+            {reviewReasonSummary}
+          </p>
+        ) : null}
+        {request.sourceFilename ? (
+          <p className="activity-row__hint" title={request.sourceFilename}>
+            {request.sourceFilename}
+          </p>
+        ) : null}
       </div>
-
-      <div className="requests-page__status" onClick={(event) => event.stopPropagation()}>
-        <RequestStatusBadge request={displayRequest} />
-        <div className="requests-page__actions">
-          {isBlockedTrack && (
-            <>
-              <button
-                type="button"
-                className="btn btn-secondary btn--icon requests-page__action"
-                aria-label={isThisPlaying ? "Pause preview" : "Play preview"}
-                title={isThisPlaying ? "Pause" : "Preview"}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onPreview(request.jobId, trackName, rowArtistName);
-                }}
-              >
-                {isThisPlaying ? (
-                  <Pause className="artist-icon-xs" />
-                ) : (
-                  <Play className="artist-icon-xs" />
-                )}
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary btn--icon requests-page__action"
-                aria-label="Approve track"
-                title="Approve"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onApprove(request.jobId);
-                }}
-                disabled={isApproving || isDenying}
-              >
-                {isApproving ? (
-                  <Loader className="artist-icon-xs animate-spin" />
-                ) : (
-                  <CheckCircle2 className="artist-icon-xs" />
-                )}
-              </button>
-              <button
-                type="button"
-                className="btn btn-secondary btn--icon requests-page__action"
-                aria-label="Deny track"
-                title="Deny"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onDeny(request.jobId);
-                }}
-                disabled={isApproving || isDenying}
-              >
-                {isDenying ? (
-                  <Loader className="artist-icon-xs animate-spin" />
-                ) : (
-                  <XCircle className="artist-icon-xs" />
-                )}
-              </button>
-            </>
-          )}
-          {jobError && <span className="requests-page__inline-error">{jobError}</span>}
-          {canReSearch && (
-            <button
-              type="button"
-              className="btn btn-secondary btn--icon requests-page__action"
-              aria-label={`Re-search ${request.albumName || displayName}`}
-              title="Re-search"
-              onClick={() => onReSearch(request)}
+      <span className="activity-row__status-label">{status.label}</span>
+      <time className="activity-row__time" dateTime={request.requestedAt || undefined}>
+        {timelineTime}
+      </time>
+      <div className="activity-row__actions" onClick={(event) => event.stopPropagation()}>
+        {isBlockedTrack ? (
+          <>
+            <TooltipButton
+              className="native-library-icon-button"
+              onClick={() => onPreview(request.jobId, trackName, request.artistName)}
+              label={isThisPlaying ? "Pause preview" : "Preview track"}
             >
-              <RotateCcw className="artist-icon-xs" />
-            </button>
-          )}
-        </div>
+              {isThisPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
+            </TooltipButton>
+            <TooltipButton
+              className="native-library-icon-button"
+              onClick={() => onApprove(request.jobId)}
+              disabled={isApproving || isDenying}
+              label="Approve track"
+            >
+              {isApproving ? <Loader className="animate-spin" aria-hidden="true" /> : <CheckCircle2 aria-hidden="true" />}
+            </TooltipButton>
+            <TooltipButton
+              className="native-library-icon-button"
+              onClick={() => onDeny(request.jobId)}
+              disabled={isApproving || isDenying}
+              label="Deny track"
+            >
+              {isDenying ? <Loader className="animate-spin" aria-hidden="true" /> : <XCircle aria-hidden="true" />}
+            </TooltipButton>
+          </>
+        ) : null}
+        {jobError ? <span className="activity-row__error" role="alert">{jobError}</span> : null}
+        {canReSearch ? (
+          <TooltipButton
+            className="native-library-icon-button"
+            onClick={() => onReSearch(request)}
+            disabled={isReSearching}
+            label={isReSearching ? "Re-searching" : "Re-search"}
+          >
+            <RotateCcw className={isReSearching ? "animate-spin" : ""} aria-hidden="true" />
+          </TooltipButton>
+        ) : null}
+        <TooltipButton
+          className="native-library-icon-button"
+          onClick={() => onInfo?.(request)}
+          label={`Show ${displayTitle} details`}
+        >
+          <Info aria-hidden="true" />
+        </TooltipButton>
       </div>
     </article>
   );

--- a/frontend/src/pages/activity/ActivityToolbar.jsx
+++ b/frontend/src/pages/activity/ActivityToolbar.jsx
@@ -1,0 +1,67 @@
+import { RefreshCw, Search, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import TooltipButton from "../../components/TooltipButton";
+
+export default function ActivityToolbar({
+  filterValue,
+  onFilterChange,
+  onRefresh,
+  refreshing = false,
+  placeholder = "Filter activity",
+}) {
+  const [filterOpen, setFilterOpen] = useState(Boolean(filterValue));
+
+  useEffect(() => {
+    if (filterValue) setFilterOpen(true);
+  }, [filterValue]);
+
+  const toggleFilter = () => {
+    if (filterOpen) onFilterChange("");
+    setFilterOpen((open) => !open);
+  };
+
+  return (
+    <div className="activity-toolbar">
+      <div className="activity-toolbar__group">
+        <TooltipButton
+          className="native-library-icon-button"
+          onClick={onRefresh}
+          disabled={refreshing}
+          label={refreshing ? "Refreshing" : "Refresh"}
+          aria-label="Refresh activity"
+        >
+          <RefreshCw className={refreshing ? "animate-spin" : ""} aria-hidden="true" />
+        </TooltipButton>
+      </div>
+      <div className="activity-toolbar__group">
+        {filterOpen ? (
+          <label className="activity-toolbar__filter">
+            <Search aria-hidden="true" />
+            <input
+              type="search"
+              value={filterValue}
+              onChange={(event) => onFilterChange(event.target.value)}
+              placeholder={placeholder}
+              aria-label={placeholder}
+              autoFocus
+            />
+            {filterValue ? (
+              <TooltipButton label="Clear filter" onClick={() => onFilterChange("")}>
+                <X aria-hidden="true" />
+              </TooltipButton>
+            ) : null}
+          </label>
+        ) : null}
+        <TooltipButton
+          className={`native-library-icon-button${filterOpen ? " is-active" : ""}`}
+          onClick={toggleFilter}
+          label={filterOpen ? "Close filter" : "Filter"}
+          aria-label={filterOpen ? "Close activity filter" : "Filter activity"}
+          aria-pressed={filterOpen}
+        >
+          <Search aria-hidden="true" />
+        </TooltipButton>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/activity/activityMissingUtils.js
+++ b/frontend/src/pages/activity/activityMissingUtils.js
@@ -1,0 +1,13 @@
+export const isMissingAurralJob = (job) =>
+  job?.status === "failed" && !job?.upgradeForJobId;
+
+export const isCutoffUnmetAurralJob = (job) =>
+  job?.status === "done" &&
+  job?.qualityOwned === true &&
+  job?.qualityState !== "preferred";
+
+export const getMissingJobKey = (job) => String(job?.id || "");
+
+export const sortMissingJobs = (left, right) =>
+  Number(right?.createdAt || 0) - Number(left?.createdAt || 0) ||
+  String(left?.trackName || "").localeCompare(String(right?.trackName || ""));

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -6,7 +6,6 @@ import {
   Pause,
   Shuffle,
   Search,
-  MoreHorizontal,
   ArrowUp,
   ArrowDown,
   Plus,
@@ -18,6 +17,7 @@ import { Link } from "react-router-dom";
 import { useAudioQueue } from "../../../contexts/audioQueueContext";
 import { normalizeFlowTrack } from "../../../utils/audioQueue";
 import { TrackPlaylistMenu, TrackPlaylistSubmenu } from "../../ArtistDetails/components/TrackPlaylistMenu";
+import { LibraryItemMenu } from "../../../components/LibraryItemMenu";
 import { PlaylistArtworkThumb } from "./PlaylistArtworkThumb.jsx";
 
 function getTrackStatusMeta(status) {
@@ -187,185 +187,84 @@ function FlowTrackKebabMenu({
   onDelete,
   playlistMenuProps = null,
 }) {
-  const [isOpen, setIsOpen] = useState(false);
   const [openSubmenu, setOpenSubmenu] = useState(null);
-  const [menuPosition, setMenuPosition] = useState(null);
-  const menuRef = useRef(null);
-  const triggerRef = useRef(null);
-  const onLoadPlaylistsRef = useRef(playlistMenuProps?.onLoadPlaylists);
-  onLoadPlaylistsRef.current = playlistMenuProps?.onLoadPlaylists;
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        setIsOpen(false);
-        setOpenSubmenu(null);
-        setMenuPosition(null);
-      }
-    };
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    onLoadPlaylistsRef.current?.();
-  }, [isOpen]);
-
-  const close = () => {
-    setIsOpen(false);
-    setOpenSubmenu(null);
-    setMenuPosition(null);
-  };
   const trackLabel = track?.trackName || "track";
-  const openMenu = () => {
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (rect) {
-      const menuWidth = 216;
-      const viewportPadding = 12;
-      setMenuPosition({
-        top: rect.bottom + 8,
-        left: Math.min(
-          Math.max(viewportPadding, rect.right - menuWidth),
-          window.innerWidth - menuWidth - viewportPadding,
-        ),
-      });
-    }
-    setIsOpen(true);
-  };
-
+  const actionItems = [
+    canReSearch
+      ? {
+          id: "re-search",
+          label: track.status === "done" ? "Search for upgrade" : "Re-search",
+          icon: Search,
+          disabled: isReSearching,
+          onSelect: () => onReSearch?.(track),
+        }
+      : null,
+    canDelete
+      ? {
+          id: "remove",
+          label: "Remove from playlist",
+          icon: Trash2,
+          danger: true,
+          disabled: isDeleting,
+          onSelect: () => onDelete?.(track),
+        }
+      : null,
+  ].filter(Boolean);
+  const additionalItemsAfter = canReSearch ? "re-search" : "remove";
   return (
-    <div
-      className={`flow-page__track-menu${isOpen ? " is-open" : ""}`}
-      ref={menuRef}
-    >
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          if (isOpen) {
-            close();
-            return;
-          }
-          openMenu();
-        }}
-        className="btn btn-secondary btn-icon btn-xs flow-page__track-menu-trigger"
-        aria-label={`Options for ${trackLabel}`}
-        title={`Options for ${trackLabel}`}
-        aria-expanded={isOpen}
-        aria-haspopup="menu"
-      >
-        <MoreHorizontal className="artist-icon-xs" />
-      </button>
-      {isOpen ? (
+    <LibraryItemMenu
+      label={trackLabel}
+      items={actionItems}
+      additionalItemsAfter={additionalItemsAfter}
+      onMenuOpen={() => {
+        setOpenSubmenu(null);
+        playlistMenuProps?.onLoadPlaylists?.();
+      }}
+      renderAdditionalItems={({ closeMenu }) => (
         <>
-          <button
-            type="button"
-            className="artist-backdrop-button"
-            onClick={close}
-            aria-label="Close track menu"
-          />
-          <div
-            className="artist-floating-menu flow-page__track-menu-dropdown"
-            style={{
-              top: menuPosition?.top ?? 0,
-              left: menuPosition?.left ?? 0,
-            }}
-            role="menu"
-          >
-            {canReSearch ? (
-              <button
-                type="button"
-                role="menuitem"
-                className="artist-menu-item"
-                disabled={isReSearching}
-                onClick={() => {
-                  onReSearch?.(track);
-                  close();
-                }}
-              >
-                <span className="artist-menu-item__main">
-                  {isReSearching ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
-                  ) : (
-                    <Search className="artist-icon-sm" />
-                  )}
-                  {track.status === "done" ? "Search for upgrade" : "Re-search"}
-                </span>
-              </button>
-            ) : null}
-            {playlistMenuProps?.onAddTrackToPlaylist ? (
-              <TrackPlaylistSubmenu
-                label="Add to playlist"
-                icon={Plus}
-                track={playlistMenuProps.track}
-                playlists={playlistMenuProps.playlists}
-                loading={playlistMenuProps.loading}
-                saving={playlistMenuProps.saving}
-                error={playlistMenuProps.error}
-                defaultNewPlaylistName={playlistMenuProps.defaultNewPlaylistName}
-                excludedPlaylistIds={playlistMenuProps.excludedPlaylistIds}
-                onSelect={playlistMenuProps.onAddTrackToPlaylist}
-                onClose={close}
-                toggleOnClick
-                isOpen={openSubmenu === "add"}
-                onToggle={() =>
-                  setOpenSubmenu((current) =>
-                    current === "add" ? null : "add",
-                  )
-                }
-              />
-            ) : null}
-            {playlistMenuProps?.onMoveTrackToPlaylist ? (
-              <TrackPlaylistSubmenu
-                label="Move to playlist"
-                icon={ListMusic}
-                track={playlistMenuProps.track}
-                playlists={playlistMenuProps.playlists}
-                loading={playlistMenuProps.loading}
-                saving={playlistMenuProps.saving}
-                error={playlistMenuProps.error}
-                defaultNewPlaylistName={playlistMenuProps.defaultNewPlaylistName}
-                excludedPlaylistIds={playlistMenuProps.excludedPlaylistIds}
-                onSelect={playlistMenuProps.onMoveTrackToPlaylist}
-                onClose={close}
-                toggleOnClick
-                isOpen={openSubmenu === "move"}
-                onToggle={() =>
-                  setOpenSubmenu((current) =>
-                    current === "move" ? null : "move",
-                  )
-                }
-              />
-            ) : null}
-            {canDelete ? (
-              <button
-                type="button"
-                role="menuitem"
-                className="artist-menu-item artist-menu-item--danger"
-                disabled={isDeleting}
-                onClick={() => {
-                  onDelete?.(track);
-                  close();
-                }}
-              >
-                <span className="artist-menu-item__main">
-                  {isDeleting ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
-                  ) : (
-                    <Trash2 className="artist-icon-sm" />
-                  )}
-                  Remove from playlist
-                </span>
-              </button>
-            ) : null}
-          </div>
+          {playlistMenuProps?.onAddTrackToPlaylist ? (
+            <TrackPlaylistSubmenu
+              label="Add to playlist"
+              icon={Plus}
+              track={playlistMenuProps.track}
+              playlists={playlistMenuProps.playlists}
+              loading={playlistMenuProps.loading}
+              saving={playlistMenuProps.saving}
+              error={playlistMenuProps.error}
+              defaultNewPlaylistName={playlistMenuProps.defaultNewPlaylistName}
+              excludedPlaylistIds={playlistMenuProps.excludedPlaylistIds}
+              onSelect={playlistMenuProps.onAddTrackToPlaylist}
+              onClose={closeMenu}
+              toggleOnClick
+              isOpen={openSubmenu === "add"}
+              onToggle={() =>
+                setOpenSubmenu((current) => (current === "add" ? null : "add"))
+              }
+            />
+          ) : null}
+          {playlistMenuProps?.onMoveTrackToPlaylist ? (
+            <TrackPlaylistSubmenu
+              label="Move to playlist"
+              icon={ListMusic}
+              track={playlistMenuProps.track}
+              playlists={playlistMenuProps.playlists}
+              loading={playlistMenuProps.loading}
+              saving={playlistMenuProps.saving}
+              error={playlistMenuProps.error}
+              defaultNewPlaylistName={playlistMenuProps.defaultNewPlaylistName}
+              excludedPlaylistIds={playlistMenuProps.excludedPlaylistIds}
+              onSelect={playlistMenuProps.onMoveTrackToPlaylist}
+              onClose={closeMenu}
+              toggleOnClick
+              isOpen={openSubmenu === "move"}
+              onToggle={() =>
+                setOpenSubmenu((current) => (current === "move" ? null : "move"))
+              }
+            />
+          ) : null}
         </>
-      ) : null}
-    </div>
+      )}
+    />
   );
 }
 
@@ -375,7 +274,7 @@ function TrackStatusDot({ status }) {
   const normalized = String(status || "").toLowerCase();
   const isLinkable = normalized !== "done";
   if (isLinkable) {
-    const targetPath = normalized === "blocked" ? "/activity/review" : "/activity/queue";
+    const targetPath = "/activity/queue";
     return (
       <Link
         to={targetPath}
@@ -863,6 +762,7 @@ export function FlowTracksPanel({
                   <tr
                     key={track.id}
                     className={`flow-page__tracks-table-row${isCurrent ? " is-current" : ""}`}
+                    data-library-menu-target={useTrackContextMenu ? "true" : undefined}
                   >
                     <td className="flow-page__tracks-table-index">
                       {editMode ? (

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -178,6 +178,9 @@ export const deleteAlbumFromLibrary = (id, deleteFiles = false) =>
     params: { deleteFiles },
   });
 
+export const deleteTrackFromLibrary = (id) =>
+  deleteData(`/library/tracks/${id}`);
+
 export const getLibraryAlbums = async (artistId) => {
   const data = await getData("/library/albums", {
     params: { artistId },

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -179,7 +179,7 @@ export const deleteAlbumFromLibrary = (id, deleteFiles = false) =>
   });
 
 export const deleteTrackFromLibrary = (id) =>
-  deleteData(`/library/tracks/${id}`);
+  deleteData(`/library/tracks/${encodeURIComponent(id)}`);
 
 export const getLibraryAlbums = async (artistId) => {
   const data = await getData("/library/albums", {

--- a/frontend/src/utils/api/endpoints/playlists.js
+++ b/frontend/src/utils/api/endpoints/playlists.js
@@ -59,6 +59,9 @@ export const getFlowJobs = (flowId, limit = null, options = {}) => {
   });
 };
 
+export const getAllFlowJobs = (options = {}) =>
+  getData("/playlists/jobs", options);
+
 export const createFlow = (payload) => postData("/playlists/flows", payload);
 
 export const updateFlow = (flowId, payload) =>


### PR DESCRIPTION
## Problem

Library items and activity entries did not have consistent actions for managing tracks, albums, artists, and playlists. Activity also split queued review work from Queue, duplicated Wanted filters as page tabs, and sent Info actions to playlist pages instead of showing operation details.

## Solution

- Add contextual item menus and deletion/removal actions across library, artist, album, playlist, and flow surfaces.
- Combine queued work and review items in Activity.
- Add a single Wanted page with Missing and Cutoff unmet sidebar filters, including re-search and upgrade actions.
- Add a Lidarr-style activity details modal and keep Refresh wired to fresh request/job data.
- Update activity documentation and focused frontend coverage.

## Verification

- `npm run lint --workspace frontend`
- Focused Activity tests: 12 passing
- `npm run build --workspace frontend`
- `npm run docs:build`
- `git diff --check`

Known limitation: the full repository test suite, provider-backed coverage, and live preview pass were not run. The shared preview browser refused navigation to the candidate's local port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Wanted views for missing and cutoff-unmet tracks, including filtering, refresh, sorting, and search or upgrade actions.
  - Added library track deletion and playlist removal actions with confirmation and progress feedback.
  - Added richer activity details, status indicators, information dialogs, and contextual menus.
  - Added granular permissions for deleting tracks.
- **Improvements**
  - Consolidated Activity navigation into Queue, History, and Wanted views.
  - Blocked and duration-mismatched items now remain in Queue.
- **Documentation**
  - Updated Activity and integration guidance to reflect the new navigation and item handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->