### PR TITLE
fix(auth): preserve session during Spotify playlist import errors

### DIFF
--- a/.tests/frontend/proxy-auth-session.test.js
+++ b/.tests/frontend/proxy-auth-session.test.js
@@ -178,19 +178,23 @@ test("a proxy 401 with a nested error body reauthenticates through the proxy", a
 test("a Spotify provider 401 does not drop the Aurral session", async (t) => {
   const vite = await withApiClient(t);
 
+  let reloads = 0;
   globalThis.sessionStorage = createStorage({ auth_token: "valid-token" });
   globalThis.localStorage = createStorage({ auth_token: "valid-token" });
   globalThis.window = {
     location: {
       origin: "https://aurral.example.com",
       pathname: "/discover",
-      reload: () => {},
+      reload: () => {
+        reloads += 1;
+      },
     },
   };
   globalThis.fetch = async () =>
     new Response(JSON.stringify({
-      error: "Failed to fetch Spotify playlists",
-      message: "Spotify is not connected",
+      error: "Spotify authentication required",
+      code: "SPOTIFY_AUTH_REQUIRED",
+      message: "Your Spotify connection expired. Connect Spotify again.",
     }), {
       status: 401,
       headers: { "content-type": "application/json" },
@@ -199,6 +203,7 @@ test("a Spotify provider 401 does not drop the Aurral session", async (t) => {
   const { default: api } = await vite.ssrLoadModule("/src/utils/api/core.js");
 
   await assert.rejects(api.get("/playlists/import/spotify/playlists"), /status code 401/);
+  assert.equal(reloads, 0);
   assert.equal(globalThis.localStorage.getItem("auth_token"), "valid-token");
   assert.equal(globalThis.sessionStorage.getItem("auth_token"), "valid-token");
 });

--- a/.tests/frontend/proxy-auth-session.test.js
+++ b/.tests/frontend/proxy-auth-session.test.js
@@ -138,6 +138,66 @@ test("an unauthorized response drops the stored session without navigating away"
   assert.equal(reloads, 0);
 });
 
+test("a proxy 401 with a nested error body reauthenticates through the proxy", async (t) => {
+  const vite = await withApiClient(t);
+
+  let reloads = 0;
+  globalThis.sessionStorage = createStorage({ auth_token: "stale-token" });
+  globalThis.localStorage = createStorage({ auth_token: "stale-token" });
+  globalThis.window = {
+    location: {
+      origin: "https://aurral.example.com",
+      pathname: "/discover",
+      reload: () => {
+        reloads += 1;
+      },
+    },
+  };
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({
+      error: { status: 401, message: "Missing/invalid/expired access token" },
+    }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+  const { default: api } = await vite.ssrLoadModule("/src/utils/api/core.js");
+
+  await assert.rejects(api.get("/playlists/import/spotify/playlists"), /status code 401/);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(reloads, 1);
+  assert.equal(globalThis.localStorage.getItem("auth_token"), null);
+  assert.equal(globalThis.sessionStorage.getItem("auth_token"), null);
+});
+
+test("a Spotify provider 401 does not drop the Aurral session", async (t) => {
+  const vite = await withApiClient(t);
+
+  globalThis.sessionStorage = createStorage({ auth_token: "valid-token" });
+  globalThis.localStorage = createStorage({ auth_token: "valid-token" });
+  globalThis.window = {
+    location: {
+      origin: "https://aurral.example.com",
+      pathname: "/discover",
+      reload: () => {},
+    },
+  };
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({
+      error: "Failed to fetch Spotify playlists",
+      message: "Spotify is not connected",
+    }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+  const { default: api } = await vite.ssrLoadModule("/src/utils/api/core.js");
+
+  await assert.rejects(api.get("/playlists/import/spotify/playlists"), /status code 401/);
+  assert.equal(globalThis.localStorage.getItem("auth_token"), "valid-token");
+  assert.equal(globalThis.sessionStorage.getItem("auth_token"), "valid-token");
+});
+
 test("a proxy 401 without an Aurral error body reloads through the proxy", async (t) => {
   const vite = await withApiClient(t);
 

--- a/.tests/frontend/proxy-auth-session.test.js
+++ b/.tests/frontend/proxy-auth-session.test.js
@@ -142,6 +142,10 @@ test("a proxy 401 with a nested error body reauthenticates through the proxy", a
   const vite = await withApiClient(t);
 
   let reloads = 0;
+  let resolveReload;
+  const reloadCompleted = new Promise((resolve) => {
+    resolveReload = resolve;
+  });
   globalThis.sessionStorage = createStorage({ auth_token: "stale-token" });
   globalThis.localStorage = createStorage({ auth_token: "stale-token" });
   globalThis.window = {
@@ -150,6 +154,7 @@ test("a proxy 401 with a nested error body reauthenticates through the proxy", a
       pathname: "/discover",
       reload: () => {
         reloads += 1;
+        resolveReload();
       },
     },
   };
@@ -164,7 +169,7 @@ test("a proxy 401 with a nested error body reauthenticates through the proxy", a
   const { default: api } = await vite.ssrLoadModule("/src/utils/api/core.js");
 
   await assert.rejects(api.get("/playlists/import/spotify/playlists"), /status code 401/);
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await reloadCompleted;
   assert.equal(reloads, 1);
   assert.equal(globalThis.localStorage.getItem("auth_token"), null);
   assert.equal(globalThis.sessionStorage.getItem("auth_token"), null);

--- a/.tests/import-lists/spotify-client.test.js
+++ b/.tests/import-lists/spotify-client.test.js
@@ -63,3 +63,54 @@ test("invalid Spotify credentials clear the connection after refresh cannot reco
   assert.equal(requestCount, 3);
   assert.equal(spotifyConnectionStore.getPublicStatus(7).connected, false);
 });
+
+test("pending track requests cannot repopulate cache after invalidation", async () => {
+  spotifyConnectionStore.saveConnection(7, {
+    accessToken: "expired-access-token",
+    refreshToken: "expired-refresh-token",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+
+  let resolveTracks;
+  let resolveTracksStarted;
+  const tracksStarted = new Promise((resolve) => {
+    resolveTracksStarted = resolve;
+  });
+  const pendingTracks = new Promise((resolve) => {
+    resolveTracks = resolve;
+  });
+  let requestCount = 0;
+  globalThis.fetch = async () => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      resolveTracksStarted();
+      return pendingTracks;
+    }
+    return new Response(JSON.stringify({
+      error: { status: 401, message: "Missing/invalid/expired access token" },
+    }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const pendingRequest = spotifyClient.listPlaylistTracks(7, "playlist");
+  await tracksStarted;
+  await assert.rejects(
+    spotifyClient.listPlaylists(7),
+    (error) => error?.code === "SPOTIFY_AUTH_REQUIRED" && error?.statusCode === 401,
+  );
+  resolveTracks(new Response(JSON.stringify({ items: [], next: null }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  }));
+  await assert.rejects(
+    pendingRequest,
+    (error) => error?.code === "SPOTIFY_AUTH_REQUIRED" && error?.statusCode === 401,
+  );
+  await assert.rejects(
+    spotifyClient.listPlaylistTracks(7, "playlist"),
+    (error) => error?.code === "SPOTIFY_AUTH_REQUIRED" && error?.statusCode === 401,
+  );
+  assert.equal(requestCount, 3);
+});

--- a/.tests/import-lists/spotify-client.test.js
+++ b/.tests/import-lists/spotify-client.test.js
@@ -114,3 +114,55 @@ test("pending track requests cannot repopulate cache after invalidation", async 
   );
   assert.equal(requestCount, 3);
 });
+
+test("stale refresh failures cannot clear a newly connected account", async () => {
+  spotifyConnectionStore.saveConnection(7, {
+    accessToken: "old-access-token",
+    refreshToken: "old-refresh-token",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+
+  let resolveRefresh;
+  let resolveRefreshStarted;
+  const refreshStarted = new Promise((resolve) => {
+    resolveRefreshStarted = resolve;
+  });
+  const pendingRefresh = new Promise((resolve) => {
+    resolveRefresh = resolve;
+  });
+  let requestCount = 0;
+  globalThis.fetch = async () => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return new Response(JSON.stringify({
+        error: { status: 401, message: "Missing/invalid/expired access token" },
+      }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    resolveRefreshStarted();
+    return pendingRefresh;
+  };
+
+  const request = spotifyClient.listPlaylists(7);
+  await refreshStarted;
+  spotifyConnectionStore.saveConnection(7, {
+    accessToken: "new-access-token",
+    refreshToken: "new-refresh-token",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+  resolveRefresh(new Response(JSON.stringify({
+    error: { status: 401, message: "Missing/invalid/expired refresh token" },
+  }), {
+    status: 401,
+    headers: { "content-type": "application/json" },
+  }));
+
+  await assert.rejects(
+    request,
+    (error) => error?.code === "SPOTIFY_AUTH_REQUIRED" && error?.statusCode === 401,
+  );
+  assert.equal(spotifyConnectionStore.getConnection(7).refreshToken, "new-refresh-token");
+  assert.equal(requestCount, 2);
+});

--- a/.tests/import-lists/spotify-client.test.js
+++ b/.tests/import-lists/spotify-client.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, , { spotifyConnectionStore }, { spotifyClient }] =
+  await setupIsolatedBackend(
+    "spotify-client",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/services/spotify/spotifyConnectionStore.js",
+    "backend/services/spotify/spotifyClient.js",
+  );
+
+const originalFetch = globalThis.fetch;
+
+test.beforeEach(() => {
+  resetDatabase(db);
+  spotifyClient.clearPlaylistTrackCache();
+});
+
+test.after(async () => {
+  globalThis.fetch = originalFetch;
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("invalid Spotify credentials clear the connection after refresh cannot recover", async () => {
+  spotifyConnectionStore.saveConnection(7, {
+    accessToken: "expired-access-token",
+    refreshToken: "expired-refresh-token",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+
+  let requestCount = 0;
+  globalThis.fetch = async () => {
+    requestCount += 1;
+    if (requestCount === 2) {
+      return new Response(JSON.stringify({
+        access_token: "refreshed-access-token",
+        refresh_token: "refreshed-refresh-token",
+        expires_in: 3600,
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({
+      error: { status: 401, message: "Missing/invalid/expired access token" },
+    }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  await assert.rejects(
+    spotifyClient.listPlaylists(7),
+    (error) => error?.code === "SPOTIFY_AUTH_REQUIRED" && error?.statusCode === 401,
+  );
+  assert.equal(requestCount, 3);
+  assert.equal(spotifyConnectionStore.getPublicStatus(7).connected, false);
+});

--- a/backend/routes/weeklyFlow/handlers/spotifyImport.js
+++ b/backend/routes/weeklyFlow/handlers/spotifyImport.js
@@ -99,7 +99,7 @@ export function registerSpotifyImport(router) {
 
   router.delete("/import/spotify", (req, res) => {
     spotifyConnectionStore.clearConnection(req.user.id);
-    spotifyClient.clearPlaylistTrackCache();
+    spotifyClient.clearPlaylistTrackCache(req.user.id);
     res.json({ connected: false });
   });
 

--- a/backend/routes/weeklyFlow/handlers/spotifyImport.js
+++ b/backend/routes/weeklyFlow/handlers/spotifyImport.js
@@ -1,6 +1,9 @@
 import { buildSpotifyOAuthUrl, SPOTIFY_API_BASE } from "../../../services/spotify/spotifyConfig.js";
 import { spotifyConnectionStore } from "../../../services/spotify/spotifyConnectionStore.js";
-import { spotifyClient } from "../../../services/spotify/spotifyClient.js";
+import {
+  SPOTIFY_AUTH_REQUIRED_CODE,
+  spotifyClient,
+} from "../../../services/spotify/spotifyClient.js";
 import { logger } from "../../../services/logger.js";
 import { parseSpotifyPlaylistItems } from "../../../services/importLists/spotifyTracks.js";
 import { syncSharedPlaylistImport } from "../../../services/importLists/importListSync.js";
@@ -20,6 +23,20 @@ const parseExpiresAt = (value) => {
   }
   return Date.now() + 3600 * 1000;
 };
+
+function sendSpotifyError(res, error, fallback) {
+  if (error?.code === SPOTIFY_AUTH_REQUIRED_CODE) {
+    return res.status(401).json({
+      error: "Spotify authentication required",
+      code: SPOTIFY_AUTH_REQUIRED_CODE,
+      message: "Your Spotify connection expired. Connect Spotify again.",
+    });
+  }
+  return res.status(error?.statusCode || 500).json({
+    error: fallback,
+    message: error?.message || "Unknown error",
+  });
+}
 
 export function registerSpotifyImport(router) {
   router.get("/import/spotify/status", (req, res) => {
@@ -91,10 +108,7 @@ export function registerSpotifyImport(router) {
       const payload = await spotifyClient.listPlaylists(req.user.id);
       res.json(payload);
     } catch (error) {
-      res.status(error?.statusCode || 500).json({
-        error: "Failed to fetch Spotify playlists",
-        message: error?.message || "Unknown error",
-      });
+      sendSpotifyError(res, error, "Failed to fetch Spotify playlists");
     }
   });
 
@@ -114,10 +128,7 @@ export function registerSpotifyImport(router) {
         previewTracks: tracks.slice(0, 3),
       });
     } catch (error) {
-      res.status(error?.statusCode || 500).json({
-        error: "Failed to preview Spotify playlist",
-        message: error?.message || "Unknown error",
-      });
+      sendSpotifyError(res, error, "Failed to preview Spotify playlist");
     }
   });
 
@@ -175,10 +186,7 @@ export function registerSpotifyImport(router) {
           message: error.message,
         });
       }
-      res.status(error?.statusCode || 500).json({
-        error: "Failed to import Spotify playlist",
-        message: error?.message || "Unknown error",
-      });
+      sendSpotifyError(res, error, "Failed to import Spotify playlist");
     }
   });
 

--- a/backend/services/spotify/spotifyClient.js
+++ b/backend/services/spotify/spotifyClient.js
@@ -10,19 +10,33 @@ const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 export const SPOTIFY_AUTH_REQUIRED_CODE = "SPOTIFY_AUTH_REQUIRED";
 const playlistTrackCache = createCache(2 * 60, 200);
 const playlistTrackInflight = new Map();
+const playlistTrackGeneration = new Map();
 const tokenRefreshInflight = new Map();
 
-const playlistTrackCacheKey = (userId, playlistId) =>
-  `${String(userId)}:${String(playlistId)}`;
+const getPlaylistTrackGeneration = (userId) =>
+  playlistTrackGeneration.get(String(userId)) || 0;
 
-const invalidateConnection = (userId) => {
-  spotifyConnectionStore.clearConnection(userId);
-  playlistTrackCache.flushAll();
-  playlistTrackInflight.clear();
-  const error = new Error("Spotify connection expired");
+const bumpPlaylistTrackGeneration = (userId) => {
+  const key = String(userId);
+  const generation = getPlaylistTrackGeneration(key) + 1;
+  playlistTrackGeneration.set(key, generation);
+  return generation;
+};
+
+const playlistTrackCacheKey = (userId, playlistId) =>
+  `${String(userId)}:${getPlaylistTrackGeneration(userId)}:${String(playlistId)}`;
+
+const createAuthRequiredError = (message) => {
+  const error = new Error(message);
   error.code = SPOTIFY_AUTH_REQUIRED_CODE;
   error.statusCode = 401;
   return error;
+};
+
+const invalidateConnection = (userId) => {
+  spotifyConnectionStore.clearConnection(userId);
+  bumpPlaylistTrackGeneration(userId);
+  return createAuthRequiredError("Spotify connection expired");
 };
 
 async function renewAccessToken(refreshToken, signal) {
@@ -68,10 +82,7 @@ const refreshConnection = (userId, refreshToken, { force = false } = {}) =>
 async function getValidConnection(userId) {
   let connection = spotifyConnectionStore.getConnection(userId);
   if (!connection) {
-    const error = new Error("Spotify is not connected");
-    error.code = SPOTIFY_AUTH_REQUIRED_CODE;
-    error.statusCode = 401;
-    throw error;
+    throw createAuthRequiredError("Spotify is not connected");
   }
   if (connection.expiresAt - TOKEN_REFRESH_BUFFER_MS > Date.now()) {
     return connection;
@@ -168,6 +179,8 @@ export const spotifyClient = {
   },
 
   async listPlaylistTracks(userId, playlistId, { forceRefresh = false } = {}) {
+    await getValidConnection(userId);
+    const generation = getPlaylistTrackGeneration(userId);
     const cacheKey = playlistTrackCacheKey(userId, playlistId);
     if (!forceRefresh) {
       const cached = playlistTrackCache.get(cacheKey);
@@ -187,6 +200,9 @@ export const spotifyClient = {
         },
       },
     ).then((items) => {
+      if (getPlaylistTrackGeneration(userId) !== generation) {
+        throw createAuthRequiredError("Spotify connection expired");
+      }
       playlistTrackCache.set(cacheKey, items);
       return items;
     });
@@ -200,7 +216,11 @@ export const spotifyClient = {
     }
   },
 
-  clearPlaylistTrackCache() {
+  clearPlaylistTrackCache(userId) {
+    if (userId != null) {
+      bumpPlaylistTrackGeneration(userId);
+      return;
+    }
     playlistTrackCache.flushAll();
     playlistTrackInflight.clear();
   },

--- a/backend/services/spotify/spotifyClient.js
+++ b/backend/services/spotify/spotifyClient.js
@@ -33,9 +33,10 @@ const createAuthRequiredError = (message) => {
   return error;
 };
 
-const invalidateConnection = (userId) => {
-  spotifyConnectionStore.clearConnection(userId);
-  bumpPlaylistTrackGeneration(userId);
+const invalidateConnection = (userId, expectedConnection) => {
+  if (spotifyConnectionStore.clearConnectionIfMatches(userId, expectedConnection)) {
+    bumpPlaylistTrackGeneration(userId);
+  }
   return createAuthRequiredError("Spotify connection expired");
 };
 
@@ -75,6 +76,14 @@ const refreshConnection = (userId, refreshToken, { force = false } = {}) =>
         return latest;
       }
       const renewed = await renewAccessToken(latest?.refreshToken || refreshToken, signal);
+      const current = spotifyConnectionStore.getConnection(userId);
+      if (!current) throw createAuthRequiredError("Spotify is not connected");
+      if (
+        current.accessToken !== latest?.accessToken ||
+        current.refreshToken !== latest?.refreshToken
+      ) {
+        return current;
+      }
       return spotifyConnectionStore.updateTokens(userId, renewed);
     },
   );
@@ -90,7 +99,7 @@ async function getValidConnection(userId) {
   try {
     return await refreshConnection(userId, connection.refreshToken);
   } catch (error) {
-    if (error?.statusCode === 401) throw invalidateConnection(userId);
+    if (error?.statusCode === 401) throw invalidateConnection(userId, connection);
     throw error;
   }
 }
@@ -110,16 +119,16 @@ async function spotifyRequest(userId, path, { searchParams, url: absoluteUrl } =
       Accept: "application/json",
     },
   });
+  let nextConnection = connection;
   if (response.status === 401) {
     const latest = spotifyConnectionStore.getConnection(userId);
-    let nextConnection;
     try {
       nextConnection =
         latest?.accessToken && latest.accessToken !== connection.accessToken
           ? latest
           : await refreshConnection(userId, connection.refreshToken, { force: true });
     } catch (error) {
-      if (error?.statusCode === 401) throw invalidateConnection(userId);
+      if (error?.statusCode === 401) throw invalidateConnection(userId, connection);
       throw error;
     }
     response = await fetch(url, {
@@ -131,7 +140,7 @@ async function spotifyRequest(userId, path, { searchParams, url: absoluteUrl } =
   }
   if (!response.ok) {
     const body = await response.text().catch(() => "");
-    if (response.status === 401) throw invalidateConnection(userId);
+    if (response.status === 401) throw invalidateConnection(userId, nextConnection);
     const error = new Error(body || `Spotify request failed (${response.status})`);
     error.statusCode = response.status;
     throw error;

--- a/backend/services/spotify/spotifyClient.js
+++ b/backend/services/spotify/spotifyClient.js
@@ -7,6 +7,7 @@ import createCache from "../apiClients/simpleCache.js";
 import { runSharedInflight } from "../sharedInflight.js";
 
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+export const SPOTIFY_AUTH_REQUIRED_CODE = "SPOTIFY_AUTH_REQUIRED";
 const playlistTrackCache = createCache(2 * 60, 200);
 const playlistTrackInflight = new Map();
 const tokenRefreshInflight = new Map();
@@ -14,13 +15,25 @@ const tokenRefreshInflight = new Map();
 const playlistTrackCacheKey = (userId, playlistId) =>
   `${String(userId)}:${String(playlistId)}`;
 
+const invalidateConnection = (userId) => {
+  spotifyConnectionStore.clearConnection(userId);
+  playlistTrackCache.flushAll();
+  playlistTrackInflight.clear();
+  const error = new Error("Spotify connection expired");
+  error.code = SPOTIFY_AUTH_REQUIRED_CODE;
+  error.statusCode = 401;
+  return error;
+};
+
 async function renewAccessToken(refreshToken, signal) {
   const url = new URL(SPOTIFY_RENEW_URI);
   url.searchParams.set("refresh_token", refreshToken);
   const response = await fetch(url, { method: "GET", signal });
   if (!response.ok) {
     const body = await response.text().catch(() => "");
-    throw new Error(body || `Spotify token refresh failed (${response.status})`);
+    const error = new Error(body || `Spotify token refresh failed (${response.status})`);
+    error.statusCode = response.status;
+    throw error;
   }
   const payload = await response.json();
   const accessToken = String(payload?.access_token || payload?.accessToken || "").trim();
@@ -56,13 +69,19 @@ async function getValidConnection(userId) {
   let connection = spotifyConnectionStore.getConnection(userId);
   if (!connection) {
     const error = new Error("Spotify is not connected");
+    error.code = SPOTIFY_AUTH_REQUIRED_CODE;
     error.statusCode = 401;
     throw error;
   }
   if (connection.expiresAt - TOKEN_REFRESH_BUFFER_MS > Date.now()) {
     return connection;
   }
-  return refreshConnection(userId, connection.refreshToken);
+  try {
+    return await refreshConnection(userId, connection.refreshToken);
+  } catch (error) {
+    if (error?.statusCode === 401) throw invalidateConnection(userId);
+    throw error;
+  }
 }
 
 async function spotifyRequest(userId, path, { searchParams, url: absoluteUrl } = {}) {
@@ -82,10 +101,16 @@ async function spotifyRequest(userId, path, { searchParams, url: absoluteUrl } =
   });
   if (response.status === 401) {
     const latest = spotifyConnectionStore.getConnection(userId);
-    const nextConnection =
-      latest?.accessToken && latest.accessToken !== connection.accessToken
-        ? latest
-        : await refreshConnection(userId, connection.refreshToken, { force: true });
+    let nextConnection;
+    try {
+      nextConnection =
+        latest?.accessToken && latest.accessToken !== connection.accessToken
+          ? latest
+          : await refreshConnection(userId, connection.refreshToken, { force: true });
+    } catch (error) {
+      if (error?.statusCode === 401) throw invalidateConnection(userId);
+      throw error;
+    }
     response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${nextConnection.accessToken}`,
@@ -95,6 +120,7 @@ async function spotifyRequest(userId, path, { searchParams, url: absoluteUrl } =
   }
   if (!response.ok) {
     const body = await response.text().catch(() => "");
+    if (response.status === 401) throw invalidateConnection(userId);
     const error = new Error(body || `Spotify request failed (${response.status})`);
     error.statusCode = response.status;
     throw error;

--- a/backend/services/spotify/spotifyConnectionStore.js
+++ b/backend/services/spotify/spotifyConnectionStore.js
@@ -107,4 +107,20 @@ export const spotifyConnectionStore = {
     writeStore(store);
     return true;
   },
+
+  clearConnectionIfMatches(userId, expected = {}) {
+    const store = readStore();
+    const key = userKey(userId);
+    const current = normalizeConnection(store[key] || null);
+    if (
+      !current ||
+      current.accessToken !== expected.accessToken ||
+      current.refreshToken !== expected.refreshToken
+    ) {
+      return false;
+    }
+    delete store[key];
+    writeStore(store);
+    return true;
+  },
 };

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -33,6 +33,7 @@ By default, a track removed from Spotify is removed from the Aurral playlist but
 Choose **None** for a fixed tracklist. You can change the schedule later from the playlist menu.
 
 Aurral stores the connection for each user. Use **Disconnect** in the import modal to revoke access.
+If Spotify expires or revokes the connection, Aurral disconnects it and asks you to connect again.
 
 Allow the OAuth pop-up window if your browser blocks it. The Aurral origin must provide `oauth.html`.
 

--- a/frontend/src/pages/flows/import/PlaylistImportModal.jsx
+++ b/frontend/src/pages/flows/import/PlaylistImportModal.jsx
@@ -23,6 +23,7 @@ const SYNC_INTERVAL_OPTIONS = [
 ];
 
 const SPOTIFY_OAUTH_BROADCAST_CHANNEL = "aurral-spotify-oauth";
+const SPOTIFY_AUTH_REQUIRED_CODE = "SPOTIFY_AUTH_REQUIRED";
 
 function tokensFromHandoffPayload(payload) {
   const accessToken = String(payload?.access_token || "").trim();
@@ -150,6 +151,13 @@ export function PlaylistImportModal({
     setJsonReview(null);
   }, []);
 
+  const handleSpotifyAuthRequired = useCallback((error) => {
+    if (error?.response?.data?.code !== SPOTIFY_AUTH_REQUIRED_CODE) return false;
+    setSpotifyStatus({ connected: false, displayName: null, connectedAt: null });
+    resetState();
+    return true;
+  }, [resetState]);
+
   useEffect(() => {
     if (!open) {
       resetState();
@@ -178,11 +186,12 @@ export function PlaylistImportModal({
         setSpotifyStatus((prev) => ({ ...prev, connected: true, displayName: payload.user }));
       }
     } catch (error) {
+      handleSpotifyAuthRequired(error);
       showError?.(error?.response?.data?.message || error?.message || "Failed to load Spotify playlists");
     } finally {
       setSpotifyLoading(false);
     }
-  }, [showError]);
+  }, [handleSpotifyAuthRequired, showError]);
 
   useEffect(() => {
     if (!open || source !== "spotify" || !spotifyStatus.connected) return;
@@ -207,6 +216,7 @@ export function PlaylistImportModal({
         setPreviewTracks(Array.isArray(payload?.previewTracks) ? payload.previewTracks : []);
       } catch (error) {
         if (!cancelled) {
+          handleSpotifyAuthRequired(error);
           showError?.(error?.response?.data?.message || error?.message || "Failed to preview playlist");
         }
       } finally {
@@ -216,7 +226,7 @@ export function PlaylistImportModal({
     return () => {
       cancelled = true;
     };
-  }, [selectedPlaylist, showError]);
+  }, [handleSpotifyAuthRequired, selectedPlaylist, showError]);
 
   const filteredPlaylists = useMemo(() => {
     const query = playlistQuery.trim().toLowerCase();
@@ -237,6 +247,7 @@ export function PlaylistImportModal({
       });
       await loadSpotifyPlaylists();
     } catch (error) {
+      handleSpotifyAuthRequired(error);
       showError?.(
         error?.response?.data?.message || error?.message || "Failed to connect Spotify",
       );
@@ -304,6 +315,7 @@ export function PlaylistImportModal({
       onImported?.();
       onClose?.();
     } catch (error) {
+      handleSpotifyAuthRequired(error);
       showError?.(
         error?.response?.data?.message ||
           error?.response?.data?.error ||

--- a/frontend/src/pages/flows/import/PlaylistImportModal.jsx
+++ b/frontend/src/pages/flows/import/PlaylistImportModal.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FileJson, Loader2, Music2, Upload } from "lucide-react";
 import { ModalShell } from "../../../components/PlaylistModals";
 import {
@@ -128,6 +128,8 @@ export function PlaylistImportModal({
   const [previewLoading, setPreviewLoading] = useState(false);
   const [importing, setImporting] = useState(false);
   const [jsonReview, setJsonReview] = useState(null);
+  const sourceRef = useRef(source);
+  const sourceRequestIdRef = useRef(0);
 
   const reservedNameKeys = useMemo(
     () =>
@@ -138,6 +140,8 @@ export function PlaylistImportModal({
   );
 
   const resetState = useCallback(() => {
+    sourceRef.current = "spotify";
+    sourceRequestIdRef.current += 1;
     setSource("spotify");
     setPlaylists([]);
     setPlaylistQuery("");
@@ -151,8 +155,9 @@ export function PlaylistImportModal({
     setJsonReview(null);
   }, []);
 
-  const handleSpotifyAuthRequired = useCallback((error) => {
+  const handleSpotifyAuthRequired = useCallback((error, requestId) => {
     if (error?.response?.data?.code !== SPOTIFY_AUTH_REQUIRED_CODE) return false;
+    if (sourceRef.current !== "spotify" || requestId !== sourceRequestIdRef.current) return false;
     setSpotifyStatus({ connected: false, displayName: null, connectedAt: null });
     resetState();
     return true;
@@ -178,6 +183,7 @@ export function PlaylistImportModal({
   }, [open, resetState]);
 
   const loadSpotifyPlaylists = useCallback(async () => {
+    const requestId = sourceRequestIdRef.current;
     setSpotifyLoading(true);
     try {
       const payload = await getSpotifyPlaylists();
@@ -186,7 +192,7 @@ export function PlaylistImportModal({
         setSpotifyStatus((prev) => ({ ...prev, connected: true, displayName: payload.user }));
       }
     } catch (error) {
-      handleSpotifyAuthRequired(error);
+      handleSpotifyAuthRequired(error, requestId);
       showError?.(error?.response?.data?.message || error?.message || "Failed to load Spotify playlists");
     } finally {
       setSpotifyLoading(false);
@@ -206,6 +212,7 @@ export function PlaylistImportModal({
       return;
     }
     let cancelled = false;
+    const requestId = sourceRequestIdRef.current;
     setPreviewLoading(true);
     (async () => {
       try {
@@ -216,7 +223,7 @@ export function PlaylistImportModal({
         setPreviewTracks(Array.isArray(payload?.previewTracks) ? payload.previewTracks : []);
       } catch (error) {
         if (!cancelled) {
-          handleSpotifyAuthRequired(error);
+          handleSpotifyAuthRequired(error, requestId);
           showError?.(error?.response?.data?.message || error?.message || "Failed to preview playlist");
         }
       } finally {
@@ -235,6 +242,7 @@ export function PlaylistImportModal({
   }, [playlistQuery, playlists]);
 
   const handleConnectSpotify = async () => {
+    const requestId = sourceRequestIdRef.current;
     setSpotifyLoading(true);
     try {
       const { oauthUrl } = await startSpotifyOAuth(getOAuthCallbackUrl());
@@ -247,7 +255,7 @@ export function PlaylistImportModal({
       });
       await loadSpotifyPlaylists();
     } catch (error) {
-      handleSpotifyAuthRequired(error);
+      handleSpotifyAuthRequired(error, requestId);
       showError?.(
         error?.response?.data?.message || error?.message || "Failed to connect Spotify",
       );
@@ -301,6 +309,7 @@ export function PlaylistImportModal({
     }
     const reservedNames = new Set(reservedNameKeys);
     const finalName = reserveUniqueFlowName(reservedNames, baseName);
+    const requestId = sourceRequestIdRef.current;
     setImporting(true);
     try {
       await importSpotifyPlaylist({
@@ -315,7 +324,7 @@ export function PlaylistImportModal({
       onImported?.();
       onClose?.();
     } catch (error) {
-      handleSpotifyAuthRequired(error);
+      handleSpotifyAuthRequired(error, requestId);
       showError?.(
         error?.response?.data?.message ||
           error?.response?.data?.error ||
@@ -434,7 +443,11 @@ export function PlaylistImportModal({
               key={option.id}
               type="button"
               className={`artist-segmented-button${source === option.id ? " is-active" : ""}`}
-              onClick={() => setSource(option.id)}
+              onClick={() => {
+                sourceRef.current = option.id;
+                sourceRequestIdRef.current += 1;
+                setSource(option.id);
+              }}
               disabled={importing}
             >
               {option.label}

--- a/frontend/src/utils/api/core.js
+++ b/frontend/src/utils/api/core.js
@@ -99,8 +99,17 @@ async function request(config) {
       const error = new Error(`Request failed with status code ${res.status}`);
       error.response = response;
       if (res.status === 401 && !isAuthEndpoint) {
-        clearAuthStorage();
-        if (!data?.error) reauthenticateThroughProxy();
+        const isAurralAuthError =
+          data?.error === "Unauthorized" ||
+          data?.code === "AUTH_REQUIRED" ||
+          data?.code === "SESSION_INVALID";
+        if (isAurralAuthError) {
+          clearAuthStorage();
+        } else if (data?.error && typeof data.error === "object") {
+          reauthenticateThroughProxy();
+        } else if (!data?.error) {
+          reauthenticateThroughProxy();
+        }
       }
       throw error;
     }


### PR DESCRIPTION
Opening Spotify playlist import could show a 401 from an expired Spotify connection and leave the modal showing the account as connected. The earlier handling also risked confusing provider authentication with Aurral authentication.

The frontend request client keeps Aurral sessions intact for Spotify errors. The Spotify client retries token refresh once, then clears the stored Spotify connection when Spotify or the refresh service still returns 401. The API returns a Spotify-specific auth error, and the modal returns to Connect Spotify instead of showing a stale signed-in state.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/import-lists/spotify-client.test.js .tests/frontend/proxy-auth-session.test.js`
- `npm run lint`
- `npm run build --workspace frontend`
- `npm run build --prefix docs`

Known limitation: live Spotify OAuth was not exercised in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of expired or revoked Spotify connections during playlist loading, previews, and imports.
  * Automatically clears invalid Spotify credentials and prompts reconnection when required.
  * Keeps playlist data current when connections are cleared or refreshed.
  * Preserves valid connections during unrelated authorization failures.

* **Bug Fixes**
  * Prevented stale requests from resetting the active import state.
  * Prevented unnecessary proxy reauthentication.
  * Ensured failed token refreshes disconnect only the affected Spotify connection.

* **Documentation**
  * Documented automatic disconnection and reconnection requirements for expired or revoked Spotify connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->