### PR TITLE
fix(discovery): surface unresolved nearby postal codes

### DIFF
--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import axios from "../../lib/axiosFetch.js";
 
-import { groupShowsByEvent } from "../../backend/services/nearbyShowsService.js";
+import { getNearbyShows, groupShowsByEvent } from "../../backend/services/nearbyShowsService.js";
 
 test("groups artists matched to the same Ticketmaster event", () => {
   const grouped = groupShowsByEvent([
@@ -18,4 +19,17 @@ test("groups artists matched to the same Ticketmaster event", () => {
       { id: "event-2", artistName: "Artist C", artistNames: ["Artist C"] },
     ],
   );
+});
+
+test("marks an unresolved postal code instead of returning a normal empty location", async (t) => {
+  t.mock.method(axios, "get", async (url) => {
+    assert.equal(url, "https://nominatim.openstreetmap.org/search");
+    return { data: [] };
+  });
+
+  const result = await getNearbyShows({ zipCode: "M5V" });
+
+  assert.equal(result.location.resolved, false);
+  assert.equal(result.total, 0);
+  assert.deepEqual(result.shows, []);
 });

--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -32,4 +32,6 @@ test("marks an unresolved postal code instead of returning a normal empty locati
   assert.equal(result.location.resolved, false);
   assert.equal(result.total, 0);
   assert.deepEqual(result.shows, []);
+  assert.deepEqual(result.libraryShows, []);
+  assert.deepEqual(result.recommendedShows, []);
 });

--- a/backend/services/nearbyShowsService.js
+++ b/backend/services/nearbyShowsService.js
@@ -207,6 +207,7 @@ const resolveZipLocation = async (zipCode) => {
         if (place) {
           const location = {
             source: "zip",
+            resolved: true,
             postalCode: normalizedZip,
             city: place["place name"] || null,
             region: place.state || null,
@@ -242,6 +243,7 @@ const resolveZipLocation = async (zipCode) => {
       const address = result.address || {};
       const location = {
         source: "zip",
+        resolved: true,
         postalCode: normalizedZip,
         city: address.city || address.town || address.village || null,
         region: address.state || null,
@@ -279,6 +281,7 @@ const resolveIpLocation = async (ipAddress) => {
     }
     const location = {
       source: "ip",
+      resolved: true,
       postalCode: sanitizeZipCode(response.data?.postal),
       city: response.data?.city || null,
       region: response.data?.region || null,
@@ -421,6 +424,7 @@ export const getNearbyShows = async ({
     location =
       (await resolveZipLocation(sanitizedZipCode)) || {
         source: "zip",
+        resolved: false,
         postalCode: sanitizedZipCode,
         city: null,
         region: null,
@@ -432,6 +436,16 @@ export const getNearbyShows = async ({
       };
   } else {
     location = await resolveIpLocation(getForwardedIp(req));
+  }
+
+  if (location.resolved === false) {
+    return {
+      location,
+      shows: [],
+      libraryShows: [],
+      recommendedShows: [],
+      total: 0,
+    };
   }
 
   const events = await fetchTicketmasterEvents({ location, radiusMiles });

--- a/frontend/src/hooks/useNearbyShows.js
+++ b/frontend/src/hooks/useNearbyShows.js
@@ -51,7 +51,11 @@ export function useNearbyShows({ enabled = true, limit } = {}) {
       .then((response) => {
         if (controller.signal.aborted) return;
         setData(response);
-        setError(null);
+        setError(
+          response?.location?.resolved === false
+            ? "We could not find that ZIP or postal code."
+            : null,
+        );
       })
       .catch((err) => {
         if (controller.signal.aborted) return;


### PR DESCRIPTION
Nearby postal-code lookups currently look like successful empty searches when geocoding fails. That makes an invalid or unsupported code indistinguishable from an area with no shows.

This change marks unresolved locations with `location.resolved: false`, skips the Ticketmaster request for them, and shows a clear error through the shared nearby-shows hook.

Verification:
- `npm test` (725 passing)
- `npm run build`
- `npm run lint:backend`
- `npm run lint --workspace frontend`

Refs #592

Known limitation: country hints for ambiguous numeric and non-US postal codes remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unrecognized ZIP codes and locations.
  * Prevented searches from returning misleading nearby show results when a location cannot be resolved.
  * Added a clear user-facing error when location lookup fails.
  * Ensured unresolved searches return no shows instead of incomplete or inaccurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->