### PR TITLE
fix(playback): clear stale Navidrome tracks during flow refresh

### DIFF
--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -276,6 +276,31 @@ test("creates an empty API playlist without waiting for a scan", async () => {
   assert.deepEqual(client.calls.created, [{ name: "Empty", songIds: [] }]);
 });
 
+test("clears an existing API playlist while a new run has no indexed tracks", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Refreshing" });
+  const client = createClient({
+    playlists: [{ id: "saved-id", name: "Refreshing" }],
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "saved-id",
+    title: playlist.name,
+  });
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [],
+    }),
+  );
+
+  assert.deepEqual(client.calls.updated, [
+    { id: "saved-id", name: "Refreshing", songIds: [] },
+  ]);
+  assert.deepEqual(client.calls.created, []);
+});
+
 test("keeps an M3U fallback when no songs are indexed", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Unindexed" });
   const client = createClient();
@@ -463,7 +488,7 @@ test("replaces a pointer whose imported source belongs to another entity", async
   assert.equal(navidromePlaylistPointerStore.getPointer(original.id, "global"), null);
 });
 
-test("keeps a stored playlist during rename cleanup until tracks resolve", async () => {
+test("clears a stored playlist during rename cleanup until tracks resolve", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed" });
   const client = createClient({
     playlists: [{ id: "imported-id", name: "Legacy Rename Fixture" }],
@@ -495,6 +520,7 @@ test("keeps a stored playlist during rename cleanup until tracks resolve", async
   await destination.publishPlaylist(snapshot);
 
   assert.deepEqual(client.calls.updated, [
+    { id: "imported-id", name: "Renamed", songIds: [] },
     { id: "imported-id", name: "Renamed", songIds: ["song-1"] },
   ]);
   assert.equal(
@@ -503,7 +529,7 @@ test("keeps a stored playlist during rename cleanup until tracks resolve", async
   );
 });
 
-test("keeps an unclaimed imported playlist during rename cleanup until tracks resolve", async () => {
+test("clears an unclaimed imported playlist during rename cleanup until tracks resolve", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed without pointer" });
   const client = createClient({
     playlists: [{ id: "unclaimed-id", name: "Legacy Unclaimed Fixture" }],
@@ -527,6 +553,7 @@ test("keeps an unclaimed imported playlist during rename cleanup until tracks re
   await destination.publishPlaylist(snapshot);
 
   assert.deepEqual(client.calls.updated, [
+    { id: "unclaimed-id", name: "Renamed without pointer", songIds: [] },
     { id: "unclaimed-id", name: "Renamed without pointer", songIds: ["song-1"] },
   ]);
   assert.equal(
@@ -535,7 +562,7 @@ test("keeps an unclaimed imported playlist during rename cleanup until tracks re
   );
 });
 
-test("renames an imported playlist before unresolved tracks are ready", async () => {
+test("renames and clears an imported playlist before unresolved tracks are ready", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed immediately" });
   const client = createClient({
     playlists: [{ id: "rename-first-id", name: "Legacy Rename First" }],
@@ -558,7 +585,9 @@ test("renames an imported playlist before unresolved tracks are ready", async ()
   assert.deepEqual(client.calls.renamed, [
     { id: "rename-first-id", name: "Renamed immediately" },
   ]);
-  assert.deepEqual(client.calls.updated, []);
+  assert.deepEqual(client.calls.updated, [
+    { id: "rename-first-id", name: "Renamed immediately", songIds: [] },
+  ]);
   assert.equal(
     navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
     "rename-first-id",

--- a/.tests/weekly-flow/playlist-import-order.test.js
+++ b/.tests/weekly-flow/playlist-import-order.test.js
@@ -17,6 +17,8 @@ const [
   playlistConfigModule,
   operationsModule,
   workerModule,
+  playlistSourceModule,
+  playlistManagerModule,
 ] = await setupIsolatedBackend(
   "playlist-import-order",
   "backend/config/db-sqlite.js",
@@ -25,6 +27,8 @@ const [
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowOperations.js",
   "backend/services/weeklyFlow/weeklyFlowWorker.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistSource.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
 );
 
 const { downloadTracker } = trackerModule;
@@ -35,6 +39,8 @@ const {
 } = playlistConfigModule;
 const { appendSharedPlaylistTracks, processWeeklyFlowOperation } = operationsModule;
 const { weeklyFlowWorker } = workerModule;
+const { playlistSource } = playlistSourceModule;
+const { playlistManager } = playlistManagerModule;
 
 const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
@@ -169,6 +175,47 @@ test("mixed reuse seeding keeps import job order", async () => {
     );
   } finally {
     weeklyFlowWorker.start = originalStart;
+    weeklyFlowWorker.stop();
+  }
+});
+
+test("flow refresh clears playback before downloads finish", async () => {
+  const originalBuildPlan = playlistSource.buildFlowRunPlan;
+  const originalRefresh = playlistManager.refreshPlaylist;
+  const refreshed = [];
+  try {
+    dbOps.updateSettings({
+      ...dbOps.getSettings(),
+      integrations: {
+        lastfm: { apiKey: "test" },
+        slskd: { enabled: true, url: "http://slskd", apiKey: "test" },
+      },
+    });
+    const flow = flowPlaylistConfig.createFlow({
+      name: "Refresh Before Download",
+      mix: { discover: 100, mix: 0, trending: 0, focus: 0 },
+      size: 1,
+      scheduleDays: [1],
+    });
+    flowPlaylistConfig.setEnabled(flow.id, true);
+    playlistSource.buildFlowRunPlan = async () => ({
+      primaryTracks: [],
+      reserveTracks: [],
+      diagnostics: { targets: { primary: 0 }, achieved: { primary: 0, reserve: 0 } },
+    });
+    playlistManager.refreshPlaylist = async (playlistId) => {
+      refreshed.push(playlistId);
+    };
+
+    await processWeeklyFlowOperation({
+      kind: "manual-start-flow",
+      flowId: flow.id,
+    });
+
+    assert.deepEqual(refreshed, [flow.id]);
+  } finally {
+    playlistSource.buildFlowRunPlan = originalBuildPlan;
+    playlistManager.refreshPlaylist = originalRefresh;
     weeklyFlowWorker.stop();
   }
 });

--- a/.tests/weekly-flow/playlist-import-order.test.js
+++ b/.tests/weekly-flow/playlist-import-order.test.js
@@ -182,7 +182,8 @@ test("mixed reuse seeding keeps import job order", async () => {
 test("flow refresh clears playback before downloads finish", async () => {
   const originalBuildPlan = playlistSource.buildFlowRunPlan;
   const originalRefresh = playlistManager.refreshPlaylist;
-  const refreshed = [];
+  const originalScheduleNextRun = flowPlaylistConfig.scheduleNextRun;
+  const events = [];
   try {
     dbOps.updateSettings({
       ...dbOps.getSettings(),
@@ -204,18 +205,26 @@ test("flow refresh clears playback before downloads finish", async () => {
       diagnostics: { targets: { primary: 0 }, achieved: { primary: 0, reserve: 0 } },
     });
     playlistManager.refreshPlaylist = async (playlistId) => {
-      refreshed.push(playlistId);
+      await new Promise((resolve) => setImmediate(resolve));
+      events.push(["refresh", playlistId]);
+    };
+    flowPlaylistConfig.scheduleNextRun = (playlistId) => {
+      events.push(["schedule", playlistId]);
     };
 
     await processWeeklyFlowOperation({
-      kind: "manual-start-flow",
+      kind: "scheduled-flow-refresh",
       flowId: flow.id,
     });
 
-    assert.deepEqual(refreshed, [flow.id]);
+    assert.deepEqual(events, [
+      ["refresh", flow.id],
+      ["schedule", flow.id],
+    ]);
   } finally {
     playlistSource.buildFlowRunPlan = originalBuildPlan;
     playlistManager.refreshPlaylist = originalRefresh;
+    flowPlaylistConfig.scheduleNextRun = originalScheduleNextRun;
     weeklyFlowWorker.stop();
   }
 });

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -443,22 +443,18 @@ export class NavidromePlaybackDestination {
 
     let playlist = null;
     if (pointer) {
-      if (songIds.length) {
-        for (const delayMs of [0, 250, 1000, 2000]) {
-          if (delayMs) await wait(delayMs);
-          try {
-            await this.client.updatePlaylist(pointer.playlistId, {
-              name: current,
-              songIds,
-            });
-            playlist = { id: pointer.playlistId };
-            break;
-          } catch (error) {
-            if (Number(error?.code) !== 70) throw error;
-          }
+      for (const delayMs of [0, 250, 1000, 2000]) {
+        if (delayMs) await wait(delayMs);
+        try {
+          await this.client.updatePlaylist(pointer.playlistId, {
+            name: current,
+            songIds,
+          });
+          playlist = { id: pointer.playlistId };
+          break;
+        } catch (error) {
+          if (Number(error?.code) !== 70) throw error;
         }
-      } else {
-        playlist = { id: pointer.playlistId };
       }
       if (!playlist) {
         navidromePlaylistPointerStore.deletePointer(snapshot.entityId, targetKey);

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -265,6 +265,7 @@ async function runFlowSeed({
     const seeded = await weeklyFlowWorker.seedFlowRun(safeFlowId, latestFlow, {
       size: effectiveSize,
     });
+    await playlistManager.refreshPlaylist(safeFlowId);
     if (scheduleNext) {
       flowPlaylistConfig.scheduleNextRun(safeFlowId);
     }


### PR DESCRIPTION
A flow refresh can leave the previous Navidrome playlist entries in place while new tracks are still downloading. A slow or missing track must not make the playlist look like the old run.

A flow refresh now publishes the current completed-track set immediately, including an empty set. Completed tracks continue to update the existing Navidrome playlist as they finish. The regression tests cover clearing stored playlists and refreshing before downloads finish.

Verification:

- `npm test` (678 passed)
- `npm run lint:backend`
- `git diff --check`

This changes Aurral's Navidrome playlist synchronization. It does not change download retry policy or Navidrome scan timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Existing playlists are now cleared when no tracks are available or track lookups are still pending, preventing outdated songs from remaining.
  * Manually started flows now refresh their playlists immediately, even when downloads have not completed.
  * Playlist refreshes now occur consistently after starting a flow run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->