### PR TITLE
refactor(ui): establish monochrome visual foundation

### DIFF
--- a/frontend/src/components/GlobalPlayerBar.jsx
+++ b/frontend/src/components/GlobalPlayerBar.jsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { useAudioQueue } from "../contexts/audioQueueContext";
+import TooltipButton from "./TooltipButton";
 
 function formatTime(seconds) {
   if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
@@ -129,68 +130,52 @@ function GlobalPlayerBar() {
 
         <div className="global-player__main">
           <div className="global-player__controls">
-            <button
-              type="button"
+            <TooltipButton
+              label={isShuffleEnabled ? "Disable shuffle" : "Enable shuffle"}
               onClick={toggleShuffle}
               className={`btn btn-secondary btn-sm btn-icon global-player__control global-player__shuffle${isShuffleEnabled ? " is-active" : ""}`}
-              aria-label={isShuffleEnabled ? "Disable shuffle" : "Enable shuffle"}
-              title={isShuffleEnabled ? "Disable shuffle" : "Enable shuffle"}
             >
               <Shuffle className="artist-icon-sm" />
-            </button>
-            <button
-              type="button"
+            </TooltipButton>
+            <TooltipButton
+              label="Previous track"
               onClick={playPrevious}
               className="btn btn-secondary btn-sm btn-icon global-player__control"
-              aria-label="Previous track"
-              title="Previous track"
             >
               <SkipBack className="artist-icon-sm" />
-            </button>
-            <button
-              type="button"
+            </TooltipButton>
+            <TooltipButton
+              label={isPlaying ? "Pause" : "Play"}
               onClick={togglePlayPause}
               className="btn btn-accent btn-sm btn-icon global-player__control global-player__control--primary"
-              aria-label={isPlaying ? "Pause" : "Play"}
-              title={isPlaying ? "Pause" : "Play"}
               disabled={isLoading}
             >
               {isPlaying ? <Pause className="artist-icon-sm" /> : <Play className="artist-icon-sm" />}
-            </button>
-            <button
-              type="button"
+            </TooltipButton>
+            <TooltipButton
+              label="Next track"
               onClick={playNext}
               className="btn btn-secondary btn-sm btn-icon global-player__control"
-              aria-label="Next track"
-              title="Next track"
             >
               <SkipForward className="artist-icon-sm" />
-            </button>
-            <button
-              type="button"
+            </TooltipButton>
+            <TooltipButton
+              label={
+                repeatMode === "one"
+                  ? "Repeat one track"
+                  : repeatMode === "all"
+                    ? "Repeat all tracks"
+                    : "Enable repeat"
+              }
               onClick={toggleRepeat}
               className={`btn btn-secondary btn-sm btn-icon global-player__control global-player__repeat${repeatMode !== "off" ? " is-active" : ""}`}
-              aria-label={
-                repeatMode === "one"
-                  ? "Repeat one track"
-                  : repeatMode === "all"
-                    ? "Repeat all tracks"
-                    : "Enable repeat"
-              }
-              title={
-                repeatMode === "one"
-                  ? "Repeat one track"
-                  : repeatMode === "all"
-                    ? "Repeat all tracks"
-                    : "Enable repeat"
-              }
             >
               {repeatMode === "one" ? (
                 <Repeat1 className="artist-icon-sm" />
               ) : (
                 <Repeat className="artist-icon-sm" />
               )}
-            </button>
+            </TooltipButton>
           </div>
 
           <div className="global-player__progress-wrap">
@@ -219,19 +204,17 @@ function GlobalPlayerBar() {
         </div>
 
         <div className="global-player__side">
-          <button
-            type="button"
+          <TooltipButton
+            label={volumePercent <= 0 ? "Unmute" : "Mute"}
             onClick={handleToggleMute}
             className="btn btn-ghost btn-icon btn-xs global-player__volume-toggle"
-            aria-label={volumePercent <= 0 ? "Unmute" : "Mute"}
-            title={volumePercent <= 0 ? "Unmute" : "Mute"}
           >
             {volumePercent <= 0 ? (
               <VolumeX className="artist-icon-sm" />
             ) : (
               <Volume2 className="artist-icon-sm" />
             )}
-          </button>
+          </TooltipButton>
           <input
             type="range"
             min="0"
@@ -243,15 +226,13 @@ function GlobalPlayerBar() {
             style={{ "--volume-percent": `${volumePercent}%` }}
             aria-label="Volume"
           />
-          <button
-            type="button"
+          <TooltipButton
+            label="Close player"
             onClick={clearQueue}
             className="btn btn-ghost btn-icon btn-xs global-player__close"
-            aria-label="Close player"
-            title="Close player"
           >
             <X className="artist-icon-sm" />
-          </button>
+          </TooltipButton>
         </div>
       </div>
     </div>

--- a/frontend/src/components/InboxMenu.jsx
+++ b/frontend/src/components/InboxMenu.jsx
@@ -17,6 +17,7 @@ import {
 import { readStoredNearbyLocation } from "../pages/discoverUtils.js";
 import { useAuth } from "../contexts/AuthContext.jsx";
 import { useToast } from "../contexts/ToastContext";
+import TooltipButton from "./TooltipButton";
 
 const ITEM_ICONS = {
   release: Music2,
@@ -262,36 +263,34 @@ function InboxMenu() {
 
   return (
     <div ref={menuRef} className="app-inbox-menu">
-      <button
-        type="button"
+      <TooltipButton
+        label={unreadCount ? "Inbox, unread notifications" : "Inbox"}
         className={`app-header-link app-inbox-menu__trigger${open ? " is-open" : ""}${unreadCount > 0 ? " has-unread" : ""}`}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={unreadCount ? "Inbox, unread notifications" : "Inbox"}
         onClick={() => {
           setOpen((current) => !current);
           if (!open) void loadInbox();
         }}
       >
         <Inbox aria-hidden="true" />
-      </button>
+      </TooltipButton>
 
       {open ? (
         <div className="app-inbox-menu__dropdown" role="menu">
           <div className="app-inbox-menu__header">
             <span>Inbox</span>
             <span className="app-inbox-menu__header-actions">
-              <button
-                type="button"
+              <TooltipButton
+                label="Filter inbox"
                 className={`app-inbox-menu__header-action${filter !== "all" ? " is-active" : ""}`}
                 aria-label="Filter inbox"
                 aria-haspopup="menu"
                 aria-expanded={filterOpen}
-                title="Filter inbox"
                 onClick={() => setFilterOpen((current) => !current)}
               >
                 <SlidersHorizontal aria-hidden="true" />
-              </button>
+              </TooltipButton>
               {unreadCount > 0 ? (
                 <button type="button" className="app-inbox-menu__read-all" onClick={handleReadAll}>
                   Mark all as read

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -17,6 +17,7 @@ import GlobalSearch from "./GlobalSearch";
 import GlobalPlayerBar from "./GlobalPlayerBar";
 import UserProfileMenu from "./UserProfileMenu";
 import InboxMenu from "./InboxMenu";
+import TooltipButton from "./TooltipButton";
 import { useAuth } from "../contexts/AuthContext";
 import { useAudioQueue } from "../contexts/audioQueueContext";
 import { DEFAULT_SETTINGS_TAB } from "../pages/Settings/settingsTabsConfig";
@@ -408,15 +409,14 @@ function Layout({ children, headerActions }) {
         }${isPlayerActive ? " app-content--player-active" : ""}`}
       >
         <header className="app-topbar">
-          <button
+          <TooltipButton
+            label={sidebarMode === "icons" ? "Expand sidebar" : "Collapse to icons"}
             type="button"
             onClick={toggleSidebarPin}
             className="app-nav-toggle"
-            aria-label={sidebarMode === "icons" ? "Expand sidebar" : "Collapse to icons"}
-            title={sidebarMode === "icons" ? "Expand sidebar" : "Collapse to icons"}
           >
             <Menu aria-hidden="true" />
-          </button>
+          </TooltipButton>
 
           <GlobalSearch settingsMode={isSettingsRoute} />
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -25,10 +25,6 @@ import {
 } from "../navigation/activityNavConfig";
 import { DEFAULT_LIBRARY_VIEW, LIBRARY_VIEWS } from "../navigation/libraryNavConfig";
 import { useDiscoverRecent } from "../contexts/DiscoverRecentProvider";
-import {
-  getDiscoverArtistPath,
-  getDiscoverRecentPageLinkState,
-} from "../utils/discoverRecentNavigation";
 import { useStorageHealth } from "../hooks/useStorageHealth";
 import SidebarStageBackdrop, {
   getSidebarStageBackdropEnabled,
@@ -58,11 +54,7 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   );
   const [ticketmasterConfigured, setTicketmasterConfigured] = useState(true);
   const [newsConfigured, setNewsConfigured] = useState(true);
-  const {
-    recentPages: discoverRecentPages,
-    clearRecentPages,
-    isDiscoverSectionActive,
-  } = useDiscoverRecent();
+  const { isDiscoverSectionActive } = useDiscoverRecent();
 
   useEffect(() => {
     setShowStageBackdrop(getSidebarStageBackdropEnabled(user?.id));
@@ -76,9 +68,6 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
   }, [user?.id]);
 
   const isIcons = mode === "icons" && isDesktop;
-  const currentDiscoverPath = `${location.pathname}${location.search}`;
-  const activeDiscoverRecentPath =
-    getDiscoverArtistPath(currentDiscoverPath) || currentDiscoverPath;
   const isOnSettings = location.pathname.startsWith("/settings");
   const isOnLibrary = location.pathname === "/library" || location.pathname.startsWith("/library/");
   const isOnShows = location.pathname.startsWith("/shows");
@@ -185,7 +174,6 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
         label: "Discover",
         icon: Sparkles,
         section: "discover",
-        subnav: discoverRecentPages,
       },
       {
         path: "/library",
@@ -244,7 +232,7 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
       (item) =>
         !item.permission || user?.role === "admin" || !!user?.permissions?.[item.permission],
     );
-  }, [discoverRecentPages, newsConfigured, ticketmasterConfigured, user]);
+  }, [newsConfigured, ticketmasterConfigured, user]);
 
   const translateClass = mode === "hidden" ? "-translate-x-full" : "translate-x-0";
 
@@ -284,29 +272,6 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
           >
             Trending
           </Link>
-          {item.subnav.length > 0 && <hr className="sidebar-subnav-separator" />}
-          {item.subnav.slice(0, 3).map((entry) => {
-            const active = activeId === entry.id;
-            return (
-              <Link
-                key={entry.id}
-                to={entry.path}
-                state={getDiscoverRecentPageLinkState(entry)}
-                className={`sidebar-subnav-link sidebar-subnav-link--recent${
-                  active ? " is-active" : ""
-                }`}
-                aria-current={active ? "page" : undefined}
-                title={entry.label}
-              >
-                <span className="sidebar-subnav-link__text">{entry.label}</span>
-              </Link>
-            );
-          })}
-          {item.subnav.length > 0 && (
-            <button type="button" className="sidebar-subnav-action" onClick={clearRecentPages}>
-              Clear recent
-            </button>
-          )}
         </nav>
       );
     }
@@ -408,17 +373,15 @@ function Sidebar({ mode, width = 208, settingsMode = false }) {
               const active = isNavItemActive(item);
               const showActivityDot = item.section === "activity" && hasReviewAlert;
               const activeSubnavId =
-                item.section === "discover"
-                  ? discoverRecentPages.find((entry) => entry.path === activeDiscoverRecentPath)?.id
-                  : item.section === "library"
-                    ? activeLibraryView
-                      : item.section === "shows"
-                        ? activeShowsFilter
-                        : item.section === "activity"
-                          ? activeActivityView
-                          : item.section === "wanted"
-                            ? activeWantedView
-                          : null;
+                item.section === "library"
+                  ? activeLibraryView
+                  : item.section === "shows"
+                    ? activeShowsFilter
+                    : item.section === "activity"
+                      ? activeActivityView
+                      : item.section === "wanted"
+                        ? activeWantedView
+                        : null;
 
               return (
                 <div key={item.path} className={getNavGroupClassName(item, active)}>

--- a/frontend/src/components/UpdateIndicator.jsx
+++ b/frontend/src/components/UpdateIndicator.jsx
@@ -5,6 +5,7 @@ import {
   normalizeReleaseVersion,
   selectNightlyUpdate,
 } from "../../../lib/release-version";
+import TooltipButton from "./TooltipButton";
 
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const NIGHTLY_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000;
@@ -179,16 +180,15 @@ const UpdateIndicator = ({ currentVersion, visible = true }) => {
 
   return (
     <div ref={indicatorRef} className="app-update-indicator">
-      <button
-        type="button"
+      <TooltipButton
+        label={updateLabel}
         className={`app-header-link app-update-indicator__trigger is-available${menuOpen ? " is-open" : ""}`}
         onClick={() => setMenuOpen((open) => !open)}
-        aria-label={updateLabel}
         aria-haspopup="dialog"
         aria-expanded={menuOpen}
       >
         <Download aria-hidden="true" />
-      </button>
+      </TooltipButton>
 
       {menuOpen && (
         <div className="app-update-indicator__popover" role="dialog" aria-label="Update preview">

--- a/frontend/src/components/UserProfileMenu.jsx
+++ b/frontend/src/components/UserProfileMenu.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { User, Heart, LogOut, ExternalLink } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
+import TooltipButton from "./TooltipButton";
 
 function GitHubIcon({ className = "" }) {
   return (
@@ -40,19 +41,17 @@ function UserProfileMenu() {
 
   return (
     <div ref={menuRef} className="app-profile-menu">
-      <button
-        type="button"
+      <TooltipButton
+        label="User menu"
         onClick={() => setMenuOpen((open) => !open)}
         className={`app-header-link app-profile-menu__trigger${menuOpen ? " is-open" : ""}`}
         aria-haspopup="menu"
         aria-expanded={menuOpen}
-        aria-label="User menu"
-        title="User menu"
       >
         <span className="app-profile-menu__icon" aria-hidden="true">
           <User />
         </span>
-      </button>
+      </TooltipButton>
 
       {menuOpen && (
         <div className="app-profile-menu__dropdown" role="menu">

--- a/frontend/src/contexts/DiscoverRecentProvider.jsx
+++ b/frontend/src/contexts/DiscoverRecentProvider.jsx
@@ -26,6 +26,7 @@ function isDiscoverHomePath(pathname) {
 
 function isDiscoverBrowsePath(pathname) {
   if (!pathname) return false;
+  if (pathname === "/discover/news" || pathname.startsWith("/discover/news/")) return false;
   if (pathname.startsWith("/artist/")) return true;
   if (pathname.startsWith("/discover/")) return true;
   if (pathname === "/search") return true;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,16 +10,16 @@
 :root {
   color-scheme: dark;
   --font-sans: ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
-  --aurral-chrome: light-dark(#e5e7eb, #000000);
-  --aurral-surface: light-dark(#ffffff, #121212);
-  --aurral-text-subtle: light-dark(#737373, #535353);
-  --aurral-text-muted: light-dark(#525252, #b3b3b3);
-  --aurral-text: light-dark(#171717, #ffffff);
-  --aurral-accent: light-dark(#4d7c0f, #84cc16);
-  --aurral-accent-contrast: light-dark(#ffffff, #000000);
+  --aurral-chrome: light-dark(#f5f5f5, #050505);
+  --aurral-surface: light-dark(#ffffff, #111111);
+  --aurral-text-subtle: light-dark(#737373, #666666);
+  --aurral-text-muted: light-dark(#525252, #a3a3a3);
+  --aurral-text: light-dark(#171717, #f5f5f5);
+  --aurral-accent: light-dark(#525252, #b3b3b3);
+  --aurral-accent-contrast: light-dark(#ffffff, #111111);
   --aurral-surface-raised: color-mix(in srgb, var(--aurral-surface) 94%, var(--aurral-text));
   --aurral-surface-popover: color-mix(in srgb, var(--aurral-surface-raised) 94%, var(--aurral-text));
-  --aurral-surface-glass: color-mix(in srgb, var(--aurral-surface-popover) 88%, transparent);
+  --aurral-surface-glass: var(--aurral-surface-popover);
   --aurral-surface-hover: color-mix(in srgb, var(--aurral-surface-popover) 90%, var(--aurral-text));
   --aurral-surface-selected: color-mix(in srgb, var(--aurral-text) 7%, var(--aurral-surface));
   --aurral-surface-mid: var(--aurral-surface-raised);
@@ -48,8 +48,8 @@
   --aurral-border-strong: color-mix(in srgb, var(--aurral-text) 14%, transparent);
   --aurral-shadow-popover: 0 12px 32px rgb(0 0 0 / 0.28);
   --aurral-shadow-modal: 0 24px 64px rgb(0 0 0 / 0.38);
-  --aurral-surface-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
-  --aurral-sidebar-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.012'/%3E%3C/svg%3E");
+  --aurral-surface-grain: none;
+  --aurral-sidebar-grain: none;
   --aurral-space-outer: 0.25rem;
   --aurral-space-page: 0.75rem;
   --aurral-space-page-lg: 1rem;
@@ -826,7 +826,7 @@ textarea {
   width: 100%;
   flex: 1;
   min-height: 0;
-  border: 1px solid var(--aurral-border);
+  border: 0;
   border-radius: var(--aurral-radius);
   background: var(--aurral-surface);
   overflow: hidden;
@@ -909,8 +909,8 @@ textarea {
   display: none;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: var(--aurral-radius-sm);
   color: var(--aurral-text-muted);
   transition:
@@ -923,8 +923,8 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: var(--aurral-radius-sm);
   color: var(--aurral-text-muted);
   transition:
@@ -947,7 +947,7 @@ textarea {
 .app-header-actions {
   display: none;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .app-update-indicator {
@@ -959,10 +959,8 @@ textarea {
   position: relative;
 }
 
-.app-update-indicator__trigger.is-available,
-.app-update-indicator__trigger.is-open,
-.app-update-indicator__trigger:hover {
-  color: var(--aurral-accent);
+.app-update-indicator__trigger.is-available {
+  color: var(--aurral-info);
 }
 
 .app-update-indicator__popover {
@@ -1160,10 +1158,12 @@ textarea {
   left: var(--aurral-space-outer);
   z-index: 50;
   display: none;
+  min-width: 0;
+  max-width: var(--sidebar-width);
   flex-direction: column;
-  border: 1px solid var(--aurral-border);
-  border-radius: var(--aurral-radius-sm);
-  background: var(--aurral-surface);
+  border: 0;
+  border-radius: 0;
+  background: var(--aurral-chrome);
   overflow: hidden;
   transition:
     transform 0.3s ease,
@@ -1191,6 +1191,18 @@ textarea {
   --stage-bp-top: #3a7ad1;
   --stage-bp-mid: #2050ae;
   --stage-bp-bottom: #101f6e;
+}
+
+:root[data-theme="light"] .sidebar-shell--nightly .sidebar-title,
+:root[data-theme="light"] .sidebar-shell--preview .sidebar-title {
+  color: #f5f5f5;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) .sidebar-shell--nightly .sidebar-title,
+  :root:not([data-theme]) .sidebar-shell--preview .sidebar-title {
+    color: #f5f5f5;
+  }
 }
 
 [data-resizing] .sidebar-shell,
@@ -1241,11 +1253,10 @@ textarea {
   position: relative;
   z-index: 1;
   display: flex;
-  height: 3.5rem;
+  height: 3.25rem;
   align-items: center;
   justify-content: center;
   padding: 0 0.875rem;
-  border-bottom: 1px solid var(--aurral-border);
 }
 
 .sidebar-logo-link {
@@ -1257,15 +1268,15 @@ textarea {
 }
 
 .sidebar-logo {
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.5rem;
+  height: 1.5rem;
   flex-shrink: 0;
 }
 
 .sidebar-title {
   color: var(--aurral-text);
-  font-size: 1.4rem;
-  font-weight: 800;
+  font-size: 1rem;
+  font-weight: 650;
 }
 
 .sidebar-body {
@@ -1311,36 +1322,6 @@ textarea {
   flex-direction: column;
 }
 
-.sidebar-nav-group.is-expanded,
-.sidebar-nav-group.is-active-row,
-.sidebar-settings-group.is-expanded {
-  background: color-mix(in srgb, var(--aurral-text) 3%, transparent);
-}
-
-.sidebar-shell--nightly .sidebar-nav-group--discover.is-expanded,
-.sidebar-shell--nightly .sidebar-nav-group--discover.is-active-row,
-.sidebar-shell--preview .sidebar-nav-group--discover.is-expanded,
-.sidebar-shell--preview .sidebar-nav-group--discover.is-active-row {
-  background: linear-gradient(
-    to bottom,
-    transparent 0,
-    color-mix(in srgb, var(--aurral-text) 3%, transparent) 2.75rem,
-    color-mix(in srgb, var(--aurral-text) 3%, transparent) 100%
-  );
-}
-
-.sidebar-nav-group.is-expanded::before,
-.sidebar-nav-group.is-active-row::before,
-.sidebar-settings-group.is-expanded::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 2px;
-  background: color-mix(in srgb, var(--aurral-accent) 72%, transparent);
-}
-
 .sidebar-link {
   position: relative;
   z-index: 1;
@@ -1358,17 +1339,17 @@ textarea {
 }
 
 .sidebar-link--full {
-  gap: 0.75rem;
-  min-height: 2.375rem;
+  gap: 0.625rem;
+  min-height: 2.25rem;
   margin-inline: 0.125rem;
-  padding: 0.5rem 0.875rem 0.5rem 1rem;
+  padding: 0.375rem 0.75rem;
 }
 
 .sidebar-link--icons {
   justify-content: center;
   margin-inline: 0.125rem;
   border-radius: var(--aurral-radius-sm);
-  padding: 0.75rem 0.5rem;
+  padding: 0.625rem 0.5rem;
 }
 
 .sidebar-link:hover {
@@ -1409,8 +1390,8 @@ textarea {
 }
 
 .sidebar-link__icon {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.125rem;
+  height: 1.125rem;
   flex-shrink: 0;
 }
 
@@ -1481,7 +1462,6 @@ textarea {
   width: 100%;
   margin-top: auto;
   padding: 0.5rem 0.375rem 0.75rem;
-  border-top: 1px solid var(--aurral-border);
 }
 
 .sidebar-shell--icons .sidebar-settings-group {
@@ -1527,12 +1507,10 @@ textarea {
 
 .sidebar-subnav-link:hover {
   color: var(--aurral-text);
-  background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
 }
 
 .sidebar-subnav-link.is-active {
   color: var(--aurral-text);
-  background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
 }
 
 .sidebar-subnav-link.is-active:hover {
@@ -1541,49 +1519,6 @@ textarea {
 
 .sidebar-subnav-link:active {
   transform: scale(0.98);
-}
-
-.sidebar-subnav-link--recent {
-  overflow: hidden;
-}
-
-.sidebar-subnav-link__text {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sidebar-subnav-action {
-  display: block;
-  width: 100%;
-  min-height: 2rem;
-  margin-top: 0.125rem;
-  padding: 0.4375rem 0.875rem 0.4375rem 2.75rem;
-  border: 0;
-  border-radius: var(--aurral-radius-sm);
-  background: transparent;
-  color: var(--aurral-text-subtle);
-  font-size: 0.75rem;
-  font-weight: 500;
-  line-height: 1.3;
-  text-align: left;
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    background-color 0.15s ease;
-}
-
-.sidebar-subnav-action:hover {
-  color: var(--aurral-text-muted);
-  background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
-}
-
-.sidebar-subnav-separator {
-  height: 1px;
-  border: none;
-  background: var(--aurral-border);
-  margin: 0.5rem 0.75rem;
 }
 
 .global-search {
@@ -1868,7 +1803,7 @@ textarea {
 }
 
 .app-inbox-menu__trigger.has-unread {
-  color: var(--aurral-green);
+  color: var(--aurral-info);
 }
 
 .app-inbox-menu__dropdown {
@@ -2571,7 +2506,7 @@ textarea {
 
 @media (min-width: 1024px) {
   .app-main {
-    padding: 1.25rem;
+    padding: 1rem;
   }
 
   .app-main--artist-details {
@@ -13048,35 +12983,11 @@ button.native-library-genre-row:focus-visible {
   max-width: 32rem;
   padding: 1px;
   border-radius: calc(var(--aurral-radius) + 1px);
-  background: conic-gradient(
-    from var(--onboarding-glow-angle),
-    color-mix(in srgb, var(--aurral-accent) 30%, #1a2e0a) 0deg,
-    color-mix(in srgb, var(--aurral-accent) 20%, var(--aurral-surface)) 95deg,
-    color-mix(in srgb, #fbbf24 30%, #1a2e0a) 180deg,
-    color-mix(in srgb, #fbbf24 20%, var(--aurral-surface)) 275deg,
-    color-mix(in srgb, var(--aurral-accent) 30%, #1a2e0a) 360deg
-  );
-  animation: onboarding-glow-border 10s linear infinite;
+  background: var(--aurral-border);
 }
 
 .onboarding-card-shell::after {
-  content: "";
-  position: absolute;
-  inset: -10px;
-  z-index: -1;
-  border-radius: calc(var(--aurral-radius) + 10px);
-  background: conic-gradient(
-    from var(--onboarding-glow-angle),
-    transparent 0deg,
-    color-mix(in srgb, var(--aurral-accent) 45%, transparent) 120deg,
-    transparent 220deg,
-    color-mix(in srgb, var(--aurral-accent) 28%, transparent) 300deg,
-    transparent 360deg
-  );
-  filter: blur(20px);
-  opacity: 0.35;
-  animation: onboarding-glow-border 12s linear infinite;
-  pointer-events: none;
+  display: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -13638,9 +13549,9 @@ button.native-library-genre-row:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 2fr) minmax(0, 1fr);
   align-items: center;
-  gap: 1.5rem;
-  min-height: 5.25rem;
-  padding: 0.35rem 1.25rem 0.45rem;
+  gap: 1rem;
+  min-height: 4.25rem;
+  padding: 0.25rem 0.875rem 0.35rem;
 }
 
 .global-player__track {
@@ -13697,8 +13608,8 @@ button.native-library-genre-row:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.65rem;
-  min-height: 3rem;
+  gap: 0.5rem;
+  min-height: 2.5rem;
 }
 
 .global-player__control {
@@ -13719,8 +13630,8 @@ button.native-library-genre-row:focus-visible {
 }
 
 .global-player__control--primary {
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-color: transparent;
   border-radius: var(--aurral-radius-round);
   background: var(--aurral-accent);
@@ -13887,8 +13798,8 @@ button.native-library-genre-row:focus-visible {
       "track side"
       "main main";
     gap: 0.2rem 0.75rem;
-    min-height: 5.25rem;
-    padding: 0.5rem 0.85rem 0.45rem;
+    min-height: 4.5rem;
+    padding: 0.35rem 0.75rem 0.3rem;
   }
 
   .global-player__track {
@@ -13914,8 +13825,8 @@ button.native-library-genre-row:focus-visible {
   }
 
   .global-player__control--primary {
-    width: 2.35rem;
-    height: 2.35rem;
+    width: 2.25rem;
+    height: 2.25rem;
   }
 
   .global-player__controls {


### PR DESCRIPTION
Aurral’s shared shell had too much brand green, decorative texture, loose spacing, sidebar clutter, and native tooltips on repeated icon controls.

This refactor establishes a compact monochrome foundation: neutral chrome and surfaces, a borderless sidebar with custom tooltips, a tighter player, quieter submenu states, blue availability indicators, and light text for readable nightly/preview art in light mode. It also keeps News from incorrectly activating Discover.

Verified with `npm run lint --workspace frontend`, `npm run build`, `git diff --check`, and live desktop/mobile checks covering the sidebar, News active state, icon-only mode, player sizing, and nightly art in dark/light modes.

Page-specific content and card redesign remain outside this shared foundation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive tooltips to player, inbox, sidebar, update, and profile controls.
* **Changes**
  * Simplified Discover navigation by removing the Recent section; Playlists, Recommended, and Trending remain available.
  * Updated navigation handling so News pages are excluded from Discover browsing.
* **Style**
  * Refreshed the interface with a neutral grayscale palette, simpler borders, reduced textures, and more compact spacing.
  * Improved light-theme sidebar title styling and streamlined onboarding and subnavigation visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->