### PR TITLE
fix(playlists): sync Spotify membership and track retention

### DIFF
--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -411,3 +411,26 @@ test("removePlaylistFileIfUnshared relocates when another playlist still referen
   assert.equal(downloadTracker.getJob(sharedJobId)?.finalPath, expectedPath);
   assert.equal(await fs.readFile(expectedPath, "utf8"), "audio");
 });
+
+test("removePlaylistFileIfUnshared preserves external files during shared cleanup", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "External" });
+  const track = {
+    artistName: "Aphex Twin",
+    trackName: "External Xtal",
+    albumName: "Selected Ambient Works",
+  };
+  const externalPath = path.join(weeklyFlowRoot, "external-xtal.flac");
+  await fs.mkdir(path.dirname(externalPath), { recursive: true });
+  await fs.writeFile(externalPath, "audio");
+  const jobId = downloadTracker.addJob(track, playlist.id);
+  downloadTracker.setDone(jobId, externalPath, track.albumName, "/music/External Xtal.flac");
+
+  const result = await removePlaylistFileIfUnshared(externalPath, playlist.id, {
+    weeklyFlowRoot,
+    excludeJobIds: [jobId],
+    deleteIfUnshared: true,
+  });
+
+  assert.equal(result.action, "skipped");
+  await fs.access(externalPath);
+});

--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -15,7 +15,7 @@ const [isolatedState, { db }, { dbOps }, playlistConfigModule, flowHandlerUtils]
     "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
     "backend/routes/weeklyFlow/handlers/utils.js",
   );
-const { flowPlaylistConfig, tracksShareMembership } = playlistConfigModule;
+const { flowPlaylistConfig, normalizeImportSource, tracksShareMembership } = playlistConfigModule;
 const { validateFlowPayload } = flowHandlerUtils;
 
 test.beforeEach(() => {
@@ -266,6 +266,22 @@ test("updates shared playlists and keeps summaries in sync", () => {
   assert.equal(updated?.tracks?.length, 1);
   assert.equal(summary?.name, "Gym Mix Updated");
   assert.equal(summary?.trackCount, 1);
+});
+
+test("defaults Spotify removed-track retention on and preserves an explicit opt-out", () => {
+  const source = normalizeImportSource({
+    provider: "spotify-playlist",
+    externalId: "playlist-id",
+    syncEnabled: true,
+    syncIntervalHours: 24,
+  });
+  const optedOut = normalizeImportSource({
+    ...source,
+    keepRemovedTracks: false,
+  });
+
+  assert.equal(source.keepRemovedTracks, true);
+  assert.equal(optedOut.keepRemovedTracks, false);
 });
 
 test("preserves rich track metadata when shared playlists are updated", () => {

--- a/.tests/weekly-flow/playlist-import-order.test.js
+++ b/.tests/weekly-flow/playlist-import-order.test.js
@@ -37,7 +37,7 @@ const {
   orderJobsBySharedPlaylistTracks,
   rebuildSharedPlaylistTracksFromJobs,
 } = playlistConfigModule;
-const { appendSharedPlaylistTracks, processWeeklyFlowOperation } = operationsModule;
+const { appendSharedPlaylistTracks, processWeeklyFlowOperation, updateSharedPlaylist } = operationsModule;
 const { weeklyFlowWorker } = workerModule;
 const { playlistSource } = playlistSourceModule;
 const { playlistManager } = playlistManagerModule;
@@ -278,6 +278,73 @@ test("deleting a track keeps remaining import order in config", async () => {
       jobsAfter.map((job) => job.trackName),
       ["One", "Three", "Four"],
     );
+  } finally {
+    weeklyFlowWorker.start = originalStart;
+    weeklyFlowWorker.stop();
+  }
+});
+
+test("replacing a shared playlist removes Spotify tracks and honors file retention", async () => {
+  const originalStart = weeklyFlowWorker.start;
+  weeklyFlowWorker.start = async () => false;
+  try {
+    const track = {
+      artistName: "A",
+      trackName: "Removed",
+      albumName: "Album",
+    };
+    const keepPlaylist = flowPlaylistConfig.createSharedPlaylist({
+      name: "Keep Removed",
+      tracks: [track],
+      importSource: {
+        provider: "spotify-playlist",
+        externalId: "keep-id",
+        syncEnabled: true,
+        syncIntervalHours: 24,
+      },
+    });
+    await fs.mkdir(weeklyFlowRoot, { recursive: true });
+    const keepPath = path.join(weeklyFlowRoot, "keep-removed.flac");
+    await fs.writeFile(keepPath, "audio");
+    const keepJobId = downloadTracker.addJob(track, keepPlaylist.id);
+    downloadTracker.setDone(keepJobId, keepPath, track.albumName);
+
+    await updateSharedPlaylist({
+      playlistId: keepPlaylist.id,
+      tracks: [],
+      hasTracksUpdate: true,
+      hasImportSourceUpdate: true,
+      importSource: keepPlaylist.importSource,
+    });
+    assert.deepEqual(flowPlaylistConfig.getSharedPlaylist(keepPlaylist.id).tracks, []);
+    await fs.access(keepPath);
+
+    const deletePlaylist = flowPlaylistConfig.createSharedPlaylist({
+      name: "Delete Removed",
+      tracks: [track],
+      importSource: {
+        provider: "spotify-playlist",
+        externalId: "delete-id",
+        syncEnabled: true,
+        syncIntervalHours: 24,
+        keepRemovedTracks: false,
+      },
+    });
+    const deletePath = path.join(weeklyFlowRoot, "delete-removed.flac");
+    await fs.writeFile(deletePath, "audio");
+    const deleteJobId = downloadTracker.addJob(track, deletePlaylist.id);
+    downloadTracker.setDone(deleteJobId, deletePath, track.albumName);
+
+    await updateSharedPlaylist({
+      playlistId: deletePlaylist.id,
+      tracks: [],
+      hasTracksUpdate: true,
+      hasImportSourceUpdate: true,
+      importSource: deletePlaylist.importSource,
+      deleteUnsharedFiles: true,
+    });
+    assert.deepEqual(flowPlaylistConfig.getSharedPlaylist(deletePlaylist.id).tracks, []);
+    await assert.rejects(fs.access(deletePath));
   } finally {
     weeklyFlowWorker.start = originalStart;
     weeklyFlowWorker.stop();

--- a/.tests/weekly-flow/playlist-import-order.test.js
+++ b/.tests/weekly-flow/playlist-import-order.test.js
@@ -415,3 +415,83 @@ test("Spotify sync keeps a retention change made while Spotify is pending", asyn
     weeklyFlowWorker.stop();
   }
 });
+
+test("Spotify cleanup serializes retention updates with file removal", async () => {
+  const originalStart = weeklyFlowWorker.start;
+  const originalListPlaylistTracks = spotifyClient.listPlaylistTracks;
+  const originalRm = fs.rm;
+  let resolveRemovalStarted;
+  let releaseRemoval;
+  const removalStarted = new Promise((resolve) => {
+    resolveRemovalStarted = resolve;
+  });
+  const removalBlocked = new Promise((resolve) => {
+    releaseRemoval = resolve;
+  });
+  weeklyFlowWorker.start = async () => false;
+  try {
+    const track = {
+      artistName: "A",
+      trackName: "Cleanup",
+      albumName: "Album",
+    };
+    const playlist = flowPlaylistConfig.createSharedPlaylist({
+      name: "Serialized Retention",
+      ownerUserId: 7,
+      tracks: [track],
+      importSource: {
+        provider: "spotify-playlist",
+        externalId: "serialized-id",
+        syncEnabled: true,
+        syncIntervalHours: 24,
+        keepRemovedTracks: false,
+      },
+    });
+    await fs.mkdir(weeklyFlowRoot, { recursive: true });
+    const finalPath = path.join(weeklyFlowRoot, "serialized-retention.flac");
+    await fs.writeFile(finalPath, "audio");
+    const jobId = downloadTracker.addJob(track, playlist.id);
+    downloadTracker.setDone(jobId, finalPath, track.albumName);
+
+    spotifyClient.listPlaylistTracks = async () => [];
+    fs.rm = async (...args) => {
+      resolveRemovalStarted();
+      await removalBlocked;
+      return originalRm(...args);
+    };
+    const syncPromise = syncSharedPlaylistImport({
+      playlistId: playlist.id,
+      user: { id: 7 },
+      force: true,
+    });
+    await removalStarted;
+
+    let retentionUpdated = false;
+    const retentionPromise = updateSharedPlaylist({
+      playlistId: playlist.id,
+      hasImportSourceUpdate: true,
+      importSource: {
+        ...playlist.importSource,
+        keepRemovedTracks: true,
+      },
+    }).then(() => {
+      retentionUpdated = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(retentionUpdated, false);
+
+    releaseRemoval();
+    await syncPromise;
+    await retentionPromise;
+    assert.equal(
+      flowPlaylistConfig.getSharedPlaylist(playlist.id).importSource.keepRemovedTracks,
+      true,
+    );
+    await assert.rejects(fs.access(finalPath));
+  } finally {
+    fs.rm = originalRm;
+    spotifyClient.listPlaylistTracks = originalListPlaylistTracks;
+    weeklyFlowWorker.start = originalStart;
+    weeklyFlowWorker.stop();
+  }
+});

--- a/.tests/weekly-flow/playlist-import-order.test.js
+++ b/.tests/weekly-flow/playlist-import-order.test.js
@@ -19,6 +19,8 @@ const [
   workerModule,
   playlistSourceModule,
   playlistManagerModule,
+  spotifyClientModule,
+  importSyncModule,
 ] = await setupIsolatedBackend(
   "playlist-import-order",
   "backend/config/db-sqlite.js",
@@ -29,6 +31,8 @@ const [
   "backend/services/weeklyFlow/weeklyFlowWorker.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistSource.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
+  "backend/services/spotify/spotifyClient.js",
+  "backend/services/importLists/importListSync.js",
 );
 
 const { downloadTracker } = trackerModule;
@@ -41,6 +45,8 @@ const { appendSharedPlaylistTracks, processWeeklyFlowOperation, updateSharedPlay
 const { weeklyFlowWorker } = workerModule;
 const { playlistSource } = playlistSourceModule;
 const { playlistManager } = playlistManagerModule;
+const { spotifyClient } = spotifyClientModule;
+const { syncSharedPlaylistImport } = importSyncModule;
 
 const weeklyFlowRoot = process.env.WEEKLY_FLOW_FOLDER;
 
@@ -346,6 +352,65 @@ test("replacing a shared playlist removes Spotify tracks and honors file retenti
     assert.deepEqual(flowPlaylistConfig.getSharedPlaylist(deletePlaylist.id).tracks, []);
     await assert.rejects(fs.access(deletePath));
   } finally {
+    weeklyFlowWorker.start = originalStart;
+    weeklyFlowWorker.stop();
+  }
+});
+
+test("Spotify sync keeps a retention change made while Spotify is pending", async () => {
+  const originalStart = weeklyFlowWorker.start;
+  const originalListPlaylistTracks = spotifyClient.listPlaylistTracks;
+  weeklyFlowWorker.start = async () => false;
+  try {
+    const track = {
+      artistName: "A",
+      trackName: "Removed",
+      albumName: "Album",
+    };
+    const playlist = flowPlaylistConfig.createSharedPlaylist({
+      name: "Pending Retention",
+      ownerUserId: 7,
+      tracks: [track],
+      importSource: {
+        provider: "spotify-playlist",
+        externalId: "pending-id",
+        syncEnabled: true,
+        syncIntervalHours: 24,
+      },
+    });
+    await fs.mkdir(weeklyFlowRoot, { recursive: true });
+    const finalPath = path.join(weeklyFlowRoot, "pending-retention.flac");
+    await fs.writeFile(finalPath, "audio");
+    const jobId = downloadTracker.addJob(track, playlist.id);
+    downloadTracker.setDone(jobId, finalPath, track.albumName);
+
+    let resolveSpotifyTracks;
+    spotifyClient.listPlaylistTracks = () =>
+      new Promise((resolve) => {
+        resolveSpotifyTracks = resolve;
+      });
+    const syncPromise = syncSharedPlaylistImport({
+      playlistId: playlist.id,
+      user: { id: 7 },
+      force: true,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
+      importSource: {
+        ...playlist.importSource,
+        keepRemovedTracks: false,
+      },
+    });
+    resolveSpotifyTracks([]);
+    await syncPromise;
+
+    const updated = flowPlaylistConfig.getSharedPlaylist(playlist.id);
+    assert.equal(updated.importSource.keepRemovedTracks, false);
+    assert.equal(updated.tracks.length, 0);
+    await assert.rejects(fs.access(finalPath));
+  } finally {
+    spotifyClient.listPlaylistTracks = originalListPlaylistTracks;
     weeklyFlowWorker.start = originalStart;
     weeklyFlowWorker.stop();
   }

--- a/backend/routes/weeklyFlow/handlers/spotifyImport.js
+++ b/backend/routes/weeklyFlow/handlers/spotifyImport.js
@@ -127,6 +127,7 @@ export function registerSpotifyImport(router) {
       const name = String(req.body?.name || "").trim();
       const externalName = String(req.body?.externalName || "").trim();
       const syncIntervalHours = Number(req.body?.syncIntervalHours ?? 24);
+      const keepRemovedTracks = req.body?.keepRemovedTracks !== false;
       const syncEnabled =
         req.body?.syncEnabled === false
           ? false
@@ -146,6 +147,7 @@ export function registerSpotifyImport(router) {
         externalName: externalName || name,
         syncEnabled,
         syncIntervalHours: syncEnabled ? syncIntervalHours : 0,
+        keepRemovedTracks,
         lastSyncAt: Date.now(),
         lastSyncTrackCount: tracks.length,
       });

--- a/backend/services/importLists/importListSync.js
+++ b/backend/services/importLists/importListSync.js
@@ -1,7 +1,7 @@
 import { flowPlaylistConfig } from "../weeklyFlow/weeklyFlowPlaylistConfig.js";
 import { spotifyClient } from "../spotify/spotifyClient.js";
 import { parseSpotifyPlaylistItems } from "./spotifyTracks.js";
-import { appendSharedPlaylistTracks } from "../weeklyFlow/weeklyFlowOperations.js";
+import { updateSharedPlaylist } from "../weeklyFlow/weeklyFlowOperations.js";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -40,15 +40,19 @@ export async function syncSharedPlaylistImport({
       { forceRefresh: true },
     );
     const tracks = parseSpotifyPlaylistItems(items).tracks;
-    const result = await appendSharedPlaylistTracks({ playlistId: playlist.id, tracks });
     const nextImportSource = {
       ...playlist.importSource,
       lastSyncAt: Date.now(),
       lastSyncError: null,
       lastSyncTrackCount: tracks.length,
     };
-    flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
+    const result = await updateSharedPlaylist({
+      playlistId: playlist.id,
+      tracks,
+      hasTracksUpdate: true,
+      hasImportSourceUpdate: true,
       importSource: nextImportSource,
+      deleteUnsharedFiles: playlist.importSource.keepRemovedTracks === false,
     });
     return {
       skipped: false,

--- a/backend/services/importLists/importListSync.js
+++ b/backend/services/importLists/importListSync.js
@@ -40,8 +40,7 @@ export async function syncSharedPlaylistImport({
       { forceRefresh: true },
     );
     const tracks = parseSpotifyPlaylistItems(items).tracks;
-    const nextImportSource = {
-      ...playlist.importSource,
+    const syncImportSource = {
       lastSyncAt: Date.now(),
       lastSyncError: null,
       lastSyncTrackCount: tracks.length,
@@ -51,8 +50,8 @@ export async function syncSharedPlaylistImport({
       tracks,
       hasTracksUpdate: true,
       hasImportSourceUpdate: true,
-      importSource: nextImportSource,
-      deleteUnsharedFiles: playlist.importSource.keepRemovedTracks === false,
+      importSource: syncImportSource,
+      mergeImportSource: true,
     });
     return {
       skipped: false,
@@ -61,9 +60,10 @@ export async function syncSharedPlaylistImport({
       tracksReused: Number(result?.tracksReused || 0),
     };
   } catch (error) {
+    const latestPlaylist = flowPlaylistConfig.getSharedPlaylist(playlist.id);
     flowPlaylistConfig.updateSharedPlaylist(playlist.id, {
       importSource: {
-        ...playlist.importSource,
+        ...(latestPlaylist?.importSource || playlist.importSource),
         lastSyncError: String(error?.message || "Spotify sync failed"),
       },
     });

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -310,6 +310,13 @@ export async function removePlaylistFileIfUnshared(finalPath, playlistId, option
     if (current === resolved) matchingJobs.push(job);
   }
   if (matchingJobs.some((job) => job.externalPath)) return { action: "skipped" };
+  if (
+    options.deleteIfUnshared === true &&
+    typeof options.shouldDelete === "function" &&
+    !(await options.shouldDelete())
+  ) {
+    return { action: "skipped" };
+  }
   const others = matchingJobs.filter((job) => !excludeJobIds.has(String(job.id || "")));
   if (others.length > 0) {
     const survivor = sortReusableJobs(others)[0];

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -287,7 +287,12 @@ export async function removePlaylistFileIfUnshared(finalPath, playlistId, option
     : flowPlaylistConfig.getSharedPlaylist(safePlaylistId)
       ? [path.resolve(weeklyFlowRoot)]
       : [path.resolve(weeklyFlowRoot, PLAYLIST_LIBRARY_DIR, safePlaylistId)];
-  if (flowPlaylistConfig.getSharedPlaylist(safePlaylistId)) return { action: "skipped" };
+  if (
+    flowPlaylistConfig.getSharedPlaylist(safePlaylistId) &&
+    options.deleteIfUnshared !== true
+  ) {
+    return { action: "skipped" };
+  }
   const resolved = path.resolve(remapLegacyWeeklyFlowPath(finalPath, weeklyFlowRoot));
   if (!playlistRoots.some((playlistRoot) => isPathInsideRoot(resolved, playlistRoot))) {
     return { action: "skipped" };
@@ -298,13 +303,14 @@ export async function removePlaylistFileIfUnshared(finalPath, playlistId, option
       .map((id) => String(id || "").trim())
       .filter(Boolean),
   );
-  const others = [];
+  const matchingJobs = [];
   for (const job of downloadTracker.getAll()) {
     if (!job || job.status !== "done" || typeof job.finalPath !== "string") continue;
-    if (excludeJobIds.has(String(job.id || ""))) continue;
     const current = path.resolve(remapLegacyWeeklyFlowPath(job.finalPath, weeklyFlowRoot));
-    if (current === resolved) others.push(job);
+    if (current === resolved) matchingJobs.push(job);
   }
+  if (matchingJobs.some((job) => job.externalPath)) return { action: "skipped" };
+  const others = matchingJobs.filter((job) => !excludeJobIds.has(String(job.id || "")));
   if (others.length > 0) {
     const survivor = sortReusableJobs(others)[0];
     const nextPath = await adoptFileIntoPlaylist(

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -450,7 +450,7 @@ export async function appendSharedPlaylistTracks({ playlistId, tracks = [] } = {
   };
 }
 
-async function updateSharedPlaylist({
+export async function updateSharedPlaylist({
   playlistId,
   name = null,
   tracks = [],
@@ -458,6 +458,7 @@ async function updateSharedPlaylist({
   hasTracksUpdate = false,
   hasImportSourceUpdate = false,
   importSource = null,
+  deleteUnsharedFiles = false,
 } = {}) {
   const safePlaylistId = String(playlistId || "").trim();
   const currentPlaylist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
@@ -510,6 +511,7 @@ async function updateSharedPlaylist({
           await removePlaylistFileIfUnshared(job.finalPath, safePlaylistId, {
             weeklyFlowRoot: weeklyFlowWorker.weeklyFlowRoot,
             excludeJobIds: [job.id, ...matchedJobIds],
+            deleteIfUnshared: deleteUnsharedFiles,
           });
         }
         downloadTracker.removeJob(job.id);

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -459,6 +459,7 @@ export async function updateSharedPlaylist({
   hasImportSourceUpdate = false,
   importSource = null,
   deleteUnsharedFiles = false,
+  mergeImportSource = false,
 } = {}) {
   const safePlaylistId = String(playlistId || "").trim();
   const currentPlaylist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
@@ -468,7 +469,7 @@ export async function updateSharedPlaylist({
     : String(currentPlaylist.name || "").trim();
   let playlist = null;
   let tracksQueued = 0;
-  const playlistUpdates = { name: safeName };
+  const playlistUpdates = hasNameUpdate ? { name: safeName } : {};
   if (hasImportSourceUpdate) {
     playlistUpdates.importSource = importSource;
   }
@@ -480,6 +481,15 @@ export async function updateSharedPlaylist({
       normalizeTrackList(tracks),
     );
     await withPlaylistMutation(safePlaylistId, async () => {
+      const lockedPlaylist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
+      const lockedImportSource = lockedPlaylist?.importSource || currentPlaylist.importSource;
+      const importSourceToStore =
+        mergeImportSource && hasImportSourceUpdate
+          ? { ...lockedImportSource, ...(importSource || {}) }
+          : importSource;
+      const shouldDeleteUnsharedFiles =
+        deleteUnsharedFiles ||
+        (mergeImportSource && lockedImportSource?.keepRemovedTracks === false);
       const existingJobs = downloadTracker.getByPlaylistType(safePlaylistId);
       const reusableJobsByIdentity = new Map();
       for (const job of existingJobs) {
@@ -511,16 +521,16 @@ export async function updateSharedPlaylist({
           await removePlaylistFileIfUnshared(job.finalPath, safePlaylistId, {
             weeklyFlowRoot: weeklyFlowWorker.weeklyFlowRoot,
             excludeJobIds: [job.id, ...matchedJobIds],
-            deleteIfUnshared: deleteUnsharedFiles,
+            deleteIfUnshared: shouldDeleteUnsharedFiles,
           });
         }
         downloadTracker.removeJob(job.id);
       }
 
       playlist = flowPlaylistConfig.updateSharedPlaylist(safePlaylistId, {
-        name: safeName,
+        ...(hasNameUpdate ? { name: safeName } : {}),
         tracks: normalizedTracks,
-        ...(hasImportSourceUpdate ? { importSource } : {}),
+        ...(hasImportSourceUpdate ? { importSource: importSourceToStore } : {}),
       });
       const queued = await queueTracksForPlaylist(tracksNeedingWork, safePlaylistId);
       tracksQueued = queued.jobIds.length;

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -469,12 +469,19 @@ export async function updateSharedPlaylist({
     : String(currentPlaylist.name || "").trim();
   let playlist = null;
   let tracksQueued = 0;
-  const playlistUpdates = hasNameUpdate ? { name: safeName } : {};
-  if (hasImportSourceUpdate) {
-    playlistUpdates.importSource = importSource;
-  }
   if (!hasTracksUpdate) {
-    playlist = flowPlaylistConfig.updateSharedPlaylist(safePlaylistId, playlistUpdates);
+    await withPlaylistMutation(safePlaylistId, async () => {
+      const lockedPlaylist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
+      const lockedImportSource = lockedPlaylist?.importSource || currentPlaylist.importSource;
+      const importSourceToStore =
+        mergeImportSource && hasImportSourceUpdate
+          ? { ...lockedImportSource, ...(importSource || {}) }
+          : importSource;
+      playlist = flowPlaylistConfig.updateSharedPlaylist(safePlaylistId, {
+        ...(hasNameUpdate ? { name: safeName } : {}),
+        ...(hasImportSourceUpdate ? { importSource: importSourceToStore } : {}),
+      });
+    });
   } else {
     const normalizedTracks = filterBlockedPlaylistTracks(
       currentPlaylist.ownerUserId,
@@ -483,13 +490,14 @@ export async function updateSharedPlaylist({
     await withPlaylistMutation(safePlaylistId, async () => {
       const lockedPlaylist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
       const lockedImportSource = lockedPlaylist?.importSource || currentPlaylist.importSource;
-      const importSourceToStore =
-        mergeImportSource && hasImportSourceUpdate
-          ? { ...lockedImportSource, ...(importSource || {}) }
-          : importSource;
       const shouldDeleteUnsharedFiles =
         deleteUnsharedFiles ||
         (mergeImportSource && lockedImportSource?.keepRemovedTracks === false);
+      const shouldDeleteCurrentFiles = mergeImportSource
+        ? () =>
+            flowPlaylistConfig.getSharedPlaylist(safePlaylistId)?.importSource
+              ?.keepRemovedTracks === false
+        : null;
       const existingJobs = downloadTracker.getByPlaylistType(safePlaylistId);
       const reusableJobsByIdentity = new Map();
       for (const job of existingJobs) {
@@ -522,11 +530,17 @@ export async function updateSharedPlaylist({
             weeklyFlowRoot: weeklyFlowWorker.weeklyFlowRoot,
             excludeJobIds: [job.id, ...matchedJobIds],
             deleteIfUnshared: shouldDeleteUnsharedFiles,
+            shouldDelete: shouldDeleteCurrentFiles,
           });
         }
         downloadTracker.removeJob(job.id);
       }
 
+      const latestImportSource = flowPlaylistConfig.getSharedPlaylist(safePlaylistId)?.importSource;
+      const importSourceToStore =
+        mergeImportSource && hasImportSourceUpdate
+          ? { ...(latestImportSource || lockedImportSource), ...(importSource || {}) }
+          : importSource;
       playlist = flowPlaylistConfig.updateSharedPlaylist(safePlaylistId, {
         ...(hasNameUpdate ? { name: safeName } : {}),
         tracks: normalizedTracks,

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
@@ -449,6 +449,7 @@ export function normalizeImportSource(value) {
     syncIntervalHours: hasSync
       ? Math.min(Math.max(Math.round(syncIntervalHours), 1), 168)
       : 0,
+    keepRemovedTracks: value.keepRemovedTracks !== false,
     lastSyncAt: Number.isFinite(lastSyncAt) && lastSyncAt > 0 ? lastSyncAt : null,
     lastSyncError: String(value.lastSyncError || "").trim() || null,
     lastSyncTrackCount:

--- a/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
@@ -150,6 +150,7 @@ export function getWeeklyFlowStatusSnapshot({
             syncIntervalHours: playlist.importSource.syncEnabled
               ? playlist.importSource.syncIntervalHours
               : 0,
+            keepRemovedTracks: playlist.importSource.keepRemovedTracks !== false,
           }
         : null,
     };

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -5,9 +5,11 @@ description: Spotify connect, JSON formats, retries, and file reuse.
 
 Imported playlists are separate from flows.
 
-- They do not regenerate on a schedule.
+- They do not regenerate from flow settings.
+- Spotify imports can synchronize on their own schedule.
 - They do not use source mix, focus filters, or deep dive.
-- They keep the exact imported tracklist.
+- Spotify imports keep their playlist membership equal to Spotify.
+- JSON imports keep the exact imported tracklist.
 - They can reuse completed Aurral tracks or existing Lidarr files when worker settings allow.
 
 ![Aurral playlist import](../../../assets/screenshots/playlist-import.webp)
@@ -24,7 +26,9 @@ The fastest path is in-app import on **Playlists**.
 6. Select a playlist.
 7. Start the import.
 
-You can set a display name and a synchronization schedule. Synchronization gets the Spotify tracklist again and queues new tracks.
+You can set a display name and a synchronization schedule. Synchronization gets the Spotify tracklist again, removes tracks that are no longer there, and queues new tracks, so the Aurral playlist count follows Spotify.
+
+By default, a track removed from Spotify is removed from the Aurral playlist but its downloaded file stays in the library. Turn off **Keep removed tracks in library** when importing, or from the playlist menu, to delete an Aurral-owned file when it is no longer used by another playlist. Lidarr or other external files are kept. This setting applies to future Spotify syncs.
 
 Choose **None** for a fixed tracklist. You can change the schedule later from the playlist menu.
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -12,14 +12,14 @@ Aurral does not write these files to your main music library.
 
 ## Flows compared with static playlists
 
-|           | Flows                                  | Static playlists                 |
-| --------- | -------------------------------------- | -------------------------------- |
-| Tracklist | Regenerates on a schedule              | Fixed from import or export      |
-| Downloads | Can generate replacement picks         | Keeps the exact imported tracks  |
-| Controls  | Schedule, source mix, focus, deep dive | None of the flow controls        |
-| Worker    | Shared download worker                 | Shared download worker           |
+|           | Flows                                  | Static playlists                         |
+| --------- | -------------------------------------- | ----------------------------------------- |
+| Tracklist | Regenerates on a schedule              | Fixed from import or follows Spotify      |
+| Downloads | Can generate replacement picks         | Keeps the exact imported tracks           |
+| Controls  | Schedule, source mix, focus, deep dive | Import, sync, and retention settings      |
+| Worker    | Shared download worker                 | Shared download worker                    |
 
-Flows refresh on a schedule and use your flow settings. Static playlists come from Spotify, JSON files, or exported flow tracklists.
+Flows refresh on a schedule and use your flow settings. Static playlists come from Spotify, JSON files, or exported flow tracklists. Spotify playlists follow Spotify membership during sync; their removed-track file-retention setting is available in the import flow and playlist menu.
 
 Flow names and static playlist names must be unique across both types. Aurral uses the same bare name for Navidrome and Plex playlists.
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11519,6 +11519,14 @@ button.native-library-genre-row:focus-visible {
   font-size: 0.75rem;
 }
 
+.flow-page__menu-sync-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
 .flow-page__menu-sync-select {
   width: 100%;
   height: 2.25rem;
@@ -12140,6 +12148,31 @@ button.native-library-genre-row:focus-visible {
 
 .playlist-import__config .input:focus-visible {
   border-color: var(--aurral-border-strong);
+}
+
+.playlist-import__retention {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.25rem 0;
+  cursor: pointer;
+}
+
+.playlist-import__retention-copy {
+  display: grid;
+  gap: 0.125rem;
+}
+
+.playlist-import__retention-title {
+  color: var(--aurral-text);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.playlist-import__retention-help {
+  color: var(--aurral-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
 }
 
 .playlist-import__summary {

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -1154,6 +1154,28 @@ function FlowPage({ mode = "all" }) {
     }
   };
 
+  const handleUpdateSpotifyRetention = async (playlist, keepRemovedTracks) => {
+    if (!playlist?.id || updatingSyncIntervalPlaylistId) return;
+    const current = playlist.importSource?.keepRemovedTracks !== false;
+    if (keepRemovedTracks === current) return;
+    setUpdatingSyncIntervalPlaylistId(playlist.id);
+    try {
+      await updateSharedPlaylist(playlist.id, {
+        importSource: { keepRemovedTracks },
+      });
+      showSuccess(
+        keepRemovedTracks
+          ? "Removed tracks will stay in the library"
+          : "Removed tracks will be deleted when unshared",
+      );
+      await fetchStatus();
+    } catch (err) {
+      showError(getApiErrorMessage(err, "Failed to update removed-track setting"));
+    } finally {
+      setUpdatingSyncIntervalPlaylistId(null);
+    }
+  };
+
   const handleNavigateArtist = async (track) => {
     if (!track?.artistMbid) return;
     if (selectedIsFlow) {
@@ -1663,6 +1685,23 @@ function FlowPage({ mode = "all" }) {
                     </option>
                   ))}
                 </select>
+              </div>
+              <div
+                className="flow-page__menu-sync-toggle-row"
+                onClick={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <span className="flow-page__menu-sync-label">
+                  Keep removed tracks in library
+                </span>
+                <PillToggle
+                  checked={selectedPlaylist.importSource?.keepRemovedTracks !== false}
+                  onChange={(event) =>
+                    handleUpdateSpotifyRetention(selectedPlaylist, event.target.checked)
+                  }
+                  disabled={updatingSyncIntervalPlaylistId === selectedPlaylist.id}
+                  aria-label="Keep removed Spotify tracks in library"
+                />
               </div>
               <div className="flow-page__menu-divider" />
             </>

--- a/frontend/src/pages/flows/import/PlaylistImportModal.jsx
+++ b/frontend/src/pages/flows/import/PlaylistImportModal.jsx
@@ -120,6 +120,7 @@ export function PlaylistImportModal({
   const [selectedPlaylist, setSelectedPlaylist] = useState(null);
   const [playlistName, setPlaylistName] = useState("");
   const [syncIntervalHours, setSyncIntervalHours] = useState(24);
+  const [keepRemovedTracks, setKeepRemovedTracks] = useState(true);
   const [previewTracks, setPreviewTracks] = useState([]);
   const [previewTrackCount, setPreviewTrackCount] = useState(0);
   const [previewSkipped, setPreviewSkipped] = useState(0);
@@ -142,6 +143,7 @@ export function PlaylistImportModal({
     setSelectedPlaylist(null);
     setPlaylistName("");
     setSyncIntervalHours(24);
+    setKeepRemovedTracks(true);
     setPreviewTracks([]);
     setPreviewTrackCount(0);
     setPreviewSkipped(0);
@@ -296,6 +298,7 @@ export function PlaylistImportModal({
         name: finalName,
         syncEnabled: syncIntervalHours > 0,
         syncIntervalHours,
+        keepRemovedTracks,
       });
       showSuccess?.(`Imported ${finalName} from Spotify`);
       onImported?.();
@@ -556,6 +559,24 @@ export function PlaylistImportModal({
                         ))}
                       </select>
                     </div>
+
+                    <label className="playlist-import__retention">
+                      <input
+                        type="checkbox"
+                        checked={keepRemovedTracks}
+                        onChange={(event) => setKeepRemovedTracks(event.target.checked)}
+                        className="artist-checkbox"
+                        disabled={importing}
+                      />
+                      <span className="playlist-import__retention-copy">
+                        <span className="playlist-import__retention-title">
+                          Keep removed tracks in library
+                        </span>
+                        <span className="playlist-import__retention-help">
+                          Spotify removals leave the downloaded file available in Aurral.
+                        </span>
+                      </span>
+                    </label>
 
                     <div className="playlist-import__summary">
                       {previewLoading ? (


### PR DESCRIPTION
Spotify-synced playlists currently append newly fetched tracks without removing tracks that disappeared from Spotify. A playlist such as Spotify's Top 50 can therefore grow beyond the source playlist's count and leave stale membership behind.

The sync now replaces Spotify playlist membership on every successful sync. It adds a Keep removed tracks in library setting, enabled by default for new and existing imports. Turning it off removes unshared Aurral-owned files when tracks leave Spotify; Lidarr and other external files remain protected. The setting is available during import and from the playlist menu.

Verification:
- Focused backend tests: 32 passing, plus status-snapshot and Spotify parser tests.
- Backend and frontend lint passing.
- Frontend and documentation builds passing.

Known limitation: the Spotify OAuth timeout report is intentionally out of scope until it recurs as a documented issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls for keeping or deleting tracks removed from Spotify playlists.
  - Spotify imports now retain removed tracks by default, with an opt-out option.
  - Spotify synchronization updates removed tracks and queues newly added tracks.
  - Playlist cleanup can remove unshared files when enabled.
  - External files are protected from deletion during cleanup.

- **Documentation**
  - Clarified Spotify synchronization, removed-track retention, and playlist behavior.
  - Updated playlist comparisons and available import sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->