### PR TITLE
fix(ui): remove duplicate library search clear and merge shows

### DIFF
--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { groupShowsByEvent } from "../../backend/services/nearbyShowsService.js";
+
+test("groups artists matched to the same Ticketmaster event", () => {
+  const grouped = groupShowsByEvent([
+    { id: "event-1", artistName: "Artist A", eventName: "Shared bill" },
+    { id: "event-1", artistName: "Artist B", eventName: "Shared bill" },
+    { id: "event-1", artistName: "Artist A", eventName: "Shared bill" },
+    { id: "event-2", artistName: "Artist C", eventName: "Solo show" },
+  ]);
+
+  assert.deepEqual(
+    grouped.map(({ id, artistName, artistNames }) => ({ id, artistName, artistNames })),
+    [
+      { id: "event-1", artistName: "Artist A", artistNames: ["Artist A", "Artist B"] },
+      { id: "event-2", artistName: "Artist C", artistNames: ["Artist C"] },
+    ],
+  );
+});

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -158,8 +158,11 @@ async function buildShowItems(userId, now, req, zipCode, libraryArtists) {
     const key = String(show?.ticketmasterEventId || show?.id || "").trim();
     if (!key) continue;
     const current = grouped.get(key) || { ...show, artistNames: [] };
-    if (show.artistName && !current.artistNames.includes(show.artistName)) {
-      current.artistNames.push(show.artistName);
+    const artistNames = Array.isArray(show.artistNames) ? show.artistNames : [show.artistName];
+    for (const artistName of artistNames) {
+      if (artistName && !current.artistNames.includes(artistName)) {
+        current.artistNames.push(artistName);
+      }
     }
     grouped.set(key, current);
   }

--- a/backend/services/nearbyShowsService.js
+++ b/backend/services/nearbyShowsService.js
@@ -350,6 +350,35 @@ const buildShowRecord = (event, artist) => {
   };
 };
 
+export const groupShowsByEvent = (shows) => {
+  const groups = new Map();
+  for (const [index, show] of (Array.isArray(shows) ? shows : []).entries()) {
+    const eventId = String(show?.ticketmasterEventId || show?.id || "").trim();
+    const key = eventId ? `event:${eventId}` : `show:${index}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = { ...show, artistNames: [], artistKeys: new Set() };
+      groups.set(key, group);
+    }
+
+    const artistNames = Array.isArray(show?.artistNames)
+      ? show.artistNames
+      : [show?.artistName];
+    for (const value of artistNames) {
+      const name = String(value || "").trim();
+      const artistKey = normalizeArtistKey(name) || name.toLowerCase();
+      if (!name || group.artistKeys.has(artistKey)) continue;
+      group.artistKeys.add(artistKey);
+      group.artistNames.push(name);
+    }
+  }
+
+  return [...groups.values()].map(({ artistKeys: _artistKeys, ...show }) => ({
+    ...show,
+    artistName: show.artistNames[0] || show.artistName || null,
+  }));
+};
+
 const buildArtistMap = (artists, sourceType) => {
   const map = new Map();
   for (const artist of artists || []) {
@@ -433,14 +462,19 @@ export const getNearbyShows = async ({
     }
   }
 
-  sortShows(libraryShows);
-  sortShows(recommendedShows);
+  const groupedShows = groupShowsByEvent([...libraryShows, ...recommendedShows]);
+  const groupedLibraryShows = groupShowsByEvent(libraryShows);
+  const groupedRecommendedShows = groupShowsByEvent(recommendedShows);
+
+  sortShows(groupedShows);
+  sortShows(groupedLibraryShows);
+  sortShows(groupedRecommendedShows);
 
   return {
     location,
-    shows: [...libraryShows, ...recommendedShows].slice(0, resolvedLimit),
-    libraryShows: libraryShows.slice(0, resolvedLimit),
-    recommendedShows: recommendedShows.slice(0, resolvedLimit),
-    total: libraryShows.length + recommendedShows.length,
+    shows: groupedShows.slice(0, resolvedLimit),
+    libraryShows: groupedLibraryShows.slice(0, resolvedLimit),
+    recommendedShows: groupedRecommendedShows.slice(0, resolvedLimit),
+    total: groupedShows.length,
   };
 };

--- a/frontend/src/components/ShowCard.jsx
+++ b/frontend/src/components/ShowCard.jsx
@@ -86,7 +86,10 @@ function ShowMeta({ showDate, showLocation, className }) {
 }
 
 const ShowCard = memo(({ show }) => {
-  const artistLabel = show.artistName || "Matched artist";
+  const artistNames = (Array.isArray(show.artistNames) ? show.artistNames : [show.artistName])
+    .filter((name) => typeof name === "string" && name.trim())
+    .map((name) => name.trim());
+  const artistLabel = artistNames.join(", ") || "Matched artist";
   const eventLabel = show.eventName || artistLabel || "Upcoming show";
   const eventUrl = getEventUrl(show.url);
   const distanceLabel = formatDistance(show.distance);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7574,6 +7574,11 @@ textarea {
   font-size: 0.76rem;
 }
 
+.native-library-search input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 .native-library-search input::placeholder {
   color: var(--aurral-text-subtle);
 }


### PR DESCRIPTION
Library search fields show two clear controls while focused because the browser adds its native search cancel button beside Aurral's clear button. Nearby shows also render one card per matched artist, so a shared event appears repeatedly.

This removes the native cancel control from library search fields and groups matched artists by Ticketmaster event before the result limit. Shared show cards and inbox items display the artist names together.

Closes #586

Verification:
- `npm test` (630 passed)
- `npm run lint:backend`
- `npm run lint --workspace frontend`
- `npm run build`
- Browser check of the library search field in focused and unfocused states
- Regression test for same-event artist grouping

Live Ticketmaster card verification was unavailable because this candidate has no Ticketmaster Consumer Key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nearby show results are now grouped by event, combining duplicate listings and displaying all unique artists.
  * Show cards support multiple artist names with cleaner formatting.

* **Bug Fixes**
  * Improved aggregation of artist information across inbox and nearby-show results.
  * Removed the default browser cancel icon from the library search field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->