### PR TITLE
fix(logging): quiet regular server output

### DIFF
--- a/.tests/helpers/console-logging.test.js
+++ b/.tests/helpers/console-logging.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 
 import { isVerboseConsoleEnabled } from "../../backend/config/constants.js";
 
@@ -27,11 +28,11 @@ test("simplified logger writes to console with level and category", async () => 
     const { logger } = await import(
       `../../backend/services/logger.js?console-test=${Date.now()}`
     );
-    logger.info("test", "info message", { key: "val" });
+    logger.info("test", "Server running on port 3001", { key: "val" });
     logger.warn("test", "warn message");
     logger.error("test", "error message");
 
-    assert.ok(output.some((entry) => entry[0] === "log" && String(entry[1]).includes("[info]") && String(entry[1]).includes("[test]") && String(entry[1]).includes("info message")));
+    assert.ok(output.some((entry) => entry[0] === "log" && String(entry[1]).includes("[info]") && String(entry[1]).includes("[test]") && String(entry[1]).includes("Server running")));
     assert.ok(output.some((entry) => entry[0] === "warn" && String(entry[1]).includes("[warn]")));
     assert.ok(output.some((entry) => entry[0] === "error" && String(entry[1]).includes("[error]")));
   } finally {
@@ -39,4 +40,69 @@ test("simplified logger writes to console with level and category", async () => 
     console.error = original.error;
     console.warn = original.warn;
   }
+});
+
+test("regular logger hides routine info and debug output", async () => {
+  const output = [];
+  const original = {
+    log: console.log,
+    error: console.error,
+    warn: console.warn,
+  };
+  console.log = (...args) => output.push(["log", ...args]);
+  console.error = (...args) => output.push(["error", ...args]);
+  console.warn = (...args) => output.push(["warn", ...args]);
+
+  try {
+    const { logger } = await import(
+      `../../backend/services/logger.js?regular-test=${Date.now()}`
+    );
+    logger.info("test", "routine info");
+    logger.debug("test", "debug detail");
+    logger.warn("test", "important warning");
+
+    assert.doesNotMatch(output.map((entry) => String(entry[1])).join("\n"), /routine info|debug detail/);
+    assert.match(output.map((entry) => String(entry[1])).join("\n"), /important warning/);
+  } finally {
+    console.log = original.log;
+    console.error = original.error;
+    console.warn = original.warn;
+  }
+});
+
+test("regular console keeps startup and problem messages", async () => {
+  const { shouldEmitDefaultConsoleMessage } = await import(
+    `../../backend/services/logger.js?policy-test=${Date.now()}`
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("log", ["Server running on port 3001"]),
+    true,
+  );
+  assert.equal(
+    shouldEmitDefaultConsoleMessage("log", ["Discovery cache is fresh"]),
+    false,
+  );
+  assert.equal(shouldEmitDefaultConsoleMessage("warn", ["warning"]), true);
+  assert.equal(shouldEmitDefaultConsoleMessage("debug", ["details"]), false);
+});
+
+test("regular server console suppresses raw routine output", () => {
+  const loggerUrl = new URL("../../backend/services/logger.js", import.meta.url).href;
+  const probe = [
+    'process.argv[1] = "/app/server.js";',
+    `await import(${JSON.stringify(loggerUrl)});`,
+    'console.log("routine raw output");',
+    'console.log("Server running on port 3001");',
+    'console.warn("important warning");',
+  ].join("\n");
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", probe], {
+    cwd: new URL("../..", import.meta.url),
+    env: { ...process.env, AURRAL_VERBOSE_LOGS: "" },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const output = `${result.stdout}${result.stderr}`;
+  assert.doesNotMatch(output, /routine raw output/);
+  assert.match(output, /Server running on port 3001/);
+  assert.match(output, /important warning/);
 });

--- a/.tests/helpers/console-logging.test.js
+++ b/.tests/helpers/console-logging.test.js
@@ -49,11 +49,13 @@ test("regular logger hides routine info and debug output", async () => {
     error: console.error,
     warn: console.warn,
   };
+  const previousVerboseLogs = process.env.AURRAL_VERBOSE_LOGS;
   console.log = (...args) => output.push(["log", ...args]);
   console.error = (...args) => output.push(["error", ...args]);
   console.warn = (...args) => output.push(["warn", ...args]);
 
   try {
+    process.env.AURRAL_VERBOSE_LOGS = "";
     const { logger } = await import(
       `../../backend/services/logger.js?regular-test=${Date.now()}`
     );
@@ -64,6 +66,8 @@ test("regular logger hides routine info and debug output", async () => {
     assert.doesNotMatch(output.map((entry) => String(entry[1])).join("\n"), /routine info|debug detail/);
     assert.match(output.map((entry) => String(entry[1])).join("\n"), /important warning/);
   } finally {
+    if (previousVerboseLogs === undefined) delete process.env.AURRAL_VERBOSE_LOGS;
+    else process.env.AURRAL_VERBOSE_LOGS = previousVerboseLogs;
     console.log = original.log;
     console.error = original.error;
     console.warn = original.warn;

--- a/backend/services/logger.js
+++ b/backend/services/logger.js
@@ -1,9 +1,54 @@
 import { isVerboseConsoleEnabled } from "../config/constants.js";
 
-let verboseEnabled = isVerboseConsoleEnabled();
+const verboseEnabled = isVerboseConsoleEnabled();
+
+const DEFAULT_VISIBLE_MESSAGES = [
+  /Server running on port \d+/,
+  /Port \d+ is already in use\./,
+  /Frontend not built\./,
+  /Uncaught Exception:/,
+  /Unhandled Rejection:/,
+  /Server error:/,
+];
+
+const messageText = (args) =>
+  args
+    .map((value) =>
+      value instanceof Error ? value.message : typeof value === "string" ? value : "",
+    )
+    .filter(Boolean)
+    .join(" ");
+
+export const shouldEmitDefaultConsoleMessage = (method, args = []) => {
+  if (method === "debug") return false;
+  if (method === "warn" || method === "error") return true;
+  return DEFAULT_VISIBLE_MESSAGES.some((pattern) =>
+    pattern.test(messageText(args)),
+  );
+};
+
+function patchDefaultConsole() {
+  if (verboseEnabled || !String(process.argv[1] || "").endsWith("/server.js")) return;
+  if (globalThis.__aurralDefaultConsolePatched) return;
+  globalThis.__aurralDefaultConsolePatched = true;
+
+  for (const method of ["log", "info", "debug"]) {
+    const original = console[method].bind(console);
+    console[method] = (...args) => {
+      if (shouldEmitDefaultConsoleMessage(method, args)) original(...args);
+    };
+  }
+}
+
+patchDefaultConsole();
 
 function log(level, category, message, data = {}) {
-  if (level === "debug" && !verboseEnabled) return;
+  if (!verboseEnabled && level === "debug") return;
+  if (
+    !verboseEnabled &&
+    level === "info" &&
+    !DEFAULT_VISIBLE_MESSAGES.some((pattern) => pattern.test(String(message)))
+  ) return;
   const line = `[${level}] [${category}] ${message}`;
   const keys = Object.keys(data).length;
   if (level === "error") {

--- a/backend/services/logger.js
+++ b/backend/services/logger.js
@@ -28,7 +28,7 @@ export const shouldEmitDefaultConsoleMessage = (method, args = []) => {
 };
 
 function patchDefaultConsole() {
-  if (verboseEnabled || !String(process.argv[1] || "").endsWith("/server.js")) return;
+  if (verboseEnabled || !/(?:^|[\\/])server\.js$/.test(String(process.argv[1] || ""))) return;
   if (globalThis.__aurralDefaultConsolePatched) return;
   globalThis.__aurralDefaultConsolePatched = true;
 

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -1,5 +1,6 @@
 import axios from "../../lib/axiosFetch.js";
 import crypto from "crypto";
+import { logger } from "./logger.js";
 
 const LEGACY_LIBRARY_DIR = "aurral-weekly-flow";
 const PLAYLIST_LIBRARY_NAME = "Aurral Playlists";
@@ -387,10 +388,12 @@ export class NavidromeClient {
 
       return this.createLibrary(name, normalizedPath);
     } catch (err) {
-      console.warn(
-        "[Navidrome] ensureWeeklyFlowLibrary failed:",
-        err?.response?.data?.error || err.message,
-      );
+      const message = err?.response?.data?.error || err.message;
+      if (err?.response?.status === 429) {
+        logger.debug("navidrome", "Navidrome library setup was rate limited", { message });
+      } else {
+        logger.warn("navidrome", "Navidrome library setup failed", { message });
+      }
       return null;
     }
   }

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { setTimeout as wait } from "node:timers/promises";
 import { userOps } from "../../db/helpers/index.js";
 import { NavidromeClient } from "../navidrome.js";
+import { logger } from "../logger.js";
 import { navidromePlaylistPointerStore } from "../navidrome/navidromePlaylistPointerStore.js";
 import {
   AURRAL_FLOWS_DIR,
@@ -212,10 +213,9 @@ export class NavidromePlaybackDestination {
           contentType,
         );
       } catch (error) {
-        console.warn(
-          "[NavidromePlaybackDestination] Failed to upload playlist artwork:",
-          error?.message,
-        );
+        logger.debug("playback", "Failed to upload optional Navidrome playlist artwork", {
+          message: error?.message || String(error),
+        });
       }
       return;
     }

--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -59,7 +59,7 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 
 | Variable | Purpose |
 | -------- | ------- |
-| `AURRAL_VERBOSE_LOGS` | Detailed server logs for problem analysis. |
+| `AURRAL_VERBOSE_LOGS` | Set to `true` to include routine and debug server logs. Regular logs show startup messages, warnings, and errors. |
 
 ## Image proxy
 


### PR DESCRIPTION
Regular container logs include every WebSocket reconnect, cache hit, worker status line, and repeated Navidrome rate-limit message. That makes the logs hard to use for the average user.

Regular mode now hides routine info, debug, and raw console output while keeping startup messages, warnings, and errors visible. Expected Navidrome 429 failures for optional artwork and library setup are debug-only. The environment documentation and logging regression tests describe and cover the new behavior.

Verification:
- `npm test` (727 passing)
- `npm run lint`
- `npm run build`
- `npm run docs:build`

Known limitation: warnings and errors remain visible in regular mode so actionable failures are not hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter server console filtering to reduce routine log noise while keeping startup messages, warnings, and errors visible.
  * Added more consistent handling of setup and optional artwork-upload messages.

* **Documentation**
  * Clarified that verbose logs include routine and debug activity, while standard logs show startup messages, warnings, and errors.

* **Bug Fixes**
  * Improved rate-limit and setup failure logging with clearer severity and error details.
  * Preserved important warnings and successful server startup output in standard logging mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->