### PR TITLE
docs: add contribution guidelines and triage automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: Bug report
+description: Report broken behavior, regressions, crashes, or reliability problems in Aurral.
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for one broken behavior, regression, crash, or reliability problem.
+        Search existing issues first. Use the feature request form for new behavior.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed passwords, tokens, private URLs, and other secrets from the report.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Aurral is affected?
+      options:
+        - Discovery and recommendations
+        - Search, library, or playback
+        - Flows, playlists, or downloads
+        - Lidarr or another integration
+        - Authentication, users, or permissions
+        - Docker, storage, or upgrades
+        - User interface
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Give the shortest reliable sequence that reproduces the problem.
+      placeholder: |
+        1. Start Aurral with ...
+        2. Open ...
+        3. Select ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Aurral to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What did Aurral do instead?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How does this affect your use of Aurral?
+      options:
+        - Blocks use of Aurral
+        - Causes a major failure or frequent errors
+        - Causes a minor or occasional problem
+        - Cosmetic or documentation issue
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Aurral version or image tag
+      description: Include the release version, Docker tag, nightly tag, or commit if known.
+      placeholder: latest, nightly, or 1.2.3
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your OS, browser, deployment method, and relevant integration versions.
+      placeholder: Docker Compose on Debian 13, Firefox 142, Lidarr 3.x
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack traces
+      description: Include only the useful lines. Remove secrets and private paths.
+      render: shell
+
+  - type: upload
+    id: attachments
+    attributes:
+      label: Screenshots or supporting files
+      description: Add screenshots, recordings, or small reproduction files when they help explain the problem. Remove secrets first.
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround
+      description: If you found a temporary workaround, describe it here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discuss a feature in Discord
+    url: https://discord.gg/cpPYfgVURJ
+    about: Talk through a feature idea with Aurral developers and testers before opening a pull request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest a focused improvement to Aurral.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to propose new behavior for Aurral.
+        Do not start implementation until a maintainer approves the direction.
+        You can also discuss the idea with developers and testers in the [Aurral Discord](https://discord.gg/cpPYfgVURJ).
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find an existing request for this idea.
+          required: true
+        - label: I have described one focused feature or improvement.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Aurral would this change affect?
+      options:
+        - Discovery and recommendations
+        - Search, library, or playback
+        - Flows, playlists, or downloads
+        - Lidarr or another integration
+        - Authentication, users, or permissions
+        - Docker, storage, or upgrades
+        - User interface
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem would this feature solve, and who experiences it?
+      placeholder: Describe the current limitation or repeated task.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the smallest useful behavior you want Aurral to support.
+      placeholder: Explain what a user should be able to do after this change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and context
+      description: What workarounds, related projects, screenshots, or examples should we consider?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,10 @@ Large or bundled pull requests may be closed or returned for splitting.
 
 <!-- If this pull request changes the UI, include clear before-and-after screenshots. Delete this section if it does not apply. -->
 
+## Testing
+
+<!-- List automated checks and manual validation. State which applicable checks were not run and why. -->
+
 ## Release impact
 
 - [ ] Major: incompatible change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,34 @@
-## Summary
+<!--
+Before opening this pull request:
+- Keep it to one focused change.
+- Get approval before implementing a new feature. Link the feature request or include the Discord context in the Why section.
+- Do not bundle unrelated fixes, refactors, formatting changes, dependency updates, or extra features.
+Large or bundled pull requests may be closed or returned for splitting.
+-->
 
-<!-- What changed, and why? -->
+## What changed
 
-<!-- Use a Conventional Commit title (`feat:`, `fix:`, etc.); merged commit subjects drive release version suggestions. -->
+<!-- Describe the change clearly and keep the scope tight. -->
 
-## Linked issues
+<!-- Use a Conventional Commit title (`feat:`, `fix:`, `docs:`, and so on). Aurral uses the title to apply release labels. -->
 
-<!-- Use Fixes #123 or Closes #123 to link. Issues stay open until the change ships in a stable release; merging only puts the fix on nightly. -->
+## Why
 
-## Validation
+<!-- Explain the problem this solves and why the change belongs in Aurral. -->
 
-- [ ] CI passes
-- [ ] Tested using the `ghcr.io/lklynet/aurral:pr-<number>` preview image, or not required
-- [ ] Upgrade, migration, and rollback notes are updated where applicable
+## Scope checklist
 
-## Test plan
+- [ ] This pull request has one clear purpose
+- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
+- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section
 
-- Affected area(s): <!-- e.g. authentication, Docker/upgrade, flows, integrations, UI, docs -->
-- Automated coverage: <!-- tests added or existing tests that cover this change -->
-- Manual steps and expected result: <!-- what should a reviewer or nightly tester exercise? -->
+## Linked issue
+
+<!-- Link the related issue when one exists. Use Fixes #123 or Closes #123 when this pull request should close it. Merging puts the change on nightly first; linked issues stay open until a stable release includes it. -->
+
+## UI changes
+
+<!-- If this pull request changes the UI, include clear before-and-after screenshots. Delete this section if it does not apply. -->
 
 ## Release impact
 

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,78 @@
+name: Sync labels
+
+on:
+  issues:
+    types: [opened]
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/release.yml"
+      - ".github/workflows/issue-labels.yml"
+      - ".github/workflows/pr-size.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Sync managed labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          while IFS='|' read -r name color description; do
+            gh label create "$name" \
+              --repo "$REPOSITORY" \
+              --color "$color" \
+              --description "$description" \
+              --force
+          done <<'LABELS'
+          bug|d73a4a|Something is broken or behaving incorrectly.
+          enhancement|a2eeef|Requested improvement or new capability.
+          documentation|0075ca|Documentation needs correction or improvement.
+          needs-triage|fbca04|Issue needs maintainer review and initial categorization.
+          dependencies|0366d6|Dependency update or maintenance work.
+          skip-changelog|ededed|Do not include this change in release notes.
+          in-progress|5319e7|A linked issue has an open pull request under review.
+          nightly|0e8a16|The change is available in nightly but not in a stable release.
+          released|5319e7|The change is included in a stable release.
+          release-readiness|fbca04|Tracks testing for the next stable release.
+          release-ready|0e8a16|The current nightly candidate passed release checks.
+          size:XS|0e8a16|0-9 changed lines.
+          size:S|5ebd3e|10-29 changed lines.
+          size:M|fbca04|30-99 changed lines.
+          size:L|fe7d37|100-499 changed lines.
+          size:XL|d93f0b|500-999 changed lines.
+          size:XXL|b60205|1,000 or more changed lines.
+          LABELS
+
+  triage:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Mark new issue for triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}/labels" \
+            -f "labels[]=needs-triage" \
+            >/dev/null

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,61 @@
+name: Label PR size
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: pr-size-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Label pull request size
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          changed_lines="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.additions + .deletions')"
+          if [ "${changed_lines}" -lt 10 ]; then
+            size_label=size:XS
+          elif [ "${changed_lines}" -lt 30 ]; then
+            size_label=size:S
+          elif [ "${changed_lines}" -lt 100 ]; then
+            size_label=size:M
+          elif [ "${changed_lines}" -lt 500 ]; then
+            size_label=size:L
+          elif [ "${changed_lines}" -lt 1000 ]; then
+            size_label=size:XL
+          else
+            size_label=size:XXL
+          fi
+
+          current_labels="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '.[].name')"
+          while IFS= read -r label; do
+            [ -z "${label}" ] && continue
+            gh api \
+              --method DELETE \
+              "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${label}" \
+              >/dev/null
+          done < <(printf '%s\n' "${current_labels}" | grep -E '^size:(XS|S|M|L|XL|XXL)$' || true)
+
+          gh api \
+            --method POST \
+            "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" \
+            -f "labels[]=${size_label}" \
+            >/dev/null
+
+          echo "PR #${PR_NUMBER}: ${changed_lines} changed lines -> ${size_label}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Aurral welcomes contributions. We review every change against the project's direction, maintenance cost, and the size of the change.
+
+Opening a pull request does not guarantee a review or a merge. We may close it, ask you to split it, defer it, or implement the idea in a different way.
+
+## Start with the right place
+
+Search existing issues and pull requests before starting work.
+
+For a bug, open a focused bug report when no existing issue covers it. Include steps that let someone reproduce the problem.
+
+For a feature, choose one of these paths before writing code:
+
+- Open a feature request issue and wait for approval.
+- Join the [Aurral Discord](https://discord.gg/cpPYfgVURJ) to discuss the idea with developers and testers.
+
+An issue or Discord conversation is not approval by itself. Start implementation after a maintainer agrees that the change fits Aurral.
+
+## GitHub labels
+
+Aurral keeps human triage labels small:
+
+- `bug` marks broken behavior.
+- `enhancement` marks a requested improvement or new capability.
+- `documentation` marks documentation work.
+- `needs-triage` marks an issue that still needs maintainer review.
+
+Pull requests receive one automatic `size:*` label based on changed lines. Release and nightly labels are maintained by automation.
+
+## Changes we can review
+
+We are most likely to accept:
+
+- Small, focused bug fixes.
+- Reliability and performance fixes.
+- Tests, documentation, and focused maintenance.
+- A feature that has been discussed and approved before implementation.
+
+Keep each pull request about one problem or one closely related change. If you have several ideas, use separate issues and pull requests.
+
+## Changes we will usually return
+
+We are unlikely to accept:
+
+- Several new features bundled into one pull request.
+- Unapproved feature work.
+- Large rewrites or opinionated refactors.
+- Drive-by formatting or unrelated cleanup.
+- New dependencies without a clear need.
+
+Large changes are not automatically wrong, but they need a clear reason and a narrow scope. A 4,000-line pull request that adds several features will be closed or returned for splitting.
+
+## Open a pull request
+
+- Use a [Conventional Commit](https://www.conventionalcommits.org/) title such as `fix: handle missing Lidarr albums`, `feat: add playlist filtering`, or `docs: clarify Docker storage`.
+- Explain what changed and why it belongs in Aurral.
+- Link the related issue when one exists.
+- Keep unrelated fixes, refactors, formatting changes, and dependency updates out of the pull request.
+- Add tests for changed behavior when the existing test setup covers it.
+- Include before-and-after screenshots for UI changes.
+
+Keep UI changes focused and explain any new interaction in the pull request.
+
+Before opening the pull request, run the checks that apply to your change and describe any manual testing in the pull request. Maintainers may ask for a smaller diff, more context, or a separate pull request.


### PR DESCRIPTION
Aurral is receiving more community contributions, but large bundled pull requests and unstructured feature work make review difficult. The repository needed clearer contribution expectations and a lightweight way to triage issues and PR size.

This change adds:
- Contributor guidance for focused issues and pull requests.
- Bug and feature request forms.
- A Discord link for discussing proposed features.
- Managed issue and lifecycle labels.
- Automatic `needs-triage` labeling for new issues.
- Automatic `size:*` labeling for pull requests.
- An updated pull request template covering scope, feature approval, issue links, UI changes, and release impact.

Verification:
- Parsed all new and changed YAML files with `js-yaml`.
- Ran `git diff --cached --check`.
- Reviewed the diff for generated files, secrets, and private development metadata.

No application tests were run because this PR changes documentation, issue forms, and GitHub workflows only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for issue reporting, feature proposals, labels, pull requests, testing, and UI screenshots.
  * Added structured bug-report and feature-request templates.
  * Updated pull request guidance with clearer requirements for scope, rationale, linked issues, screenshots, and testing.

* **Chores**
  * Added automated issue triage, label synchronization, and pull request size labeling.
  * Added configuration for blank issues and community discussion links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->