### PR TITLE
feat(discover): open library artists from discovery cards

### DIFF
--- a/frontend/src/components/ArtistContextMenu.jsx
+++ b/frontend/src/components/ArtistContextMenu.jsx
@@ -26,6 +26,7 @@ export function ArtistContextMenu({
   isInLibrary = false,
   canAddArtist = false,
   onAddToLibrary,
+  onOpenInLibrary,
   onFeedback,
   feedbackUsed = {},
   className = "",
@@ -40,6 +41,14 @@ export function ArtistContextMenu({
   const closeMenuRef = useRef(null);
   const labelName = artistName || artist?.name || artist?.artistName || "artist";
   const isInlineActions = menuLayout === "inline";
+  const hasLibraryItem =
+    (canAddArtist && onAddToLibrary) || (isInLibrary && onOpenInLibrary);
+  const libraryAction = isInLibrary ? onOpenInLibrary : onAddToLibrary;
+  const libraryLabel = isInLibrary
+    ? onOpenInLibrary
+      ? "Open in library"
+      : "In library"
+    : "Add to library";
 
   const closeMenu = useCallback(() => {
     setShowMenu(false);
@@ -59,10 +68,10 @@ export function ArtistContextMenu({
 
   const estimateMenuHeight = useCallback(() => {
     let items = 0;
-    if (canAddArtist && onAddToLibrary) items += 1;
+    if (hasLibraryItem) items += 1;
     if (onFeedback) items += 3;
     return Math.max(items, 1) * 42 + 8;
-  }, [canAddArtist, onAddToLibrary, onFeedback]);
+  }, [hasLibraryItem, onFeedback]);
 
   const updateMenuPosition = useCallback(() => {
     const button = menuButtonRef.current;
@@ -184,7 +193,7 @@ export function ArtistContextMenu({
     setPendingAction(null);
   };
 
-  const showMenuTrigger = (canAddArtist && onAddToLibrary) || onFeedback;
+  const showMenuTrigger = hasLibraryItem || onFeedback;
 
   if (!showMenuTrigger) return null;
 
@@ -195,11 +204,11 @@ export function ArtistContextMenu({
         style={{ position: "relative", flexShrink: 0 }}
         onClick={(event) => event.stopPropagation()}
       >
-        {canAddArtist && onAddToLibrary && (
+        {hasLibraryItem && (
           <TooltipButton
-            label={isInLibrary ? "In library" : "Add to library"}
-            onClick={(event) => handleAction(event, "library", onAddToLibrary)}
-            disabled={isInLibrary || !!pendingAction}
+            label={libraryLabel}
+            onClick={(event) => handleAction(event, "library", libraryAction)}
+            disabled={!libraryAction || !!pendingAction}
             className={`btn btn-icon-square artist-context-menu__inline-action${isInLibrary ? " is-selected" : ""}`}
           >
             {pendingAction === "library" ? (
@@ -285,14 +294,14 @@ export function ArtistContextMenu({
               }}
               onClick={(event) => event.stopPropagation()}
             >
-              {canAddArtist && onAddToLibrary && (
+              {hasLibraryItem && (
                 <button
                   type="button"
-                  onClick={(event) => handleAction(event, "library", onAddToLibrary)}
-                  disabled={isInLibrary || !!pendingAction}
+                  onClick={(event) => handleAction(event, "library", libraryAction)}
+                  disabled={!libraryAction || !!pendingAction}
                   className="artist-menu-item--discover"
-                  aria-label={isInLibrary ? "In library" : "Add to library"}
-                  title={isInLibrary ? "In library" : "Add to library"}
+                  aria-label={libraryLabel}
+                  title={libraryLabel}
                 >
                   <div className="artist-menu-item__main--discover">
                     {pendingAction === "library" ? (
@@ -301,7 +310,7 @@ export function ArtistContextMenu({
                       <Library className="artist-icon-sm" />
                     )}
                     <span className="artist-menu-item__text--discover">
-                      {isInLibrary ? "In Library" : "Add to Library"}
+                      {libraryLabel}
                     </span>
                   </div>
                 </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -827,7 +827,7 @@ textarea {
   flex: 1;
   min-height: 0;
   border: 0;
-  border-radius: var(--aurral-radius);
+  border-radius: var(--aurral-radius) 0 0 0;
   background: var(--aurral-surface);
   overflow: hidden;
 }
@@ -836,7 +836,7 @@ textarea {
   width: 100%;
   height: 100%;
   padding: var(--aurral-space-page);
-  border-radius: var(--aurral-radius);
+  border-radius: var(--aurral-radius) 0 0 0;
   background: var(--aurral-surface);
   overflow-y: auto;
   overflow-x: hidden;
@@ -2460,6 +2460,35 @@ textarea {
 }
 
 @media (min-width: 768px) {
+  .app-topbar {
+    min-height: 3rem;
+    padding-bottom: 0.25rem;
+  }
+
+  .global-search__box,
+  .global-search__input {
+    min-height: 2.5rem;
+  }
+
+  .global-search__input-wrap--unified {
+    padding-inline: 0;
+  }
+
+  .global-search__input-wrap--unified .global-search__input {
+    padding: 0 0.75rem 0 2.25rem;
+  }
+
+  .global-search__icon {
+    left: 0.75rem;
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+
+  .global-search__placeholder {
+    padding-right: 0.75rem;
+    padding-left: 2.25rem;
+  }
+
   .app-nav-toggle {
     display: inline-flex;
   }
@@ -2469,7 +2498,7 @@ textarea {
   }
 
   .app-content {
-    padding: var(--aurral-space-outer) var(--aurral-space-outer) var(--aurral-space-outer) 0;
+    padding: var(--aurral-space-outer) 0 0;
   }
 
   .app-content--sidebar-full,
@@ -13751,7 +13780,12 @@ button.native-library-genre-row:focus-visible {
 }
 
 .app-content--player-active {
-  padding-bottom: 0.25rem;
+  padding-bottom: 0;
+}
+
+.app-content--player-active .app-main-wrap,
+.app-content--player-active .app-main {
+  border-radius: var(--aurral-radius) 0 0 var(--aurral-radius);
 }
 
 @media (max-width: 1023px) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7875,12 +7875,29 @@ textarea {
 
 .native-library-item-menu__panel .artist-menu-submenu__panel {
   right: auto;
-  left: calc(100% + 0.5rem);
+  left: calc(100% + 0.125rem);
 }
 
 .native-library-item-menu__panel.is-submenu-left .artist-menu-submenu__panel {
-  right: calc(100% + 0.5rem);
+  right: calc(100% + 0.125rem);
   left: auto;
+}
+
+@media (min-width: 768px) {
+  .native-library-item-menu__panel .artist-menu-submenu__panel {
+    display: block;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 120ms ease, visibility 0s linear 120ms;
+  }
+
+  .native-library-item-menu__panel .artist-menu-submenu:hover .artist-menu-submenu__panel,
+  .native-library-item-menu__panel .artist-menu-submenu:focus-within .artist-menu-submenu__panel,
+  .native-library-item-menu__panel .artist-menu-submenu.is-open .artist-menu-submenu__panel {
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0s;
+  }
 }
 
 .native-library-item-menu__panel :focus-visible {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3605,7 +3605,7 @@ textarea {
 .artist-pick-panel__tracks-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 0.75rem;
   margin-bottom: 0.5rem;
 }
@@ -3629,14 +3629,6 @@ textarea {
   border-color: transparent;
   background: var(--aurral-surface-hover);
   color: var(--aurral-text);
-}
-
-.artist-pick-panel__tracks-label {
-  color: var(--aurral-text-muted);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .artist-pick-panel__show-all {

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -7,7 +7,10 @@ import {
   getSimilarArtistsForArtist,
   updateArtistOverrides,
 } from "../../utils/api/endpoints/artists.js";
-import { addArtistToLibrary } from "../../utils/api/endpoints/library.js";
+import {
+  addArtistToLibrary,
+  downloadTrackToLibrary,
+} from "../../utils/api/endpoints/library.js";
 import {
   addSharedPlaylistTracks,
   createSharedPlaylist,
@@ -79,6 +82,7 @@ function ArtistDetailsPage() {
     loadSharedPlaylists,
   } = useSharedPlaylists();
   const [playlistMenuSavingKey, setPlaylistMenuSavingKey] = useState("");
+  const [libraryTrackSavingKey, setLibraryTrackSavingKey] = useState("");
   const [visibleReleaseGroupCoverIds, setVisibleReleaseGroupCoverIds] = useState([]);
   const [visibleAppearsOnCoverIds, setVisibleAppearsOnCoverIds] = useState([]);
   const [visibleLibraryCoverIds, setVisibleLibraryCoverIds] = useState([]);
@@ -408,6 +412,33 @@ function ArtistDetailsPage() {
     return saveTrackToPlaylist(payload, target, savingKey);
   };
 
+  const handleTrackAddToLibrary = async (track, releaseGroup = null) => {
+    const payload = releaseGroup
+      ? buildReleaseTrackPayload(track, releaseGroup)
+      : buildPreviewTrackPayload(track);
+    const savingKey = String(track?.id ?? track?.mbid ?? track?.title ?? "");
+    setLibraryTrackSavingKey(savingKey);
+    try {
+      const result = await downloadTrackToLibrary(payload);
+      showSuccess(
+        result?.alreadyOwned
+          ? `${payload.trackName} is already in your library`
+          : result?.queued
+            ? `Queued ${payload.trackName} for your library`
+            : `Added ${payload.trackName} to your library`,
+      );
+    } catch (err) {
+      showError(
+        err.response?.data?.message ||
+          err.response?.data?.error ||
+          err.message ||
+          "Failed to add track to library",
+      );
+    } finally {
+      setLibraryTrackSavingKey("");
+    }
+  };
+
   if (loading) {
     return (
       <div className="artist-loading">
@@ -480,6 +511,8 @@ function ArtistDetailsPage() {
         isArtistPlaybackActive={isArtistPlaybackActive}
         handlePreviewPlay={handlePreviewPlay}
         onAddTrackToPlaylist={handlePreviewTrackAdd}
+        onAddTrackToLibrary={handleTrackAddToLibrary}
+        libraryTrackSavingKey={libraryTrackSavingKey}
         resolveMembershipTrack={buildPreviewTrackPayload}
         playlists={sharedPlaylists}
         playlistsLoading={playlistModalLoading}
@@ -502,6 +535,8 @@ function ArtistDetailsPage() {
         playbackSource={playbackSource}
         artistName={artistDisplayName}
         onAddTrackToPlaylist={handleReleaseTrackAdd}
+        onAddTrackToLibrary={handleTrackAddToLibrary}
+        libraryTrackSavingKey={libraryTrackSavingKey}
         resolveMembershipTrack={buildReleaseTrackPayload}
         playlists={sharedPlaylists}
         playlistsLoading={playlistModalLoading}

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -82,7 +82,7 @@ function ArtistDetailsPage() {
     loadSharedPlaylists,
   } = useSharedPlaylists();
   const [playlistMenuSavingKey, setPlaylistMenuSavingKey] = useState("");
-  const [libraryTrackSavingKey, setLibraryTrackSavingKey] = useState("");
+  const [libraryTrackSavingKeys, setLibraryTrackSavingKeys] = useState(() => new Set());
   const [visibleReleaseGroupCoverIds, setVisibleReleaseGroupCoverIds] = useState([]);
   const [visibleAppearsOnCoverIds, setVisibleAppearsOnCoverIds] = useState([]);
   const [visibleLibraryCoverIds, setVisibleLibraryCoverIds] = useState([]);
@@ -412,12 +412,17 @@ function ArtistDetailsPage() {
     return saveTrackToPlaylist(payload, target, savingKey);
   };
 
-  const handleTrackAddToLibrary = async (track, releaseGroup = null) => {
+  const handleTrackAddToLibrary = async (track, releaseGroup = null, trackKey = null) => {
     const payload = releaseGroup
       ? buildReleaseTrackPayload(track, releaseGroup)
       : buildPreviewTrackPayload(track);
-    const savingKey = String(track?.id ?? track?.mbid ?? track?.title ?? "");
-    setLibraryTrackSavingKey(savingKey);
+    if (!payload?.artistName || !payload?.trackName) {
+      showError("Track details are incomplete");
+      return false;
+    }
+    const savingKey = String(trackKey ?? track?.id ?? track?.mbid ?? track?.title ?? "");
+    if (!savingKey) return false;
+    setLibraryTrackSavingKeys((current) => new Set(current).add(savingKey));
     try {
       const result = await downloadTrackToLibrary(payload);
       showSuccess(
@@ -435,7 +440,11 @@ function ArtistDetailsPage() {
           "Failed to add track to library",
       );
     } finally {
-      setLibraryTrackSavingKey("");
+      setLibraryTrackSavingKeys((current) => {
+        const next = new Set(current);
+        next.delete(savingKey);
+        return next;
+      });
     }
   };
 
@@ -512,7 +521,7 @@ function ArtistDetailsPage() {
         handlePreviewPlay={handlePreviewPlay}
         onAddTrackToPlaylist={handlePreviewTrackAdd}
         onAddTrackToLibrary={handleTrackAddToLibrary}
-        libraryTrackSavingKey={libraryTrackSavingKey}
+        libraryTrackSavingKeys={libraryTrackSavingKeys}
         resolveMembershipTrack={buildPreviewTrackPayload}
         playlists={sharedPlaylists}
         playlistsLoading={playlistModalLoading}
@@ -536,7 +545,7 @@ function ArtistDetailsPage() {
         artistName={artistDisplayName}
         onAddTrackToPlaylist={handleReleaseTrackAdd}
         onAddTrackToLibrary={handleTrackAddToLibrary}
-        libraryTrackSavingKey={libraryTrackSavingKey}
+        libraryTrackSavingKeys={libraryTrackSavingKeys}
         resolveMembershipTrack={buildReleaseTrackPayload}
         playlists={sharedPlaylists}
         playlistsLoading={playlistModalLoading}

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
@@ -48,7 +48,7 @@ export function ArtistDetailsDownloadTargets({
   playbackSource = null,
   onAddTrackToPlaylist,
   onAddTrackToLibrary,
-  libraryTrackSavingKey,
+  libraryTrackSavingKeys,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -292,7 +292,7 @@ export function ArtistDetailsDownloadTargets({
                             playlists={playlists}
                             loading={playlistsLoading}
                             saving={playlistSavingKey === currentTrackId}
-                            librarySaving={libraryTrackSavingKey === currentTrackId}
+                            librarySaving={libraryTrackSavingKeys?.has(currentTrackId)}
                             error={playlistError}
                             defaultNewPlaylistName={getDefaultPlaylistName?.(
                               track,
@@ -305,6 +305,7 @@ export function ArtistDetailsDownloadTargets({
                                     onAddTrackToLibrary(
                                       track,
                                       missingReleasePick.releaseGroup,
+                                      currentTrackId,
                                     )
                                 : null
                             }

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
@@ -47,6 +47,8 @@ export function ArtistDetailsDownloadTargets({
   artistName = "",
   playbackSource = null,
   onAddTrackToPlaylist,
+  onAddTrackToLibrary,
+  libraryTrackSavingKey,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -210,7 +212,6 @@ export function ArtistDetailsDownloadTargets({
             </div>
             <div className="artist-pick-panel__content">
               <div className="artist-min-0">
-                <div className="artist-eyebrow">Aurral Pick</div>
                 <h2 className="artist-pick-title">{missingReleasePick.title}</h2>
                 <div className="artist-meta-line">
                   {missingReleasePick.year && <span>{missingReleasePick.year}</span>}
@@ -246,7 +247,6 @@ export function ArtistDetailsDownloadTargets({
             ) : tracks.length ? (
               <>
                 <div className="artist-pick-panel__tracks-header">
-                  <span className="artist-pick-panel__tracks-label">Preview tracks</span>
                   <ArtistTrackListToolbar
                     disabled={toolbarDisabled}
                     isPlaying={isListPlaying}
@@ -288,15 +288,26 @@ export function ArtistDetailsDownloadTargets({
                                 ? resolveMembershipTrack(track, missingReleasePick.releaseGroup)
                                 : track
                             }
+                            triggerVariant="kebab"
                             playlists={playlists}
                             loading={playlistsLoading}
                             saving={playlistSavingKey === currentTrackId}
+                            librarySaving={libraryTrackSavingKey === currentTrackId}
                             error={playlistError}
                             defaultNewPlaylistName={getDefaultPlaylistName?.(
                               track,
                               missingReleasePick.releaseGroup,
                             )}
                             onLoadPlaylists={onLoadPlaylists}
+                            onAddToLibrary={
+                              onAddTrackToLibrary
+                                ? () =>
+                                    onAddTrackToLibrary(
+                                      track,
+                                      missingReleasePick.releaseGroup,
+                                    )
+                                : null
+                            }
                             onSelect={(target) =>
                               onAddTrackToPlaylist(track, missingReleasePick.releaseGroup, target)
                             }

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
@@ -12,6 +12,8 @@ export function ArtistDetailsPreviewTracks({
   isArtistPlaybackActive,
   handlePreviewPlay,
   onAddTrackToPlaylist,
+  onAddTrackToLibrary,
+  libraryTrackSavingKey,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -113,12 +115,17 @@ export function ArtistDetailsPreviewTracks({
                       <TrackPlaylistMenu
                         track={resolveMembershipTrack ? resolveMembershipTrack(track) : track}
                         menuVariant="preview-tracks"
+                        triggerVariant="kebab"
                         playlists={playlists}
                         loading={playlistsLoading}
                         saving={playlistSavingKey === trackId}
+                        librarySaving={libraryTrackSavingKey === trackId}
                         error={playlistError}
                         defaultNewPlaylistName={getDefaultPlaylistName?.(track)}
                         onLoadPlaylists={onLoadPlaylists}
+                        onAddToLibrary={
+                          onAddTrackToLibrary ? () => onAddTrackToLibrary(track) : null
+                        }
                         onSelect={(target) => onAddTrackToPlaylist(track, target)}
                       />
                     </div>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
@@ -13,7 +13,7 @@ export function ArtistDetailsPreviewTracks({
   handlePreviewPlay,
   onAddTrackToPlaylist,
   onAddTrackToLibrary,
-  libraryTrackSavingKey,
+  libraryTrackSavingKeys,
   resolveMembershipTrack,
   playlists,
   playlistsLoading,
@@ -119,12 +119,14 @@ export function ArtistDetailsPreviewTracks({
                         playlists={playlists}
                         loading={playlistsLoading}
                         saving={playlistSavingKey === trackId}
-                        librarySaving={libraryTrackSavingKey === trackId}
+                        librarySaving={libraryTrackSavingKeys?.has(trackId)}
                         error={playlistError}
                         defaultNewPlaylistName={getDefaultPlaylistName?.(track)}
                         onLoadPlaylists={onLoadPlaylists}
                         onAddToLibrary={
-                          onAddTrackToLibrary ? () => onAddTrackToLibrary(track) : null
+                          onAddTrackToLibrary
+                            ? () => onAddTrackToLibrary(track, null, trackId)
+                            : null
                         }
                         onSelect={(target) => onAddTrackToPlaylist(track, target)}
                       />

--- a/frontend/src/pages/ArtistDetails/hooks/useResponsiveReleaseLimit.js
+++ b/frontend/src/pages/ArtistDetails/hooks/useResponsiveReleaseLimit.js
@@ -3,13 +3,16 @@ import { useCallback, useEffect, useState } from "react";
 const RELEASE_CARD_MIN_WIDTH = 144;
 const RELEASE_GRID_GAP = 12;
 
-export const getResponsiveReleaseLimit = (width) =>
+export const getResponsiveReleaseLimit = (width, cardMinWidth = RELEASE_CARD_MIN_WIDTH) =>
   Math.max(
     1,
-    Math.floor((Math.max(0, Number(width)) + RELEASE_GRID_GAP) / (RELEASE_CARD_MIN_WIDTH + RELEASE_GRID_GAP)),
+    Math.floor(
+      (Math.max(0, Number(width)) + RELEASE_GRID_GAP) /
+        (cardMinWidth + RELEASE_GRID_GAP),
+    ),
   );
 
-export function useResponsiveReleaseLimit() {
+export function useResponsiveReleaseLimit({ cardMinWidth = RELEASE_CARD_MIN_WIDTH } = {}) {
   const [gridElement, setGridElement] = useState(null);
   const [limit, setLimit] = useState(6);
   const gridRef = useCallback((element) => setGridElement(element), []);
@@ -18,7 +21,7 @@ export function useResponsiveReleaseLimit() {
     if (!gridElement) return undefined;
 
     const updateLimit = () => {
-      setLimit(getResponsiveReleaseLimit(gridElement.clientWidth));
+      setLimit(getResponsiveReleaseLimit(gridElement.clientWidth, cardMinWidth));
     };
     updateLimit();
 
@@ -30,7 +33,7 @@ export function useResponsiveReleaseLimit() {
     const observer = new ResizeObserver(updateLimit);
     observer.observe(gridElement);
     return () => observer.disconnect();
-  }, [gridElement]);
+  }, [cardMinWidth, gridElement]);
 
   return [gridRef, limit];
 }

--- a/frontend/src/pages/DiscoverCards.jsx
+++ b/frontend/src/pages/DiscoverCards.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useState, useEffect } from "react";
 import { getReleaseGroupCover, getArtistCover } from "../utils/api/endpoints/artists.js";
 
-import { Library, Music } from "lucide-react";
+import { Music } from "lucide-react";
 import ArtistImage from "../components/ArtistImage";
 import AddActionButton from "../components/AddActionButton";
 import { ArtistContextMenu } from "../components/ArtistContextMenu";
@@ -84,7 +84,6 @@ export const ArtistCard = memo(
     const navigateTo = artist.navigateTo || artist.id;
     const hasValidMbid = navigateTo && navigateTo !== "null" && navigateTo !== "undefined";
     const artistMetaText = getRecommendationReason(artist);
-    const [openingInLibrary, setOpeningInLibrary] = useState(false);
     const handleClick = useCallback(() => {
       if (hasValidMbid) {
         onNavigate(`/artist/${navigateTo}`, {
@@ -95,20 +94,6 @@ export const ArtistCard = memo(
         });
       }
     }, [navigateTo, hasValidMbid, artist.name, isInLibrary, onNavigate]);
-    const handleOpenInLibrary = useCallback(
-      async (event) => {
-        event.stopPropagation();
-        if (!onOpenInLibrary || openingInLibrary) return;
-        setOpeningInLibrary(true);
-        try {
-          await onOpenInLibrary(artist);
-        } finally {
-          setOpeningInLibrary(false);
-        }
-      },
-      [artist, onOpenInLibrary, openingInLibrary],
-    );
-
     return (
       <div
         role="button"
@@ -130,21 +115,6 @@ export const ArtistCard = memo(
             enablePreviewPlayback={hasValidMbid}
             isInLibrary={isInLibrary}
           />
-          {isInLibrary && onOpenInLibrary && (
-            <div
-              className="artist-discover-card__action"
-              onClick={(event) => event.stopPropagation()}
-              role="none"
-            >
-              <AddActionButton
-                Icon={Library}
-                label={`Open ${artist.name} in library`}
-                onClick={handleOpenInLibrary}
-                isLoading={openingInLibrary}
-                disabled={openingInLibrary}
-              />
-            </div>
-          )}
         </div>
 
         <div className="artist-discover-card__content">
@@ -175,6 +145,7 @@ export const ArtistCard = memo(
               isInLibrary={isInLibrary}
               canAddArtist={canAddArtist}
               onAddToLibrary={onAddToLibrary}
+              onOpenInLibrary={onOpenInLibrary}
               onFeedback={onFeedback}
               feedbackUsed={feedbackUsed}
             />

--- a/frontend/src/pages/DiscoverCards.jsx
+++ b/frontend/src/pages/DiscoverCards.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useState, useEffect } from "react";
 import { getReleaseGroupCover, getArtistCover } from "../utils/api/endpoints/artists.js";
 
-import { Music } from "lucide-react";
+import { Library, Music } from "lucide-react";
 import ArtistImage from "../components/ArtistImage";
 import AddActionButton from "../components/AddActionButton";
 import { ArtistContextMenu } from "../components/ArtistContextMenu";
@@ -76,6 +76,7 @@ export const ArtistCard = memo(
     isInLibrary,
     canAddArtist,
     onNavigate,
+    onOpenInLibrary,
     onAddToLibrary,
     onFeedback,
     feedbackUsed = {},
@@ -83,6 +84,7 @@ export const ArtistCard = memo(
     const navigateTo = artist.navigateTo || artist.id;
     const hasValidMbid = navigateTo && navigateTo !== "null" && navigateTo !== "undefined";
     const artistMetaText = getRecommendationReason(artist);
+    const [openingInLibrary, setOpeningInLibrary] = useState(false);
     const handleClick = useCallback(() => {
       if (hasValidMbid) {
         onNavigate(`/artist/${navigateTo}`, {
@@ -93,6 +95,19 @@ export const ArtistCard = memo(
         });
       }
     }, [navigateTo, hasValidMbid, artist.name, isInLibrary, onNavigate]);
+    const handleOpenInLibrary = useCallback(
+      async (event) => {
+        event.stopPropagation();
+        if (!onOpenInLibrary || openingInLibrary) return;
+        setOpeningInLibrary(true);
+        try {
+          await onOpenInLibrary(artist);
+        } finally {
+          setOpeningInLibrary(false);
+        }
+      },
+      [artist, onOpenInLibrary, openingInLibrary],
+    );
 
     return (
       <div
@@ -115,6 +130,21 @@ export const ArtistCard = memo(
             enablePreviewPlayback={hasValidMbid}
             isInLibrary={isInLibrary}
           />
+          {isInLibrary && onOpenInLibrary && (
+            <div
+              className="artist-discover-card__action"
+              onClick={(event) => event.stopPropagation()}
+              role="none"
+            >
+              <AddActionButton
+                Icon={Library}
+                label={`Open ${artist.name} in library`}
+                onClick={handleOpenInLibrary}
+                isLoading={openingInLibrary}
+                disabled={openingInLibrary}
+              />
+            </div>
+          )}
         </div>
 
         <div className="artist-discover-card__content">
@@ -169,6 +199,7 @@ export const ArtistCard = memo(
       prevProps.feedbackUsed?.less_like_this === nextProps.feedbackUsed?.less_like_this &&
       prevProps.feedbackUsed?.block_artist === nextProps.feedbackUsed?.block_artist &&
       prevProps.onNavigate === nextProps.onNavigate &&
+      prevProps.onOpenInLibrary === nextProps.onOpenInLibrary &&
       prevProps.onAddToLibrary === nextProps.onAddToLibrary &&
       prevProps.onFeedback === nextProps.onFeedback
     );

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { readLibraryLookupCache, lookupArtistsInLibraryBatch } from "../utils/api/endpoints/library.js";
+import {
+  lookupArtistInLibrary,
+  lookupArtistsInLibraryBatch,
+  readLibraryLookupCache,
+} from "../utils/api/endpoints/library.js";
 import { getMyDiscoverLayout, updateMyDiscoverLayout } from "../utils/api/endpoints/auth.js";
 
 import { useDiscoverNavigation } from "../hooks/useDiscoverNavigation";
@@ -379,6 +383,22 @@ function DiscoverPage() {
     [navigate],
   );
 
+  const handleOpenArtistInLibrary = useCallback(
+    async (artist) => {
+      const artistId = getArtistId(artist);
+      if (!artistId) return;
+      try {
+        const lookup = await lookupArtistInLibrary(artistId);
+        const canonicalId = lookup?.artist?.canonicalId;
+        if (!canonicalId) throw new Error("Library artist was not found");
+        navigate(`/library/artist/${encodeURIComponent(canonicalId)}`);
+      } catch (requestError) {
+        showError(requestError?.message || "Failed to open artist in library");
+      }
+    },
+    [navigate, showError],
+  );
+
   const discoverArtistIds = useMemo(() => {
     const ids = new Set();
     for (const artist of data?.recommendations || []) {
@@ -471,6 +491,7 @@ function DiscoverPage() {
                   isInLibrary={!!libraryLookup[getArtistId(artist)]}
                   canAddArtist={canAddArtist}
                   onNavigate={navigate}
+                  onOpenInLibrary={handleOpenArtistInLibrary}
                   onAddToLibrary={handleAddArtistToLibrary}
                   onFeedback={handleDiscoveryFeedback}
                   feedbackUsed={getArtistFeedbackFlags(artistFeedbackLookup, artist)}
@@ -503,6 +524,7 @@ function DiscoverPage() {
                     isInLibrary={!!libraryLookup[artistId]}
                     canAddArtist={false}
                     onNavigate={navigate}
+                    onOpenInLibrary={handleOpenArtistInLibrary}
                     artist={{
                       id: artistId,
                       name: artist.artistName,
@@ -610,6 +632,7 @@ function DiscoverPage() {
                     isInLibrary={!!libraryLookup[getArtistId(artist)]}
                     canAddArtist={canAddArtist}
                     onNavigate={navigate}
+                    onOpenInLibrary={handleOpenArtistInLibrary}
                     onAddToLibrary={handleAddArtistToLibrary}
                     onFeedback={handleDiscoveryFeedback}
                     feedbackUsed={getArtistFeedbackFlags(artistFeedbackLookup, artist)}
@@ -816,6 +839,7 @@ function DiscoverPage() {
                   isInLibrary={!!libraryLookup[getArtistId(artist)]}
                   canAddArtist={canAddArtist}
                   onNavigate={navigate}
+                  onOpenInLibrary={handleOpenArtistInLibrary}
                   onAddToLibrary={handleAddArtistToLibrary}
                   onFeedback={handleDiscoveryFeedback}
                   feedbackUsed={getArtistFeedbackFlags(artistFeedbackLookup, artist)}
@@ -855,6 +879,7 @@ function DiscoverPage() {
                       isInLibrary={!!libraryLookup[getArtistId(artist)]}
                       canAddArtist={canAddArtist}
                       onNavigate={navigate}
+                      onOpenInLibrary={handleOpenArtistInLibrary}
                       onAddToLibrary={handleAddArtistToLibrary}
                       onFeedback={handleDiscoveryFeedback}
                       feedbackUsed={getArtistFeedbackFlags(artistFeedbackLookup, artist)}

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -392,8 +392,10 @@ function DiscoverPage() {
         const canonicalId = lookup?.artist?.canonicalId;
         if (!canonicalId) throw new Error("Library artist was not found");
         navigate(`/library/artist/${encodeURIComponent(canonicalId)}`);
+        return true;
       } catch (requestError) {
         showError(requestError?.message || "Failed to open artist in library");
+        return false;
       }
     },
     [navigate, showError],

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -70,6 +70,7 @@ import {
   buildSharedPlaylistTrackPayload,
   reserveUniquePlaylistName,
 } from "./ArtistDetails/utils";
+import { useResponsiveReleaseLimit } from "./ArtistDetails/hooks/useResponsiveReleaseLimit";
 
 const LIBRARY_VIEW_IDS = new Set(LIBRARY_VIEWS.map((view) => view.id));
 
@@ -309,6 +310,9 @@ function LibraryPage() {
   const [libraryRemoval, setLibraryRemoval] = useState(null);
   const [deleteFiles, setDeleteFiles] = useState(false);
   const [deletingLibraryEntity, setDeletingLibraryEntity] = useState(false);
+  const [homeAlbumsGridRef, homeAlbumColumns] = useResponsiveReleaseLimit({
+    cardMinWidth: 152,
+  });
 
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
@@ -440,7 +444,7 @@ function LibraryPage() {
             getCanonicalLibraryPage({
               kind: "albums",
               page: 1,
-              pageSize: 12,
+              pageSize,
               sort: "newest",
             }),
             getCanonicalLibraryPage({
@@ -1125,8 +1129,8 @@ function LibraryPage() {
     () =>
       [...library.albums]
         .sort((left, right) => text(right.releaseDate).localeCompare(text(left.releaseDate)))
-        .slice(0, 12),
-    [library.albums],
+        .slice(0, Math.max(2, homeAlbumColumns) * 2),
+    [homeAlbumColumns, library.albums],
   );
   const homeGenres = useMemo(
     () =>
@@ -2011,8 +2015,10 @@ function LibraryPage() {
       )}
       {homeAlbums.length > 0 && (
         <section className="native-library-section">
-          {renderSectionHeader("Recently added", library.albums.length, "/library/albums")}
-          <div className="native-library-grid">{homeAlbums.map(renderAlbumCard)}</div>
+          {renderSectionHeader("Recently added", homeAlbums.length, "/library/albums")}
+          <div ref={homeAlbumsGridRef} className="native-library-grid">
+            {homeAlbums.map(renderAlbumCard)}
+          </div>
         </section>
       )}
       {homeTracks.length > 0 && (


### PR DESCRIPTION
## Summary

Adds an action to discovery artist cards that are already in the library, allowing users to open the corresponding library artist page directly. Also adjusts desktop layout spacing and responsive album counts on the library page.

## Linked issues

Not provided.

## Validation

- [ ] CI passes
- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
- [ ] Upgrade, migration, and rollback notes are updated where applicable

## Test plan

- Affected area(s): Discover UI, library UI, responsive layout
- Automated coverage: Existing frontend checks, if applicable
- Manual steps and expected result: Open Discover, find an artist already in the library, select the library action, and verify navigation to that artist's library page. Check the library home page at desktop widths and confirm recently added albums fill the available columns.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open library artists directly from Discover cards.
  * Save multiple preview and release tracks to the library concurrently.
  * Unified artist library actions across cards and menus.

* **UI Improvements**
  * Improved responsive album loading and display on the Library page.
  * Adjusted release card counts based on available screen space.
  * Refined desktop spacing, corner rounding, search controls, topbar, and active player styling.
  * Added loading and disabled states for library actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->