### PR TITLE
fix(security): allow raw github content connections

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -129,7 +129,7 @@ if (process.env.OIDC_ENABLED === "true" && !isOidcEnabled()) {
   );
 }
 
-const connectSrcDirectives = ["'self'", "ws:", "wss:", "https://api.github.com"];
+const connectSrcDirectives = ["'self'", "ws:", "wss:", "https://api.github.com", "https://raw.githubusercontent.com"];
 if (process.env.AUTH_PROXY_DOMAIN) {
   connectSrcDirectives.push(process.env.AUTH_PROXY_DOMAIN);
 }


### PR DESCRIPTION
## What changed

Allow browser connections to `https://raw.githubusercontent.com` through the Content Security Policy.

## Why

GitHub-hosted raw content was blocked by the application's connection policy, preventing supported GitHub content from loading.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Not run; this is a one-line Content Security Policy update.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled supported connections to resources hosted on `raw.githubusercontent.com` by updating the application’s security policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->