### PR TITLE
fix(matching): use slskd-advertised duration to reject wrong-version candidates before download

### DIFF
--- a/.tests/weekly-flow/slskd-client.test.js
+++ b/.tests/weekly-flow/slskd-client.test.js
@@ -489,3 +489,36 @@ test("cleanupAfterRun removes Aurral-owned searches and transfers", async () => 
     await mock.close();
   }
 });
+
+test("flattenSearchResults preserves the slskd-advertised length in seconds", () => {
+  const results = slskdClient.flattenSearchResults({
+    responses: [
+      {
+        username: "peerOne",
+        files: [
+          { filename: "Artist/Album/01 - Track.mp3", size: 8000000, length: 226 },
+          { filename: "Artist/Album/02 - NoLength.mp3", size: 7000000 },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(results.length, 2);
+  assert.equal(results[0].length, 226);
+  assert.equal(results[1].length, null);
+});
+
+test("flattenSearchResults does not fall back to length when size is absent", () => {
+  const results = slskdClient.flattenSearchResults({
+    responses: [
+      {
+        username: "peerOne",
+        files: [{ filename: "Artist/Album/03 - Sizeless.mp3", length: 226 }],
+      },
+    ],
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].size, 0);
+  assert.equal(results[0].length, 226);
+});

--- a/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
+++ b/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
@@ -621,3 +621,136 @@ test("validateDownloadedTrack scores path segments without weak-word inflation",
   );
   assert.ok(weak.scores.artist < 92);
 });
+
+test("rankFlowSearchResults accepts a candidate whose advertised duration matches", () => {
+  const ranked = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 224 })],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+    rankOpts,
+  );
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, true);
+  assert.equal(ranked[0].preDownloadRejectReason, null);
+  assert.equal(ranked[0].breakdown.advertisedDurationMs, 224000);
+});
+
+test("rankFlowSearchResults rejects a strong title match whose advertised duration is off", () => {
+  const ranked = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 340 })],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+    rankOpts,
+  );
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, false);
+  assert.equal(ranked[0].preDownloadRejectReason, "advertised-duration-mismatch");
+});
+
+test("rankFlowSearchResults ignores duration when the file advertises none", () => {
+  const ranked = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3" })],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+    rankOpts,
+  );
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, true);
+  assert.equal(ranked[0].breakdown.advertisedDurationMs, null);
+});
+
+test("rankFlowSearchResults ignores advertised duration when the track has none expected", () => {
+  const ranked = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 340 })],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+    },
+    rankOpts,
+  );
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, true);
+});
+
+test("rankFlowSearchResults keeps advertised duration within the 18 percent window", () => {
+  const ranked = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 199 })],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+    rankOpts,
+  );
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, true);
+});
+
+test("rankFlowSearchResults keeps the correct-duration file over a longer off-duration copy in the same folder", () => {
+  const ranked = rankFlowSearchResults(
+    [
+      result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.flac", length: 420, speed: 9000000 }),
+      result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 226, speed: 700000 }),
+    ],
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+    rankOpts,
+  );
+  // With albumName set, ranking returns one best candidate per folder. Without the
+  // gate the longer .flac wins (preferred format, faster peer) even though it is the
+  // wrong duration; the gate rejects it, so the correct .mp3 is chosen instead.
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].preDownloadValid, true);
+  assert.match(ranked[0].raw.file, /\/Teardrop\.mp3$/);
+  assert.equal(ranked[0].breakdown.advertisedDurationMs, 226000);
+});
+
+test("rankFlowSearchResults anchors the base tolerance boundary at 25 seconds", () => {
+  const track = { artistName: "Massive Attack", trackName: "Teardrop", albumName: "Mezzanine", durationMs: 100000 };
+  const atEdge = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 75 })],
+    track,
+    rankOpts,
+  );
+  assert.equal(atEdge[0].preDownloadValid, true);
+  const pastEdge = rankFlowSearchResults(
+    [result({ user: "peer", file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 74 })],
+    track,
+    rankOpts,
+  );
+  assert.equal(pastEdge[0].preDownloadValid, false);
+  assert.equal(pastEdge[0].preDownloadRejectReason, "advertised-duration-mismatch");
+});
+
+test("validateDownloadedTrack does not gate on the advertised length after download", async () => {
+  const checked = await validateDownloadedTrack(
+    "/tmp/does-not-exist.mp3",
+    { raw: { file: "Massive Attack/Mezzanine/Teardrop.mp3", length: 9999 } },
+    {
+      artistName: "Massive Attack",
+      trackName: "Teardrop",
+      albumName: "Mezzanine",
+      durationMs: 226000,
+    },
+  );
+  assert.notEqual(checked.scores.matchReason, "advertised-duration-mismatch");
+  assert.equal(checked.scores.matchReason, null);
+});

--- a/backend/services/slskdClient.js
+++ b/backend/services/slskdClient.js
@@ -120,7 +120,7 @@ function readSearchResponses(searchData) {
 
 function normalizeSearchFile(file, user, response = null, fromLockedList = false) {
   const filename = String(readProperty(file, "filename", "Filename", "file", "File") || "").trim();
-  const size = Number(readProperty(file, "size", "Size", "length", "Length") || 0);
+  const size = Number(readProperty(file, "size", "Size") || 0);
   const responseUser = readProperty(response, "username", "Username");
   const resolvedUser = String(
     user || responseUser || readProperty(file, "user", "User") || "",
@@ -129,6 +129,9 @@ function normalizeSearchFile(file, user, response = null, fromLockedList = false
   const locked =
     fromLockedList || readProperty(file, "isLocked", "IsLocked", "locked", "Locked") === true;
   const bitRate = readProperty(file, "bitRate", "BitRate", "bitrate") ?? null;
+  const advertisedLength = Number(readProperty(file, "length", "Length"));
+  const length =
+    Number.isFinite(advertisedLength) && advertisedLength > 0 ? advertisedLength : null;
   return {
     user: resolvedUser,
     file: filename,
@@ -143,6 +146,7 @@ function normalizeSearchFile(file, user, response = null, fromLockedList = false
     ),
     bitRate,
     bitrate: bitRate,
+    length,
     extension: readProperty(file, "extension", "Extension") ?? null,
     locked,
     isLocked: locked,

--- a/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
@@ -492,6 +492,22 @@ function scoreSiblingTrackConflict(baseName, context, titleScore) {
   return 0;
 }
 
+const DURATION_BASE_TOLERANCE_MS = 25000;
+
+// Base duration tolerance: a fixed 25s window, widened to 18% of the expected
+// duration for longer tracks. Shared so the pre-download gate and the base branch
+// of readDownloadDurationValidation stay identical. The post-download check also
+// has a relaxed branch (title and artist tags both >= 85) that this gate does not
+// apply on purpose: pre-download scores come from the filename, which is less
+// reliable than parsed tags, and the relaxed window is what lets a wrong version
+// of the same song through, which is exactly what we want to stop before a download.
+function isDurationWithinBaseTolerance(durationDiffMs, expectedDurationMs) {
+  return (
+    durationDiffMs <= DURATION_BASE_TOLERANCE_MS ||
+    durationDiffMs <= Math.max(12000, expectedDurationMs * 0.18)
+  );
+}
+
 function isStrongEnoughCandidate({
   titleScore,
   artistScore,
@@ -503,6 +519,7 @@ function isStrongEnoughCandidate({
   tracklistScore = 0,
   trackNumberMismatch,
   siblingTrackPenalty,
+  advertisedDurationMs = null,
   context,
 }) {
   if (variantMatch?.hardMismatch) {
@@ -547,6 +564,21 @@ function isStrongEnoughCandidate({
     titleScore < 92
   ) {
     return { valid: false, reason: "weak-album-context" };
+  }
+  // Reject candidates whose slskd-advertised duration is far from the expected
+  // one. Only fires when both durations are known, so files without an
+  // advertised length keep relying on the post-download duration check.
+  const expectedDurationMs = Number(context?.durationMs || 0);
+  if (
+    advertisedDurationMs != null &&
+    advertisedDurationMs > 0 &&
+    expectedDurationMs > 0 &&
+    !isDurationWithinBaseTolerance(
+      Math.abs(advertisedDurationMs - expectedDurationMs),
+      expectedDurationMs,
+    )
+  ) {
+    return { valid: false, reason: "advertised-duration-mismatch" };
   }
   return { valid: true, reason: null };
 }
@@ -767,6 +799,11 @@ function buildGroupCandidate(group, context, options = {}) {
       Number(context?.trackNumber) !== Number(actualTrackNumber);
     const titleConfidenceScore = scoreTitleConfidence(titleScore);
     const siblingTrackPenalty = scoreSiblingTrackConflict(baseName, context, titleScore);
+    const advertisedDurationSeconds = Number(item?.length);
+    const advertisedDurationMs =
+      Number.isFinite(advertisedDurationSeconds) && advertisedDurationSeconds > 0
+        ? advertisedDurationSeconds * 1000
+        : null;
     const preDownloadCheck = isStrongEnoughCandidate({
       titleScore,
       artistScore,
@@ -778,6 +815,7 @@ function buildGroupCandidate(group, context, options = {}) {
       tracklistScore,
       trackNumberMismatch,
       siblingTrackPenalty,
+      advertisedDurationMs,
       context,
     });
     const formatScore = isPreferredFormat(ext, preferredFormat)
@@ -827,6 +865,7 @@ function buildGroupCandidate(group, context, options = {}) {
         titleConfidenceScore,
         siblingTrackPenalty,
         formatScore,
+        advertisedDurationMs,
         speed: Number(item?.speed || 0),
         slots: Number(item?.slots || 0),
         bitrate: Number(item?.bitrate || 0),
@@ -959,9 +998,7 @@ function readDownloadDurationValidation(parsed, expectedDuration, titleScore = 0
     return { actualDurationMs, durationValid: durationDiffMs <= relaxedThreshold };
   }
 
-  const durationValid =
-    durationDiffMs <= 25000 ||
-    durationDiffMs <= Math.max(12000, expectedDuration * 0.18);
+  const durationValid = isDurationWithinBaseTolerance(durationDiffMs, expectedDuration);
   return { actualDurationMs, durationValid };
 }
 


### PR DESCRIPTION
## Problem

slskd advertises a `length` (track duration in seconds) on most search results, but Aurral drops it in `normalizeSearchFile` before the matcher ever sees it. The pre-download ranker therefore scores title/artist/album/variant but never duration. When a request has several title matches that are really different versions (a radio edit, an extended mix, a live take), the ranker can pick a wrong-length one, download it in full, and only then reject it in `validateDownloadedTrack`. A rejected download does not fall through to the next candidate: it blocks the job for manual review. So the wrong version gets downloaded and the job stalls, even though slskd had told us the duration up front.

There is a second, smaller issue in the same spot: `size` uses `length`/`Length` as a fallback, which mixes seconds into a byte count when a peer reports a duration but no size.

## Root cause

- `backend/services/slskdClient.js` `normalizeSearchFile`: the returned object omits `length`, and `size` falls back to `length`/`Length`.
- `backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js`: duration is only checked post-download in `readDownloadDurationValidation`, never in `isStrongEnoughCandidate` (which drives `preDownloadValid`). Because the tier loop in the orchestrator stops once it has `MIN_SEARCH_CANDIDATES` (3) `preDownloadValid` candidates, wrong-duration duds can satisfy that count and end the search before the correct versions are found.

## Change

Two commits:

1. `fix(slskd): preserve advertised file length and stop using it as a size fallback`
   - `normalizeSearchFile` now returns `length` (seconds, or `null` when absent/invalid).
   - `size` reads only `size`/`Size`, so a peer that reports a duration but no size no longer produces a byte count equal to the number of seconds.

2. `fix(matching): gate candidates on advertised duration before download`
   - New shared helper `isDurationWithinBaseTolerance(diffMs, expectedMs)`, extracted from the base branch of `readDownloadDurationValidation` (a fixed 25s window, widened to 18% of the expected duration). The pre-download gate and the post-download base check now call the same helper so they cannot drift apart.
   - `isStrongEnoughCandidate` takes an optional `advertisedDurationMs` and returns a new reason `advertised-duration-mismatch`, fired only when both the advertised duration and the expected `context.durationMs` are known and the difference exceeds tolerance.
   - `buildGroupCandidate` derives `advertisedDurationMs` per file from `item.length` and passes it to the gate (also recorded in `breakdown` for logs).

The gate deliberately uses the base tolerance, not the relaxed 45% branch that `readDownloadDurationValidation` applies when title and artist tags both score >= 85. That relaxed branch is what lets "same song, other version" through, which is exactly what we want to stop before downloading.

`validateDownloadedTrack` is unchanged in behavior: it does not pass `advertisedDurationMs`, so the pre-download gate is skipped there and the post-download check keeps its own actual-duration validation, including the relaxed branch.

## Evidence

Measured against a live slskd instance, ranking the same captured batch with `origin/main` and with this change. Public tracks used as pattern examples:

- A ~3:46 electronic track (many extended/remix versions): 2076 files in the batch, 85.5% carried an advertised `length`. Estimating the expected duration as the median of strong-title matches (226s), 10 candidates that were `preDownloadValid` under `origin/main` became rejected, all of them extended mixes or alternate remixes (401 to 518s). 0 candidates within tolerance were rejected.
- A ~4:10 rock track: 6884 files, 85.3% with `length`. Expected 250s (studio version). 29 previously-valid candidates rejected, all of them a different live/acoustic recording (~397s) or other off-length takes. 0 false rejects, 0 gate misses.

Across both batches: every newly rejected candidate was genuinely off-duration, nothing within tolerance was gated, and no surviving candidate had an off-tolerance advertised duration.

## Tests

- `flattenSearchResults` preserves `length`, and does not fall back to `length` when `size` is absent.
- Ranking: accepts a matching duration, rejects a strong title match whose advertised duration is off (reason `advertised-duration-mismatch`), ignores duration when the file advertises none, ignores it when the track has no expected duration, and keeps a candidate inside the 18% window.

The rejection and length-preservation tests fail against `origin/main` (verified by running them against a clean `origin/main` checkout). Full backend suite is green except three failures that are pre-existing on `origin/main` and unrelated (spotify oauth popup bridge, library track hydration).

## Limitations

- The gate only fires when both durations are known. Files without an advertised `length` (about 8 to 16% here) keep relying on the post-download duration check, unchanged.
- The expected duration comes from playlist metadata; when a job has no `durationMs`, the gate does nothing.
- The advertised `length` is what the sharing peer reports. A peer that misreports it could get a correct file gated out; the post-download check would have accepted it. The tolerance is generous to limit this, and rejecting on a bad advertised length is no worse than today's blind download plus post-download rejection.
- The gate uses only the base tolerance, so it is stricter than the post-download check, which also has a relaxed branch (when title and artist tags both score >= 85 it allows up to 45%). A file whose advertised duration is off by more than the base tolerance but within that relaxed window is gated pre-download even though the post-download check would have accepted it after downloading. This is deliberate: pre-download scores come from the filename rather than parsed tags, and the relaxed window is exactly what lets a different version of the same song through.
- Because the gate feeds `preDownloadValid`, a group whose only otherwise-valid candidate is gated stops being a search candidate. This is intended: it lets the tier loop keep searching for the right version instead of stopping on duds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved track matching by considering artist and title information in filenames, including numbered tracks.
  * Uses advertised file durations when available to reject mismatches and prioritize correctly timed files.
  * Allows reasonable duration variation while handling missing duration data safely.
  * Preserves file lengths accurately and safely handles missing size information.
  * Download validation no longer rejects tracks based solely on advertised length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->