### PR TITLE
fix(weekly-flow): read the artist and title from the filename when the folder hides them

### DIFF
--- a/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
+++ b/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
@@ -477,6 +477,231 @@ const rankFlowCases = [
     },
   },
   {
+    name: "rankFlowSearchResults reads the artist from the filename when the folder hides it",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Top 100 Hits of 2004\\82. Marlow Vance - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 100);
+      assert.equal(ranked[0].preDownloadValid, true);
+    },
+  },
+  {
+    name: "rankFlowSearchResults still rejects a filename naming a different artist",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Top 100 Hits of 2004\\82. Priya Raman - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].preDownloadValid, false);
+      assert.equal(ranked[0].preDownloadRejectReason, "weak-artist-match");
+    },
+  },
+  {
+    name: "rankFlowSearchResults does not credit an artist segment that only shares a word",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Top 100 Hits of 2004\\82. Marlow Sinclair - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].preDownloadValid, false);
+      assert.equal(ranked[0].preDownloadRejectReason, "weak-artist-match");
+    },
+  },
+  {
+    name: "rankFlowSearchResults keeps a numeric artist name without a leading track number",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Club Hits\\50 Cent - In Da Club.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "50 Cent",
+      trackName: "In Da Club",
+      albumName: "Album Name",
+      releaseYear: "2003",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 100);
+      assert.equal(ranked[0].preDownloadValid, true);
+    },
+  },
+  {
+    name: "rankFlowSearchResults keeps an artist name that starts with digits",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Club Hits\\07. 50 Cent - In Da Club.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "50 Cent",
+      trackName: "In Da Club",
+      albumName: "Album Name",
+      releaseYear: "2003",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 100);
+      assert.equal(ranked[0].preDownloadValid, true);
+    },
+  },
+  {
+    name: "rankFlowSearchResults only credits the leading filename segment as the artist",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Hits\\Other Artist - Marlow Vance - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].preDownloadValid, false);
+      assert.equal(ranked[0].preDownloadRejectReason, "weak-artist-match");
+    },
+  },
+  {
+    name: "rankFlowSearchResults does not read an artist from a title - artist filename",
+    results: [
+      result({
+        user: "ripUser",
+        file: "Various\\Rips\\Wide Awake Tonight - Marlow Vance.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].preDownloadValid, false);
+    },
+  },
+  {
+    name: "rankFlowSearchResults rejects a filename naming a different artist even in an album-matching folder",
+    results: [
+      result({
+        user: "albumUser",
+        file: "Some Person\\Album Name (2004)\\05. Other Artist - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].breakdown.albumScore >= 35, true);
+      assert.equal(ranked[0].preDownloadValid, false);
+      assert.equal(ranked[0].preDownloadRejectReason, "weak-artist-match");
+    },
+  },
+  {
+    name: "rankFlowSearchResults keeps the folder artist score when the filename names someone else",
+    results: [
+      result({
+        user: "albumUser",
+        file: "Marlow Vance\\Album Name (2004)\\03 - Guest Person - Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 100);
+      assert.equal(ranked[0].preDownloadValid, true);
+    },
+  },
+  {
+    name: "rankFlowSearchResults does not read an artist from a filename without the artist - title shape",
+    results: [
+      result({
+        user: "compilationUser",
+        file: "Various\\Top 100 Hits of 2004\\82. Wide Awake Tonight.mp3",
+        bitrate: 320,
+      }),
+    ],
+    track: {
+      artistName: "Marlow Vance",
+      trackName: "Wide Awake Tonight",
+      albumName: "Album Name",
+      releaseYear: "2004",
+      artistAliases: [],
+    },
+    assertRanked(ranked) {
+      assert.equal(ranked.length, 1);
+      assert.equal(ranked[0].breakdown.artistScore, 0);
+      assert.equal(ranked[0].preDownloadValid, false);
+    },
+  },
+  {
     name: "rankFlowSearchResults does not treat live as a variant in ordinary title words",
     results: [
       {

--- a/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
@@ -569,6 +569,32 @@ function pickBestArtistScore(context, text) {
   return candidates.reduce((best, entry) => Math.max(best, scoreAgainstPath(text, entry)), 0);
 }
 
+function splitArtistTitleSegments(text) {
+  return String(text || "")
+    .split(/\s+(?:-|–|—)\s+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function readSegmentsArtistTitle(context, segments) {
+  if (segments.length < 2) return null;
+  const artistScore = pickBestArtistScore(context, segments[0]);
+  if (artistScore < 92) return null;
+  return { artistScore, title: segments[segments.length - 1] };
+}
+
+function readFileNameArtistTitle(context, filePath) {
+  const baseName = getFileBaseName(filePath);
+  // Try the basename both as-is and with a leading track number removed. The
+  // strip helps "07. Artist - Title", but it also eats the digits of a numeric
+  // artist ("50 Cent - ..."), so keep whichever parse names the artist best.
+  return [stripLeadingTrackNumber(baseName), baseName].reduce((best, text) => {
+    const parsed = readSegmentsArtistTitle(context, splitArtistTitleSegments(text));
+    if (parsed && (!best || parsed.artistScore > best.artistScore)) return parsed;
+    return best;
+  }, null);
+}
+
 function collectArtistTags(common) {
   return [
     common?.artist,
@@ -722,7 +748,7 @@ function buildGroupCandidate(group, context, options = {}) {
     return [];
   }
   const {
-    artistScore,
+    artistScore: folderArtistScore,
     albumScore,
     yearScore,
     yearMismatch,
@@ -748,9 +774,12 @@ function buildGroupCandidate(group, context, options = {}) {
   for (const item of files) {
     const ext = getFileExtension(String(item?.file || ""));
     const baseName = getFileBaseName(String(item?.file || ""));
+    const fileNameParts = readFileNameArtistTitle(context, String(item?.file || ""));
+    const artistScore = Math.max(folderArtistScore, fileNameParts?.artistScore || 0);
     const titleScore = Math.max(
       scoreTextMatch(baseName, context?.trackName),
       scoreTextMatch(getFileName(String(item?.file || "")), context?.trackName),
+      fileNameParts ? scoreTextMatch(fileNameParts.title, context?.trackName) : 0,
     );
     const variantMatch = scoreVariantCompatibility(context?.trackName, baseName);
     const variantScore = variantMatch.score;


### PR DESCRIPTION
## Problem

While ranking, the artist score comes from `scoreReleaseFolder`, which scores `group.directoryPath`. That path is the folder, not the file, so the filename never gets a look. A track sitting in a compilation folder like `Various\Wedding Hits 2024\82. Artist Name - Song Title.mp3` scores `artistScore` 0 and gets dropped as `weak-artist-match`, even though the artist is right there in the filename.

The tell is the asymmetry with the post-download check. `validateDownloadedTrack` does score the artist against the remote filename (`pickBestArtistScore(context, remoteFilename)`), so the exact same file is treated as a stranger before the download and as a match after it. One of the two paths is wrong, and it is the ranking one.

## Change

When a filename has the `artist - title` shape, read both parts from it.

* Split the basename (after `stripLeadingTrackNumber`) on `" - "`.
* A leading segment only counts as the artist when it scores at least 92, the same cut `scoreAgainstPath` already applies to path segments.
* The trailing segment is only trusted as the title when that artist check passed.

The filename artist goes through `Math.max` with the folder artist score, and the filename title through `Math.max` with the scores the title already had. So the change is additive: no candidate that passes today can start failing.

## Why the title is gated on the artist

This matters, and it is the reason for the 92 gate on the whole thing rather than just the artist. An earlier version scored the trailing segment as the title unconditionally. On live slskd results for a track whose album happens to share its name, that pulled in three same-title recordings by **different** artists: the raised title score cleared the `titleScore >= 72 && albumScore >= 35` bypass inside the `weak-artist-match` gate, so a wrong-artist file in a right-named folder slipped through. Requiring the filename to name the right artist first removes all three and keeps the real gain. There is a regression test that pins exactly this (`rejects a filename naming a different artist even in an album-matching folder`); it goes red if the gate is removed.

## Evidence

Measured against `main`, ranking the same batch of real slskd results both ways.

* Synthetic sanity check: a file in a compilation folder goes from `artistScore` 0 to 100, and `titleScore` 70 to 100, so it clears the gate instead of dying at it.
* Edge cases verified live, all behaving: an artist whose name starts with a number in a numbered track (`07. 50 Cent - In Da Club.mp3`) still reads as the full artist; `title - artist` order gains nothing; `AC-DC` is not split because there is no space around the hyphen; `Artist feat. Guest - Title` scores the leading segment too low to count.
* End to end on a live instance with a strict MP3 320 profile: a track that had been failing with `No suitable slskd search results` downloaded at 320 kbps, 200 s against the requested duration, correct artist and title. Its only in-profile copy lived in a compilation folder that never named the artist in the path, which is exactly the case this fixes.

## Validation

* 8 new cases in `.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js`, covering the fix, both halves of the false-positive gate, the number-led artist, the inverted order, the no-artist-shape filename, and the folder-wins case. Three fail on `main` before the change; the rest are regression guards.
* Full backend suite: 592 tests, 0 failures.
* `npm run lint:backend` clean.

## Limitations

None of these are regressions, since the change only ever raises a score through `Math.max`:

* Filenames in `title - artist` order gain nothing from this.
* `Artist feat. Guest - Title` scores the leading segment too low to count.
* Separators without surrounding spaces are deliberately not split, so `AC-DC` and similar names stay intact.
* An artist whose name leads with digits and no track number (`50 Cent - In Da Club.mp3` on its own) loses those digits to `stripLeadingTrackNumber` and falls back to the folder score.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music search result matching by recognizing artist and title information in filenames.
  * Supports filenames with leading track numbers and `Artist - Title` formatting.
  * Uses folder names as a fallback when filename details are incomplete.
  * Improves matching for numeric artist names, shared-word artist names, and mismatched artist results.
  * Provides more accurate ranking when filename and folder artist information differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->