### PR TITLE
fix(matching): fold Latin diacritics before comparing titles and artists

### DIFF
--- a/.tests/weekly-flow/diacritics-matching.test.js
+++ b/.tests/weekly-flow/diacritics-matching.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  artistNamesMatch,
+  foldDiacritics,
+  getNormalizedText,
+  normalizeTitle,
+  scoreTextMatch,
+} from "../../backend/services/providers/brainzmashRanking.js";
+
+const matcher = { extended: true };
+
+test("foldDiacritics maps accented and special letters to their base form", () => {
+  assert.equal(foldDiacritics("Canción"), "Cancion");
+  assert.equal(foldDiacritics("Aunque tú no lo sepas"), "Aunque tu no lo sepas");
+  assert.equal(foldDiacritics("Björk"), "Bjork");
+  assert.equal(foldDiacritics("Sigur Rós"), "Sigur Ros");
+  assert.equal(foldDiacritics("Motörhead"), "Motorhead");
+  assert.equal(foldDiacritics("Café del Mar"), "Cafe del Mar");
+  assert.equal(foldDiacritics("Blue Öyster Cult"), "Blue Oyster Cult");
+  assert.equal(foldDiacritics("Mötley Crüe"), "Motley Crue");
+  assert.equal(foldDiacritics("Nothing to fold"), "Nothing to fold");
+});
+
+test("foldDiacritics handles letters that carry no combining mark", () => {
+  assert.equal(foldDiacritics("Sinéad Ó'Connor"), "Sinead O'Connor");
+  assert.equal(foldDiacritics("Anastacia — Größe"), "Anastacia — Grosse");
+  assert.equal(foldDiacritics("Æther"), "AEther");
+  assert.equal(foldDiacritics("Håkan Hellström"), "Hakan Hellstrom");
+});
+
+test("foldDiacritics only folds Latin script, leaving other writing systems intact", () => {
+  // Japanese dakuten and the Cyrillic breve are combining marks too: folding them
+  // would merge distinct characters (ka/ga, i/short-i) and collide unrelated titles.
+  assert.equal(foldDiacritics("がき"), "がき");
+  assert.notEqual(foldDiacritics("がき"), foldDiacritics("かき"));
+  assert.equal(foldDiacritics("ばら"), "ばら");
+  assert.notEqual(foldDiacritics("ぱん"), foldDiacritics("はん"));
+  assert.equal(foldDiacritics("Мумий Тролль"), "Мумий Тролль");
+  assert.notEqual(foldDiacritics("мой"), foldDiacritics("мои"));
+});
+
+test("scoreTextMatch keeps non-Latin near-homographs apart", () => {
+  assert.notEqual(scoreTextMatch("がき", "かき", matcher), 100);
+  assert.notEqual(scoreTextMatch("мой", "мои", matcher), 100);
+});
+
+test("normalizeTitle ignores diacritics so accented shares still match", () => {
+  assert.equal(
+    normalizeTitle("Aunque tú no lo sepas", matcher),
+    normalizeTitle("Aunque Tu No Lo Sepas", matcher),
+  );
+  assert.equal(normalizeTitle("Déjà Vu", matcher), normalizeTitle("Deja Vu", matcher));
+});
+
+test("scoreTextMatch treats an accent difference as an exact match", () => {
+  assert.equal(scoreTextMatch("Cancion", "Canción", matcher), 100);
+  assert.equal(scoreTextMatch("Aunque Tu No Lo Sepas", "Aunque tú no lo sepas", matcher), 100);
+  assert.equal(scoreTextMatch("Un Canto a Galicia", "Un canto a Galícia", matcher), 100);
+});
+
+test("getNormalizedText keeps accented words whole instead of splitting them", () => {
+  assert.equal(getNormalizedText("Canción"), "cancion");
+  assert.equal(getNormalizedText("Rocío Jurado"), "rocio jurado");
+  assert.equal(getNormalizedText("Björk"), "bjork");
+});
+
+test("artistNamesMatch ignores diacritics", () => {
+  assert.equal(artistNamesMatch("Rocio Jurado", "Rocío Jurado"), true);
+  assert.equal(artistNamesMatch("Sigur Ros", "Sigur Rós"), true);
+  assert.equal(artistNamesMatch("Rocio Jurado", "Rocio Durcal"), false);
+});
+
+test("scoreTextMatch still separates genuinely different titles", () => {
+  assert.ok(scoreTextMatch("Aunque Tu No Lo Sepas", "Zapatillas", matcher) < 50);
+  assert.equal(scoreTextMatch("", "Canción", matcher), 0);
+});

--- a/.tests/weekly-flow/diacritics-matching.test.js
+++ b/.tests/weekly-flow/diacritics-matching.test.js
@@ -22,6 +22,14 @@ test("foldDiacritics maps accented and special letters to their base form", () =
   assert.equal(foldDiacritics("Nothing to fold"), "Nothing to fold");
 });
 
+test("foldDiacritics folds sharp s in both cases", () => {
+  // The fold runs before lowercasing, so the capital form needs its own mapping.
+  assert.equal(foldDiacritics("Straße"), "Strasse");
+  assert.equal(foldDiacritics("STRAẞE"), "STRASSE");
+  assert.equal(getNormalizedText("STRAẞE"), "strasse");
+  assert.equal(artistNamesMatch("STRASSE", "STRAẞE"), true);
+});
+
 test("foldDiacritics handles letters that carry no combining mark", () => {
   assert.equal(foldDiacritics("Sinéad Ó'Connor"), "Sinead O'Connor");
   assert.equal(foldDiacritics("Anastacia — Größe"), "Anastacia — Grosse");

--- a/backend/services/providers/brainzmashRanking.js
+++ b/backend/services/providers/brainzmashRanking.js
@@ -14,6 +14,7 @@ const UNDECOMPOSED_LETTERS = {
   þ: "th",
   Þ: "TH",
   ß: "ss",
+  ẞ: "SS",
 };
 
 export function foldDiacritics(value) {
@@ -21,7 +22,7 @@ export function foldDiacritics(value) {
     .normalize("NFD")
     .replace(/(\p{Script=Latin})\p{M}+/gu, "$1")
     .normalize("NFC")
-    .replace(/[øØæÆœŒđĐðÐłŁþÞß]/g, (letter) => UNDECOMPOSED_LETTERS[letter]);
+    .replace(/[øØæÆœŒđĐðÐłŁþÞßẞ]/g, (letter) => UNDECOMPOSED_LETTERS[letter]);
 }
 
 function normalizeText(value) {

--- a/backend/services/providers/brainzmashRanking.js
+++ b/backend/services/providers/brainzmashRanking.js
@@ -1,6 +1,31 @@
-function normalizeText(value) {
+const UNDECOMPOSED_LETTERS = {
+  ø: "o",
+  Ø: "O",
+  æ: "ae",
+  Æ: "AE",
+  œ: "oe",
+  Œ: "OE",
+  đ: "d",
+  Đ: "D",
+  ð: "d",
+  Ð: "D",
+  ł: "l",
+  Ł: "L",
+  þ: "th",
+  Þ: "TH",
+  ß: "ss",
+};
+
+export function foldDiacritics(value) {
   return String(value || "")
-    .normalize("NFKD")
+    .normalize("NFD")
+    .replace(/(\p{Script=Latin})\p{M}+/gu, "$1")
+    .normalize("NFC")
+    .replace(/[øØæÆœŒđĐðÐłŁþÞß]/g, (letter) => UNDECOMPOSED_LETTERS[letter]);
+}
+
+function normalizeText(value) {
+  return foldDiacritics(String(value || "").normalize("NFKD"))
     .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, " ")
     .replace(/\s+/g, " ")
@@ -36,7 +61,7 @@ const MATCHER_STRIP =
   /\b(deluxe|expanded|anniversary|remaster(?:ed)?|bonus|edition|live|mono|stereo|single|ep|explicit|clean)\b/g;
 
 export function normalizeReleaseText(value, { extended = false } = {}) {
-  return String(value || "")
+  return foldDiacritics(value)
     .toLowerCase()
     .replace(/&/g, " and ")
     .replace(/\(.*?\)|\[.*?\]/g, " ")


### PR DESCRIPTION
### What happens

Playlist tracks whose title or artist carries diacritics fail even when the network holds exact, correctly named copies at an enabled quality tier. The files come back in the search results, get ranked, and are then discarded as `weak-title-match` or `weak-artist-match`.

The cause is in `backend/services/providers/brainzmashRanking.js`: both normalizers leave combining marks in place.

`normalizeReleaseText` lowercases and strips punctuation but never folds accents, so:

```js
scoreTextMatch("Cancion", "Canción", { extended: true })  // => 0
```

Two spellings of the same word score zero, which is well below every match threshold downstream.

`normalizeText` is worse, because it decomposes with NFKD and then replaces every non letter/digit with a **space** — the leftover combining mark splits the word in half:

```js
getNormalizedText("Canción")                         // => "cancio n"
artistNamesMatch("Rocio Jurado", "Rocío Jurado")     // => false
```

This affects every language that uses diacritics. It is particularly bad on Soulseek, where the same release circulates spelled both ways, so the metadata and the share almost never agree on accents.

### The change

- add `foldDiacritics`: decompose, drop the combining marks **that sit on a Latin base letter**, recompose, then map the letters that carry no combining mark at all (`ø æ œ đ ð ł þ ß`, case preserved)
- call it from both `normalizeReleaseText` and `normalizeText`, so every consumer benefits: title and artist scoring, release-folder scoring, tracklist fingerprinting and the Lidarr artist lookup

No thresholds or scoring weights are touched; the comparison simply stops depending on how the uploader spelled the accents.

The fold is deliberately restricted to Latin script. Stripping every combining mark would also merge characters that are distinct letters elsewhere — Japanese dakuten (か/が, は/ば/ぱ) and the Cyrillic breve (и/й) are combining marks too, and folding them would collide unrelated J-pop or Russian titles. With the restriction, non-Latin text comes out identical to the input; there are tests for exactly that.

### Validation

- Full backend test suite passes (577 tests). New file `.tests/weekly-flow/diacritics-matching.test.js` covers the folding helper, both normalizers, `artistNamesMatch`, the non-Latin safety cases above, and asserts that genuinely different titles still score low.
- Replayed real failing jobs from my instance against live slskd search results, with the quality profile set to MP3 320 + M4A 320 only. A Spanish-language track whose title carries an accent went from **0 candidates surviving pre-download validation to 4**, one of them an exact 320 kbps copy that `main` had rejected as `weak-title-match`. Reproduced on two independent captures of the same track, hours apart.

### Note on scope

Folding is deliberately one-way and lossy (`ñ` becomes `n`, `ü` becomes `u`). That is the standard trade-off for fuzzy filename matching and it is what makes accented shares reachable at all; the risk of two genuinely different titles colliding is far smaller than the current failure rate. Exact-identity checks that must not fold (if any exist outside these two helpers) are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching of titles and artists when Latin accents or special characters differ.
  * Added more consistent handling of Latin transliterations and normalized text.
  * Preserved accurate matching for non-Latin writing systems.
  * Improved ranking consistency for normalized release text.

* **Tests**
  * Added coverage for accented characters, transliteration, title scoring, artist matching, and distinct or empty titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->