### PR TITLE
fix(playback): scan canonical flow directories in Plex and Navidrome

### DIFF
--- a/.tests/auth/navidrome-settings.int.test.js
+++ b/.tests/auth/navidrome-settings.int.test.js
@@ -123,7 +123,7 @@ test("admin can update and test Navidrome after onboarding", async () => {
   );
   assert.deepEqual(libraryRequest?.body, {
     name: "Aurral Playlists",
-    path: path.join(isolatedState.baseDir, "weekly-flow", "aurral-weekly-flow"),
+    path: path.join(isolatedState.baseDir, "weekly-flow"),
   });
 
   const tested = await apiFetch("/api/settings/navidrome/test", {

--- a/.tests/library/storage-health.test.js
+++ b/.tests/library/storage-health.test.js
@@ -364,7 +364,7 @@ test("Navidrome health does not compare reused Lidarr and Navidrome paths", asyn
 });
 
 test("configured Plex is included and validates its Aurral library path", async (t) => {
-  const expectedPath = path.join(resolvePlaylistRoot(), "aurral-weekly-flow");
+  const expectedPath = resolvePlaylistRoot();
   const server = await createMockHttpServer((request, response) => {
     response.writeHead(200, { "content-type": "application/json" });
     if (request.url?.startsWith("/identity")) {
@@ -396,8 +396,8 @@ test("configured Plex is included and validates its Aurral library path", async 
 });
 
 test("POSIX library paths remain case-sensitive", async (t) => {
-  const expectedPath = path.join(resolvePlaylistRoot(), "aurral-weekly-flow");
-  const wrongCasePath = expectedPath.replace(/aurral-weekly-flow$/, "AURRAL-WEEKLY-FLOW");
+  const expectedPath = resolvePlaylistRoot();
+  const wrongCasePath = expectedPath.toUpperCase();
   const server = await createMockHttpServer((request, response) => {
     response.writeHead(200, { "content-type": "application/json" });
     if (request.url?.startsWith("/rest/ping")) {

--- a/.tests/notifications/notification-events.test.js
+++ b/.tests/notifications/notification-events.test.js
@@ -370,7 +370,7 @@ test("notifyWeeklyFlowDone uses display name and track library path placeholders
     });
 
     const playlistId = "c0c01bc3-72ca-4110-8ab6-681f132a6e63";
-    const flowPath = `/data/downloads/aurral-weekly-flow/${playlistId}`;
+    const flowPath = `/data/downloads/aurral/.flows/${playlistId}`;
     await notifyWeeklyFlowDone(
       playlistId,
       { completed: 3, failed: 1 },

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -125,7 +125,7 @@ test("ensures the Navidrome library without creating an M3U playlist", async () 
     { ok: true },
   );
 
-  assert.deepEqual(client.calls.ensured, [destination.playlistLibraryRoot.replace(/\\/g, "/")]);
+  assert.deepEqual(client.calls.ensured, [destination.mediaLibraryRoot.replace(/\\/g, "/")]);
   await assert.rejects(
     fs.access(path.join(destination.libraryRoot, "jody - Morning Mix.m3u")),
   );

--- a/.tests/playback/plex-playback-destination.test.js
+++ b/.tests/playback/plex-playback-destination.test.js
@@ -136,13 +136,20 @@ test("recovers a managed-user token and retries with the stored client identifie
 });
 
 test("resolves managed and reused Lidarr paths to private Plex rating keys", async () => {
-  const destination = makeDestination({ mainLibrarySectionId: "9" });
+  const destination = makeDestination({ downloadsPath: "/data", mainLibrarySectionId: "9" });
   const managedPath = path.join(
     destination.playlistLibraryRoot,
+    ".flows",
     "flow-1",
     "Artist",
     "Album",
     "Managed.flac",
+  );
+  const canonicalPath = path.join(
+    destination.playlistLibraryRoot,
+    "Artist",
+    "Album",
+    "Canonical.flac",
   );
   const reusedRoot = path.join(weeklyFlowRoot, "..", "lidarr");
   const reusedPath = path.join(reusedRoot, "Artist", "Reused.flac");
@@ -154,8 +161,9 @@ test("resolves managed and reused Lidarr paths to private Plex rating keys", asy
   destination._libraryTracks = [
     {
       ratingKey: "101",
-      files: ["/data/aurral-weekly-flow/another-flow/Artist/Album/Managed.flac"],
+      files: ["/data/.flows/flow-1/Artist/Album/Managed.flac"],
     },
+    { ratingKey: "102", files: ["/data/Artist/Album/Canonical.flac"] },
   ];
   destination._mainLibraryTracks = [
     { ratingKey: "202", files: ["/music/Artist/Reused.flac"] },
@@ -166,19 +174,21 @@ test("resolves managed and reused Lidarr paths to private Plex rating keys", asy
       snapshot({
         tracks: [
           { path: managedPath, title: "Managed", artist: "Artist" },
+          { path: canonicalPath, title: "Canonical", artist: "Artist" },
           { path: reusedPath, title: "Reused", artist: "Artist" },
         ],
       }),
     ),
-    ["101", "202"],
+    ["101", "102", "202"],
   );
 });
 
 test("reuses a Lidarr file linked into the entity folder without a main Plex library", async () => {
-  const destination = makeDestination();
+  const destination = makeDestination({ downloadsPath: "/data" });
   const reusedPath = path.join(weeklyFlowRoot, "..", "lidarr", "Artist", "Track.flac");
   const linkedPath = path.join(
     destination.playlistLibraryRoot,
+    ".flows",
     "flow-1",
     "Artist",
     "Album",
@@ -189,7 +199,7 @@ test("reuses a Lidarr file linked into the entity folder without a main Plex lib
   await fs.writeFile(reusedPath, "track");
   await fs.symlink(reusedPath, linkedPath);
   destination._libraryTracks = [
-    { ratingKey: "303", files: ["/data/aurral-weekly-flow/flow-1/Artist/Album/Track.flac"] },
+    { ratingKey: "303", files: ["/data/.flows/flow-1/Artist/Album/Track.flac"] },
   ];
   destination._mainLibraryTracks = [];
 
@@ -202,16 +212,17 @@ test("reuses a Lidarr file linked into the entity folder without a main Plex lib
 });
 
 test("upserts from the entity-owner pointer and stores the returned pointer privately", async () => {
-  const destination = makeDestination();
+  const destination = makeDestination({ downloadsPath: "/data" });
   const trackPath = path.join(
     destination.playlistLibraryRoot,
+    ".flows",
     "flow-1",
     "Artist",
     "Album",
     "Track.flac",
   );
   destination._libraryTracks = [
-    { ratingKey: "101", files: ["/data/aurral-weekly-flow/flow-1/Artist/Album/Track.flac"] },
+    { ratingKey: "101", files: ["/data/.flows/flow-1/Artist/Album/Track.flac"] },
   ];
   destination._mainLibraryTracks = [];
   plexPlaylistPointerStore.setPointer("flow-1", "global", {
@@ -291,11 +302,43 @@ test("ensures and scans the Plex library through the adapter", async () => {
   assert.deepEqual(await destination.ensureLibrary(), { ok: true });
   assert.deepEqual(await destination.requestScan(), { ok: true });
   assert.deepEqual(calls, [
-    ["ensure", "/downloads/aurral-weekly-flow"],
+    ["ensure", "/downloads"],
     ["tracks", "7"],
     ["tracks", "7"],
     ["scan", "7"],
   ]);
+});
+
+test("configures Plex with the canonical root and explicit flow location", async () => {
+  const client = new PlexClient("http://plex.local:32400", "admin-token", "admin-client");
+  const root = "/downloads/aurral";
+  const calls = [];
+  let reads = 0;
+  mock.method(client, "getLibraries", async () => {
+    reads += 1;
+    return reads === 1
+      ? []
+      : [{
+          key: "7",
+          title: "Aurral",
+          Location: [
+            { path: `${root}/.flows` },
+            { path: root },
+          ],
+        }];
+  });
+  mock.method(client, "request", async (requestPath, options) => {
+    calls.push({ requestPath, options });
+    return {};
+  });
+
+  assert.equal((await client.ensureWeeklyFlowLibrary(root)).key, "7");
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].requestPath,
+    `/library/sections?name=Aurral&type=artist&agent=tv.plex.agents.music&scanner=Plex+Music&language=en-US&location=${encodeURIComponent(root)}&location=${encodeURIComponent(`${root}/.flows`)}`,
+  );
+  assert.equal(calls[0].options.method, "POST");
 });
 
 test("keeps Navidrome and Plex failures isolated when both destinations are configured", async (t) => {

--- a/.tests/weekly-flow/weekly-flow-webhook-vars.test.js
+++ b/.tests/weekly-flow/weekly-flow-webhook-vars.test.js
@@ -99,7 +99,7 @@ test("weekly flow completion sends display name and track library path", async (
     assert.deepEqual(requests, [
       {
         name: "Late Night",
-        path: path.join(playlistManager.playlistLibraryRoot, playlist.id),
+        path: playlistManager.weeklyFlowRoot,
       },
     ]);
     assert.doesNotMatch(requests[0].path, /_playlists/);

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -54,6 +54,7 @@ export class NavidromePlaybackDestination {
     this.name = "Navidrome";
     this.weeklyFlowRoot = resolvePlaylistRoot(weeklyFlowRoot);
     this.playlistLibraryRoot = path.join(this.weeklyFlowRoot, PLAYLIST_LIBRARY_DIR);
+    this.mediaLibraryRoot = this.weeklyFlowRoot;
     this.libraryRoot = path.join(this.playlistLibraryRoot, "_playlists");
     this.client = client;
     this._configKey = "";
@@ -335,7 +336,7 @@ export class NavidromePlaybackDestination {
       await fs.mkdir(this.libraryRoot, { recursive: true });
       if (this.isConfigured()) {
         await this.client.ensureWeeklyFlowLibrary(
-          this.playlistLibraryRoot.replace(/\\/g, "/").replace(/\/+$/, ""),
+          this.mediaLibraryRoot.replace(/\\/g, "/").replace(/\/+$/, ""),
         );
         await this._loadPlaylists(true);
       }

--- a/backend/services/playback/plexPlaybackDestination.js
+++ b/backend/services/playback/plexPlaybackDestination.js
@@ -7,7 +7,7 @@ import { plexConnectionStore } from "../plex/plexConnectionStore.js";
 import { plexPlaylistPointerStore } from "../plex/plexPlaylistPointerStore.js";
 import { getPathMappings, resolveLocalPath } from "../pathMappings.js";
 import {
-  PLAYLIST_LIBRARY_DIR,
+  AURRAL_FLOWS_DIR,
   isPathInsideRoot,
   resolvePlaylistRoot,
 } from "../playlistPaths.js";
@@ -39,7 +39,7 @@ export class PlexPlaybackDestination {
     this.key = "plex";
     this.name = "Plex";
     this.weeklyFlowRoot = resolvePlaylistRoot(weeklyFlowRoot);
-    this.playlistLibraryRoot = path.join(this.weeklyFlowRoot, PLAYLIST_LIBRARY_DIR);
+    this.playlistLibraryRoot = this.weeklyFlowRoot;
     this.client = client;
     this._configKey = "";
     this._downloadsPath = "";
@@ -82,8 +82,7 @@ export class PlexPlaybackDestination {
 
   _libraryPath() {
     const override = String(this._downloadsPath || "").trim();
-    if (!override) return this.playlistLibraryRoot.replace(/\\/g, "/").replace(/\/+$/, "");
-    return `${override.replace(/\\/g, "/").replace(/\/+$/, "")}/${PLAYLIST_LIBRARY_DIR}`;
+    return (override || this.weeklyFlowRoot).replace(/\\/g, "/").replace(/\/+$/, "");
   }
 
   async testConnection() {
@@ -269,21 +268,33 @@ export class PlexPlaybackDestination {
 
   _relativeManagedPath(file) {
     const normalized = String(file || "").replace(/\\/g, "/");
-    const marker = `/${PLAYLIST_LIBRARY_DIR}/`;
-    const index = normalized.indexOf(marker);
-    if (index < 0) return null;
-    const segments = normalized.slice(index + marker.length).split("/");
-    segments.shift();
-    return segments.join("/") || null;
+    const root = this._libraryPath();
+    const marker = `${root}/`;
+    if (!normalized.startsWith(marker)) return null;
+    const relative = normalized.slice(marker.length);
+    const normalizedRelative = path.posix.normalize(relative);
+    if (
+      !normalizedRelative ||
+      normalizedRelative === "." ||
+      normalizedRelative === ".." ||
+      normalizedRelative.startsWith("../") ||
+      path.posix.isAbsolute(normalizedRelative)
+    ) {
+      return null;
+    }
+    return normalizedRelative;
   }
 
   async _resolveRatingKeys(snapshot) {
-    const managedByRelative = new Map();
+    const managedByPath = new Map();
     for (const track of this._libraryTracks || []) {
-      const relative = this._relativeManagedPath(track.files?.[0]);
-      if (!relative) continue;
-      if (!managedByRelative.has(relative)) managedByRelative.set(relative, []);
-      managedByRelative.get(relative).push(track);
+      for (const file of track.files || []) {
+        const relative = this._relativeManagedPath(file);
+        if (!relative) continue;
+        const localPath = path.resolve(this.weeklyFlowRoot, relative);
+        if (!managedByPath.has(localPath)) managedByPath.set(localPath, []);
+        managedByPath.get(localPath).push(track);
+      }
     }
     const mainByPath = new Map();
     const mappings = getPathMappings("plex");
@@ -295,36 +306,20 @@ export class PlexPlaybackDestination {
       }
     }
     const keys = [];
-    const entityRoot = path.join(this.playlistLibraryRoot, snapshot.entityId);
     for (const track of snapshot.tracks) {
       const localPath = path.resolve(track.path);
-      if (!isPathInsideRoot(localPath, this.playlistLibraryRoot)) {
-        const ratingKey = mainByPath.get(localPath);
-        if (ratingKey) keys.push(ratingKey);
-        continue;
-      }
-      const relative = path.relative(entityRoot, localPath).replace(/\\/g, "/");
-      const group = managedByRelative.get(relative) || [];
-      const own = group.find((candidate) =>
-        candidate.files?.some((file) =>
-          String(file).replace(/\\/g, "/").includes(`/${snapshot.entityId}/`),
-        ),
-      );
-      const ratingKey = (own || group[0])?.ratingKey;
+      const ratingKey = managedByPath.get(localPath)?.[0]?.ratingKey || mainByPath.get(localPath);
       if (ratingKey) keys.push(ratingKey);
     }
-    for (const [relative, group] of managedByRelative) {
+    const entityRoot = path.join(this.weeklyFlowRoot, AURRAL_FLOWS_DIR, snapshot.entityId);
+    for (const [localPath, group] of managedByPath) {
+      if (!isPathInsideRoot(localPath, entityRoot)) continue;
       try {
-        await fs.access(path.join(entityRoot, relative));
+        await fs.access(localPath);
       } catch {
         continue;
       }
-      const own = group.find((candidate) =>
-        candidate.files?.some((file) =>
-          String(file).replace(/\\/g, "/").includes(`/${snapshot.entityId}/`),
-        ),
-      );
-      const ratingKey = (own || group[0])?.ratingKey;
+      const ratingKey = group[0]?.ratingKey;
       if (ratingKey) keys.push(ratingKey);
     }
     return [...new Set(keys.map(String))];

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -248,6 +248,7 @@ export class PlexClient {
   async ensureWeeklyFlowLibrary(libraryPath) {
     if (!this.isConfigured()) return null;
     const name = "Aurral";
+    const locations = [libraryPath, `${libraryPath.replace(/\/+$/, "")}/.flows`];
     // Also match the legacy "Aurral Flow" name so existing libraries are reused
     // and renamed rather than duplicated.
     const findExisting = (libs) =>
@@ -255,7 +256,7 @@ export class PlexClient {
         (lib) =>
           lib.title === name ||
           lib.title === "Aurral Flow" ||
-          (lib.Location || []).some((loc) => loc.path === libraryPath),
+          (lib.Location || []).some((loc) => locations.includes(loc.path)),
       );
 
     const existing = findExisting(await this.getLibraries());
@@ -263,11 +264,13 @@ export class PlexClient {
       // Reconcile name + folder so a rename or a changed downloads-path setting
       // actually takes effect (Plex keeps the originals otherwise).
       const currentLocations = (existing.Location || []).map((loc) => loc.path).filter(Boolean);
-      const locationOk = currentLocations.length === 1 && currentLocations[0] === libraryPath;
+      const locationOk =
+        currentLocations.length === locations.length &&
+        locations.every((location) => currentLocations.includes(location));
       const nameOk = existing.title === name;
       if (!locationOk || !nameOk) {
         try {
-          await this.editLibrary(existing.key, { name, locations: [libraryPath] });
+          await this.editLibrary(existing.key, { name, locations });
           return findExisting(await this.getLibraries()) || existing;
         } catch (err) {
           console.warn(
@@ -283,17 +286,15 @@ export class PlexClient {
     // is inconsistent across versions, so we create then re-read the section
     // list to resolve the new library (and its `key`) reliably.
     try {
-      await this.request("/library/sections", {
-        method: "POST",
-        params: {
-          name,
-          type: MUSIC_SECTION_TYPE,
-          agent: MUSIC_AGENT,
-          scanner: MUSIC_SCANNER,
-          language: "en-US",
-          location: libraryPath,
-        },
+      const params = new URLSearchParams({
+        name,
+        type: MUSIC_SECTION_TYPE,
+        agent: MUSIC_AGENT,
+        scanner: MUSIC_SCANNER,
+        language: "en-US",
       });
+      for (const location of locations) params.append("location", location);
+      await this.request(`/library/sections?${params.toString()}`, { method: "POST" });
     } catch (err) {
       const detail = err?.response?.data || err.message;
       const status = err?.response?.status;

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -10,7 +10,7 @@ import { sabnzbdClient } from "./sabnzbdClient.js";
 import { NavidromeClient } from "./navidrome.js";
 import { PlexClient } from "./plex.js";
 import { runLidarrLibraryAccessTest } from "./lidarrLibraryAccessTest.js";
-import { PLAYLIST_LIBRARY_DIR, resolvePlaylistRoot } from "./playlistPaths.js";
+import { resolvePlaylistRoot } from "./playlistPaths.js";
 import {
   getPathMappings,
   looksLikeExternalOnlyPath,
@@ -736,10 +736,7 @@ async function checkNavidromeSection() {
     return buildSection("navidrome", "Navidrome playback", steps);
   }
 
-  const expectedLibraryPath = path
-    .join(resolvePlaylistRoot(), PLAYLIST_LIBRARY_DIR)
-    .replace(/\\/g, "/")
-    .replace(/\/+$/, "");
+  const expectedLibraryPath = resolvePlaylistRoot().replace(/\\/g, "/").replace(/\/+$/, "");
   const expectedLibraryCandidates = [expectedLibraryPath];
 
   let libraries = [];
@@ -866,10 +863,6 @@ async function checkNativePlaybackSection() {
   ]);
 }
 
-function appendPortablePath(basePath, child) {
-  return `${String(basePath || "").trim().replace(/\\/g, "/").replace(/\/+$/, "")}/${child}`;
-}
-
 function getPlexLibraryLocations(libraries) {
   return (Array.isArray(libraries) ? libraries : []).flatMap((library) => {
     const locations = Array.isArray(library?.Location)
@@ -925,18 +918,18 @@ async function checkPlexSection() {
   }
 
   const configuredBase = String(plex.downloadsPath || "").trim() || resolvePlaylistRoot();
-  const expectedPath = appendPortablePath(configuredBase, PLAYLIST_LIBRARY_DIR);
+  const expectedPath = configuredBase.replace(/\\/g, "/").replace(/\/+$/, "");
   const locations = getPlexLibraryLocations(libraries);
   const coveringLocation = locations.find((location) => pathCoversPrefix(location, expectedPath));
   if (coveringLocation) {
     steps.push(
-      healthStep("aurral-library", "pass", "Plex scans the Aurral playlist folder", {
+      healthStep("aurral-library", "pass", "Plex scans the Aurral download folder", {
         detail: `${expectedPath} (library: ${coveringLocation})`,
       }),
     );
   } else {
     steps.push(
-      healthStep("aurral-library", "warn", "Plex scans the Aurral playlist folder", {
+      healthStep("aurral-library", "warn", "Plex scans the Aurral download folder", {
         detail: expectedPath,
         fix: "Confirm Plex Aurral Library path is the path the Plex server uses for Aurral's downloads, save settings, then run Sync to Plex so Aurral can create or repair its library.",
       }),

--- a/backend/services/weeklyFlow/weeklyFlowWorker.js
+++ b/backend/services/weeklyFlow/weeklyFlowWorker.js
@@ -13,7 +13,10 @@ import {
   repairReusableTrackLinks,
   reuseTrackForPlaylist,
 } from "./weeklyFlowFileReuse.js";
-import { resolvePlaylistRoot as resolveWeeklyFlowRoot } from "../playlistPaths.js";
+import {
+  AURRAL_FLOWS_DIR,
+  resolvePlaylistRoot as resolveWeeklyFlowRoot,
+} from "../playlistPaths.js";
 import { startSlskdOrchestratorWorker } from "../slskdOrchestratorWorker.js";
 import { withHonkerLock } from "../honkerDb.js";
 import {
@@ -884,10 +887,9 @@ export class WeeklyFlowWorker {
             const completed = done;
             const flowName =
               playlistManager.getPlaylistName(playlistType) || playlistType;
-            const flowPath = path.join(
-              playlistManager.playlistLibraryRoot,
-              playlistType,
-            );
+            const flowPath = flowPlaylistConfig.getFlow(playlistType)
+              ? path.join(playlistManager.weeklyFlowRoot, AURRAL_FLOWS_DIR, playlistType)
+              : playlistManager.weeklyFlowRoot;
             const { notifyWeeklyFlowDone } = await import("../notificationService.js");
             notifyWeeklyFlowDone(
               playlistType,

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -36,7 +36,7 @@ description: Common setup and runtime issues.
 - Make sure that **Settings > Download Clients > Downloads Folder > Path** is under that mount.
 - In **Settings > Playback > Navidrome**, test the Navidrome connection. Changes save automatically.
 - Make sure that Navidrome scans Aurral's downloads path and not only Lidarr's library.
-- Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file under `aurral-weekly-flow`, then wait for the Navidrome scan.
+- Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file in the Downloads Folder or `.flows`, then wait for the Navidrome scan.
 - If the library is missing, check that the Navidrome account can manage libraries through its API.
 - Review the [Navidrome missing-track setting](/integrations/navidrome/#remove-missing-tracks).
 
@@ -88,7 +88,7 @@ See [Navidrome: Filesystem paths](/integrations/navidrome/#filesystem-paths).
 **Sync to Plex now** can succeed while the playlists have no tracks. The Aurral library can also stay empty after a scan.
 
 - Make sure that Plex can read the flow download tree.
-- The Plex container or host must contain this path: `<downloads>/aurral-weekly-flow/<flow-id>/...`.
+- The Plex container or host must contain the Downloads Folder, including `<downloads>/artist/album/track` and `<downloads>/.flows/<flow-id>/...`.
 - If Plex and Aurral use different mounts, set **Settings > Playback > Plex > Plex Aurral Library path** to the folder that Plex sees.
 - Leave **Plex Aurral Library path** blank if both apps use the same path prefix.
 - Make sure the Plex settings have finished saving automatically.

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -58,9 +58,9 @@ If a service uses a separate path for its own database or configuration, keep th
 
 1. Aurral asks a download client to find the track.
 2. The download client writes the completed file under `/data/downloads/...`.
-3. Aurral reads that file and moves it to `/data/downloads/aurral/aurral-weekly-flow/...`.
-4. Aurral writes a playlist file next to the downloaded tracks.
-5. Navidrome scans `/data/downloads/aurral/aurral-weekly-flow` and can play the tracks.
+3. Aurral imports the file into its Downloads Folder. Permanent tracks use `artist/album/track`; flow tracks use `.flows/<flow-id>/artist/album/track`.
+4. Aurral writes playlist sidecars under `aurral-weekly-flow/_playlists`.
+5. Navidrome scans the Downloads Folder and can play the tracks.
 
 If Aurral writes a file as `/data/downloads/aurral/track.flac` but Navidrome sees the same host folder as `/downloads/track.flac`, Navidrome cannot open the path in Aurral's playlist file. The API connection can still work, but the playlist will be empty or the tracks will not play. Use matching container paths, or follow [When paths cannot match](#when-paths-cannot-match).
 
@@ -86,7 +86,9 @@ Choose one directory on the Docker host as the media root. The example uses `/sr
     |-- slskd/complete/             # optional Soulseek completed files
     |-- usenet/complete/            # optional SABnzbd or NZBGet files
     \-- aurral/                     # Aurral Downloads Folder
-        \-- aurral-weekly-flow/     # generated tracks and playlists
+        |-- Artist/Album/track      # permanent canonical tracks
+        |-- .flows/flow-id/...      # temporary flow tracks
+        \-- aurral-weekly-flow/     # playlist sidecars
 ```
 
 Use the same host directory in every media-service mount:
@@ -157,7 +159,7 @@ After you add the mounts, use the container paths shown below.
 | slskd | Completed download folder | `/data/downloads/slskd/complete` |
 | SABnzbd or NZBGet | Completed download folder | `/data/downloads/usenet/complete` |
 | Aurral | **Settings > Download Clients > Downloads Folder > Path** | `/data/downloads/aurral` |
-| Navidrome | Aurral playlist library | Aurral creates `/data/downloads/aurral/aurral-weekly-flow` through the API. |
+| Navidrome | Aurral library | Aurral creates `/data/downloads/aurral` through the API. |
 | Plex | Aurral library | Aurral creates the library through the API at the path Plex uses for the Aurral Downloads Folder. |
 
 The exact download-client folder names are not important. The important rules are:
@@ -189,10 +191,11 @@ Use these checks in order:
 3. **Output check:** after a flow or playlist downloads a track, the file must exist under:
 
    ```text
-   /data/downloads/aurral/aurral-weekly-flow/
+   /data/downloads/aurral/Artist/Album/Track.flac
+   /data/downloads/aurral/.flows/<flow-id>/Artist/Album/Track.flac
    ```
 
-4. **Playback check:** Navidrome or Plex must have that folder in its own filesystem and must scan it.
+4. **Playback check:** Navidrome or Plex must have the Downloads Folder in its own filesystem and must scan it.
 
 If the API check passes but the file check fails, do not change the API URL. Fix the volume mapping, permissions, or path mapping.
 
@@ -232,7 +235,7 @@ This is also separate from Aurral's Remote Path Mappings.
 
 1. Open **Settings > Playback > Plex**.
 2. Set **Plex Aurral Library path** to the Downloads Folder path as Plex sees it.
-3. Do not include `/aurral-weekly-flow`; Aurral adds that folder.
+3. Enter the Downloads Folder path only. Do not add `/aurral-weekly-flow`.
 4. After the settings save automatically, select **Sync to Plex now**.
 
 Example:

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -63,10 +63,10 @@ volumes:
 5. Enter the Navidrome URL, username, and password. Select **Test connection**, then save.
 6. Run a flow or update a playlist so Aurral can create or update the **Aurral Playlists** library and request a Navidrome scan.
 
-Aurral creates the **Aurral Playlists** library at:
+Aurral creates the **Aurral Playlists** library at the Downloads Folder root:
 
 ```text
-/data/downloads/aurral/aurral-weekly-flow
+/data/downloads/aurral
 ```
 
 You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
@@ -93,7 +93,7 @@ Aurral also uploads its generated playlist artwork to API playlists and updates 
 
 If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
-- confirm that a track exists under `aurral-weekly-flow`;
+- confirm that a permanent track exists under the Downloads Folder or a flow track exists under `.flows`;
 - confirm that the Navidrome library path points to that folder;
 - run a Navidrome scan or save the Aurral Navidrome settings;
 - wait for the scan to finish.

--- a/docs/src/content/docs/integrations/notifications.mdx
+++ b/docs/src/content/docs/integrations/notifications.mdx
@@ -31,7 +31,7 @@ Enter these values for each webhook:
 - **URL**: the endpoint to call (must start with `http://` or `https://`)
 - **Body**: optional JSON data. Use these placeholders:
   - `$flowName`: playlist display name
-  - `$flowPath`: on-disk playlist track folder under `aurral-weekly-flow` (not the `_playlists` artwork folder)
+  - `$flowPath`: on-disk Aurral media path. For a Flow, this is `.flows/<flow-id>`; for a static playlist, it is the Downloads Folder root.
   - `$albumName`, `$artistName`, `$username`, `$userId`, and `$event` for request events
 - **Headers**: optional key-value pairs
 

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -34,7 +34,7 @@ volumes:
 8. Select **Test connection**.
 9. After a flow downloads tracks, select **Sync to Plex now**.
 
-Aurral registers the library at `<plex-visible-downloads>/aurral-weekly-flow`. Track files are in flow subfolders under that path.
+Aurral registers the library at `<plex-visible-downloads>`. Permanent tracks are in `artist/album/track` folders. Temporary flow tracks are under `.flows/<flow-id>`.
 
 You do not need to create this library manually in Plex. The library can be empty until a flow finishes downloading tracks. Plex can take several minutes to scan the files.
 
@@ -55,7 +55,9 @@ Leave this field blank when Aurral and Plex use the same filesystem view. They c
 
 Set **Plex Aurral Library path** if Plex uses a different mount prefix than Aurral.
 
-Enter the downloads folder as Plex sees it. Aurral adds `/aurral-weekly-flow` when it creates the library.
+Enter the Downloads Folder as Plex sees it. Aurral uses that path as the library root.
+
+Aurral also adds the `.flows` directory as an explicit second Plex library location. Plex otherwise skips hidden directories below the library root, which would hide flow tracks from scans.
 
 | Aurral writes to            | Plex sees                      | Plex Aurral Library path |
 | --------------------------- | ------------------------------ | ------------------------- |
@@ -64,7 +66,7 @@ Enter the downloads folder as Plex sees it. Aurral adds `/aurral-weekly-flow` wh
 
 **Browse** shows folders as Aurral sees them. If Plex's mount differs, type Plex's path manually as Plex sees it. The folder must also exist inside the Plex container.
 
-**Plex Aurral Library path** matches the Plex and Aurral library roots. Navidrome library paths are configured in Navidrome.
+**Plex Aurral Library path** matches the Plex-side and Aurral Downloads Folder roots. Navidrome library paths are configured in Navidrome.
 
 ## Reusing tracks from an existing library
 

--- a/docs/src/content/docs/integrations/usenet.mdx
+++ b/docs/src/content/docs/integrations/usenet.mdx
@@ -53,7 +53,7 @@ Open the **SABnzbd** card under **Download clients**:
 - **Source priority**: relative to slskd. The default is `20`. The slskd default is `10`.
 - **Add NZBs paused**: send jobs to SABnzbd in a paused state
 
-Aurral monitors SABnzbd until the download is complete. Aurral then imports the best audio file into `aurral-weekly-flow`.
+Aurral monitors SABnzbd until the download is complete. Aurral then imports the best audio file into the Aurral Downloads Folder.
 
 ## NZBGet
 
@@ -67,7 +67,7 @@ Open the **NZBGet** card under **Download clients**:
 - **Completed download path**: optional override when Aurral cannot infer the finished-file location
 - **Add NZBs paused**: send jobs to NZBGet in a paused state
 
-Aurral monitors NZBGet until the download is complete. Aurral then imports the best audio file into `aurral-weekly-flow`.
+Aurral monitors NZBGet until the download is complete. Aurral then imports the best audio file into the Aurral Downloads Folder.
 
 If NZBGet runs on Windows and reports host paths, mount the parent folder into Aurral.
 

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -690,7 +690,7 @@ export function SettingsPlaybackSection({
               hint={
                 <>
                   Only needed when Plex sees downloads at a different path. Enter the Plex-side
-                  path; Aurral appends <code>/aurral-weekly-flow</code>.
+                  path to the Aurral Downloads Folder.
                 </>
               }
             >


### PR DESCRIPTION
Downloaded tracks moved to the canonical Downloads Folder root, but the playback integrations still treated the old `aurral-weekly-flow` directory as the media library. Plex also skipped hidden `.flows` directories when only the parent folder was configured, leaving flow tracks out of Plex.

This updates Plex and Navidrome to scan the canonical Downloads Folder, configures Plex with an explicit `.flows` location, updates flow completion paths and storage-health guidance, and documents the new layout. Existing legacy Plex/Navidrome library names and paths are reconciled where applicable.

Verification:
- 663 unit tests passed.
- 54 integration tests passed.
- Lint, backend build, docs build, image build, and diff checks passed.
- Live Plex and Navidrome checks indexed canonical and `.flows` tracks and published the correct flow playlist item.
- Restart persistence and provider outage/recovery checks passed.
- No uncaught exceptions or unhandled rejections.
- The disposable live stack and candidate container were cleaned up.

Limitation: the local test environment has no upstream Usenet account, so provider-backed downloading was not claimed; the documented controlled fixture was used to validate the handoff and playback path.