### PR TITLE
fix(weekly-flow): fall back to artist + title queries when album tiers find nothing

### DIFF
--- a/.tests/weekly-flow/quality-profile.test.js
+++ b/.tests/weekly-flow/quality-profile.test.js
@@ -92,3 +92,18 @@ test("prefilters advertised candidates without trusting unknown metadata", () =>
   );
   assert.deepEqual(ordered, ["Song.flac", "Song.mp3"]);
 });
+
+test("orderAdvertisedQualityCandidates drops formats that can never satisfy a tier", () => {
+  const profile = normalizeQualityProfile({
+    enabled: ["mp3-320", "m4a-320"],
+    cutoff: "mp3-320",
+  });
+  const ordered = orderAdvertisedQualityCandidates(
+    ["Song.opus", "Song 320kbps.mp3", "Song.ogg", "Song.wav", "Mystery Song.mp3"],
+    {
+      profile,
+      readName: (entry) => entry,
+    },
+  );
+  assert.deepEqual(ordered, ["Song 320kbps.mp3", "Mystery Song.mp3"]);
+});

--- a/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
+++ b/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
@@ -6,6 +6,7 @@ import {
   rankFlowSearchResults,
   selectRankedMatchAttempts,
   stripReleaseTypeSuffix,
+  stripVersionSuffix,
   validateDownloadedTrack,
 } from "../../backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js";
 
@@ -63,6 +64,62 @@ test("buildFlowSearchTiers uses a short album-first plan", () => {
         tier.queries.includes("Mezzanine Teardrop"),
     ),
   );
+});
+
+test("buildFlowSearchTiers appends an artist + title fallback tier after album tiers", () => {
+  const tiers = buildFlowSearchTiers({
+    artistName: "Massive Attack",
+    trackName: "Teardrop",
+    albumName: "Mezzanine",
+    releaseYear: "1998",
+    artistAliases: [],
+  });
+
+  const last = tiers[tiers.length - 1];
+  assert.equal(last?.name, "primary_track");
+  assert.ok(last.queries.includes("Massive Attack Teardrop"));
+  assert.ok(tiers.findIndex((tier) => tier.name === "album_track") < tiers.length - 1);
+});
+
+test("buildFlowSearchTiers fallback tier adds a version-suffix-stripped query", () => {
+  const tiers = buildFlowSearchTiers({
+    artistName: "Milk Inc.",
+    trackName: "Never Again - Single Mix",
+    albumName: "The Best Of",
+    releaseYear: "2007",
+    artistAliases: [],
+  });
+
+  const primary = tiers.find((tier) => tier.name === "primary_track");
+  assert.ok(primary?.queries.includes("Milk Inc. Never Again - Single Mix"));
+  assert.ok(primary?.queries.includes("Milk Inc. Never Again"));
+  assert.ok(primary?.queries.includes("Milk Inc Never Again"));
+});
+
+test("stripVersionSuffix removes trailing version descriptors only", () => {
+  assert.equal(stripVersionSuffix("Never Again - Single Mix"), "Never Again");
+  assert.equal(stripVersionSuffix("Look at me now - Radio Edit"), "Look at me now");
+  assert.equal(stripVersionSuffix("Flying Free - Original Mix"), "Flying Free");
+  assert.equal(stripVersionSuffix("Back in Black - Live"), "Back in Black");
+  assert.equal(stripVersionSuffix("Highway - Star City"), "Highway - Star City");
+  assert.equal(stripVersionSuffix("Teardrop"), "Teardrop");
+});
+
+test("buildFlowSearchTiers fallback tier skips queries already covered by earlier tiers", () => {
+  const tiers = buildFlowSearchTiers({
+    artistName: "Massive Attack",
+    trackName: "Teardrop",
+    albumName: "",
+    releaseYear: "",
+    artistAliases: [],
+  });
+
+  const albumTrack = tiers.find((tier) => tier.name === "album_track");
+  assert.ok(albumTrack?.queries.includes("Massive Attack Teardrop"));
+  const primary = tiers.find((tier) => tier.name === "primary_track");
+  if (primary) {
+    assert.ok(!primary.queries.includes("Massive Attack Teardrop"));
+  }
 });
 
 const rankFlowCases = [

--- a/backend/services/qualityProfileModel.js
+++ b/backend/services/qualityProfileModel.js
@@ -174,6 +174,8 @@ export function classifyAdvertisedQuality(fileName, bitrate = null) {
   return null;
 }
 
+const NEVER_TIERED_ADVERTISED_EXTENSION = /\.(?:opus|ogg|oga|wma|wav|aiff?|ape|mpc|ac3|dts|mka)\s*$/i;
+
 export function orderAdvertisedQualityCandidates(
   entries,
   { profile, currentTier = null, upgrade = false, readName, readBitrate } = {},
@@ -181,14 +183,21 @@ export function orderAdvertisedQualityCandidates(
   const normalized = normalizeQualityProfile(profile);
   const enabled = new Set(normalized.enabled);
   return (Array.isArray(entries) ? entries : [])
-    .map((entry, index) => ({
-      entry,
-      index,
-      tier: classifyAdvertisedQuality(readName?.(entry), readBitrate?.(entry)),
-    }))
-    .filter(({ tier }) =>
-      !tier || enabled.has(tier) && (!upgrade || isQualityUpgrade({ tier }, currentTier, normalized)),
-    )
+    .map((entry, index) => {
+      const name = readName?.(entry);
+      return {
+        entry,
+        index,
+        name,
+        tier: classifyAdvertisedQuality(name, readBitrate?.(entry)),
+      };
+    })
+    .filter(({ tier, name }) => {
+      if (!tier) {
+        return !NEVER_TIERED_ADVERTISED_EXTENSION.test(String(name || "").trim());
+      }
+      return enabled.has(tier) && (!upgrade || isQualityUpgrade({ tier }, currentTier, normalized));
+    })
     .sort((left, right) => {
       if (!left.tier && !right.tier) return left.index - right.index;
       if (!left.tier) return 1;

--- a/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
@@ -179,11 +179,42 @@ function joinSearchParts(...parts) {
     .join(" ");
 }
 
+export function stripVersionSuffix(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const stripped = text
+    .replace(
+      /\s+(?:-|–|—)\s+[^-–—]*\b(?:mix|edit|version|remaster(?:ed)?|radio|extended|instrumental|acoustic|live|demo|mono|stereo)\b[^-–—]*$/i,
+      "",
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+  return stripped || text;
+}
+
+function stripTrailingWordPeriods(value) {
+  const text = String(value || "").trim();
+  const cleaned = text
+    .split(/\s+/)
+    .map((word) => word.replace(/\.+$/, ""))
+    .filter(Boolean)
+    .join(" ");
+  return cleaned || text;
+}
+
 function buildPrimaryTrackTierQueries(ctx) {
   const queries = [];
   const primaryTrack = ctx.trackVariants[0] || ctx.trackName;
   if (!ctx.artistName || !primaryTrack) return queries;
   queries.push(joinSearchParts(ctx.artistName, primaryTrack));
+  const strippedTrack = stripVersionSuffix(primaryTrack);
+  if (strippedTrack.toLowerCase() !== primaryTrack.toLowerCase()) {
+    queries.push(joinSearchParts(ctx.artistName, strippedTrack));
+  }
+  const cleanedArtist = stripTrailingWordPeriods(ctx.artistName);
+  if (cleanedArtist.toLowerCase() !== ctx.artistName.toLowerCase()) {
+    queries.push(joinSearchParts(cleanedArtist, strippedTrack));
+  }
   if (ctx.releaseYear) {
     queries.push(joinSearchParts(ctx.artistName, primaryTrack, ctx.releaseYear));
   }
@@ -243,11 +274,14 @@ export function buildFlowSearchTiers(context) {
   if (albumTrack.length > 0) {
     tiers.push({ tier: 2, name: "album_track", queries: albumTrack });
   }
-  if (tiers.length === 0) {
-    const primaryTrack = buildPrimaryTrackTierQueries(ctx);
-    if (primaryTrack.length > 0) {
-      tiers.push({ tier: 0, name: "primary_track", queries: primaryTrack });
-    }
+  const priorQueries = new Set(
+    tiers.flatMap((tier) => tier.queries.map((query) => query.toLowerCase())),
+  );
+  const primaryTrack = buildPrimaryTrackTierQueries(ctx).filter(
+    (query) => !priorQueries.has(query.toLowerCase()),
+  );
+  if (primaryTrack.length > 0) {
+    tiers.push({ tier: tiers.length === 0 ? 0 : 3, name: "primary_track", queries: primaryTrack });
   }
   return tiers;
 }


### PR DESCRIPTION
Fixes #626.

### What this changes

`buildFlowSearchTiers` only used artist + title queries when a track had no album metadata at all. With album metadata present, all tiers were album-scoped, and a track whose album resolves to a compilation exhausts them and fails with `No suitable slskd search results`, even when the network is full of eligible copies. This PR:

1. **Appends a `primary_track` fallback tier after the album tiers.** The orchestrator already stops as soon as a tier yields enough candidates, so this tier only ever runs when the album-scoped plan came up empty. Queries already issued by earlier tiers are deduplicated out. The no-album behavior is unchanged (still `primary_track` alone, tier 0).
2. **Adds a version-suffix-stripped query variant.** Titles like `Track - Single Mix` narrow results badly: the extra tokens must all match, and the bare ` - ` token is Soulseek's exclusion operator. The stripped variant (`Artist Track`) is only used for the query; ranking still scores against the full title, so version matching downstream is not weakened.
3. **Adds a trailing-period-stripped artist variant.** Soulseek matches terms at word boundaries, so a term like `Artist.` only matches paths containing the literal dotted form. Measured on a live instance: the same query with and without the trailing period returned 209 vs 86 unique files.
4. **Excludes advertised formats that can never satisfy a tier** (opus, ogg, wav, ape, ...) from download candidates in `orderAdvertisedQualityCandidates`. They used to pass through as "unknown tier", win the download slot, and get rejected by the post-download check every time — a guaranteed wasted transfer per candidate. Unknown-bitrate files in profile-eligible families (e.g. a plain `.mp3` with no advertised bitrate) still pass, as before.

### Validation

- `.tests` suite: 567/567 backend tests pass (5 new tests cover the fallback tier, the dedup, the suffix stripping, and the never-tiered format exclusion).
- Replayed real failed jobs from my instance against a live slskd with the patched matcher: a track that had failed with `quality-unknown` (the only album-tier candidate was a low-bitrate rip) now produces 5 eligible candidates, the top three being 320 MP3s, with the profile untouched (MP3 320 + M4A 320 only).

### Known remaining gaps (out of scope here, logged for reference)

While validating I found two tracks that still fail after this change, for reasons deeper in the ranker: `normalizeTitle` drops the word "single" from `... - Single Mix` titles which then trips `weak-title-match` / `variant-mismatch` against files literally named `(Single Mix)`, and one track whose only valid candidate is rejected by the sibling-track heuristics. Happy to file details separately if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly music matching by generating fallback searches for alternate track versions and artist-name variations.
  * Prevented duplicate searches across matching tiers.
  * Improved quality filtering so unsupported formats are excluded while valid and unknown-quality MP3 candidates remain available.
  * Preserved valid candidates that were previously at risk of being incorrectly classified as unrecognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->