### PR TITLE
fix(playback): skip redundant Navidrome artwork uploads

### DIFF
--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -209,7 +209,7 @@ test("does not re-upload artwork when republishing an existing API playlist", as
   await fs.mkdir(destination.libraryRoot, { recursive: true });
   await fs.writeFile(path.join(destination.libraryRoot, "Existing Art.webp"), "image");
 
-  await destination.publishPlaylist(
+  const result = await destination.publishPlaylist(
     createPlaybackPlaylistSnapshot({
       entityId: playlist.id,
       displayName: playlist.name,
@@ -217,6 +217,12 @@ test("does not re-upload artwork when republishing an existing API playlist", as
     }),
   );
 
+  assert.equal(result.ok, true);
+  assert.deepEqual(client.calls.updated, [{
+    id: "existing",
+    name: playlist.name,
+    songIds: ["song-1"],
+  }]);
   assert.deepEqual(client.calls.artwork, []);
 });
 

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -195,6 +195,31 @@ test("uploads generated artwork for API playlists", async () => {
   }]);
 });
 
+test("does not re-upload artwork when republishing an existing API playlist", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Existing Art" });
+  const client = createClient({
+    playlists: [{ id: "existing", name: playlist.name }],
+    songs: { Song: { id: "song-1" } },
+  });
+  navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
+    playlistId: "existing",
+    title: playlist.name,
+  });
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  await fs.mkdir(destination.libraryRoot, { recursive: true });
+  await fs.writeFile(path.join(destination.libraryRoot, "Existing Art.webp"), "image");
+
+  await destination.publishPlaylist(
+    createPlaybackPlaylistSnapshot({
+      entityId: playlist.id,
+      displayName: playlist.name,
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
+    }),
+  );
+
+  assert.deepEqual(client.calls.artwork, []);
+});
+
 test("syncs and clears artwork for an existing API playlist", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Artwork Sync" });
   const client = createClient({ songs: { Song: { id: "song-1" } } });

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -444,6 +444,7 @@ export class NavidromePlaybackDestination {
     }
 
     let playlist = null;
+    let artworkNeedsUpload = false;
     if (pointer) {
       for (const delayMs of [0, 250, 1000, 2000]) {
         if (delayMs) await wait(delayMs);
@@ -472,6 +473,7 @@ export class NavidromePlaybackDestination {
         await this.client.updatePlaylist(playlist.id, { name: current, songIds });
       } else {
         playlist = await this.client.createPlaylist(current, songIds);
+        artworkNeedsUpload = true;
       }
     }
     if (!playlist?.id) throw new Error("Navidrome did not return a playlist ID");
@@ -479,7 +481,7 @@ export class NavidromePlaybackDestination {
       playlistId: playlist.id,
       title: current,
     });
-    await this._uploadPlaylistArtwork(snapshot, playlist.id);
+    if (artworkNeedsUpload) await this._uploadPlaylistArtwork(snapshot, playlist.id);
     if (hasUnresolvedSongs) {
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
       return playbackOperationSuccess();


### PR DESCRIPTION
Restarting Aurral re-published existing Navidrome playlists and uploaded their local artwork again, causing avoidable 429 warnings even when the artwork was unchanged.

The Navidrome adapter now uploads artwork only when it creates or recreates a playlist. Explicit artwork upload and generate paths still sync artwork to Navidrome.

Verification:
- Focused Navidrome playback tests: 29 passing
- Navidrome client tests: 15 passing
- `npm run lint:backend`
- `git diff --check`

Known limitation: if artwork is deleted directly in Navidrome, a restart will not restore it. Changing or regenerating the artwork still syncs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed playlist republishing so existing Navidrome playlists no longer re-upload their artwork unnecessarily.
  - Preserved artwork uploads when creating new playlists.

- **Tests**
  - Added regression coverage to verify artwork is not uploaded again when an existing playlist is republished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->