### PR TITLE
feat(subsonic): complete saves, playlists, and flow promotion

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -143,6 +143,87 @@ test("scanMusicRoot derives stable fallback records when tags are missing", asyn
   }
 });
 
+test("scanMusicRoot applies trusted job metadata when file tags omit identities", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-job-metadata-"));
+  const source = `test-job-metadata-${process.pid}`;
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Aurral Artist/Aurral Album/01 Track.flac");
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => ({ common: {}, format: {} }),
+      metadataEnricher: () => ({
+        artistMbid: "11111111-1111-4111-8111-111111111111",
+        albumMbid: "22222222-2222-4222-8222-222222222222",
+        trackMbid: "33333333-3333-4333-8333-333333333333",
+        artistName: "Aurral Artist",
+        albumName: "Aurral Album",
+        trackName: "Track",
+      }),
+    });
+    const indexed = db.prepare(
+      `SELECT artist.mbid AS artistMbid, album.release_group_mbid AS releaseGroupMbid,
+        track.mbid AS trackMbid
+       FROM library_media_files AS media
+       JOIN library_tracks AS track ON track.id = media.track_id
+       JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+       JOIN library_albums AS album ON album.id = album_track.album_id
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       WHERE media.source = ? AND media.path = ?`,
+    ).get(source, filePath);
+
+    assert.deepEqual(indexed, {
+      artistMbid: "11111111-1111-4111-8111-111111111111",
+      releaseGroupMbid: "22222222-2222-4222-8222-222222222222",
+      trackMbid: "33333333-3333-4333-8333-333333333333",
+    });
+  } finally {
+    if (filePath) deleteIndexedFile(source, filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("scanMusicRoot reads Aurral identity markers from portable comments", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-comment-metadata-"));
+  const source = `test-comment-metadata-${process.pid}`;
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Aurral Artist/Aurral Album/01 Track.flac");
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => ({
+        common: {
+          comment: [{
+            text: 'AURRAL_IDS={"artistMbid":"11111111-1111-4111-1111-111111111111","albumMbid":"22222222-2222-2222-2222-222222222222","trackMbid":"33333333-3333-3333-3333-333333333333"}',
+          }],
+        },
+        format: {},
+      }),
+    });
+    const indexed = db.prepare(
+      `SELECT artist.mbid AS artistMbid, album.release_group_mbid AS releaseGroupMbid,
+        track.mbid AS trackMbid
+       FROM library_media_files AS media
+       JOIN library_tracks AS track ON track.id = media.track_id
+       JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+       JOIN library_albums AS album ON album.id = album_track.album_id
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       WHERE media.source = ? AND media.path = ?`,
+    ).get(source, filePath);
+
+    assert.deepEqual(indexed, {
+      artistMbid: "11111111-1111-4111-1111-111111111111",
+      releaseGroupMbid: "22222222-2222-2222-2222-222222222222",
+      trackMbid: "33333333-3333-3333-3333-333333333333",
+    });
+  } finally {
+    if (filePath) deleteIndexedFile(source, filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a successful rescan marks removed files unavailable without removing media records", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-reconcile-"));
   const source = `test-reconcile-${process.pid}`;

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -444,17 +444,14 @@ test("creates durable Subsonic playlists around one promoted library job", async
   await stat(libraryJobs[0].finalPath);
 });
 
-test("failed Subsonic playlist creation removes the empty shared playlist", async () => {
-  const flow = responseJson(await request("getPlaylists")).playlists.playlist.find(
-    (entry) => entry.name === "Canonical Flow",
-  );
-  const flowSong = responseJson(await request("getPlaylist", { id: flow.id })).playlist.entry[0];
+test("failed Subsonic playlist creation rolls back its playlist and jobs", async () => {
+  const canonicalSong = responseJson(await request("search3", { query: "Canonical Song" })).searchResult3.song[0];
   const user = userOps.getUserByUsername("alice");
   const originalUpdate = flowPlaylistConfig.updateSharedPlaylist;
   flowPlaylistConfig.updateSharedPlaylist = () => null;
   try {
     assert.equal(
-      createSubsonicPlaylist(user, { name: "Failed Subsonic Playlist", songIds: [flowSong.id] }),
+      createSubsonicPlaylist(user, { name: "Failed Subsonic Playlist", songIds: [canonicalSong.id] }),
       null,
     );
     assert.equal(
@@ -462,6 +459,12 @@ test("failed Subsonic playlist creation removes the empty shared playlist", asyn
         (playlist) => playlist.name === "Failed Subsonic Playlist",
       ),
       false,
+    );
+    assert.equal(
+      db.prepare(
+        "SELECT id FROM playlist_download_jobs WHERE playlist_type = ? AND track_name = ? LIMIT 1",
+      ).get("library", "Canonical Song"),
+      undefined,
     );
   } finally {
     flowPlaylistConfig.updateSharedPlaylist = originalUpdate;

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -26,6 +26,7 @@ const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidar
 );
 
 let aurral;
+let authToken;
 let fixtureRoot;
 let fixturePath;
 let sharedPlaylist;
@@ -57,8 +58,29 @@ async function request(method, params = {}, options = {}) {
   };
 }
 
+async function apiFetch(pathname, options = {}) {
+  return fetch(`http://127.0.0.1:${aurral.port}${pathname}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers || {}),
+    },
+  });
+}
+
 function responseJson(result) {
   return JSON.parse(result.body)["subsonic-response"];
+}
+
+async function waitFor(check, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await check();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Timed out waiting for Subsonic mutation");
 }
 
 test.before(async () => {
@@ -137,6 +159,17 @@ test.before(async () => {
     durationMs: 1000,
   }, sharedPlaylist.id);
   downloadTracker.setDone(sharedJobId, fixturePath);
+  const favoriteFlow = flowPlaylistConfig.createFlow({ name: "Favorite Toggle Flow", size: 1 });
+  const favoritePath = path.join(fixtureRoot, "Favorite Artist", "Favorite Album", "Favorite Song.flac");
+  await mkdir(path.dirname(favoritePath), { recursive: true });
+  await writeFile(favoritePath, "favorite");
+  const favoriteJobId = downloadTracker.addJob({
+    artistName: "Favorite Artist",
+    albumName: "Favorite Album",
+    trackName: "Favorite Song",
+    durationMs: 1000,
+  }, favoriteFlow.id);
+  downloadTracker.setDone(favoriteJobId, favoritePath);
   await mkdir(playlistManager.libraryRoot, { recursive: true });
   await writeFile(
     path.join(playlistManager.libraryRoot, `${playlistManager.getPlaylistName(flow.id)}.webp`),
@@ -147,6 +180,13 @@ test.before(async () => {
     "shared-artwork",
   );
   aurral = await startServerProcess();
+  const login = await fetch(`http://127.0.0.1:${aurral.port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "alice", password: "password123" }),
+  });
+  authToken = (await login.json()).token;
+  assert.equal(login.status, 200);
 });
 
 test.after(async () => {
@@ -328,6 +368,81 @@ test("does not expose another user's static playlist", async () => {
     p: "bob-password",
   }));
   assert.deepEqual(result.error, { code: 70, message: "Requested data was not found" });
+});
+
+test("creates durable Subsonic playlists around one promoted library job", async () => {
+  const flow = responseJson(await request("getPlaylists")).playlists.playlist.find(
+    (entry) => entry.name === "Canonical Flow",
+  );
+  const flowPlaylist = responseJson(await request("getPlaylist", { id: flow.id })).playlist;
+  const flowSong = flowPlaylist.entry[0];
+
+  const firstCreate = responseJson(await request("createPlaylist", {
+    name: "Subsonic Keep One",
+    songId: flowSong.id,
+  }));
+  const first = firstCreate.playlist;
+  assert.equal(first.name, "Subsonic Keep One");
+  const jobIdFromSong = (songId) =>
+    decodeURIComponent(songId.slice("shared-song:".length)).split(":").at(-1);
+  const canonicalJobId = jobIdFromSong(first.entry[0].id);
+
+  const second = responseJson(await request("createPlaylist", {
+    name: "Subsonic Keep Two",
+    songId: flowSong.id,
+  })).playlist;
+  assert.equal(jobIdFromSong(second.entry[0].id), canonicalJobId);
+
+  await waitFor(() => db.prepare(
+    "SELECT status FROM playlist_download_jobs WHERE id = ?",
+  ).get(canonicalJobId)?.status === "done");
+  const firstReady = await waitFor(async () => {
+    const result = responseJson(await request("getPlaylist", { id: first.id }));
+    return result.playlist?.entry?.[0];
+  });
+  assert.equal(firstReady.id, responseJson(await request("getPlaylist", { id: first.id })).playlist.entry[0].id);
+  const stream = await request("stream", { id: firstReady.id });
+  assert.equal(stream.response.status, 200);
+  assert.equal(stream.body, "0123456789");
+
+  const libraryJobs = db.prepare(
+    "SELECT id, final_path AS finalPath FROM playlist_download_jobs WHERE playlist_type = ? AND track_name = ?",
+  ).all("library", "Flow Song");
+  assert.equal(libraryJobs.length, 1);
+
+  const removed = responseJson(await request("updatePlaylist", {
+    playlistId: first.id,
+    songIndexToRemove: "0",
+  }));
+  assert.equal(removed.status, "ok");
+  const secondEntry = responseJson(await request("getPlaylist", { id: second.id })).playlist.entry[0];
+  assert.equal((await request("stream", { id: secondEntry.id })).response.status, 200);
+  await stat(libraryJobs[0].finalPath);
+
+  assert.equal(responseJson(await request("deletePlaylist", { id: second.id })).status, "ok");
+  await stat(libraryJobs[0].finalPath);
+});
+
+test("favorites can keep Flow tracks and respect the auto-keep setting", async () => {
+  const flow = responseJson(await request("getPlaylists")).playlists.playlist.find(
+    (entry) => entry.name === "Favorite Toggle Flow",
+  );
+  const entry = responseJson(await request("getPlaylist", { id: flow.id })).playlist.entry[0];
+
+  const saveSettings = (subsonic) => apiFetch("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({ subsonic }),
+  });
+  assert.equal((await saveSettings({ favoriteAutoKeep: false })).status, 200);
+  assert.equal(responseJson(await request("star", { id: entry.id })).status, "ok");
+  assert.equal(
+    Boolean(db.prepare(
+      "SELECT 1 FROM playlist_download_jobs WHERE playlist_type = ? AND track_name = ? LIMIT 1",
+    ).get("library", "Favorite Song")),
+    false,
+  );
+  assert.equal(responseJson(await request("getStarred")).starred.song[0].id, entry.id);
+  assert.equal((await saveSettings({ favoriteAutoKeep: true })).status, 200);
 });
 
 test("streams canonical files with full and range responses", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -11,7 +11,7 @@ import {
   startServerProcess,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }, { resolveArtworkUrl }, { warmImageProxy }, { playlistManager }] =
+const [isolatedState, { db }, { dbOps, userOps }, { hashPassword }, { indexLidarrLibrary }, { flowPlaylistConfig }, { downloadTracker }, { resolveArtworkUrl, createSubsonicPlaylist }, { warmImageProxy }, { playlistManager }] =
   await setupIsolatedBackend(
     "subsonic-canonical",
     "backend/config/db-sqlite.js",
@@ -353,6 +353,19 @@ test("exposes owned static playlists and keeps their entries playable", async ()
   assert.equal(artwork.response.status, 200);
   assert.equal(artwork.body, "shared-artwork");
 
+  const pendingJobId = downloadTracker.addJob({
+    artistName: "Pending Artist",
+    albumName: "Pending Album",
+    trackName: "Pending Song",
+    durationMs: 1000,
+  }, sharedPlaylist.id);
+  try {
+    const refreshed = responseJson(await request("getPlaylist", { id: shared.id })).playlist;
+    assert.equal(refreshed.entry.some((entry) => entry.title === "Pending Song"), false);
+  } finally {
+    downloadTracker.removeJob(pendingJobId);
+  }
+
   const song = responseJson(await request("getSong", { id: playlist.entry[0].id })).song;
   assert.equal(song.title, "Flow Song");
   const stream = await request("stream", { id: song.id });
@@ -381,16 +394,24 @@ test("creates durable Subsonic playlists around one promoted library job", async
     name: "Subsonic Keep One",
     songId: flowSong.id,
   }));
-  const first = firstCreate.playlist;
+  const firstId = firstCreate.playlist.id;
+  const first = await waitFor(async () => {
+    const playlist = responseJson(await request("getPlaylist", { id: firstId })).playlist;
+    return playlist.entry?.[0] ? playlist : null;
+  });
   assert.equal(first.name, "Subsonic Keep One");
   const jobIdFromSong = (songId) =>
     decodeURIComponent(songId.slice("shared-song:".length)).split(":").at(-1);
   const canonicalJobId = jobIdFromSong(first.entry[0].id);
 
-  const second = responseJson(await request("createPlaylist", {
+  const secondCreate = responseJson(await request("createPlaylist", {
     name: "Subsonic Keep Two",
     songId: flowSong.id,
-  })).playlist;
+  }));
+  const second = await waitFor(async () => {
+    const playlist = responseJson(await request("getPlaylist", { id: secondCreate.playlist.id })).playlist;
+    return playlist.entry?.[0] ? playlist : null;
+  });
   assert.equal(jobIdFromSong(second.entry[0].id), canonicalJobId);
 
   await waitFor(() => db.prepare(
@@ -423,6 +444,39 @@ test("creates durable Subsonic playlists around one promoted library job", async
   await stat(libraryJobs[0].finalPath);
 });
 
+test("failed Subsonic playlist creation removes the empty shared playlist", async () => {
+  const flow = responseJson(await request("getPlaylists")).playlists.playlist.find(
+    (entry) => entry.name === "Canonical Flow",
+  );
+  const flowSong = responseJson(await request("getPlaylist", { id: flow.id })).playlist.entry[0];
+  const user = userOps.getUserByUsername("alice");
+  const originalUpdate = flowPlaylistConfig.updateSharedPlaylist;
+  flowPlaylistConfig.updateSharedPlaylist = () => null;
+  try {
+    assert.equal(
+      createSubsonicPlaylist(user, { name: "Failed Subsonic Playlist", songIds: [flowSong.id] }),
+      null,
+    );
+    assert.equal(
+      flowPlaylistConfig.getSharedPlaylistsForUser(user).some(
+        (playlist) => playlist.name === "Failed Subsonic Playlist",
+      ),
+      false,
+    );
+  } finally {
+    flowPlaylistConfig.updateSharedPlaylist = originalUpdate;
+  }
+});
+
+test("malformed Subsonic settings do not crash the settings update", async () => {
+  const response = await apiFetch("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({ subsonic: null }),
+  });
+  assert.equal(response.status, 200);
+  assert.equal(dbOps.getSettings().subsonic.favoriteAutoKeep, true);
+});
+
 test("favorites can keep Flow tracks and respect the auto-keep setting", async () => {
   const flow = responseJson(await request("getPlaylists")).playlists.playlist.find(
     (entry) => entry.name === "Favorite Toggle Flow",
@@ -443,6 +497,14 @@ test("favorites can keep Flow tracks and respect the auto-keep setting", async (
   );
   assert.equal(responseJson(await request("getStarred")).starred.song[0].id, entry.id);
   assert.equal((await saveSettings({ favoriteAutoKeep: true })).status, 200);
+  assert.equal(responseJson(await request("unstar", { id: entry.id })).status, "ok");
+  assert.equal(responseJson(await request("star", { id: entry.id })).status, "ok");
+  const autoKeepJob = db.prepare(
+    "SELECT id FROM playlist_download_jobs WHERE playlist_type = ? AND track_name = ? LIMIT 1",
+  ).get("library", "Favorite Song");
+  assert.ok(autoKeepJob);
+  downloadTracker.removeJob(autoKeepJob.id);
+  assert.equal(responseJson(await request("unstar", { id: entry.id })).status, "ok");
 });
 
 test("streams canonical files with full and range responses", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -472,12 +472,22 @@ test("failed Subsonic playlist creation rolls back its playlist and jobs", async
 });
 
 test("malformed Subsonic settings do not crash the settings update", async () => {
+  const disable = await apiFetch("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({ subsonic: { favoriteAutoKeep: false } }),
+  });
+  assert.equal(disable.status, 200);
   const response = await apiFetch("/api/settings", {
     method: "POST",
     body: JSON.stringify({ subsonic: null }),
   });
   assert.equal(response.status, 200);
-  assert.equal(dbOps.getSettings().subsonic.favoriteAutoKeep, true);
+  assert.equal(dbOps.getSettings().subsonic.favoriteAutoKeep, false);
+  const restore = await apiFetch("/api/settings", {
+    method: "POST",
+    body: JSON.stringify({ subsonic: { favoriteAutoKeep: true } }),
+  });
+  assert.equal(restore.status, 200);
 });
 
 test("favorites can keep Flow tracks and respect the auto-keep setting", async () => {

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -472,22 +472,32 @@ test("failed Subsonic playlist creation rolls back its playlist and jobs", async
 });
 
 test("malformed Subsonic settings do not crash the settings update", async () => {
-  const disable = await apiFetch("/api/settings", {
-    method: "POST",
-    body: JSON.stringify({ subsonic: { favoriteAutoKeep: false } }),
-  });
-  assert.equal(disable.status, 200);
-  const response = await apiFetch("/api/settings", {
-    method: "POST",
-    body: JSON.stringify({ subsonic: null }),
-  });
-  assert.equal(response.status, 200);
-  assert.equal(dbOps.getSettings().subsonic.favoriteAutoKeep, false);
-  const restore = await apiFetch("/api/settings", {
-    method: "POST",
-    body: JSON.stringify({ subsonic: { favoriteAutoKeep: true } }),
-  });
-  assert.equal(restore.status, 200);
+  const initialFavoriteAutoKeep = dbOps.getSettings().subsonic.favoriteAutoKeep;
+  try {
+    const disable = await apiFetch("/api/settings", {
+      method: "POST",
+      body: JSON.stringify({ subsonic: { favoriteAutoKeep: false } }),
+    });
+    assert.equal(disable.status, 200);
+    assert.equal((await (await apiFetch("/api/settings")).json()).subsonic.favoriteAutoKeep, false);
+    const response = await apiFetch("/api/settings", {
+      method: "POST",
+      body: JSON.stringify({ subsonic: null }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal((await (await apiFetch("/api/settings")).json()).subsonic.favoriteAutoKeep, false);
+    const partial = await apiFetch("/api/settings", {
+      method: "POST",
+      body: JSON.stringify({ subsonic: {} }),
+    });
+    assert.equal(partial.status, 200);
+    assert.equal((await (await apiFetch("/api/settings")).json()).subsonic.favoriteAutoKeep, false);
+  } finally {
+    await apiFetch("/api/settings", {
+      method: "POST",
+      body: JSON.stringify({ subsonic: { favoriteAutoKeep: initialFavoriteAutoKeep } }),
+    });
+  }
 });
 
 test("favorites can keep Flow tracks and respect the auto-keep setting", async () => {

--- a/.tests/weekly-flow/ytdlp-metadata.test.js
+++ b/.tests/weekly-flow/ytdlp-metadata.test.js
@@ -43,6 +43,9 @@ test("yt-dlp output receives Aurral's canonical Navidrome tags", async () => {
     trackName: "Bonzo Goes to Bitburg",
     artistName: "Ramones",
     albumName: "Animal Boy",
+    artistMbid: "11111111-1111-4111-8111-111111111111",
+    albumMbid: "22222222-2222-4222-8222-222222222222",
+    trackMbid: "33333333-3333-4333-8333-333333333333",
     releaseYear: "1986",
     trackNumber: 5,
   });
@@ -54,6 +57,14 @@ test("yt-dlp output receives Aurral's canonical Navidrome tags", async () => {
   assert.equal(common.album, "Animal Boy");
   assert.equal(common.year, 1986);
   assert.equal(common.track.no, 5);
+  assert.equal(
+    common.comment?.some((entry) =>
+      String(entry?.text || entry).includes(
+        'AURRAL_IDS={"artistMbid":"11111111-1111-4111-8111-111111111111","albumMbid":"22222222-2222-4222-8222-222222222222","trackMbid":"33333333-3333-4333-8333-333333333333"}',
+      ),
+    ),
+    true,
+  );
 });
 
 test("startup repair tags existing completed yt-dlp M4As", async () => {
@@ -66,6 +77,9 @@ test("startup repair tags existing completed yt-dlp M4As", async () => {
       trackName: "Dead And Lovely",
       artistName: "Tom Waits",
       albumName: "Real Gone (Original Version)",
+      artistMbid: "44444444-4444-4444-8444-444444444444",
+      albumMbid: "55555555-5555-4555-8555-555555555555",
+      trackMbid: "66666666-6666-4666-8666-666666666666",
       releaseYear: "2004",
       trackNumber: 2,
     },

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -23,6 +23,9 @@ export const normalizeDateTimeFormat = (value) =>
 export const defaultData = {
   settings: {
     dateTimeFormat: "browser",
+    subsonic: {
+      favoriteAutoKeep: true,
+    },
     integrations: {
       navidrome: {
         url: "",

--- a/backend/db/helpers/settings.js
+++ b/backend/db/helpers/settings.js
@@ -131,6 +131,7 @@ export const dbOps = {
     const sharedPlaylists = readStoredSettingJson("sharedPlaylists", [
       "sharedFlowPlaylists",
     ]);
+    const subsonic = readStoredSettingJson("subsonic") || {};
     const playlistWorker = normalizePlaylistWorkerSettings(
       readStoredSettingJson("playlistWorker", ["weeklyFlowWorker"]),
     );
@@ -174,6 +175,9 @@ export const dbOps = {
       releaseTypes: releaseTypes || [],
       flows: flows || null,
       sharedPlaylists: sharedPlaylists || null,
+      subsonic: {
+        favoriteAutoKeep: subsonic.favoriteAutoKeep !== false,
+      },
       playlistWorker,
       playlistArtwork,
       inbox: {
@@ -318,6 +322,14 @@ export const dbOps = {
         upsertSettingStmt.run(
           "sharedPlaylists",
           dbHelpers.stringifyJSON(settings.sharedPlaylists),
+        );
+      }
+      if (settings.subsonic !== undefined) {
+        upsertSettingStmt.run(
+          "subsonic",
+          dbHelpers.stringifyJSON({
+            favoriteAutoKeep: settings.subsonic.favoriteAutoKeep !== false,
+          }),
         );
       }
       if (settings.playlistWorker !== undefined) {

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -348,7 +348,11 @@ export function registerGeneral(router) {
             ? {
                 ...(currentSettings.subsonic || defaultData.settings.subsonic),
                 ...normalizedSubsonic,
-                favoriteAutoKeep: normalizedSubsonic.favoriteAutoKeep !== false,
+                favoriteAutoKeep:
+                  normalizedSubsonic.favoriteAutoKeep !== undefined
+                    ? normalizedSubsonic.favoriteAutoKeep !== false
+                    : (currentSettings.subsonic || defaultData.settings.subsonic)
+                        .favoriteAutoKeep !== false,
               }
             : currentSettings.subsonic || defaultData.settings.subsonic,
         rootFolderPath:

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -92,6 +92,7 @@ export function registerGeneral(router) {
       const {
         quality,
         qualityProfile,
+        subsonic,
         releaseTypes,
         integrations,
         rootFolderPath,
@@ -338,6 +339,14 @@ export function registerGeneral(router) {
                 integrations?.slskd,
               )
             : currentSettings.qualityProfile,
+        subsonic:
+          subsonic !== undefined
+            ? {
+                ...(currentSettings.subsonic || defaultData.settings.subsonic),
+                ...subsonic,
+                favoriteAutoKeep: subsonic.favoriteAutoKeep !== false,
+              }
+            : currentSettings.subsonic || defaultData.settings.subsonic,
         rootFolderPath:
           rootFolderPath !== undefined
             ? rootFolderPath

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -325,7 +325,7 @@ export function registerGeneral(router) {
       const normalizedSubsonic =
         subsonic && typeof subsonic === "object" && !Array.isArray(subsonic)
           ? subsonic
-          : {};
+          : null;
       const updatedSettings = {
         ...currentSettings,
         dateTimeFormat:
@@ -344,7 +344,7 @@ export function registerGeneral(router) {
               )
             : currentSettings.qualityProfile,
         subsonic:
-          subsonic !== undefined
+          normalizedSubsonic !== null
             ? {
                 ...(currentSettings.subsonic || defaultData.settings.subsonic),
                 ...normalizedSubsonic,

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -322,6 +322,10 @@ export function registerGeneral(router) {
       if (mergedIntegrations?.coverArtArchive) {
         delete mergedIntegrations.coverArtArchive;
       }
+      const normalizedSubsonic =
+        subsonic && typeof subsonic === "object" && !Array.isArray(subsonic)
+          ? subsonic
+          : {};
       const updatedSettings = {
         ...currentSettings,
         dateTimeFormat:
@@ -343,8 +347,8 @@ export function registerGeneral(router) {
           subsonic !== undefined
             ? {
                 ...(currentSettings.subsonic || defaultData.settings.subsonic),
-                ...subsonic,
-                favoriteAutoKeep: subsonic.favoriteAutoKeep !== false,
+                ...normalizedSubsonic,
+                favoriteAutoKeep: normalizedSubsonic.favoriteAutoKeep !== false,
               }
             : currentSettings.subsonic || defaultData.settings.subsonic,
         rootFolderPath:

--- a/backend/routes/subsonic.js
+++ b/backend/routes/subsonic.js
@@ -1,7 +1,7 @@
 import express from "express";
 
 import { APP_NAME, APP_VERSION } from "../config/constants.js";
-import { resolveSubsonicTokenUser, resolveUser } from "../middleware/auth.js";
+import { hasPermission, resolveSubsonicTokenUser, resolveUser } from "../middleware/auth.js";
 import { streamAudioFile } from "../services/audioFileStream.js";
 import {
   getAlbum,
@@ -17,11 +17,14 @@ import {
   getStarred,
   getTopSongs,
   listArtists,
+  createSubsonicPlaylist,
+  deleteSubsonicPlaylist,
   resolvePlaylistArtwork,
   resolveArtworkUrl,
   resolveStreamPath,
   searchLibrary,
   starMany,
+  updateSubsonicPlaylist,
   unstarMany,
 } from "../services/subsonicLibraryService.js";
 import { recordPlayEvent } from "../services/playEventService.js";
@@ -210,7 +213,7 @@ async function handleSubsonicRequest(req, res) {
         downloadRole: true,
         folder: [1],
         jukeboxRole: false,
-        playlistRole: Boolean(req.user.permissions?.accessFlow),
+        playlistRole: hasPermission(req.user, "accessFlow"),
         podcastRole: false,
         scrobblingEnabled: true,
         settingsRole: isAdmin,
@@ -329,6 +332,37 @@ async function handleSubsonicRequest(req, res) {
   if (method === "getplaylists") {
     return sendResponse(res, format, "ok", null, { playlists: { playlist: getFlowPlaylists(user) } });
   }
+  if (method === "createplaylist") {
+    const playlistId = getParameter(req, "playlistId");
+    const name = getParameter(req, "name");
+    if (!playlistId && !name) {
+      return sendError(res, format, 10, "Required parameter is missing: name");
+    }
+    try {
+      const playlist = playlistId
+        ? updateSubsonicPlaylist(user, {
+            playlistId,
+            name: name || undefined,
+            comment: Object.hasOwn(req.query || {}, "comment")
+              ? getParameter(req, "comment")
+              : undefined,
+            songIdsToAdd: getParameters(req, ["songId"]),
+          })
+        : createSubsonicPlaylist(user, {
+            name,
+            songIds: getParameters(req, ["songId"]),
+          });
+      if (!playlist) return sendError(res, format, 70, "Requested data was not found");
+      return sendResponse(res, format, "ok", null, {
+        playlist: getFlowPlaylist(`shared:${encodeURIComponent(playlist.id)}`, user),
+      });
+    } catch (error) {
+      if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
+        return sendError(res, format, 50, error.message);
+      }
+      return sendError(res, format, 0, "Failed to update playlist");
+    }
+  }
   if (method === "getstarred" || method === "getstarred2") {
     return sendResponse(res, format, "ok", null, {
       [method === "getstarred" ? "starred" : "starred2"]: getStarred(user),
@@ -356,6 +390,39 @@ async function handleSubsonicRequest(req, res) {
     const playlist = getFlowPlaylist(getParameter(req, "id"), user);
     return playlist
       ? sendResponse(res, format, "ok", null, { playlist })
+      : sendError(res, format, 70, "Requested data was not found");
+  }
+  if (method === "updateplaylist") {
+    const playlistId = getParameter(req, "playlistId");
+    if (!playlistId) return sendError(res, format, 10, "Required parameter is missing: playlistId");
+    const songIndexesToRemove = getParameters(req, ["songIndexToRemove"])
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => Number.isInteger(value) && value >= 0);
+    try {
+      const playlist = updateSubsonicPlaylist(user, {
+        playlistId,
+        name: Object.hasOwn(req.query || {}, "name") ? getParameter(req, "name") : undefined,
+        comment: Object.hasOwn(req.query || {}, "comment")
+          ? getParameter(req, "comment")
+          : undefined,
+        songIdsToAdd: getParameters(req, ["songIdToAdd"]),
+        songIndexesToRemove,
+      });
+      return playlist
+        ? sendResponse(res, format)
+        : sendError(res, format, 70, "Requested data was not found");
+    } catch (error) {
+      if (error?.code === "SHARED_PLAYLIST_NAME_CONFLICT") {
+        return sendError(res, format, 50, error.message);
+      }
+      return sendError(res, format, 0, "Failed to update playlist");
+    }
+  }
+  if (method === "deleteplaylist") {
+    const playlistId = getParameter(req, "id");
+    if (!playlistId) return sendError(res, format, 10, "Required parameter is missing: id");
+    return deleteSubsonicPlaylist(user, playlistId)
+      ? sendResponse(res, format)
       : sendError(res, format, 70, "Requested data was not found");
   }
   if (method === "stream" || method === "download") {

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -12,6 +12,7 @@ import {
   upsertLibraryTrack,
   withLibraryScan,
 } from "./libraryMediaStore.js";
+import { parseAurralIdentityComment } from "./playlistDownloadUtils.js";
 
 const AUDIO_EXTENSIONS = new Set([
   ".aac",
@@ -52,6 +53,32 @@ const numberPart = (value, fallback = 0) => {
 const normalizeMbid = (value) => text(first(value)) || null;
 
 const normalizeMetadata = (metadata) => metadata?.common || {};
+
+const applyMetadataEnrichment = (metadata, enrichment = null) => {
+  const common = { ...normalizeMetadata(metadata) };
+  const embedded = parseAurralIdentityComment(common.comment);
+  if ((!enrichment || typeof enrichment !== "object") && !embedded) return metadata;
+  const trusted = { ...(embedded || {}), ...(enrichment || {}) };
+  const fallbackFields = {
+    albumartist: trusted.artistName,
+    artist: trusted.artistName,
+    album: trusted.albumName,
+    title: trusted.trackName,
+    date: trusted.releaseYear,
+    track: trusted.trackNumber,
+    musicbrainz_artistid: trusted.artistMbid,
+    musicbrainz_albumartistid: trusted.artistMbid,
+    musicbrainz_albumid: trusted.albumMbid,
+    musicbrainz_releasegroupid: trusted.albumMbid,
+    musicbrainz_recordingid: trusted.trackMbid,
+    musicbrainz_trackid: trusted.trackMbid,
+  };
+  for (const [key, value] of Object.entries(fallbackFields)) {
+    if (value == null || String(value).trim() === "") continue;
+    if (common[key] == null || String(common[key]).trim() === "") common[key] = value;
+  }
+  return { ...(metadata || {}), common };
+};
 
 function readPathFallback(filePath, rootPath) {
   const relative = path.relative(rootPath, filePath);
@@ -146,6 +173,7 @@ export async function scanMusicRoot({
   source = "aurral",
   filePaths = null,
   metadataReader = parseFile,
+  metadataEnricher = null,
 } = {}) {
   const resolvedRoot = path.resolve(String(rootPath || ""));
   await fs.mkdir(resolvedRoot, { recursive: true });
@@ -173,7 +201,13 @@ export async function scanMusicRoot({
             metadataReader(filePath, { skipCovers: true }),
             fs.stat(filePath),
           ]);
-          const record = buildMetadataRecord(metadata, filePath, resolvedRoot);
+          const enrichedMetadata = applyMetadataEnrichment(
+            metadata,
+            typeof metadataEnricher === "function"
+              ? await metadataEnricher(metadata, filePath)
+              : null,
+          );
+          const record = buildMetadataRecord(enrichedMetadata, filePath, resolvedRoot);
           const artist = upsertLibraryArtist({
             identityKey: record.artistKey,
             mbid: record.artistMbid,

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -1,9 +1,44 @@
+import path from "node:path";
+import { db } from "../config/db-sqlite.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 import { scanMusicRoot } from "./libraryFileScanner.js";
 import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
 
+function getAurralJobMetadataByPath() {
+  const rows = db
+    .prepare(
+      `SELECT final_path, artist_name, album_name, track_name,
+        artist_mbid, album_mbid, track_mbid, release_year, track_number
+       FROM playlist_download_jobs
+       WHERE status = 'done' AND final_path IS NOT NULL
+       ORDER BY completed_at DESC, created_at DESC`,
+    )
+    .all();
+  const byPath = new Map();
+  for (const row of rows) {
+    const filePath = String(row.final_path || "").trim();
+    if (!filePath || byPath.has(path.resolve(filePath))) continue;
+    byPath.set(path.resolve(filePath), {
+      artistName: row.artist_name,
+      albumName: row.album_name,
+      trackName: row.track_name,
+      artistMbid: row.artist_mbid,
+      albumMbid: row.album_mbid,
+      trackMbid: row.track_mbid,
+      releaseYear: row.release_year,
+      trackNumber: row.track_number,
+    });
+  }
+  return byPath;
+}
+
 export async function scanConfiguredLibrary({ musicRoot = resolvePlaylistRoot(), lidarrClient } = {}) {
-  const local = await scanMusicRoot({ rootPath: musicRoot, source: "aurral" });
+  const jobMetadataByPath = getAurralJobMetadataByPath();
+  const local = await scanMusicRoot({
+    rootPath: musicRoot,
+    source: "aurral",
+    metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
+  });
   let lidarr = { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   try {
     lidarr = await indexLidarrLibrary({ client: lidarrClient });

--- a/backend/services/playback/playbackPlaylistTracks.js
+++ b/backend/services/playback/playbackPlaylistTracks.js
@@ -20,12 +20,21 @@ async function isFile(filePath) {
 
 export async function collectPlaybackPlaylistTracks(entityId, options = {}) {
   const weeklyFlowRoot = path.resolve(options.weeklyFlowRoot || resolvePlaylistRoot());
-  const jobs = downloadTracker
-    .getByPlaylistType(entityId)
+  const playlist = flowPlaylistConfig.getSharedPlaylist(entityId);
+  const referencedJobs = (playlist?.tracks || [])
+    .map((track) => (track?.canonicalJobId ? downloadTracker.getJob(track.canonicalJobId) : null))
+    .filter(Boolean);
+  const jobs = [
+    ...referencedJobs,
+    ...downloadTracker.getByPlaylistType(entityId),
+  ]
+    .filter((job, index, values) =>
+      values.findIndex((candidate) => candidate.id === job.id) === index,
+    )
     .filter((job) => job?.status === "done" && typeof job?.finalPath === "string");
   const orderedJobs = orderJobsBySharedPlaylistTracks(
     jobs,
-    flowPlaylistConfig.getSharedPlaylist(entityId)?.tracks,
+    playlist?.tracks,
   );
   const tracks = [];
   for (const job of orderedJobs) {

--- a/backend/services/playlistDownloadUtils.js
+++ b/backend/services/playlistDownloadUtils.js
@@ -5,6 +5,7 @@ import fs from "fs/promises";
 import { parseFile } from "music-metadata";
 
 const execFileAsync = promisify(execFile);
+const AURRAL_IDENTITY_PREFIX = "AURRAL_IDS=";
 
 export function sanitizePathPart(value, fallback = "Unknown") {
   const text = String(value || "")
@@ -37,6 +38,30 @@ export function parseStringListJson(value) {
 export function stringifyStringListJson(value) {
   const normalized = normalizeStringList(value);
   return normalized.length > 0 ? JSON.stringify(normalized) : null;
+}
+
+export function buildAurralIdentityComment(metadata = {}) {
+  const identity = Object.fromEntries(
+    ["artistMbid", "albumMbid", "trackMbid"]
+      .map((key) => [key, String(metadata?.[key] || "").trim()])
+      .filter(([, value]) => value),
+  );
+  return Object.keys(identity).length > 0
+    ? `${AURRAL_IDENTITY_PREFIX}${JSON.stringify(identity)}`
+    : null;
+}
+
+export function parseAurralIdentityComment(value) {
+  const comments = Array.isArray(value) ? value : [value];
+  for (const entry of comments) {
+    const text = String(typeof entry === "object" ? entry?.text || "" : entry || "").trim();
+    if (!text.startsWith(AURRAL_IDENTITY_PREFIX)) continue;
+    try {
+      const parsed = JSON.parse(text.slice(AURRAL_IDENTITY_PREFIX.length));
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    } catch {}
+  }
+  return null;
 }
 
 export function buildResolvedPlaylistTrack(job, payloadTrack = {}) {
@@ -140,6 +165,13 @@ export async function writeAudioMetadata(filePath, metadata = {}) {
     ["artist", metadata.artistName],
     ["album_artist", metadata.artistName],
     ["album", metadata.albumName],
+    ["musicbrainz_artistid", metadata.artistMbid],
+    ["musicbrainz_albumartistid", metadata.artistMbid],
+    ["musicbrainz_albumid", metadata.albumMbid],
+    ["musicbrainz_releasegroupid", metadata.albumMbid],
+    ["musicbrainz_recordingid", metadata.trackMbid],
+    ["musicbrainz_trackid", metadata.trackMbid],
+    ["comment", buildAurralIdentityComment(metadata)],
     ["date", metadata.releaseYear],
     ["track", normalizePositiveInteger(metadata.trackNumber)],
   ].filter(([, value]) => value != null && String(value).trim());
@@ -194,8 +226,32 @@ export async function repairYtdlpMetadata(jobs = []) {
         [common.albumartist, job.artistName],
         [common.album, job.albumName],
       ].filter(([, value]) => String(value || "").trim());
+      const embeddedIdentity = parseAurralIdentityComment(common.comment) || {};
+      const expectedIdentity = [
+        [
+          common.musicbrainz_albumartistid ||
+            common.musicbrainz_artistid ||
+            embeddedIdentity.artistMbid,
+          job.artistMbid,
+        ],
+        [
+          common.musicbrainz_releasegroupid ||
+            common.musicbrainz_albumid ||
+            embeddedIdentity.albumMbid,
+          job.albumMbid,
+        ],
+        [
+          common.musicbrainz_recordingid ||
+            common.musicbrainz_trackid ||
+            embeddedIdentity.trackMbid,
+          job.trackMbid,
+        ],
+      ].filter(([, value]) => String(value || "").trim());
       if (
         expected.every(
+          ([actual, value]) => String(actual || "").trim() === String(value).trim(),
+        ) &&
+        expectedIdentity.every(
           ([actual, value]) => String(actual || "").trim() === String(value).trim(),
         )
       ) {

--- a/backend/services/slskdOrchestrator.js
+++ b/backend/services/slskdOrchestrator.js
@@ -30,6 +30,7 @@ import {
   commitImportToPlaylistLibrary,
   joinUnderRoot,
   sanitizePathPart,
+  writeAudioMetadata,
 } from "./playlistDownloadUtils.js";
 import {
   getPayloadCandidate,
@@ -1023,13 +1024,14 @@ async function handleFinalize(payload) {
   const finalDir = joinUnderRoot(playlistRoot, destination);
   const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".mp3"}`;
   const finalPath = path.join(finalDir, finalName);
+  const resolvedTrack = {
+    ...buildResolvedTrack(job, payload.track),
+    upgradeForJobId: payload.upgradeForJobId || null,
+  };
   const validation = await validateDownloadedTrack(
     sourcePath,
     candidate,
-    {
-      ...buildResolvedTrack(job, payload.track),
-      upgradeForJobId: payload.upgradeForJobId || null,
-    },
+    resolvedTrack,
   );
   if (!validation.valid) {
     logger.warn("slskd", "slskd download validation failed", {
@@ -1080,6 +1082,7 @@ async function handleFinalize(payload) {
       : null;    if (nextPayload) return nextPayload;
     return failOrTryNextSource(payload, job, validation.reason || "Download validation failed");
   }
+  await writeAudioMetadata(sourcePath, resolvedTrack);
   import("./aurralHistoryService.js")
     .then(({ recordTrackJobMoving }) => recordTrackJobMoving(job))
     .catch((err) => { logger.warn("slskd", "Failed to record track job moving", { jobId: job.id, error: err?.message || String(err) }); });

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -634,7 +634,7 @@ const findAvailableCanonicalFile = (track) => {
   return file?.available && file.path ? { file, albumName: findAlbumForTrack(library, candidate)?.title } : null;
 };
 
-const ensureLibraryJob = (track) => {
+const ensureLibraryJob = (track, createdJobIds = null) => {
   const existing = findLibraryJob(track);
   if (existing) {
     if (existing.status === "failed") {
@@ -648,6 +648,7 @@ const ensureLibraryJob = (track) => {
 
   const jobId = downloadTracker.addJob(track, "library");
   if (!jobId) return null;
+  if (createdJobIds) createdJobIds.push(jobId);
   const owned = findAvailableCanonicalFile(track);
   if (owned) {
     downloadTracker.setDone(jobId, owned.file.path, owned.albumName || track.albumName || null);
@@ -725,11 +726,13 @@ export function createSubsonicPlaylist(user, { name, songIds = [] } = {}) {
     ownerUserId: user.id,
     tracks: [],
   });
-  return replaceSubsonicPlaylistTracks(
+  const updated = replaceSubsonicPlaylistTracks(
     user,
     playlist,
     resolved.map((entry) => entry.track),
   );
+  if (!updated) flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+  return updated;
 }
 
 export function updateSubsonicPlaylist(
@@ -796,8 +799,12 @@ export function starMany(user, values) {
       : !findCanonical(library, target),
   )) return false;
   if (favoriteAutoKeepEnabled()) {
+    const createdJobIds = [];
     for (const entry of playlistSongs.filter(Boolean)) {
-      if (!ensureLibraryJob(entry.track)) return false;
+      if (!ensureLibraryJob(entry.track, createdJobIds)) {
+        for (const jobId of createdJobIds) downloadTracker.removeJob(jobId);
+        return false;
+      }
     }
   }
   const addStars = db.transaction(() => {
@@ -931,9 +938,7 @@ export function getFlowPlaylist(value, user) {
   const kind = parsed?.kind === "shared" ? "shared" : "flow";
   const playlist = playlistFromId(user, value);
   if (!playlist) return null;
-  const jobs = flowJobs(playlist, {
-    includePending: parsed?.kind === "shared",
-  });
+  const jobs = flowJobs(playlist);
   return {
     id: idFor(kind, playlist.id),
     name: playlist.name,

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -684,7 +684,7 @@ const normalizeSharedPlaylistId = (value) => {
   return parsed?.kind === "shared" ? parsed.key : String(value || "").trim();
 };
 
-const canonicalizePlaylistTracks = (tracks) => {
+const canonicalizePlaylistTracks = (tracks, createdJobIds = null) => {
   const normalized = [];
   for (const track of Array.isArray(tracks) ? tracks : []) {
     const candidate = normalizeSharedTrack(track);
@@ -694,7 +694,7 @@ const canonicalizePlaylistTracks = (tracks) => {
       : null;
     const jobId = existingJob && isSameTrack(existingJob, candidate)
       ? existingJob.id
-      : ensureLibraryJob(candidate);
+      : ensureLibraryJob(candidate, createdJobIds);
     if (!jobId) return null;
     normalized.push(toCanonicalPlaylistTrack(candidate, jobId));
   }
@@ -703,12 +703,20 @@ const canonicalizePlaylistTracks = (tracks) => {
 
 const replaceSubsonicPlaylistTracks = (user, playlist, tracks, updates = {}) => {
   if (!playlist || !flowPlaylistConfig.canUserAccessSharedPlaylist(user, playlist)) return null;
-  const canonicalTracks = canonicalizePlaylistTracks(tracks);
-  if (!canonicalTracks) return null;
+  const createdJobIds = [];
+  const canonicalTracks = canonicalizePlaylistTracks(tracks, createdJobIds);
+  if (!canonicalTracks) {
+    for (const jobId of createdJobIds) downloadTracker.removeJob(jobId);
+    return null;
+  }
   const updated = flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
     ...updates,
     tracks: canonicalTracks,
   });
+  if (!updated) {
+    for (const jobId of createdJobIds) downloadTracker.removeJob(jobId);
+    return null;
+  }
   removeLegacyPlaylistJobs(playlist.id);
   refreshSubsonicPlaylist(playlist.id);
   return updated;

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { dbOps } from "../db/helpers/index.js";
 import { db } from "../config/db-sqlite.js";
 import { getCanonicalLibrary } from "./libraryQueryService.js";
@@ -5,9 +6,16 @@ import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
 import { getArtistImage } from "./imageService.js";
 import { buildImageProxyUrl, warmPublicImageUrl } from "./imageProxyService.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
-import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
+import {
+  flowPlaylistConfig,
+  normalizeSharedTrack,
+  orderJobsBySharedPlaylistTracks,
+  tracksShareMembership,
+} from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
 import { playlistManager } from "./weeklyFlow/weeklyFlowPlaylistManager.js";
+import { weeklyFlowWorker } from "./weeklyFlow/weeklyFlowWorker.js";
 import { hasPermission } from "../middleware/auth.js";
+import { recordTrackJobQueued } from "./aurralHistoryService.js";
 
 const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
 const LIBRARY_IMAGE_PROFILE = "library";
@@ -275,6 +283,26 @@ function toPlaylistSong(playlist, kind, job) {
   };
 }
 
+function playlistJobs(playlist) {
+  if (!playlist) return [];
+  const referencedJobs = (playlist.tracks || [])
+    .map((track) => (track?.canonicalJobId ? downloadTracker.getJob(track.canonicalJobId) : null))
+    .filter(Boolean);
+  const jobs = [...referencedJobs, ...downloadTracker.getByPlaylistType(playlist.id)];
+  const uniqueJobs = jobs.filter(
+    (job, index, values) => values.findIndex((candidate) => candidate.id === job.id) === index,
+  );
+  return orderJobsBySharedPlaylistTracks(uniqueJobs, playlist.tracks);
+}
+
+function playlistOwnsJob(playlist, job) {
+  if (!playlist || !job) return false;
+  if (String(job.playlistType || "") === String(playlist.id || "")) return true;
+  return (playlist.tracks || []).some(
+    (track) => String(track?.canonicalJobId || "") === String(job.id || ""),
+  );
+}
+
 function playlistJobFromId(user, value) {
   const parsed = parseId(value);
   if (!parsed || !["flow-song", "shared-song"].includes(parsed.kind)) return null;
@@ -284,15 +312,15 @@ function playlistJobFromId(user, value) {
   const playlist = playlistFromId(user, idFor(kind, parsed.key.slice(0, separator)));
   if (!playlist) return null;
   const job = downloadTracker.getJob(parsed.key.slice(separator + 1));
-  return job?.playlistType === playlist.id && job.status === "done" && job.finalPath
+  return playlistOwnsJob(playlist, job) && job.status === "done" && job.finalPath
     ? { kind, playlist, job }
     : null;
 }
 
-const flowJobs = (flow) =>
-  downloadTracker
-    .getByPlaylistType(flow.id)
-    .filter((job) => job.status === "done" && job.finalPath);
+const flowJobs = (flow, { includePending = false } = {}) =>
+  playlistJobs(flow).filter(
+    (job) => includePending || (job.status === "done" && job.finalPath),
+  );
 
 const playlistCoverArt = (kind, playlistId) => idFor(kind, playlistId);
 
@@ -528,9 +556,225 @@ const removeStarStmt = db.prepare(
   "DELETE FROM subsonic_stars WHERE user_id = ? AND entity_kind = ? AND entity_key = ?",
 );
 
+const isSameTrack = (left, right) => tracksShareMembership(left, right);
+
+const trackFromJob = (job) => normalizeSharedTrack({
+  artistName: job?.artistName,
+  trackName: job?.trackName,
+  albumName: job?.albumName,
+  artistMbid: job?.artistMbid,
+  albumMbid: job?.albumMbid,
+  trackMbid: job?.trackMbid,
+  releaseYear: job?.releaseYear,
+  durationMs: job?.durationMs,
+  trackNumber: job?.trackNumber,
+  albumTrackCount: job?.albumTrackCount,
+  albumTrackTitles: job?.albumTrackTitles,
+  artistAliases: job?.artistAliases,
+});
+
+const trackFromCanonical = (library, track) => {
+  const album = findAlbumForTrack(library, track);
+  return normalizeSharedTrack({
+    artistName: track?.artistName,
+    trackName: track?.title,
+    albumName: album?.title,
+    artistMbid: findArtistForAlbum(library, album)?.mbid,
+    albumMbid: album?.mbid || album?.releaseGroupMbid,
+    trackMbid: track?.mbid,
+    releaseYear: year(album?.releaseDate),
+    durationMs: firstFile(track)?.durationMs,
+    trackNumber: track?.albums?.[0]?.trackNumber,
+  });
+};
+
+const resolvePlaylistSong = (user, value) => {
+  const parsed = parseId(value);
+  if (!parsed || !["flow-song", "shared-song"].includes(parsed.kind)) return null;
+  const separator = parsed.key.indexOf(":");
+  if (separator < 1) return null;
+  const kind = parsed.kind === "flow-song" ? "flow" : "shared";
+  const playlist = playlistFromId(user, idFor(kind, parsed.key.slice(0, separator)));
+  if (!playlist) return null;
+  const job = downloadTracker.getJob(parsed.key.slice(separator + 1));
+  if (!playlistOwnsJob(playlist, job)) return null;
+  const track = trackFromJob(job);
+  return track ? { kind, playlist, job, track } : null;
+};
+
+const resolveSubsonicTrack = (user, value) => {
+  const playlistSong = resolvePlaylistSong(user, value);
+  if (playlistSong) return playlistSong;
+  const parsed = parseId(value);
+  if (parsed?.kind !== "song") return null;
+  const library = readLibrary();
+  const track = findCanonical(library, parsed);
+  const normalized = trackFromCanonical(library, track);
+  return normalized ? { kind: "song", track: normalized, canonical: track } : null;
+};
+
+const favoriteAutoKeepEnabled = () => dbOps.getSettings()?.subsonic?.favoriteAutoKeep !== false;
+
+const findLibraryJob = (track) => {
+  const jobs = downloadTracker
+    .getAll()
+    .filter((job) => job.playlistType === "library" && isSameTrack(job, track));
+  return (
+    jobs.find((job) => job.status === "pending" || job.status === "downloading") ||
+    jobs.find((job) => job.status === "done") ||
+    jobs.find((job) => job.status === "failed") ||
+    null
+  );
+};
+
+const findAvailableCanonicalFile = (track) => {
+  const library = readLibrary();
+  const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
+  const file = firstFile(candidate);
+  return file?.available && file.path ? { file, albumName: findAlbumForTrack(library, candidate)?.title } : null;
+};
+
+const ensureLibraryJob = (track) => {
+  const existing = findLibraryJob(track);
+  if (existing) {
+    if (existing.status === "failed") {
+      downloadTracker.setPending(existing.id, "Requested again", { asRetryCycle: true });
+    }
+    if (existing.status !== "done") {
+      weeklyFlowWorker.start().catch(() => {});
+    }
+    return existing.id;
+  }
+
+  const jobId = downloadTracker.addJob(track, "library");
+  if (!jobId) return null;
+  const owned = findAvailableCanonicalFile(track);
+  if (owned) {
+    downloadTracker.setDone(jobId, owned.file.path, owned.albumName || track.albumName || null);
+    return jobId;
+  }
+  recordTrackJobQueued(downloadTracker.getJob(jobId));
+  weeklyFlowWorker.start().catch(() => {});
+  return jobId;
+};
+
+const toCanonicalPlaylistTrack = (track, canonicalJobId) => ({
+  ...track,
+  canonicalJobId: String(canonicalJobId || "").trim() || null,
+});
+
+const removeLegacyPlaylistJobs = (playlistId) => {
+  for (const job of downloadTracker.getByPlaylistType(playlistId)) {
+    downloadTracker.removeJob(job.id);
+  }
+};
+
+const refreshSubsonicPlaylist = (playlistId) => {
+  playlistManager.updateConfig(false);
+  Promise.all([
+    playlistManager.ensureSmartPlaylists(),
+    playlistManager.refreshPlaylist(playlistId),
+  ]).catch(() => {});
+  playlistManager.scheduleScanLibrary();
+};
+
+const normalizeSharedPlaylistId = (value) => {
+  const parsed = parseId(value);
+  return parsed?.kind === "shared" ? parsed.key : String(value || "").trim();
+};
+
+const canonicalizePlaylistTracks = (tracks) => {
+  const normalized = [];
+  for (const track of Array.isArray(tracks) ? tracks : []) {
+    const candidate = normalizeSharedTrack(track);
+    if (!candidate) continue;
+    const existingJob = candidate.canonicalJobId
+      ? downloadTracker.getJob(candidate.canonicalJobId)
+      : null;
+    const jobId = existingJob && isSameTrack(existingJob, candidate)
+      ? existingJob.id
+      : ensureLibraryJob(candidate);
+    if (!jobId) return null;
+    normalized.push(toCanonicalPlaylistTrack(candidate, jobId));
+  }
+  return normalized;
+};
+
+const replaceSubsonicPlaylistTracks = (user, playlist, tracks, updates = {}) => {
+  if (!playlist || !flowPlaylistConfig.canUserAccessSharedPlaylist(user, playlist)) return null;
+  const canonicalTracks = canonicalizePlaylistTracks(tracks);
+  if (!canonicalTracks) return null;
+  const updated = flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
+    ...updates,
+    tracks: canonicalTracks,
+  });
+  removeLegacyPlaylistJobs(playlist.id);
+  refreshSubsonicPlaylist(playlist.id);
+  return updated;
+};
+
+export function createSubsonicPlaylist(user, { name, songIds = [] } = {}) {
+  if (!hasPermission(user, "accessFlow")) return null;
+  const safeName = String(name || "").trim();
+  if (!safeName) return null;
+  const resolved = songIds.map((id) => resolveSubsonicTrack(user, id));
+  if (resolved.some((entry) => !entry)) return null;
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    id: randomUUID(),
+    name: safeName,
+    ownerUserId: user.id,
+    tracks: [],
+  });
+  return replaceSubsonicPlaylistTracks(
+    user,
+    playlist,
+    resolved.map((entry) => entry.track),
+  );
+}
+
+export function updateSubsonicPlaylist(
+  user,
+  { playlistId, name, comment, songIdsToAdd = [], songIndexesToRemove = [] } = {},
+) {
+  const playlist = flowPlaylistConfig.getSharedPlaylistForUser(
+    user,
+    normalizeSharedPlaylistId(playlistId),
+  );
+  if (!playlist || !hasPermission(user, "accessFlow")) return null;
+  const resolvedAdds = songIdsToAdd.map((id) => resolveSubsonicTrack(user, id));
+  if (resolvedAdds.some((entry) => !entry)) return null;
+  const removals = new Set(songIndexesToRemove);
+  const currentTracks = playlist.tracks.filter((_track, index) => !removals.has(index));
+  const nextTracks = [
+    ...currentTracks,
+    ...resolvedAdds.map((entry) => entry.track),
+  ];
+  const updates = {};
+  if (name !== undefined) updates.name = String(name || "").trim();
+  if (comment !== undefined) updates.description = String(comment || "").trim() || null;
+  return replaceSubsonicPlaylistTracks(user, playlist, nextTracks, updates);
+}
+
+export function deleteSubsonicPlaylist(user, playlistId) {
+  const playlist = flowPlaylistConfig.getSharedPlaylistForUser(
+    user,
+    normalizeSharedPlaylistId(playlistId),
+  );
+  if (!playlist || !hasPermission(user, "accessFlow")) return false;
+  removeLegacyPlaylistJobs(playlist.id);
+  const deleted = flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+  if (deleted) {
+    playlistManager.updateConfig(false);
+    playlistManager.deletePlaybackPlaylist(playlist).catch(() => {});
+  }
+  return deleted;
+}
+
 const starTarget = (value) => {
   const parsed = parseId(value);
-  return parsed && ["artist", "album", "song"].includes(parsed.kind) ? parsed : null;
+  return parsed && ["artist", "album", "song", "flow-song", "shared-song"].includes(parsed.kind)
+    ? parsed
+    : null;
 };
 
 export function star(user, value) {
@@ -541,7 +785,21 @@ export function starMany(user, values) {
   const parsed = values.map(starTarget);
   if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
   const library = readLibrary();
-  if (parsed.some((target) => !findCanonical(library, target))) return false;
+  const playlistSongs = parsed.map((target) =>
+    ["flow-song", "shared-song"].includes(target.kind)
+      ? resolvePlaylistSong(user, idFor(target.kind, target.key))
+      : null,
+  );
+  if (parsed.some((target, index) =>
+    ["flow-song", "shared-song"].includes(target.kind)
+      ? !playlistSongs[index]
+      : !findCanonical(library, target),
+  )) return false;
+  if (favoriteAutoKeepEnabled()) {
+    for (const entry of playlistSongs.filter(Boolean)) {
+      if (!ensureLibraryJob(entry.track)) return false;
+    }
+  }
   const addStars = db.transaction(() => {
     for (const target of parsed) addStarStmt.run(user.id, target.kind, target.key, Date.now());
   });
@@ -569,10 +827,22 @@ export function getStarredIdentityKeys(user) {
   return new Set(starredRows(user).map((row) => `${row.entity_kind}:${row.entity_key}`));
 }
 
-const buildStarred = (library, rows) => {
+const buildStarred = (library, rows, user) => {
   const starred = { album: [], artist: [], song: [] };
   for (const row of rows) {
     const parsed = { kind: row.entity_kind, key: row.entity_key };
+    if (["flow-song", "shared-song"].includes(parsed.kind)) {
+      const separator = parsed.key.indexOf(":");
+      const kind = parsed.kind === "flow-song" ? "flow" : "shared";
+      const playlist = separator > 0
+        ? playlistFromId(user, idFor(kind, parsed.key.slice(0, separator)))
+        : null;
+      const job = separator > 0 ? downloadTracker.getJob(parsed.key.slice(separator + 1)) : null;
+      if (playlist && playlistOwnsJob(playlist, job)) {
+        starred.song.push(toPlaylistSong(playlist, kind, job));
+      }
+      continue;
+    }
     const entity = findCanonical(library, parsed);
     if (!entity) continue;
     if (parsed.kind === "artist") starred.artist.push(toArtistSummary(entity));
@@ -584,10 +854,11 @@ const buildStarred = (library, rows) => {
 
 export function getStarredWithLibrary(user) {
   const rows = starredRows(user);
+  const canonicalRows = rows.filter((row) => ["artist", "album", "song"].includes(row.entity_kind));
   const library = getCanonicalLibrary({
-    favoriteKeys: rows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),
+    favoriteKeys: canonicalRows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),
   });
-  return { starred: buildStarred(indexLibrary(library), rows), library };
+  return { starred: buildStarred(indexLibrary(library), rows, user), library };
 }
 
 export function getStarred(user) {
@@ -637,7 +908,7 @@ export function getFlowPlaylists(user) {
     return playlist;
   });
   const sharedPlaylists = flowPlaylistConfig.getSharedPlaylistsForUser(user).map((playlist) => {
-    const jobs = flowJobs(playlist);
+    const jobs = flowJobs(playlist, { includePending: true });
     const value = {
       id: idFor("shared", playlist.id),
       name: playlist.name,
@@ -660,7 +931,9 @@ export function getFlowPlaylist(value, user) {
   const kind = parsed?.kind === "shared" ? "shared" : "flow";
   const playlist = playlistFromId(user, value);
   if (!playlist) return null;
-  const jobs = flowJobs(playlist);
+  const jobs = flowJobs(playlist, {
+    includePending: parsed?.kind === "shared",
+  });
   return {
     id: idFor(kind, playlist.id),
     name: playlist.name,

--- a/backend/services/usenetOrchestrator.js
+++ b/backend/services/usenetOrchestrator.js
@@ -21,6 +21,7 @@ import {
   commitImportToPlaylistLibrary,
   joinUnderRoot,
   sanitizePathPart,
+  writeAudioMetadata,
 } from "./playlistDownloadUtils.js";
 import {
   getPayloadCandidate,
@@ -416,6 +417,7 @@ async function handleUsenetFinalize(payload, helpers) {
   const finalDir = joinUnderRoot(playlistRoot, destination);
   const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".mp3"}`;
   const finalPath = path.join(finalDir, finalName);
+  await writeAudioMetadata(found.filePath, resolvedTrack);
   const committedFinalPath = await commitImportToPlaylistLibrary(
     found.filePath,
     finalPath,

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -116,6 +116,11 @@ function isFlowPlaylistType(playlistType) {
   return Boolean(flowPlaylistConfig.getFlow(String(playlistType || "").trim()));
 }
 
+function isCanonicalPlaylistType(playlistType) {
+  const key = String(playlistType || "").trim();
+  return key === "library" || Boolean(flowPlaylistConfig.getSharedPlaylist(key));
+}
+
 function tracksShareLibraryMembership(left, right) {
   const leftTrackMbid = String(left?.trackMbid || "").trim();
   const rightTrackMbid = String(right?.trackMbid || "").trim();
@@ -192,7 +197,7 @@ export async function adoptFileIntoPlaylist(sourcePath, targetPlaylistType, week
   if (!safeTarget || !(await fileExists(resolvedSource))) return null;
 
   const knownFlow = isFlowPlaylistType(safeTarget);
-  const knownPlaylist = Boolean(flowPlaylistConfig.getSharedPlaylist(safeTarget));
+  const knownPlaylist = isCanonicalPlaylistType(safeTarget);
   const canonical = knownFlow || knownPlaylist;
   const ephemeral = knownFlow;
   const targetRoot = ephemeral
@@ -768,15 +773,42 @@ export async function reuseTrackForPlaylist(track, playlistType, options = {}) {
     return { reused: false, reason: "Existing file reuse is disabled" };
   }
   const weeklyFlowRoot = path.resolve(options.weeklyFlowRoot || resolveWeeklyFlowRoot());
+  const targetPlaylistType = String(options.targetPlaylistType || playlistType || "").trim();
+  if (targetPlaylistType === "library") {
+    const excluded = new Set(
+      (Array.isArray(options.excludeJobIds) ? options.excludeJobIds : [])
+        .map((id) => String(id || "").trim())
+        .filter(Boolean),
+    );
+    const activeSource = downloadTracker.getAll().find(
+      (job) =>
+        job &&
+        (job.status === "pending" || job.status === "downloading") &&
+        !excluded.has(String(job.id || "")) &&
+        job.playlistType !== "library" &&
+        tracksShareLibraryMembership(track, job),
+    );
+    if (activeSource) {
+      return {
+        reused: false,
+        deferred: true,
+        sourceJobId: activeSource.id,
+        reason: "Waiting for an existing acquisition",
+      };
+    }
+  }
   const { source, reason } = await resolveReusableTrackSource(track, {
     ...options,
     existingFileMode: mode,
     weeklyFlowRoot,
-    targetPlaylistType: playlistType,
+    targetPlaylistType,
   });
   if (!source) return { reused: false, reason };
 
-  const finalPath = path.resolve(source.sourcePath);
+  const finalPath =
+    targetPlaylistType === "library" && source.sourceType === "aurral"
+      ? await adoptFileIntoPlaylist(source.sourcePath, "library", weeklyFlowRoot, { track })
+      : path.resolve(source.sourcePath);
   if (!(await fileExists(finalPath))) {
     return { reused: false, reason: "Source file is missing" };
   }

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -96,11 +96,21 @@ const sharedPlaylistTracksMatchJobs = (playlist, jobs) => {
   return unmatchedJobs.size === 0;
 };
 
+const getSharedPlaylistJobs = (playlist) => {
+  const referencedJobs = (playlist?.tracks || [])
+    .map((track) => (track?.canonicalJobId ? downloadTracker.getJob(track.canonicalJobId) : null))
+    .filter(Boolean);
+  const jobs = [...referencedJobs, ...downloadTracker.getByPlaylistType(playlist?.id)];
+  return jobs.filter(
+    (job, index, values) => values.findIndex((candidate) => candidate.id === job.id) === index,
+  );
+};
+
 const syncSharedPlaylistConfigFromJobs = async (playlistId) => {
   const safePlaylistId = String(playlistId || "").trim();
   const playlist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
   if (!playlist) return null;
-  const jobs = downloadTracker.getByPlaylistType(safePlaylistId);
+  const jobs = getSharedPlaylistJobs(playlist);
   if (sharedPlaylistTracksMatchJobs(playlist, jobs)) {
     return playlist;
   }
@@ -118,6 +128,13 @@ const queueTracksForPlaylist = async (tracks, playlistId) => {
   const jobIds = [];
   const createdJobIds = [];
   for (const track of normalizeTrackList(tracks)) {
+    const canonicalJob = track.canonicalJobId
+      ? downloadTracker.getJob(track.canonicalJobId)
+      : null;
+    if (canonicalJob && tracksShareMembership(canonicalJob, track)) {
+      reusedJobIds.push(canonicalJob.id);
+      continue;
+    }
     const jobId = downloadTracker.addJob(track, playlistId);
     if (!jobId) continue;
     createdJobIds.push(jobId);
@@ -148,7 +165,11 @@ const filterTracksMissingDownloadJobs = (tracks, playlistId) => {
   const missing = [];
   const queued = [];
   for (const track of normalizeTrackList(tracks)) {
+    const canonicalJob = track.canonicalJobId
+      ? downloadTracker.getJob(track.canonicalJobId)
+      : null;
     const duplicate =
+      Boolean(canonicalJob && tracksShareMembership(canonicalJob, track)) ||
       existingJobs.some((job) => tracksShareMembership(job, track)) ||
       queued.some((entry) => tracksShareMembership(entry, track));
     if (duplicate) continue;

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
@@ -295,6 +295,7 @@ export const normalizeSharedTrack = (track) => {
     ? track.artistAliases.map((entry) => String(entry || "").trim()).filter(Boolean)
     : [];
   const reason = String(track.reason ?? "").trim();
+  const canonicalJobId = String(track.canonicalJobId ?? track.libraryJobId ?? "").trim();
   return {
     artistName,
     trackName,
@@ -306,6 +307,7 @@ export const normalizeSharedTrack = (track) => {
     durationMs,
     artistAliases,
     reason: reason || null,
+    ...(canonicalJobId ? { canonicalJobId } : {}),
   };
 };
 

--- a/backend/services/weeklyFlow/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlow/weeklyFlowWorker.js
@@ -803,6 +803,13 @@ export class WeeklyFlowWorker {
           };
           return;
         }
+        if (reuse.deferred) {
+          downloadTracker.deferPendingToBack(job.id, reuse.reason, {
+            keepRetryTier: true,
+          });
+          this._scheduleProcessIn(JOB_COOLDOWN_MS);
+          return;
+        }
       }
       if (!isAnyDownloadSourceConfigured()) {
         throw new Error(getDownloadSourceNotConfiguredMessage());

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -9,7 +9,11 @@ Navidrome must be able to read and scan the Aurral download tree for that destin
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
-Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist/album/song search, artwork, direct streaming with byte ranges, and user-scoped favorites through `getStarred`, `star`, and `unstar`. Completed flow entries and accessible shared-playlist entries are exposed as read-only playlist items through `getPlaylists` and `getPlaylist`; the endpoint does not create or update playlists, transcode audio, or write to the canonical library. Navidrome remains optional for clients that connect directly to Aurral.
+Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It supports XML and JSON browsing, canonical artist, album, and song search, artwork, direct streaming with byte ranges, user-scoped favorites, and playlist changes through `createPlaylist`, `updatePlaylist`, and `deletePlaylist`. Flow entries and accessible shared-playlist entries are available through `getPlaylists` and `getPlaylist`. Navidrome remains optional for clients that connect directly to Aurral.
+
+When a Subsonic client adds a Flow or shared-playlist entry to a playlist, Aurral stores a reference to one canonical library acquisition job. The acquisition runs in the background. Multiple playlists that add the same track share that job. Removing a playlist entry removes only that playlist reference. It does not delete the canonical media file.
+
+Favoriting a Flow or shared-playlist entry uses the same canonical acquisition by default. To keep the favorite without acquiring the track, turn off **Favorite Flow tracks** in **Settings > System > Subsonic**. This setting does not change favorites for tracks that already exist in the canonical library.
 
 ## Connect a Subsonic client
 

--- a/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
@@ -3,6 +3,7 @@ import { AlertCircle, Check, Copy, RotateCcw } from "lucide-react";
 import { getApiKey, rotateApiKey } from "../../../utils/api/endpoints/auth";
 import { SettingsSystemSection } from "./SettingsStorageSection";
 import { SettingsSelect } from "./SettingsField";
+import PillToggle from "../../../components/PillToggle";
 import { setDateTimeFormat } from "../../../utils/dateTime.js";
 
 export function SettingsSystemTab({ health, settings, updateSettings, showSuccess, showError }) {
@@ -85,6 +86,40 @@ export function SettingsSystemTab({ health, settings, updateSettings, showSucces
               <option value="day-first">14:30 09/08/2026</option>
               <option value="year-first">2026/08/09 14:30</option>
             </SettingsSelect>
+          </div>
+        </div>
+      </section>
+
+      <section className="settings-system__section">
+        <div className="settings-system__section-header">
+          <h2 className="settings-system__section-title">Subsonic</h2>
+        </div>
+        <div className="settings-system__rows">
+          <div className="settings-system__row">
+            <div className="settings-system__copy">
+              <label className="settings-system__label" htmlFor="subsonic-favorite-auto-keep">
+                Favorite Flow tracks
+              </label>
+              <p className="settings-system__description">
+                Keep a Flow track in the permanent Library when a Subsonic client favorites it.
+              </p>
+            </div>
+            <div className="settings-system__value">
+              <PillToggle
+                id="subsonic-favorite-auto-keep"
+                checked={settings.subsonic?.favoriteAutoKeep !== false}
+                onChange={(event) =>
+                  updateSettings({
+                    ...settings,
+                    subsonic: {
+                      ...(settings.subsonic || {}),
+                      favoriteAutoKeep: event.target.checked,
+                    },
+                  })
+                }
+                aria-label="Keep Flow tracks when favorited through Subsonic"
+              />
+            </div>
           </div>
         </div>
       </section>

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -25,6 +25,9 @@ import {
 
 const defaultSettings = {
   dateTimeFormat: "browser",
+  subsonic: {
+    favoriteAutoKeep: true,
+  },
   rootFolderPath: "",
   downloadFolderPath: "",
   pathMappings: [],

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -37,6 +37,9 @@ export const normalizeSettings = (savedSettings) => {
   return {
     ...savedSettings,
     dateTimeFormat: normalizeDateTimeFormat(savedSettings.dateTimeFormat),
+    subsonic: {
+      favoriteAutoKeep: savedSettings.subsonic?.favoriteAutoKeep !== false,
+    },
     downloadFolderPath: String(savedSettings.downloadFolderPath || "").trim(),
     pathMappings: Array.isArray(savedSettings.pathMappings) ? savedSettings.pathMappings : [],
     playlistArtwork: {


### PR DESCRIPTION
Subsonic saves and playlist promotion were not complete enough for the Nightly 3.4 release, and Aurral-owned library files could lose their MusicBrainz identities during indexing. That prevented artwork and Discover linkage even when matching metadata already existed.

This PR completes the 3.4 Subsonic save, playlist, and Flow-promotion behavior. It also preserves MusicBrainz IDs through yt-dlp, Soulseek, and Usenet finalization, embeds a portable identity marker for M4A files, and enriches existing Aurral-owned files from trusted completed download-job metadata during library refresh. Ambiguous records remain explicit fallback identities.

Verification:
- `npm run lint`
- `npm test` — 642 passing
- `npm run test:integration` — 54 passing
- `npm run build`
- `(cd docs && npm run build)` — 32 pages
- Built candidate image and passed health, login, authenticated API, and static-asset checks
- Controlled untagged-file refresh produced MBID-based canonical artist, album, and track records
- Candidate logs showed no uncaught, unhandled, fatal, or error-level failures
- `git diff --check`

Known limitation: the collaborative browser preview navigated successfully but its DOM snapshot/evaluate calls timed out; equivalent HTTP page, asset, login, and API checks passed. No production state was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Subsonic playlist creation, editing, and deletion.
  * Preserved shared tracks across playlists while avoiding duplicate library downloads.
  * Added configurable automatic saving of favorited Flow tracks to the Library.
  * Improved metadata preservation, including MusicBrainz identifiers, during downloads and library scans.
  * Added portable AURRAL identity metadata support in audio files.
  * Improved playlist playback and handling of pending downloads.

* **Documentation**
  * Updated Navidrome integration documentation with playlist and favorite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->