### PR TITLE
fix(downloads): review weak yt-dlp title matches

### DIFF
--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -123,6 +123,57 @@ test("yt-dlp sends plausible duration mismatches to review", async () => {
   await assertReviewable(jobId, filePath, "ytdlp");
 });
 
+test("yt-dlp sends weak title matches to review", async () => {
+  const jobId = downloadTracker.addJob(
+    {
+      artistName: "Artist Name",
+      trackName: "Correct Track",
+      albumName: "Album Name",
+      durationMs: 1000,
+    },
+    "ytdlp-weak-title-review",
+  );
+  downloadTracker.setDownloading(jobId);
+  const filePath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    ".ytdlp-staging",
+    jobId,
+    "Artist Name - Wrong Track.mp3",
+  );
+  await writeOneSecondMp3(filePath);
+  downloadTracker.updateDownloadMetadata(jobId, {
+    downloadSource: "ytdlp",
+    downloadClient: "ytdlp",
+    releaseGuid: "video-weak-title",
+    remoteFilename: "Artist Name - Wrong Track",
+  });
+
+  const result = await processYtdlpPipelinePayload(
+    {
+      phase: "finalize",
+      source: "ytdlp",
+      jobId,
+      downloadedPath: filePath,
+      destination: "ytdlp-weak-title-review/Artist Name/Album Name",
+      candidate: {
+        raw: {
+          id: "video-weak-title",
+          title: "Artist Name - Wrong Track",
+        },
+      },
+      candidateIndex: 0,
+    },
+    { failOrTryNextSource: failIfPipelineFallsThrough },
+  );
+
+  assert.equal(result, null);
+  const job = downloadTracker.getJob(jobId);
+  assert.equal(job.status, "blocked");
+  assert.match(job.error, /^weak-title-match:/);
+  assert.equal(job.stagingPath, filePath);
+  await access(filePath);
+});
+
 test("Usenet sends its best plausible duration mismatch to review", async () => {
   const server = await createMockHttpServer((req, res) => {
     req.resume();

--- a/V2.md
+++ b/V2.md
@@ -30,7 +30,7 @@ v2 is a major rewrite. Hundreds of improvements, but here is what you will actua
 - **yt-dlp** - built-in YouTube and web fallback. The Docker image includes it, and you do not need a separate daemon.
 - **Usenet support** - Prowlarr + SABnzbd/NZBGet as an alternate or fallback download source
 - **Source priority** - Aurral tries sources in priority order. The defaults are slskd `10`, Usenet `20`, and yt-dlp `50`.
-- **Track review** - sends plausible duration mismatches to Review before import
+- **Track review** - sends plausible duration or weak yt-dlp title matches to Review before import
 
 ### Discovery
 

--- a/backend/services/ytdlpOrchestrator.js
+++ b/backend/services/ytdlpOrchestrator.js
@@ -181,14 +181,14 @@ async function handleYtdlpFinalize(payload, helpers) {
     resolvedTrack,
   );
   if (!validation.valid) {
-    if (
-      blockPipelineJobForReview({
-        downloadTracker,
-        job,
-        validation,
-        sourcePath: filePath,
-      })
-    ) {
+    const reviewable =
+      validation.blocked || validation.scores?.matchReason === "weak-title-match";
+    if (reviewable && blockPipelineJobForReview({
+      downloadTracker,
+      job,
+      validation: { ...validation, blocked: true },
+      sourcePath: filePath,
+    })) {
       return null;
     }
     await fs.rm(filePath, { force: true }).catch(() => {});


### PR DESCRIPTION
Weak yt-dlp results currently fail after download when the title match is below the validation threshold, even when the user knows the result is the best available source. The staged file is removed before Activity can offer a choice.

When yt-dlp final validation reports `weak-title-match`, Aurral now preserves the staged file and sends the job to the existing Activity review flow. Users can preview, approve, or deny it. Other providers and validation failures keep their current behavior.

Verification:
- `npm test` — 689 passed
- `npm run lint:backend`
- `npm run lint --workspace frontend`
- `npm run build`
- `git diff --check`

Known limitation: no live yt-dlp provider download was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track review now identifies both plausible duration mismatches and weak title matches before import.
* **Bug Fixes**
  * Downloads with weak title matches are routed to review instead of being incorrectly imported or retried from another source.
  * Items sent for review retain their staged download path for easier follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->