### PR TITLE
ci(nightly): limit nightly images to amd64

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
           provenance: mode=max
           sbom: true
           tags: ghcr.io/${{ github.repository }}:nightly
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             APP_VERSION=${{ steps.version.outputs.value }}
             GITHUB_REPO=${{ github.repository }}

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -61,6 +61,8 @@ Non-stable channels also mark the sidebar.
 
 :::caution
 `nightly` is not a stable release. Back up `./config` before switching to it.
+
+Nightly images currently support `linux/amd64` only. On ARM, use `latest` or a versioned stable tag.
 :::
 
 ## Test a pull request preview


### PR DESCRIPTION
## What changed

- Configure nightly Docker images to build for `linux/amd64` only.
- Document the current ARM guidance for nightly users.

## Why

Nightly images currently support `linux/amd64` only. The documentation now directs ARM users to `latest` or a versioned stable tag.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

No linked issue.

## Testing

- Reviewed the GitHub Actions platform configuration.
- Reviewed the Docker documentation update.
- Automated checks were not run because this change only updates CI configuration and documentation.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that nightly Docker images support `linux/amd64` only.
  * Recommended ARM users choose the `latest` image or a versioned stable tag.

* **Chores**
  * Updated nightly image builds to target `linux/amd64` exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->