### PR TITLE
feat(activity): search all wanted tracks

### DIFF
--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -18,6 +18,7 @@ const [
   { flowPlaylistConfig },
   { playlistManager },
   { weeklyFlowWorker },
+  honkerDb,
   { registerJobs },
 ] = await setupIsolatedBackend(
   "approved-import-path",
@@ -27,6 +28,7 @@ const [
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
   "backend/services/weeklyFlow/weeklyFlowWorker.js",
+  "backend/services/honkerDb.js",
   "backend/routes/weeklyFlow/handlers/jobs.js",
 );
 
@@ -173,9 +175,21 @@ test("search all stays within the requesting user's playlist access", async () =
     { artistName: "Artist", trackName: "Missing", albumName: "Album" },
     ownedPlaylistId,
   );
+  const otherJobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Private", albumName: "Album" },
+    otherPlaylistId,
+  );
   downloadTracker.setFailed(jobId, "No source");
+  downloadTracker.setFailed(otherJobId, "No source");
 
   const originalStart = weeklyFlowWorker.start;
+  const systemTaskQueue = honkerDb.getSystemTaskQueue();
+  const originalEnqueue = systemTaskQueue.enqueue;
+  const enqueuedTasks = [];
+  systemTaskQueue.enqueue = (payload, options) => {
+    enqueuedTasks.push({ payload, options });
+    return originalEnqueue.call(systemTaskQueue, payload, options);
+  };
   weeklyFlowWorker.start = async () => {};
   requestUser = { role: "user", id: 7 };
   try {
@@ -184,13 +198,26 @@ test("search all stays within the requesting user's playlist access", async () =
     assert.equal(missingResponse.status, 200, JSON.stringify(missingPayload));
     assert.equal(missingPayload.requeued, 1);
     assert.equal(downloadTracker.getJob(jobId)?.status, "pending");
+    assert.equal(downloadTracker.getJob(otherJobId)?.status, "failed");
 
     const upgradeResponse = await fetch(`${baseUrl}/quality-upgrades`, { method: "POST" });
     const upgradePayload = await upgradeResponse.json();
     assert.equal(upgradeResponse.status, 200, JSON.stringify(upgradePayload));
     assert.equal(upgradePayload.scheduled, true);
     assert.equal(upgradePayload.playlistCount, 1);
+    assert.deepEqual(enqueuedTasks, [
+      {
+        payload: {
+          kind: "quality-upgrade-check",
+          force: true,
+          playlistId: ownedPlaylistId,
+          limit: 500,
+        },
+        options: { priority: -10, runAt: null },
+      },
+    ]);
   } finally {
+    systemTaskQueue.enqueue = originalEnqueue;
     weeklyFlowWorker.start = originalStart;
     requestUser = { role: "admin" };
   }

--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -17,6 +17,7 @@ const [
   { downloadTracker },
   { flowPlaylistConfig },
   { playlistManager },
+  { weeklyFlowWorker },
   { registerJobs },
 ] = await setupIsolatedBackend(
   "approved-import-path",
@@ -25,13 +26,15 @@ const [
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
+  "backend/services/weeklyFlow/weeklyFlowWorker.js",
   "backend/routes/weeklyFlow/handlers/jobs.js",
 );
 
 const app = express();
 app.use(express.json());
+let requestUser = { role: "admin" };
 app.use((req, _res, next) => {
-  req.user = { role: "admin" };
+  req.user = requestUser;
   next();
 });
 const router = express.Router();
@@ -149,4 +152,46 @@ test("reports when an upgrade search is already queued for a track", async () =>
   assert.equal(second.status, 200, JSON.stringify(payload));
   assert.equal(payload.alreadyQueued, true);
   assert.equal(payload.queued, 0);
+});
+
+test("search all stays within the requesting user's playlist access", async () => {
+  const ownedPlaylistId = "c0de1f39-226f-4ab8-8f37-09d8adf47b5a";
+  const otherPlaylistId = "a2b9ae35-7fb7-474e-a0d4-8ac4bdb8d9e6";
+  flowPlaylistConfig.createSharedPlaylist({
+    id: ownedPlaylistId,
+    name: "Owned wanted",
+    ownerUserId: 7,
+    tracks: [{ artistName: "Artist", trackName: "Missing", albumName: "Album" }],
+  });
+  flowPlaylistConfig.createSharedPlaylist({
+    id: otherPlaylistId,
+    name: "Other wanted",
+    ownerUserId: 8,
+    tracks: [{ artistName: "Artist", trackName: "Private", albumName: "Album" }],
+  });
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Missing", albumName: "Album" },
+    ownedPlaylistId,
+  );
+  downloadTracker.setFailed(jobId, "No source");
+
+  const originalStart = weeklyFlowWorker.start;
+  weeklyFlowWorker.start = async () => {};
+  requestUser = { role: "user", id: 7 };
+  try {
+    const missingResponse = await fetch(`${baseUrl}/research-missing`, { method: "POST" });
+    const missingPayload = await missingResponse.json();
+    assert.equal(missingResponse.status, 200, JSON.stringify(missingPayload));
+    assert.equal(missingPayload.requeued, 1);
+    assert.equal(downloadTracker.getJob(jobId)?.status, "pending");
+
+    const upgradeResponse = await fetch(`${baseUrl}/quality-upgrades`, { method: "POST" });
+    const upgradePayload = await upgradeResponse.json();
+    assert.equal(upgradeResponse.status, 200, JSON.stringify(upgradePayload));
+    assert.equal(upgradePayload.scheduled, true);
+    assert.equal(upgradePayload.playlistCount, 1);
+  } finally {
+    weeklyFlowWorker.start = originalStart;
+    requestUser = { role: "admin" };
+  }
 });

--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -188,7 +188,7 @@ test("search all stays within the requesting user's playlist access", async () =
   const enqueuedTasks = [];
   systemTaskQueue.enqueue = (payload, options) => {
     enqueuedTasks.push({ payload, options });
-    return originalEnqueue.call(systemTaskQueue, payload, options);
+    return enqueuedTasks.length;
   };
   weeklyFlowWorker.start = async () => {};
   requestUser = { role: "user", id: 7 };

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -38,6 +38,13 @@ import {
   queueQualityUpgrade,
 } from "../../../services/qualityProfileService.js";
 
+const getAccessiblePlaylistIds = (user) => [
+  ...new Set([
+    ...flowPlaylistConfig.getFlowsForUser(user),
+    ...flowPlaylistConfig.getSharedPlaylistsForUser(user),
+  ].map((playlist) => playlist.id)),
+];
+
 export function registerJobs(router) {
   router.get("/status", noCache, (req, res) => {
     res.json(getWeeklyFlowStatusSnapshot({ user: req.user }));
@@ -72,6 +79,37 @@ export function registerJobs(router) {
     );
     const profile = getQualityProfile();
     res.json(jobs.map((job) => decorateJobQuality(job, profile)));
+  });
+
+  router.post("/research-missing", async (req, res) => {
+    try {
+      let requeued = 0;
+      for (const playlistId of getAccessiblePlaylistIds(req.user)) {
+        requeued += await weeklyFlowWorker.researchMissingTracks(playlistId);
+      }
+      return res.json({ success: true, requeued });
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to re-search missing tracks",
+        message: error.message,
+      });
+    }
+  });
+
+  router.post("/quality-upgrades", (req, res) => {
+    const playlistIds = getAccessiblePlaylistIds(req.user);
+    for (const playlistId of playlistIds) {
+      enqueueSystemTaskJob(
+        { kind: "quality-upgrade-check", force: true, playlistId, limit: 500 },
+        { priority: -10 },
+      );
+    }
+    return res.json({
+      success: true,
+      queued: 0,
+      scheduled: true,
+      playlistCount: playlistIds.length,
+    });
   });
 
   router.post("/quality-upgrades/:playlistId/:jobId", async (req, res) => {

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -184,6 +184,7 @@ prefix redirects to it with status `308`.
 | `GET` | `/api/playlists/status` | Flow worker and playlist status |
 | `GET` | `/api/playlists/jobs` | List flow jobs |
 | `GET` | `/api/playlists/jobs/:flowId` | List jobs for a flow or static playlist |
+| `POST` | `/api/playlists/research-missing` | Research all missing tracks in accessible operations |
 | `POST` | `/api/playlists/start/:flowId` | Run a flow |
 | `POST` | `/api/playlists/flows` | Create a flow |
 | `PUT` | `/api/playlists/flows/:flowId` | Update a flow |
@@ -208,6 +209,7 @@ prefix redirects to it with status `308`.
 | `POST` | `/api/playlists/shared-playlists/:playlistId/research-missing` | Research all missing tracks |
 | `POST` | `/api/playlists/quality-upgrades/:playlistId/:jobId` | Search for a track upgrade |
 | `POST` | `/api/playlists/quality-upgrades/:playlistId` | Search for playlist upgrades |
+| `POST` | `/api/playlists/quality-upgrades` | Search for upgrades in accessible operations |
 | `POST` | `/api/playlists/shared-playlists/:playlistId/sync` | Sync a shared playlist |
 | `PUT` | `/api/playlists/playlists/:playlistId/retry-cycle` | Pause or resume retries for a static playlist |
 | `POST` | `/api/playlists/jobs/:jobId/approve` | Approve a flow job |

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -30,6 +30,9 @@ Use the search action on a Wanted row to re-search a failed Aurral operation or
 search for a quality upgrade. These actions apply across flows and static
 playlists.
 
+Use **Search all** to re-search every missing track or queue upgrade searches
+for every cutoff-unmet track in the active Wanted view.
+
 Use the info action on any activity or Wanted row to inspect the operation
 details without leaving the page.
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8840,6 +8840,10 @@ button.native-library-genre-row:focus-visible {
   min-width: 0;
 }
 
+.activity-toolbar__group--end {
+  margin-left: auto;
+}
+
 .activity-toolbar__filter {
   display: flex;
   width: min(20rem, 45vw);

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -16,8 +16,10 @@ import {
   getAllFlowJobs,
   getFlowStatus,
   reSearchFlowTrack,
+  reSearchAllMissingTracks,
   reSearchSharedPlaylistTrack,
   searchTrackUpgrade,
+  searchAllUpgrades,
 } from "../../utils/api/endpoints/playlists.js";
 import ActivityToolbar from "./ActivityToolbar";
 import ActivityInfoModal from "./ActivityInfoModal";
@@ -144,7 +146,7 @@ export default function ActivityMissingPage() {
   const [actionStates, setActionStates] = useState({});
   const [filterValue, setFilterValue] = useState("");
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const [searchingAll, setSearchingAll] = useState(false);
   const [visibleCount, setVisibleCount] = useState(WANTED_PAGE_SIZE);
   const [error, setError] = useState("");
   const activeTab = searchParams.get("tab") === "cutoff" ? "cutoff" : "missing";
@@ -157,8 +159,7 @@ export default function ActivityMissingPage() {
   }, [activeTab]);
 
   const loadJobs = useCallback(async ({ silent = false } = {}) => {
-    if (silent) setRefreshing(true);
-    else setLoading(true);
+    if (!silent) setLoading(true);
     setError("");
     try {
       const [allJobs, status] = await Promise.all([getAllFlowJobs(), getFlowStatus()]);
@@ -196,8 +197,7 @@ export default function ActivityMissingPage() {
           "Failed to load wanted tracks",
       );
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (!silent) setLoading(false);
     }
   }, []);
 
@@ -219,6 +219,9 @@ export default function ActivityMissingPage() {
   }, [filterValue, jobs, showingCutoff]);
   const pagedJobs = visibleJobs.slice(0, visibleCount);
   const hasMoreJobs = visibleCount < visibleJobs.length;
+  const hasWantedJobs = jobs.some((job) =>
+    showingCutoff ? isCutoffUnmetAurralJob(job) : isMissingAurralJob(job),
+  );
 
   const handleAction = async (job) => {
     const id = getMissingJobKey(job);
@@ -259,14 +262,69 @@ export default function ActivityMissingPage() {
     }
   };
 
+  const handleSearchAll = useCallback(async () => {
+    if (searchingAll || !hasWantedJobs) return;
+    setSearchingAll(true);
+    try {
+      const result = showingCutoff
+        ? await searchAllUpgrades()
+        : await reSearchAllMissingTracks();
+      if (showingCutoff) {
+        showSuccess("Cutoff upgrade search queued");
+      } else {
+        const requeued = Number(result?.requeued || 0);
+        showSuccess(
+          requeued > 0
+            ? `Re-searching ${requeued} missing track${requeued === 1 ? "" : "s"}`
+            : "No missing tracks to re-search",
+        );
+      }
+      await loadJobs({ silent: true });
+    } catch (requestError) {
+      showError(
+        requestError.response?.data?.message ||
+          requestError.response?.data?.error ||
+          requestError.message ||
+          (showingCutoff
+            ? "Failed to search for upgrades"
+            : "Failed to re-search missing tracks"),
+      );
+    } finally {
+      setSearchingAll(false);
+    }
+  }, [hasWantedJobs, loadJobs, searchingAll, showingCutoff, showError, showSuccess]);
+
+  const searchAllButton = (
+    <TooltipButton
+      className="native-library-icon-button"
+      onClick={handleSearchAll}
+      disabled={searchingAll || !hasWantedJobs}
+      aria-busy={searchingAll}
+      label={
+        searchingAll
+          ? "Searching all"
+          : showingCutoff
+            ? "Search all cutoff-unmet tracks"
+            : "Re-search all missing tracks"
+      }
+    >
+      {searchingAll ? (
+        <Loader className="animate-spin" aria-hidden="true" />
+      ) : showingCutoff ? (
+        <ArrowUpCircle aria-hidden="true" />
+      ) : (
+        <RotateCcw aria-hidden="true" />
+      )}
+    </TooltipButton>
+  );
+
   if (loading) {
     return (
       <div>
         <ActivityToolbar
           filterValue={filterValue}
           onFilterChange={setFilterValue}
-          onRefresh={() => loadJobs({ silent: true })}
-          refreshing={refreshing}
+          action={searchAllButton}
           placeholder={filterPlaceholder}
         />
         <div className="activity-page__loading">
@@ -281,8 +339,7 @@ export default function ActivityMissingPage() {
       <ActivityToolbar
         filterValue={filterValue}
         onFilterChange={setFilterValue}
-        onRefresh={() => loadJobs({ silent: true })}
-        refreshing={refreshing}
+        action={searchAllButton}
         placeholder={filterPlaceholder}
       />
       {error ? (

--- a/frontend/src/pages/activity/ActivityToolbar.jsx
+++ b/frontend/src/pages/activity/ActivityToolbar.jsx
@@ -7,6 +7,7 @@ export default function ActivityToolbar({
   onFilterChange,
   onRefresh,
   refreshing = false,
+  action = null,
   placeholder = "Filter activity",
 }) {
   const [filterOpen, setFilterOpen] = useState(Boolean(filterValue));
@@ -22,18 +23,20 @@ export default function ActivityToolbar({
 
   return (
     <div className="activity-toolbar">
-      <div className="activity-toolbar__group">
-        <TooltipButton
-          className="native-library-icon-button"
-          onClick={onRefresh}
-          disabled={refreshing}
-          label={refreshing ? "Refreshing" : "Refresh"}
-          aria-label="Refresh activity"
-        >
-          <RefreshCw className={refreshing ? "animate-spin" : ""} aria-hidden="true" />
-        </TooltipButton>
-      </div>
-      <div className="activity-toolbar__group">
+      {onRefresh ? (
+        <div className="activity-toolbar__group">
+          <TooltipButton
+            className="native-library-icon-button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            label={refreshing ? "Refreshing" : "Refresh"}
+            aria-label="Refresh activity"
+          >
+            <RefreshCw className={refreshing ? "animate-spin" : ""} aria-hidden="true" />
+          </TooltipButton>
+        </div>
+      ) : null}
+      <div className="activity-toolbar__group activity-toolbar__group--end">
         {filterOpen ? (
           <label className="activity-toolbar__filter">
             <Search aria-hidden="true" />
@@ -61,6 +64,7 @@ export default function ActivityToolbar({
         >
           <Search aria-hidden="true" />
         </TooltipButton>
+        {action}
       </div>
     </div>
   );

--- a/frontend/src/utils/api/endpoints/playlists.js
+++ b/frontend/src/utils/api/endpoints/playlists.js
@@ -62,6 +62,9 @@ export const getFlowJobs = (flowId, limit = null, options = {}) => {
 export const getAllFlowJobs = (options = {}) =>
   getData("/playlists/jobs", options);
 
+export const reSearchAllMissingTracks = () =>
+  postData("/playlists/research-missing");
+
 export const createFlow = (payload) => postData("/playlists/flows", payload);
 
 export const updateFlow = (flowId, payload) =>
@@ -133,6 +136,8 @@ export const searchTrackUpgrade = (playlistId, jobId) =>
 
 export const searchPlaylistUpgrades = (playlistId) =>
   postData(`/playlists/quality-upgrades/${encodeURIComponent(playlistId)}`);
+
+export const searchAllUpgrades = () => postData("/playlists/quality-upgrades");
 
 export const approveBlockedJob = (jobId) =>
   postData(`/playlists/jobs/${jobId}/approve`);


### PR DESCRIPTION
Wanted's Missing and Cutoff unmet views only supported row-by-row searches, making bulk recovery tedious.

Adds a visible icon action beside the Wanted filter that re-searches all accessible missing tracks or queues all accessible cutoff-upgrade checks. The redundant Wanted refresh control is removed, and the action uses distinct icons and hover labels for re-search versus upgrade.

Scope:
- Backend/API: access-scoped bulk missing-track and cutoff-upgrade endpoints.
- Frontend: Wanted toolbar action, loading/disabled states, and context-aware tooltips.
- Tests/docs: playlist-access coverage plus API and activity documentation.

Release impact:
- No database migration, configuration change, or provider contract change.
- Existing Wanted row actions and non-Wanted Activity refresh behavior are unchanged.

Verification:
- Frontend lint
- Frontend production build
- Backend lint
- Documentation build
- Focused activity tests
- Weekly-flow route/access test
- Diff/secret checks

Known limitation: provider-specific live searches remain covered by the existing integration boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Search all** actions in the Wanted view to re-search missing tracks and find quality upgrades across accessible playlists.
  - Added loading, success, and error feedback for bulk searches, with automatic job status refresh.
  - Added API support for triggering both bulk search operations.

- **Documentation**
  - Documented the new bulk-search actions and playlist API endpoints.

- **Bug Fixes**
  - Bulk actions now respect playlist access and ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->