### PR TITLE
fix(playback): migrate flow files out of hidden folders

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -86,6 +86,7 @@ test("scanMusicRoot indexes tagged media and ignores Flow output", async () => {
     await createAudioFile(root, "_playlists/ignored.flac");
     await createAudioFile(root, "_staging/ignored.flac");
     await createAudioFile(root, "_fallback/ignored.flac");
+    await createAudioFile(root, "_flows/flow/ignored.flac");
     await createAudioFile(root, ".hidden/ignored.flac");
 
     const result = await scanMusicRoot({

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -15,7 +15,7 @@ const [
   { dbOps },
   { flowPlaylistConfig },
   { downloadTracker },
-  { migrateAurralDownloadFolder },
+  { migrateAurralDownloadFolder, migrateLegacyFlowFolder },
 ] = await setupIsolatedBackend(
   "aurral-download-folder-migration",
   "backend/config/db-sqlite.js",
@@ -41,6 +41,44 @@ test.beforeEach(async () => {
 
 test.after(async () => {
   await cleanupIsolatedState(isolatedState);
+});
+
+test("moves legacy dot flow files into the visible flow directory", async () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Legacy Nightly", enabled: true });
+  const source = path.join(
+    root,
+    ".flows",
+    flow.id,
+    "Artist",
+    "Album",
+    "Flow Track.flac",
+  );
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "flow audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
+    flow.id,
+  );
+  downloadTracker.setDone(jobId, source);
+
+  const result = await migrateLegacyFlowFolder({ root });
+  const destination = path.join(
+    root,
+    "_flows",
+    flow.id,
+    "Artist",
+    "Album",
+    "Flow Track.flac",
+  );
+
+  assert.equal(result.migrated, 1);
+  assert.equal(downloadTracker.getJob(jobId).finalPath, destination);
+  assert.equal(await fs.readFile(destination, "utf8"), "flow audio");
+  await assert.rejects(() => fs.access(source));
+
+  const retry = await migrateLegacyFlowFolder({ root });
+  assert.equal(retry.scanned, 0);
+  assert.equal(retry.migrated, 0);
 });
 
 test("migrates permanent tracks, isolates active flows, and removes unkept flow files", async () => {
@@ -99,7 +137,7 @@ test("migrates permanent tracks, isolates active flows, and removes unkept flow 
   });
 
   const permanentDestination = path.join(root, "Artist", "Album", "Track.flac");
-  const flowDestination = path.join(root, ".flows", flow.id, "Artist", "Album", "Flow Track.flac");
+  const flowDestination = path.join(root, "_flows", flow.id, "Artist", "Album", "Flow Track.flac");
   assert.equal(result.migrated, 2);
   assert.equal(result.flowMigrated, 1);
   assert.equal(result.removed, 1);

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "fs/promises";
 import path from "path";
@@ -43,6 +43,8 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
+test.afterEach(() => mock.restoreAll());
+
 test("moves legacy dot flow files into the visible flow directory", async () => {
   const flow = flowPlaylistConfig.createFlow({ name: "Legacy Nightly", enabled: true });
   const source = path.join(
@@ -59,7 +61,17 @@ test("moves legacy dot flow files into the visible flow directory", async () => 
     { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
     flow.id,
   );
-  downloadTracker.setDone(jobId, source);
+  downloadTracker.setDone(
+    jobId,
+    path.join(
+      "/app/downloads",
+      ".flows",
+      flow.id,
+      "Artist",
+      "Album",
+      "Flow Track.flac",
+    ),
+  );
 
   const result = await migrateLegacyFlowFolder({ root });
   const destination = path.join(
@@ -79,6 +91,29 @@ test("moves legacy dot flow files into the visible flow directory", async () => 
   const retry = await migrateLegacyFlowFolder({ root });
   assert.equal(retry.scanned, 0);
   assert.equal(retry.migrated, 0);
+});
+
+test("retains the legacy source when tracker updates fail", async () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Failed Legacy Nightly", enabled: true });
+  const source = path.join(root, ".flows", flow.id, "Artist", "Album", "Flow Track.flac");
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "flow audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
+    flow.id,
+  );
+  downloadTracker.setDone(jobId, source);
+  mock.method(downloadTracker, "updateFinalPath", () => {
+    throw new Error("tracker unavailable");
+  });
+
+  const result = await migrateLegacyFlowFolder({ root, logger: { warn() {} } });
+  const destination = path.join(root, "_flows", flow.id, "Artist", "Album", "Flow Track.flac");
+
+  assert.equal(result.failed, 1);
+  await assert.doesNotReject(() => fs.access(source));
+  await assert.doesNotReject(() => fs.access(destination));
+  assert.equal(downloadTracker.getJob(jobId).finalPath, source);
 });
 
 test("migrates permanent tracks, isolates active flows, and removes unkept flow files", async () => {

--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -116,6 +116,25 @@ test("retains the legacy source when tracker updates fail", async () => {
   assert.equal(downloadTracker.getJob(jobId).finalPath, source);
 });
 
+test("retains the legacy source when tracker updates are not persisted", async () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Unpersisted Legacy Nightly", enabled: true });
+  const source = path.join(root, ".flows", flow.id, "Artist", "Album", "Flow Track.flac");
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "flow audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Flow Track" },
+    flow.id,
+  );
+  downloadTracker.setDone(jobId, source);
+  mock.method(downloadTracker, "updateFinalPath", () => false);
+
+  const result = await migrateLegacyFlowFolder({ root, logger: { warn() {} } });
+
+  assert.equal(result.failed, 1);
+  await assert.doesNotReject(() => fs.access(source));
+  assert.equal(downloadTracker.getJob(jobId).finalPath, source);
+});
+
 test("migrates permanent tracks, isolates active flows, and removes unkept flow files", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Saved" });
   const flow = flowPlaylistConfig.createFlow({ name: "Nightly", enabled: true });

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -174,43 +174,29 @@ test("batches large playlist replacement requests", async () => {
   assert.ok(urls.every((url) => url.toString().length < 8192));
 });
 
-test("prefers the exact path and metadata when duplicate songs match", async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => jsonResponse({
-    "subsonic-response": {
-      status: "ok",
-      searchResult3: {
-        song: [
-          { id: "other", title: "Song", artist: "Artist", album: "Other", path: "Song.flac" },
-          {
-            id: "match",
-            title: "Song",
-            artist: "Artist",
-            album: "Album",
-            path: "Artist/Album/Song.flac",
-            duration: 240,
-          },
-        ],
-      },
+test("prefers the exact indexed path when duplicate songs match", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._getIndexedSongs = async () => [
+    { id: "other", title: "Song", artist: "Artist", album: "Other", path: "Other/Song.flac" },
+    {
+      id: "match",
+      title: "Song",
+      artist: "Artist",
+      album: "Album",
+      path: "Artist/Album/Song.flac",
+      duration: 240,
     },
+  ];
+  const song = await client.findSong("Song", "Artist", {
+    album: "Album",
+    durationMs: 240000,
+    path: "/music/Artist/Album/Song.flac",
   });
-
-  let song;
-  try {
-    song = await new NavidromeClient("http://navidrome.test", "user", "password")
-      .findSong("Song", "Artist", {
-        album: "Album",
-        durationMs: 240000,
-        path: "/music/Artist/Album/Song.flac",
-      });
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
 
   assert.equal(song.id, "match");
 });
 
-test("matches metadata variants and falls back to title search", async () => {
+test("does not match an unindexed track from metadata search", async () => {
   const originalFetch = globalThis.fetch;
   const queries = [];
   globalThis.fetch = async (url) => {
@@ -246,11 +232,11 @@ test("matches metadata variants and falls back to title search", async () => {
     globalThis.fetch = originalFetch;
   }
 
-  assert.equal(song.id, "variant");
-  assert.deepEqual(queries.filter(Boolean), ["The Goo Goo Dolls Slide", "Slide"]);
+  assert.equal(song, null);
+  assert.deepEqual(queries, []);
 });
 
-test("uses an indexed path before metadata matching", async () => {
+test("uses an indexed path without metadata matching", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [{
     id: "path-match",
@@ -267,6 +253,25 @@ test("uses an indexed path before metadata matching", async () => {
   });
 
   assert.equal(song.id, "path-match");
+});
+
+test("uses an exact indexed recording MBID when the path differs", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._getIndexedSongs = async () => [{
+    id: "mbid-match",
+    musicBrainzId: "recording-mbid",
+    path: "Artist/Album/track.flac",
+  }];
+  client.request = async () => {
+    throw new Error("metadata search should not run");
+  };
+
+  const song = await client.findSong("Wanted title", "Wanted artist", {
+    mbid: "recording-mbid",
+    path: "/data/music/Other/track.flac",
+  });
+
+  assert.equal(song.id, "mbid-match");
 });
 
 test("uploads playlist artwork through the native API", async () => {

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -177,13 +177,13 @@ test("batches large playlist replacement requests", async () => {
 test("prefers the exact indexed path when duplicate songs match", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [
-    { id: "other", title: "Song", artist: "Artist", album: "Other", path: "Other/Song.flac" },
+    { id: "other", title: "Song", artist: "Artist", album: "Other", path: "/music/Other/Song.flac" },
     {
       id: "match",
       title: "Song",
       artist: "Artist",
       album: "Album",
-      path: "Artist/Album/Song.flac",
+      path: "/music/Artist/Album/Song.flac",
       duration: 240,
     },
   ];
@@ -240,7 +240,7 @@ test("uses an indexed path without metadata matching", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [{
     id: "path-match",
-    path: "Artist/Album/track.flac",
+    path: "/data/music/Artist/Album/track.flac",
     title: "Different tag",
     artist: "Different artist",
   }];
@@ -253,6 +253,20 @@ test("uses an indexed path without metadata matching", async () => {
   });
 
   assert.equal(song.id, "path-match");
+});
+
+test("does not match a path suffix from another library", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._getIndexedSongs = async () => [{
+    id: "other-library",
+    path: "/library/Artist/Album/track.flac",
+  }];
+
+  const song = await client.findSong("Track", "Artist", {
+    path: "/other-library/Artist/Album/track.flac",
+  });
+
+  assert.equal(song, null);
 });
 
 test("uses an exact indexed recording MBID when the path differs", async () => {
@@ -272,6 +286,27 @@ test("uses an exact indexed recording MBID when the path differs", async () => {
   });
 
   assert.equal(song.id, "mbid-match");
+});
+
+test("loads the complete indexed song list in pages", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  const requests = [];
+  client._nativeRequest = async (_method, requestPath) => {
+    requests.push(requestPath);
+    const start = Number(new URL(`http://navidrome.test${requestPath}`).searchParams.get("_start"));
+    if (start === 0) return Array.from({ length: 1_000 }, (_, index) => ({ id: `song-${index}` }));
+    if (start === 1_000) return [{ id: "song-after-first-page" }];
+    return [];
+  };
+
+  const songs = await client._getIndexedSongs();
+
+  assert.equal(songs.length, 1_001);
+  assert.equal(songs.at(-1).id, "song-after-first-page");
+  assert.deepEqual(requests, [
+    "/api/song?_start=0&_end=1000",
+    "/api/song?_start=1000&_end=2000",
+  ]);
 });
 
 test("uploads playlist artwork through the native API", async () => {

--- a/.tests/notifications/notification-events.test.js
+++ b/.tests/notifications/notification-events.test.js
@@ -370,7 +370,7 @@ test("notifyWeeklyFlowDone uses display name and track library path placeholders
     });
 
     const playlistId = "c0c01bc3-72ca-4110-8ab6-681f132a6e63";
-    const flowPath = `/data/downloads/aurral/.flows/${playlistId}`;
+  const flowPath = `/data/downloads/aurral/_flows/${playlistId}`;
     await notifyWeeklyFlowDone(
       playlistId,
       { completed: 3, failed: 1 },

--- a/.tests/playback/plex-playback-destination.test.js
+++ b/.tests/playback/plex-playback-destination.test.js
@@ -138,8 +138,8 @@ test("recovers a managed-user token and retries with the stored client identifie
 test("resolves managed and reused Lidarr paths to private Plex rating keys", async () => {
   const destination = makeDestination({ downloadsPath: "/data", mainLibrarySectionId: "9" });
   const managedPath = path.join(
-    destination.playlistLibraryRoot,
-    ".flows",
+    destination.weeklyFlowRoot,
+    "_flows",
     "flow-1",
     "Artist",
     "Album",
@@ -161,7 +161,7 @@ test("resolves managed and reused Lidarr paths to private Plex rating keys", asy
   destination._libraryTracks = [
     {
       ratingKey: "101",
-      files: ["/data/.flows/flow-1/Artist/Album/Managed.flac"],
+      files: ["/data/_flows/flow-1/Artist/Album/Managed.flac"],
     },
     { ratingKey: "102", files: ["/data/Artist/Album/Canonical.flac"] },
   ];
@@ -187,8 +187,8 @@ test("reuses a Lidarr file linked into the entity folder without a main Plex lib
   const destination = makeDestination({ downloadsPath: "/data" });
   const reusedPath = path.join(weeklyFlowRoot, "..", "lidarr", "Artist", "Track.flac");
   const linkedPath = path.join(
-    destination.playlistLibraryRoot,
-    ".flows",
+    destination.weeklyFlowRoot,
+    "_flows",
     "flow-1",
     "Artist",
     "Album",
@@ -199,7 +199,7 @@ test("reuses a Lidarr file linked into the entity folder without a main Plex lib
   await fs.writeFile(reusedPath, "track");
   await fs.symlink(reusedPath, linkedPath);
   destination._libraryTracks = [
-    { ratingKey: "303", files: ["/data/.flows/flow-1/Artist/Album/Track.flac"] },
+    { ratingKey: "303", files: ["/data/_flows/flow-1/Artist/Album/Track.flac"] },
   ];
   destination._mainLibraryTracks = [];
 
@@ -214,15 +214,15 @@ test("reuses a Lidarr file linked into the entity folder without a main Plex lib
 test("upserts from the entity-owner pointer and stores the returned pointer privately", async () => {
   const destination = makeDestination({ downloadsPath: "/data" });
   const trackPath = path.join(
-    destination.playlistLibraryRoot,
-    ".flows",
+    destination.weeklyFlowRoot,
+    "_flows",
     "flow-1",
     "Artist",
     "Album",
     "Track.flac",
   );
   destination._libraryTracks = [
-    { ratingKey: "101", files: ["/data/.flows/flow-1/Artist/Album/Track.flac"] },
+    { ratingKey: "101", files: ["/data/_flows/flow-1/Artist/Album/Track.flac"] },
   ];
   destination._mainLibraryTracks = [];
   plexPlaylistPointerStore.setPointer("flow-1", "global", {
@@ -336,7 +336,7 @@ test("configures Plex with the canonical root and explicit flow location", async
   assert.equal(calls.length, 1);
   assert.equal(
     calls[0].requestPath,
-    `/library/sections?name=Aurral&type=artist&agent=tv.plex.agents.music&scanner=Plex+Music&language=en-US&location=${encodeURIComponent(root)}&location=${encodeURIComponent(`${root}/.flows`)}`,
+    `/library/sections?name=Aurral&type=artist&agent=tv.plex.agents.music&scanner=Plex+Music&language=en-US&location=${encodeURIComponent(root)}&location=${encodeURIComponent(`${root}/_flows`)}&location=${encodeURIComponent(`${root}/.flows`)}`,
   );
   assert.equal(calls[0].options.method, "POST");
 });

--- a/.tests/weekly-flow/weekly-flow-paths.test.js
+++ b/.tests/weekly-flow/weekly-flow-paths.test.js
@@ -17,6 +17,8 @@ const {
   remapLegacyPath: remapLegacyWeeklyFlowPath,
   resolveExistingTrackPath: resolveExistingWeeklyFlowTrackPath,
   migrateLegacyPaths,
+  AURRAL_FLOWS_DIR,
+  LEGACY_AURRAL_FLOWS_DIR,
 } = playlistPaths;
 
 test.after(async () => {
@@ -68,6 +70,15 @@ test("remapLegacyWeeklyFlowPath rewrites legacy roots and library dir names", ()
   assert.equal(
     remapLegacyWeeklyFlowPath(previousV2Path, "/data/downloads/tmp"),
     "/data/downloads/tmp/aurral-weekly-flow/playlist-id/Artist/Album/Track.flac",
+  );
+  assert.equal(AURRAL_FLOWS_DIR, "_flows");
+  assert.equal(LEGACY_AURRAL_FLOWS_DIR, ".flows");
+  assert.equal(
+    remapLegacyWeeklyFlowPath(
+      "/data/downloads/tmp/.flows/flow-id/Artist/Album/Track.flac",
+      "/data/downloads/tmp",
+    ),
+    "/data/downloads/tmp/_flows/flow-id/Artist/Album/Track.flac",
   );
 });
 

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -318,7 +318,9 @@ export async function migrateLegacyFlowFolder(options = {}) {
     try {
       const committedPath = await copyWithoutRemovingSource(sourcePath, destination);
       for (const job of jobsByPath.get(sourcePath) || []) {
-        downloadTracker.updateFinalPath(job.id, committedPath);
+        if (!downloadTracker.updateFinalPath(job.id, committedPath)) {
+          throw new Error(`Could not update tracker path for job ${job.id}`);
+        }
       }
       await removeSource(sourcePath, rootPath);
       result.migrated += 1;

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -13,6 +13,8 @@ import { getLibraryMediaFile } from "./libraryMediaStore.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
 import {
+  AURRAL_FLOWS_DIR,
+  LEGACY_AURRAL_FLOWS_DIR,
   PLAYLIST_LIBRARY_DIR,
   buildAurralTrackDestination,
   isPathInsideRoot,
@@ -281,6 +283,61 @@ async function removeSource(sourcePath, rootPath) {
     }
     current = path.dirname(current);
   }
+}
+
+export async function migrateLegacyFlowFolder(options = {}) {
+  const rootPath = path.resolve(options.root || resolvePlaylistRoot());
+  const legacyRoot = path.join(rootPath, LEGACY_AURRAL_FLOWS_DIR);
+  const currentRoot = path.join(rootPath, AURRAL_FLOWS_DIR);
+  const logger = options.logger || console;
+  const files = await walkFiles(legacyRoot);
+  const jobsByPath = new Map();
+  for (const job of downloadTracker.getAll()) {
+    if (job?.status !== "done" || typeof job.finalPath !== "string") continue;
+    const finalPath = path.resolve(job.finalPath);
+    if (!isPathInsideRoot(finalPath, legacyRoot)) continue;
+    const matches = jobsByPath.get(finalPath) || [];
+    matches.push(job);
+    jobsByPath.set(finalPath, matches);
+  }
+  const result = {
+    status: "complete",
+    rootPath,
+    scanned: files.length,
+    migrated: 0,
+    retained: 0,
+    failed: 0,
+    failures: [],
+  };
+
+  for (const sourcePath of files) {
+    const destination = path.resolve(currentRoot, path.relative(legacyRoot, sourcePath));
+    try {
+      const destinationStat = await fs.stat(destination).catch(() => null);
+      if (destinationStat) {
+        if (!destinationStat.isFile() || !(await filesMatch(sourcePath, destination))) {
+          throw new Error("Canonical flow destination conflicts with source content");
+        }
+      } else {
+        await fs.mkdir(path.dirname(destination), { recursive: true });
+        await fs.rename(sourcePath, destination);
+      }
+      for (const job of jobsByPath.get(sourcePath) || []) {
+        downloadTracker.updateFinalPath(job.id, destination);
+      }
+      if (path.resolve(sourcePath) !== path.resolve(destination)) {
+        await removeSource(sourcePath, rootPath);
+      }
+      result.migrated += 1;
+    } catch (error) {
+      result.retained += 1;
+      result.failed += 1;
+      result.failures.push({ sourcePath, reason: error.message });
+      log(logger, "warn", `[AurralMigration] Retained ${sourcePath}: ${error.message}`);
+    }
+  }
+  if (result.failed > 0) result.status = "needs-review";
+  return result;
 }
 
 function updateJobPaths(jobs, destination) {

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -294,11 +294,14 @@ export async function migrateLegacyFlowFolder(options = {}) {
   const jobsByPath = new Map();
   for (const job of downloadTracker.getAll()) {
     if (job?.status !== "done" || typeof job.finalPath !== "string") continue;
-    const finalPath = path.resolve(job.finalPath);
-    if (!isPathInsideRoot(finalPath, legacyRoot)) continue;
-    const matches = jobsByPath.get(finalPath) || [];
+    const canonicalPath = remapLegacyPath(job.finalPath, rootPath);
+    const relative = path.relative(currentRoot, canonicalPath);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
+    const legacyPath = path.resolve(legacyRoot, relative);
+    if (!isPathInsideRoot(legacyPath, legacyRoot)) continue;
+    const matches = jobsByPath.get(legacyPath) || [];
     matches.push(job);
-    jobsByPath.set(finalPath, matches);
+    jobsByPath.set(legacyPath, matches);
   }
   const result = {
     status: "complete",
@@ -313,21 +316,11 @@ export async function migrateLegacyFlowFolder(options = {}) {
   for (const sourcePath of files) {
     const destination = path.resolve(currentRoot, path.relative(legacyRoot, sourcePath));
     try {
-      const destinationStat = await fs.stat(destination).catch(() => null);
-      if (destinationStat) {
-        if (!destinationStat.isFile() || !(await filesMatch(sourcePath, destination))) {
-          throw new Error("Canonical flow destination conflicts with source content");
-        }
-      } else {
-        await fs.mkdir(path.dirname(destination), { recursive: true });
-        await fs.rename(sourcePath, destination);
-      }
+      const committedPath = await copyWithoutRemovingSource(sourcePath, destination);
       for (const job of jobsByPath.get(sourcePath) || []) {
-        downloadTracker.updateFinalPath(job.id, destination);
+        downloadTracker.updateFinalPath(job.id, committedPath);
       }
-      if (path.resolve(sourcePath) !== path.resolve(destination)) {
-        await removeSource(sourcePath, rootPath);
-      }
+      await removeSource(sourcePath, rootPath);
       result.migrated += 1;
     } catch (error) {
       result.retained += 1;

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -31,6 +31,7 @@ const AUDIO_EXTENSIONS = new Set([
 const EXCLUDED_DIRECTORIES = new Set([
   ".git",
   "_fallback",
+  "_flows",
   "_playlists",
   "_staging",
   "aurral-weekly-flow",

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -11,31 +11,6 @@ const NAVIDROME_RATE_LIMIT_MAX_DELAY_MS = 5_000;
 
 const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
-function normalizeSearchText(value) {
-  return String(value || "")
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/&/g, " and ")
-    .replace(/[^\p{L}\p{N}]+/gu, " ")
-    .trim();
-}
-
-function titleForms(value) {
-  const normalized = normalizeSearchText(value);
-  const base = normalized.split(/\s+-\s+|\s+\(/, 1)[0].trim();
-  return new Set([normalized, base].filter(Boolean));
-}
-
-function artistForms(value) {
-  const normalized = normalizeSearchText(value);
-  return new Set([normalized, normalized.replace(/^the\s+/, "")].filter(Boolean));
-}
-
-function stripTrackPrefix(value) {
-  return String(value || "").replace(/^\s*\d{1,3}(?:[-_. ]+\d{1,3})?\s*[-_. ]+/, "");
-}
-
 function normalizeLibraryPath(value) {
   return String(value || "")
     .trim()
@@ -120,75 +95,21 @@ export class NavidromeClient {
     return this.request("ping");
   }
 
-  async findSong(title, artist, track = {}) {
+  async findSong(_title, _artist, track = {}) {
     const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
-    if (normalizedPath) {
-      const indexedSongs = await this._getIndexedSongs();
-      const matchesPathSuffix = (songPath) => songPath
-        && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`));
-      const pathMatch = indexedSongs.find((song) => {
-        const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
-        return matchesPathSuffix(songPath);
-      });
-      if (pathMatch) return pathMatch;
-    }
-    const search = (query, songCount) => this.request("search3", {
-      query,
-      songCount,
-      artistCount: 0,
-      albumCount: 0,
-    });
-    const toList = (value) => {
-      if (!value) return [];
-      return Array.isArray(value) ? value : [value];
-    };
-    let data = await search(`${artist} ${title}`, 5);
-    let songs = toList(data.searchResult3?.song);
-    if (!songs.length) {
-      data = await search(title, 25);
-      songs = toList(data.searchResult3?.song);
-    }
-    if (!songs.length) {
-      data = await search(artist, 25);
-      songs = toList(data.searchResult3?.song);
-    }
-    const candidates = songs;
-    const fileName = normalizedPath.split("/").at(-1);
-    const album = String(track.album || "").toLowerCase();
-    const mbid = String(track.mbid || "").toLowerCase();
-    const duration = Number(track.durationMs) / 1000;
-    const wantedTitles = titleForms(title);
-    const wantedArtists = artistForms(artist);
-    const wantedAlbum = normalizeSearchText(album);
-    const wantedFileStem = normalizeSearchText(stripTrackPrefix(fileName?.replace(/\.[^.]+$/, "")));
-    const score = (song) => {
+    const indexedSongs = await this._getIndexedSongs();
+    const matchesPath = (song) => {
       const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
-      const candidateTitles = titleForms(song.title);
-      const candidateArtists = artistForms(song.artist);
-      const candidateAlbum = normalizeSearchText(song.album);
-      const candidateFileStem = normalizeSearchText(
-        stripTrackPrefix(songPath.split("/").at(-1)?.replace(/\.[^.]+$/, "")),
-      );
-      let value = 0;
-      if (mbid && String(song.musicBrainzId || "").toLowerCase() === mbid) value += 8;
-      if (songPath && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`))) value += 8;
-      else if (fileName && songPath.split("/").at(-1) === fileName) value += 4;
-      if (wantedTitles.has(normalizeSearchText(song.title))) value += 10;
-      else if ([...wantedTitles].some((form) => candidateTitles.has(form))) value += 7;
-      if ([...wantedArtists].some((form) => candidateArtists.has(form))) value += 6;
-      if (wantedAlbum && candidateAlbum === wantedAlbum) value += 3;
-      if (wantedFileStem && candidateFileStem && (
-        wantedFileStem === candidateFileStem
-        || wantedFileStem.startsWith(candidateFileStem)
-        || candidateFileStem.startsWith(wantedFileStem)
-      )) value += 6;
-      if (Number.isFinite(duration) && Math.abs(Number(song.duration) - duration) <= 2) value += 1;
-      return value;
+      return songPath && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`));
     };
-    return candidates
-      .map((song) => ({ song, score: score(song) }))
-      .filter(({ score: value }) => value >= 13)
-      .sort((a, b) => b.score - a.score)[0]?.song || null;
+    const pathMatch = normalizedPath ? indexedSongs.find(matchesPath) : null;
+    if (pathMatch) return pathMatch;
+
+    const mbid = String(track.mbid || "").trim().toLowerCase();
+    if (!mbid) return null;
+    return indexedSongs.find(
+      (song) => String(song.musicBrainzId || "").trim().toLowerCase() === mbid,
+    ) || null;
   }
 
   async searchSongsByArtist(artistName, limit = 5) {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -5,6 +5,7 @@ const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PLAYLIST_LIBRARY_NAME = "Aurral Playlists";
 const LEGACY_LIBRARY_NAMES = new Set(["Aurral Weekly Flow"]);
 const PLAYLIST_SONG_BATCH_SIZE = 50;
+const NAVIDROME_SONG_PAGE_SIZE = 1_000;
 const NAVIDROME_RATE_LIMIT_RETRIES = 2;
 const NAVIDROME_RATE_LIMIT_DELAY_MS = 250;
 const NAVIDROME_RATE_LIMIT_MAX_DELAY_MS = 5_000;
@@ -100,7 +101,7 @@ export class NavidromeClient {
     const indexedSongs = await this._getIndexedSongs();
     const matchesPath = (song) => {
       const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
-      return songPath && (normalizedPath === songPath || normalizedPath.endsWith(`/${songPath}`));
+      return songPath && normalizedPath === songPath;
     };
     const pathMatch = normalizedPath ? indexedSongs.find(matchesPath) : null;
     if (pathMatch) return pathMatch;
@@ -268,8 +269,20 @@ export class NavidromeClient {
 
   async _getIndexedSongs() {
     if (!this._indexedSongsPromise) {
-      this._indexedSongsPromise = this._nativeRequest("GET", "/api/song?_start=0&_end=100000")
-        .then((songs) => (Array.isArray(songs) ? songs : []))
+      this._indexedSongsPromise = (async () => {
+        const songs = [];
+        for (let start = 0; ; ) {
+          const page = await this._nativeRequest(
+            "GET",
+            `/api/song?_start=${start}&_end=${start + NAVIDROME_SONG_PAGE_SIZE}`,
+          );
+          if (!Array.isArray(page) || page.length === 0) break;
+          songs.push(...page);
+          if (page.length < NAVIDROME_SONG_PAGE_SIZE) break;
+          start += page.length;
+        }
+        return songs;
+      })()
         .catch(() => {
           this._indexedSongsPromise = null;
           return [];

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -5,6 +5,7 @@ import { userOps } from "../../db/helpers/index.js";
 import { NavidromeClient } from "../navidrome.js";
 import { navidromePlaylistPointerStore } from "../navidrome/navidromePlaylistPointerStore.js";
 import {
+  AURRAL_FLOWS_DIR,
   PLAYLIST_LIBRARY_DIR,
   resolvePlaylistRoot,
 } from "../playlistPaths.js";
@@ -334,6 +335,7 @@ export class NavidromePlaybackDestination {
   async ensureLibrary() {
     try {
       await fs.mkdir(this.libraryRoot, { recursive: true });
+      await fs.mkdir(path.join(this.weeklyFlowRoot, AURRAL_FLOWS_DIR), { recursive: true });
       if (this.isConfigured()) {
         await this.client.ensureWeeklyFlowLibrary(
           this.mediaLibraryRoot.replace(/\\/g, "/").replace(/\/+$/, ""),

--- a/backend/services/playback/playbackPlaylistTracks.js
+++ b/backend/services/playback/playbackPlaylistTracks.js
@@ -6,7 +6,7 @@ import {
 } from "../weeklyFlow/weeklyFlowPlaylistConfig.js";
 import { downloadTracker } from "../weeklyFlow/weeklyFlowDownloadTracker.js";
 import {
-  remapLegacyPath,
+  resolveExistingTrackPath,
   resolvePlaylistRoot,
 } from "../playlistPaths.js";
 
@@ -38,10 +38,10 @@ export async function collectPlaybackPlaylistTracks(entityId, options = {}) {
   );
   const tracks = [];
   for (const job of orderedJobs) {
-    const localPath = path.resolve(remapLegacyPath(job.finalPath, weeklyFlowRoot));
-    if (!(await isFile(localPath))) continue;
+    const resolved = await resolveExistingTrackPath(job.finalPath, weeklyFlowRoot);
+    if (!resolved || !(await isFile(resolved.path))) continue;
     tracks.push({
-      path: localPath,
+      path: resolved.path,
       title: String(job.trackName || "").trim() || "Unknown Track",
       artist: String(job.artistName || "").trim() || "Unknown Artist",
       ...(job.albumName ? { album: job.albumName } : {}),

--- a/backend/services/playlistPaths.js
+++ b/backend/services/playlistPaths.js
@@ -8,7 +8,8 @@ import {
 import { commitImportToPlaylistLibrary } from "./playlistDownloadUtils.js";
 
 export const PLAYLIST_LIBRARY_DIR = "aurral-weekly-flow";
-export const AURRAL_FLOWS_DIR = ".flows";
+export const AURRAL_FLOWS_DIR = "_flows";
+export const LEGACY_AURRAL_FLOWS_DIR = ".flows";
 const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PREVIOUS_V2_LIBRARY_DIR = "aurral-playlists";
 const LEGACY_DOCKER_PLAYLIST_ROOT = "/app/downloads";
@@ -53,6 +54,15 @@ export function remapLegacyPath(finalPath, playlistRoot = resolvePlaylistRoot())
     resolved = path.resolve(
       root,
       path.relative(root, resolved).replaceAll(LEGACY_LIBRARY_DIR, PLAYLIST_LIBRARY_DIR),
+    );
+  }
+  const relative = path.relative(root, resolved);
+  const legacyFlowPrefix = `${LEGACY_AURRAL_FLOWS_DIR}${path.sep}`;
+  if (relative === LEGACY_AURRAL_FLOWS_DIR || relative.startsWith(legacyFlowPrefix)) {
+    return path.resolve(
+      root,
+      AURRAL_FLOWS_DIR,
+      relative.slice(legacyFlowPrefix.length),
     );
   }
   return resolved;

--- a/backend/services/plex.js
+++ b/backend/services/plex.js
@@ -1,5 +1,6 @@
 import axios from "../../lib/axiosFetch.js";
 import crypto from "crypto";
+import { AURRAL_FLOWS_DIR, LEGACY_AURRAL_FLOWS_DIR } from "./playlistPaths.js";
 
 const PLEX_TV = "https://plex.tv";
 const PLEX_AUTH_APP = "https://app.plex.tv";
@@ -248,7 +249,12 @@ export class PlexClient {
   async ensureWeeklyFlowLibrary(libraryPath) {
     if (!this.isConfigured()) return null;
     const name = "Aurral";
-    const locations = [libraryPath, `${libraryPath.replace(/\/+$/, "")}/.flows`];
+    const flowRoot = libraryPath.replace(/\/+$/, "");
+    const locations = [
+      libraryPath,
+      `${flowRoot}/${AURRAL_FLOWS_DIR}`,
+      `${flowRoot}/${LEGACY_AURRAL_FLOWS_DIR}`,
+    ];
     // Also match the legacy "Aurral Flow" name so existing libraries are reused
     // and renamed rather than duplicated.
     const findExisting = (libs) =>

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -76,7 +76,7 @@ async function processSystemTask(payload = {}) {
     }
     case "playlist-startup-migration": {
       const [
-        { migrateAurralDownloadFolder },
+        migrationModule,
         trackerModule,
         { playlistManager },
         { repairYtdlpMetadata },
@@ -86,6 +86,7 @@ async function processSystemTask(payload = {}) {
         import("./weeklyFlow/weeklyFlowPlaylistManager.js"),
         import("./playlistDownloadUtils.js"),
       ]);
+      const { migrateAurralDownloadFolder, migrateLegacyFlowFolder } = migrationModule;
       let result = {
         migrated: 0,
         flowMigrated: 0,
@@ -93,6 +94,20 @@ async function processSystemTask(payload = {}) {
         retained: 0,
         failed: 0,
       };
+      let legacyFlowResult = { migrated: 0, retained: 0, failed: 0 };
+      try {
+        legacyFlowResult = await migrateLegacyFlowFolder();
+      } catch (error) {
+        console.error(`[Playlists] Legacy flow folder migration failed: ${error.message}`);
+      }
+      if (legacyFlowResult.migrated > 0) {
+        console.log(`[Playlists] Migrated ${legacyFlowResult.migrated} legacy flow file(s)`);
+      }
+      if (legacyFlowResult.retained > 0 || legacyFlowResult.failed > 0) {
+        console.warn(
+          `[Playlists] Retained ${legacyFlowResult.retained} legacy flow file(s) for review`,
+        );
+      }
       try {
         result = await migrateAurralDownloadFolder();
       } catch (error) {

--- a/docs/architecture/0001-playback-destination.md
+++ b/docs/architecture/0001-playback-destination.md
@@ -36,7 +36,7 @@ Destination adapters own their names, authentication, configuration, vendor IDs,
 
 ## Compatibility
 
-The Navidrome adapter resolves snapshot paths and metadata to Subsonic song IDs. It stores a Navidrome playlist ID for each Aurral entity and owner. If Navidrome has not indexed a track, a post-scan catch-up retries the API playlist. The adapter adopts and removes legacy M3U playlists during migration. It owns Navidrome naming, migration cleanup, library setup, and scans.
+The Navidrome adapter resolves snapshot paths or exact recording MBIDs to Subsonic song IDs. It never substitutes a metadata search result for an unindexed file. It stores a Navidrome playlist ID for each Aurral entity and owner. If Navidrome has not indexed a track, a post-scan catch-up retries the API playlist. The adapter adopts and removes legacy M3U playlists during migration. It owns Navidrome naming, migration cleanup, library setup, and scans.
 
 The Plex adapter resolves snapshot paths to Plex rating keys. It keeps section IDs, user tokens, playlist pointers, owner-specific titles, library setup, and scans inside the adapter.
 

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -36,7 +36,7 @@ description: Common setup and runtime issues.
 - Make sure that **Settings > Download Clients > Downloads Folder > Path** is under that mount.
 - In **Settings > Playback > Navidrome**, test the Navidrome connection. Changes save automatically.
 - Make sure that Navidrome scans Aurral's downloads path and not only Lidarr's library.
-- Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file in the Downloads Folder or `.flows`, then wait for the Navidrome scan.
+- Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file in the Downloads Folder or `_flows`, then wait for the Navidrome scan.
 - If the library is missing, check that the Navidrome account can manage libraries through its API.
 - Review the [Navidrome missing-track setting](/integrations/navidrome/#remove-missing-tracks).
 
@@ -88,7 +88,7 @@ See [Navidrome: Filesystem paths](/integrations/navidrome/#filesystem-paths).
 **Sync to Plex now** can succeed while the playlists have no tracks. The Aurral library can also stay empty after a scan.
 
 - Make sure that Plex can read the flow download tree.
-- The Plex container or host must contain the Downloads Folder, including `<downloads>/artist/album/track` and `<downloads>/.flows/<flow-id>/...`.
+- The Plex container or host must contain the Downloads Folder, including `<downloads>/artist/album/track` and `<downloads>/_flows/<flow-id>/...`.
 - If Plex and Aurral use different mounts, set **Settings > Playback > Plex > Plex Aurral Library path** to the folder that Plex sees.
 - Leave **Plex Aurral Library path** blank if both apps use the same path prefix.
 - Make sure the Plex settings have finished saving automatically.

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -58,7 +58,7 @@ If a service uses a separate path for its own database or configuration, keep th
 
 1. Aurral asks a download client to find the track.
 2. The download client writes the completed file under `/data/downloads/...`.
-3. Aurral imports the file into its Downloads Folder. Permanent tracks use `artist/album/track`; flow tracks use `.flows/<flow-id>/artist/album/track`.
+3. Aurral imports the file into its Downloads Folder. Permanent tracks use `artist/album/track`; flow tracks use `_flows/<flow-id>/artist/album/track`.
 4. Aurral writes playlist sidecars under `aurral-weekly-flow/_playlists`.
 5. Navidrome scans the Downloads Folder and can play the tracks.
 
@@ -87,7 +87,7 @@ Choose one directory on the Docker host as the media root. The example uses `/sr
     |-- usenet/complete/            # optional SABnzbd or NZBGet files
     \-- aurral/                     # Aurral Downloads Folder
         |-- Artist/Album/track      # permanent canonical tracks
-        |-- .flows/flow-id/...      # temporary flow tracks
+        |-- _flows/flow-id/...      # temporary flow tracks
         \-- aurral-weekly-flow/     # playlist sidecars
 ```
 
@@ -192,7 +192,7 @@ Use these checks in order:
 
    ```text
    /data/downloads/aurral/Artist/Album/Track.flac
-   /data/downloads/aurral/.flows/<flow-id>/Artist/Album/Track.flac
+   /data/downloads/aurral/_flows/<flow-id>/Artist/Album/Track.flac
    ```
 
 4. **Playback check:** Navidrome or Plex must have the Downloads Folder in its own filesystem and must scan it.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -69,6 +69,9 @@ Aurral creates the **Aurral Playlists** library at the Downloads Folder root:
 /data/downloads/aurral
 ```
 
+Flow files live under `_flows`, which is visible to Navidrome scanners. Existing
+nightly installations migrate the old `.flows` directory to `_flows` at startup.
+
 You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
 
 Navidrome must have permission to manage libraries through its API. If Aurral cannot create the library, use **Settings > System > Storage Health** for the exact path and error, then check the Navidrome account permissions and mount.
@@ -83,7 +86,7 @@ Add `/data/music` as a normal Navidrome music library if it is not already prese
 
 Aurral uses the Subsonic API for playlists, so it does not have a Navidrome playlist path-mapping setting. The automatically managed **Aurral Playlists** library must use the same absolute path in Aurral and Navidrome. Mount the shared download tree at matching paths in both applications.
 
-Reused Lidarr tracks do not need matching path strings because Aurral resolves indexed songs by metadata. For generated tracks, Aurral first uses the exact indexed Navidrome path to get the Navidrome song ID, then uses metadata search only when the path is not available. Navidrome still needs its own library for those files. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) only when Aurral cannot read a path reported by Lidarr or a download client.
+Reused Lidarr tracks do not need matching path strings because Aurral resolves indexed songs by their exact recording MBID. Generated tracks use the exact indexed Navidrome filepath or recording MBID; Aurral does not substitute a title match. Navidrome still needs its own library for those files. Use a separate [Remote Path Mapping](/getting-started/storage/#paths-reported-by-lidarr-or-download-clients) only when Aurral cannot read a path reported by Lidarr or a download client.
 
 ## API playlists and scans
 
@@ -91,9 +94,9 @@ Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names 
 
 Aurral also uploads its generated playlist artwork to API playlists and updates it when you change or regenerate artwork in Aurral. Aurral revalidates its local artwork response after restart, so the image stays current in the Aurral UI. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
 
-If a new track is not indexed, Aurral publishes the indexed tracks and adds the missing track during the next scan catch-up. If no tracks are indexed yet, it keeps a temporary M3U fallback until Navidrome can resolve at least one track. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
+If a new track is not indexed, Aurral leaves it out until Navidrome scans it; it never substitutes a same-title track from another artist. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
-- confirm that a permanent track exists under the Downloads Folder or a flow track exists under `.flows`;
+- confirm that a permanent track exists under the Downloads Folder or a flow track exists under `_flows`;
 - confirm that the Navidrome library path points to that folder;
 - run a Navidrome scan or save the Aurral Navidrome settings;
 - wait for the scan to finish.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -70,7 +70,7 @@ Aurral creates the **Aurral Playlists** library at the Downloads Folder root:
 ```
 
 Flow files live under `_flows`, which is visible to Navidrome scanners. Existing
-nightly installations migrate the old `.flows` directory to `_flows` at startup.
+installations migrate the old `.flows` directory to `_flows` at startup.
 
 You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
 

--- a/docs/src/content/docs/integrations/notifications.mdx
+++ b/docs/src/content/docs/integrations/notifications.mdx
@@ -31,7 +31,7 @@ Enter these values for each webhook:
 - **URL**: the endpoint to call (must start with `http://` or `https://`)
 - **Body**: optional JSON data. Use these placeholders:
   - `$flowName`: playlist display name
-  - `$flowPath`: on-disk Aurral media path. For a Flow, this is `.flows/<flow-id>`; for a static playlist, it is the Downloads Folder root.
+  - `$flowPath`: on-disk Aurral media path. For a Flow, this is `_flows/<flow-id>`; for a static playlist, it is the Downloads Folder root.
   - `$albumName`, `$artistName`, `$username`, `$userId`, and `$event` for request events
 - **Headers**: optional key-value pairs
 

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -34,7 +34,7 @@ volumes:
 8. Select **Test connection**.
 9. After a flow downloads tracks, select **Sync to Plex now**.
 
-Aurral registers the library at `<plex-visible-downloads>`. Permanent tracks are in `artist/album/track` folders. Temporary flow tracks are under `.flows/<flow-id>`.
+Aurral registers the library at `<plex-visible-downloads>`. Permanent tracks are in `artist/album/track` folders. Temporary flow tracks are under `_flows/<flow-id>`.
 
 You do not need to create this library manually in Plex. The library can be empty until a flow finishes downloading tracks. Plex can take several minutes to scan the files.
 
@@ -57,7 +57,7 @@ Set **Plex Aurral Library path** if Plex uses a different mount prefix than Aurr
 
 Enter the Downloads Folder as Plex sees it. Aurral uses that path as the library root.
 
-Aurral also adds the `.flows` directory as an explicit second Plex library location. Plex otherwise skips hidden directories below the library root, which would hide flow tracks from scans.
+Aurral also adds the `_flows` directory as an explicit second Plex library location. It keeps the legacy `.flows` location during migration.
 
 | Aurral writes to            | Plex sees                      | Plex Aurral Library path |
 | --------------------------- | ------------------------------ | ------------------------- |

--- a/docs/src/content/docs/using/flows.mdx
+++ b/docs/src/content/docs/using/flows.mdx
@@ -4,7 +4,7 @@ description: Schedule, source mix, focus, and flow generation behavior.
 ---
 
 Flows are dynamic discovery features. They regenerate on their schedule and
-download temporary files under `.flows` in the Aurral root. Aurral can send
+download temporary files under `_flows` in the Aurral root. Aurral can send
 their playlist references to Navidrome or Plex without making the files part of
 the permanent Library.
 

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -30,7 +30,7 @@ configured.
 
 Permanent Aurral tracks use the canonical `artist/album/track` layout under
 the configured Aurral download folder. Flow media is temporary and lives under
-`.flows`; it is not added to the canonical Library. Static playlist membership
+`_flows`; it is not added to the canonical Library. Static playlist membership
 is stored by Aurral's Subsonic model, so deleting a playlist does not delete a
 canonical track.
 
@@ -49,7 +49,7 @@ to them.
 When Lidarr imports a download, or a file changes in the Aurral root, Aurral's
 filesystem watcher queues a scan. The watcher waits briefly for a file move or
 rename to finish and ignores `_playlists`, `_staging`, `_fallback`, hidden
-folders, `.flows`, and the legacy `aurral-weekly-flow` tree.
+folders, `_flows`, the legacy `.flows` tree, and the legacy `aurral-weekly-flow` tree.
 
 When the scan completes, an open Library page reloads its canonical records
 automatically. The home page and **Newest** album or track sorting use the time

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -39,7 +39,7 @@ Static playlist membership is stored as canonical track references. Permanent
 Aurral tracks use the canonical `artist/album/track` layout under the configured
 Aurral download folder. Set this path in **Settings > Download Clients**.
 
-Flow media is temporary and lives under `.flows` below that root. Usually, the
+Flow media is temporary and lives under `_flows` below that root. Usually, the
 legacy playlist folder was:
 
 ```text


### PR DESCRIPTION
Fresh flow files under `.flows` were invisible to Navidrome's scanner, so refreshes could leave stale playlist entries or fall back to wrong same-title songs.

Aurral now stores flow files in visible `_flows`, migrates legacy `.flows` files at startup with conflict retention and idempotence, excludes `_flows` from Aurral's own canonical library, updates Plex locations, and resolves Navidrome entries only by exact path or recording MBID. Docs and tests cover the migration and provider behavior.

Verification:
- `npm test` — 681 passed
- `npm run lint:backend`
- `npm run docs:build`
- `git diff --check`

Known limitation: live provider verification and deployment were not performed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow media now uses the `_flows` directory.
  * Existing `.flows` content is migrated automatically at startup, with files retained when migration requires review.
  * Plex supports both current and legacy flow locations during migration.

* **Bug Fixes**
  * Library scans exclude flow-media directories.
  * Playback resolves only existing, indexed tracks.
  * Navidrome matching uses indexed paths or exact recording IDs for more reliable results.

* **Documentation**
  * Updated storage, setup, troubleshooting, integration, and playlist guidance for the new directory layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->