### PR TITLE
docs: update nightly release documentation

### DIFF
--- a/docs/src/content/docs/admin/environment.mdx
+++ b/docs/src/content/docs/admin/environment.mdx
@@ -11,13 +11,13 @@ Use the web UI for most settings. Use these variables for Docker deployment sett
 | -------- | ------- |
 | `PUID` / `PGID` | Run the container as the user that owns mounted folders. |
 | `AURRAL_DATA_DIR` | Override app data directory. Default `/config`. |
-| `DOWNLOAD_FOLDER` | Initial Downloads Folder path. Prefer **Settings > Download Clients > Downloads Folder > Path**. Use an absolute path under your media mount. |
+| `DOWNLOAD_FOLDER` | Initial Downloads Folder path. Prefer **Settings > Download clients > Downloads Folder > Path**. Use an absolute path under your media mount. |
 
 ## Path mappings
 
 | Variable | Purpose |
 | -------- | ------- |
-| `PATH_MAPPINGS` | Translate paths for mixed Windows and Docker setups. Use the format `remote\|local`. Separate multiple mappings with `;`. To limit a mapping to one source, use `source\|remote\|local`. Aurral applies these mappings at runtime. Edit them under **Settings > Download Clients > Remote Path Mappings**. |
+| `PATH_MAPPINGS` | Translate paths for mixed Windows and Docker setups. Use the format `remote\|local`. Separate multiple mappings with `;`. To limit a mapping to one source, use `source\|remote\|local`. Aurral applies these mappings at runtime. Edit them under **Settings > Download clients > Remote Path Mappings**. |
 
 ## Authentication
 

--- a/docs/src/content/docs/admin/storage.mdx
+++ b/docs/src/content/docs/admin/storage.mdx
@@ -3,7 +3,7 @@ title: Storage and backups
 description: Aurral app data, shared media mounts, and what to back up.
 ---
 
-Aurral keeps app state and generated music separate. It also needs compatible filesystem views of Lidarr, your download clients, and Navidrome or Plex.
+Aurral keeps app state and managed media separate. It also needs compatible filesystem views of Lidarr, your download clients, and any playback server.
 
 For the complete mount model, follow [Filesystem and mounts](/getting-started/storage/). Use the Lidarr media root and set the Downloads Folder to a path inside Aurral, such as `/data/downloads/aurral`.
 
@@ -13,7 +13,7 @@ For the complete mount model, follow [Filesystem and mounts](/getting-started/st
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/config`                        | Database, settings, users, sessions, cache state, playlist jobs, and the default yt-dlp staging directory. Mount it with `./config:/config`. Do not share it with other apps. |
 | `/data` (or Lidarr's media root) | Shared library and downloads. Mount the same host media root here in Aurral, Lidarr, download clients, and playback servers.                                                      |
-| Downloads Folder                 | Generated flows, imported playlists, and playlist files. Set in **Settings > Download Clients > Downloads Folder > Path** (for example `/data/downloads/aurral`).          |
+| Downloads Folder                 | Aurral-owned permanent tracks, temporary Flow tracks, imported playlists, and playlist artwork. Set in **Settings > Download clients > Downloads Folder > Path** (for example `/data/downloads/aurral`). |
 
 :::note
 `/config` replaces the older `/app/backend/data` path from Aurral v1. At startup, Aurral automatically detects existing databases in either location.
@@ -25,10 +25,12 @@ For the complete mount model, follow [Filesystem and mounts](/getting-started/st
 - Back up the Downloads Folder if you want to keep generated playlists after a rebuild.
 - Back up the Compose file and the environment file that contains your host paths.
 
-yt-dlp stages downloads in `/config/_staging` by default. You can mount another persistent path and select it under **Settings > Download Clients > yt-dlp > Staging path**. Keep it outside media-server libraries to avoid scanner activity while files are incomplete.
+The Downloads Folder migration can move older Aurral files into the canonical layout. Keep both `/config` and the Downloads Folder backed up until the migration finishes.
+
+yt-dlp stages downloads in `/config/_staging` by default. You can mount another persistent path and select it under **Settings > Download clients > yt-dlp > Staging path**. Keep it outside media-server libraries to avoid scanner activity while files are incomplete.
 
 ## Library safety
 
 - Aurral does not write into your root music library.
 - Artist and album changes go through Lidarr.
-- Flows and imported playlists stay under Aurral's Downloads Folder path.
+- Aurral-owned media stays under the Downloads Folder path. Flow files use `_flows`; permanent tracks use the canonical `artist/album/track` layout.

--- a/docs/src/content/docs/admin/storage.mdx
+++ b/docs/src/content/docs/admin/storage.mdx
@@ -15,17 +15,11 @@ For the complete mount model, follow [Filesystem and mounts](/getting-started/st
 | `/data` (or Lidarr's media root) | Shared library and downloads. Mount the same host media root here in Aurral, Lidarr, download clients, and playback servers.                                                      |
 | Downloads Folder                 | Aurral-owned permanent tracks, temporary Flow tracks, imported playlists, and playlist artwork. Set in **Settings > Download clients > Downloads Folder > Path** (for example `/data/downloads/aurral`). |
 
-:::note
-`/config` replaces the older `/app/backend/data` path from Aurral v1. At startup, Aurral automatically detects existing databases in either location.
-:::
-
 ## Back up your data
 
 - Back up the mounted `/config` folder.
 - Back up the Downloads Folder if you want to keep generated playlists after a rebuild.
 - Back up the Compose file and the environment file that contains your host paths.
-
-The Downloads Folder migration can move older Aurral files into the canonical layout. Keep both `/config` and the Downloads Folder backed up until the migration finishes.
 
 yt-dlp stages downloads in `/config/_staging` by default. You can mount another persistent path and select it under **Settings > Download clients > yt-dlp > Staging path**. Keep it outside media-server libraries to avoid scanner activity while files are incomplete.
 

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -20,20 +20,20 @@ description: Common setup and runtime issues.
 
 ## Playlists do not download
 
-- Configure one or more download sources. Use **Settings > Download Clients** or **Settings > Indexers**.
+- Configure one or more download sources. Use **Settings > Download clients** or **Settings > Indexers**.
 - For yt-dlp, select **Test connection**.
 - Make sure that the host has `yt-dlp` and ffmpeg. The Docker image includes both programs.
 - For slskd, check the connection and the Soulseek login status.
 - For Usenet, enable the Prowlarr indexers.
 - Make sure that the Usenet client can reach completed files.
-- If FLAC matches are scarce, enable acceptable MP3 or M4A tiers in **Settings > Download Clients > Quality Profile**.
+- If FLAC matches are scarce, enable acceptable MP3 or M4A tiers in **Settings > Download clients > Quality profile**.
 - Make sure that the cutoff and tier order match the quality that you want.
-- Check job states on the Playlists page and **History**.
+- Check job states on the Playlists or Flows page and **Activity**.
 
 ## Files do not appear in Navidrome
 
 - Make sure that Aurral mounts the same media root as Lidarr ([Filesystem and mounts](/getting-started/storage/)).
-- Make sure that **Settings > Download Clients > Downloads Folder > Path** is under that mount.
+- Make sure that **Settings > Download clients > Downloads Folder > Path** is under that mount.
 - In **Settings > Playback > Navidrome**, test the Navidrome connection. Changes save automatically.
 - Make sure that Navidrome scans Aurral's downloads path and not only Lidarr's library.
 - Aurral's **Aurral Playlists** library can be empty until a flow finishes a download. Check for a file in the Downloads Folder or `_flows`, then wait for the Navidrome scan.
@@ -53,8 +53,8 @@ Completed slskd or Usenet files can also remain in their source folders. **Test 
 - After you change Compose `volumes` or `environment`, recreate the container: `docker compose up -d --force-recreate`.
 - Run **Settings > Lidarr > Test library access** to see the exact path Aurral cannot read.
 - If necessary, set `PATH_MAPPINGS=N:/ServerFolders/Music|/music` in the Compose file.
-- You can also add mappings under **Settings > Download Clients > Remote Path Mappings**.
-- For NZBGet on Windows, open **Settings > Download Clients > NZBGet**.
+- You can also add mappings under **Settings > Download clients > Remote Path Mappings**.
+- For NZBGet on Windows, open **Settings > Download clients > NZBGet**.
 - Set **Completed download path** if Aurral cannot detect the folder automatically.
 
 See [Filesystem and mounts: Windows and mixed Docker setups](/getting-started/storage/#windows-and-mixed-docker-setups).
@@ -85,7 +85,7 @@ See [Navidrome: Filesystem paths](/integrations/navidrome/#filesystem-paths).
 
 ## Plex playlists are empty or tracks are missing
 
-**Sync to Plex now** can succeed while the playlists have no tracks. The Aurral library can also stay empty after a scan.
+**Sync to Plex now** can succeed while the playlists have no tracks. The Aurral library can also stay empty while Plex is still scanning.
 
 - Make sure that Plex can read the flow download tree.
 - The Plex container or host must contain the Downloads Folder, including `<downloads>/artist/album/track` and `<downloads>/_flows/<flow-id>/...`.

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -103,6 +103,9 @@ instance API key for WebSocket connections.
 | `POST` | `/api/library/downloads/album` | Monitor an album and optionally run the configured search |
 | `POST` | `/api/library/downloads/album/search` | Trigger a Lidarr album search |
 
+`POST /api/library/downloads/track` requires an authenticated user with the
+`addAlbum` permission.
+
 ## Artist metadata
 
 | Method | Path | Purpose |
@@ -295,6 +298,9 @@ The repeated `playlists` segment in
 | `GET` | `/api/users/plex-link/home-users` | List Plex home users |
 | `POST` | `/api/users/:id/plex-link/managed` | Link a managed Plex user |
 | `DELETE` | `/api/users/:id/plex-link` | Remove a managed Plex link |
+
+The current-user Plex-link routes require authentication. The Plex home-user
+and managed-link routes require administrator access.
 
 ## Administration and settings
 

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -30,6 +30,8 @@ can change Aurral, Lidarr, files, users, or external services.
 | `GET` | `/api/auth/me` | Current authenticated identity |
 | `GET` | `/api/auth/api-key` | Read or create the instance API key |
 | `POST` | `/api/auth/api-key/rotate` | Replace the instance API key |
+| `GET` | `/api/auth/oidc/login` | Start an OpenID Connect login |
+| `POST` | `/api/auth/oidc/exchange` | Exchange an OpenID Connect code for a session |
 
 The liveness, bootstrap, and health routes do not require authentication.
 Aurral returns detailed health fields only for a request with a valid
@@ -81,8 +83,12 @@ instance API key for WebSocket connections.
 | `GET` | `/api/library/tracks` | List album tracks |
 | `POST` | `/api/library/refresh` | Queue a canonical library scan |
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
+| `GET` | `/api/library/canonical` | Read the canonical artists, albums, and tracks |
+| `GET` | `/api/library/favorites` | Read the current user's library favorites |
+| `POST` | `/api/library/favorites` | Add or remove a library favorite |
 | `GET` | `/api/library/playback-queue` | Build the playback queue |
 | `GET` | `/api/library/stream/:songId` | Stream a library song |
+| `GET` | `/api/library/canonical-stream/:trackId` | Stream a canonical library track |
 | `GET` | `/api/library/file-stream/:albumId/:trackId` | Stream an album track file |
 | `GET` | `/api/library/rootfolder` | List Lidarr root-folder paths |
 | `GET` | `/api/library/lookup/:mbid` | Check whether an artist is in the library |
@@ -93,6 +99,7 @@ instance API key for WebSocket connections.
 | `GET` | `/api/library/downloads` | List download jobs |
 | `GET` | `/api/library/downloads/status` | Get statuses for the required `albumIds` query |
 | `GET` | `/api/library/downloads/status/all` | Get all download statuses |
+| `POST` | `/api/library/downloads/track` | Download or request a track |
 | `POST` | `/api/library/downloads/album` | Monitor an album and optionally run the configured search |
 | `POST` | `/api/library/downloads/album/search` | Trigger a Lidarr album search |
 
@@ -164,6 +171,7 @@ accept `releaseTypes` and `sort`. `GET /api/requests` accepts `refresh=true`.
 | `GET` | `/api/news` | Read recent news for the current user's library |
 | `GET` | `/api/news/preferences` | Read the current user's blocked publishers |
 | `PATCH` | `/api/news/preferences` | Replace the current user's blocked publishers |
+| `POST` | `/api/news/feeds/disable` | Disable a news feed |
 
 `/api/news` accepts an optional `limit` query parameter. News preferences are
 user-scoped; the `blockedPublishers` request field is an array of publisher
@@ -280,6 +288,13 @@ The repeated `playlists` segment in
 | `GET` | `/api/users/me/discover-layout` | Current user's discovery layout |
 | `PATCH` | `/api/users/me/discover-layout` | Update current user's discovery layout |
 | `POST` | `/api/users/me/password` | Change current user's password |
+| `GET` | `/api/users/me/plex-link/status` | Read the current user's Plex link |
+| `POST` | `/api/users/me/plex-link/oauth/pin` | Start Plex linking for the current user |
+| `POST` | `/api/users/me/plex-link/oauth/complete` | Complete Plex linking for the current user |
+| `DELETE` | `/api/users/me/plex-link` | Remove the current user's Plex link |
+| `GET` | `/api/users/plex-link/home-users` | List Plex home users |
+| `POST` | `/api/users/:id/plex-link/managed` | Link a managed Plex user |
+| `DELETE` | `/api/users/:id/plex-link` | Remove a managed Plex link |
 
 ## Administration and settings
 
@@ -310,8 +325,28 @@ Every route in this section requires an administrator.
 | `POST` | `/api/settings/plex/auth/check` | Check Plex authentication |
 | `POST` | `/api/settings/plex/resources` | List Plex resources |
 | `POST` | `/api/settings/plex/test` | Test Plex |
+| `GET` | `/api/settings/plex/libraries` | List Plex libraries |
+| `GET` | `/api/settings/plex/libraries/:sectionId/access-check` | Check access to a Plex library |
 | `POST` | `/api/settings/plex/sync` | Synchronize Plex |
 | `POST` | `/api/settings/navidrome/test` | Test Navidrome credentials |
+| `GET` | `/api/settings/playback` | Read playback settings |
+| `POST` | `/api/settings/playback/:key/test` | Test a playback integration |
+
+## Scrobbling and play events
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/scrobbling/status` | Read scrobbling provider status |
+| `GET` | `/api/scrobbling/lastfm/link` | Start or read Last.fm linking |
+| `GET` | `/api/scrobbling/lastfm/link/callback` | Complete Last.fm linking |
+| `DELETE` | `/api/scrobbling/lastfm/link` | Unlink Last.fm |
+| `GET` | `/api/scrobbling/listenbrainz/link` | Read ListenBrainz linking |
+| `PUT` | `/api/scrobbling/listenbrainz/link` | Link ListenBrainz |
+| `DELETE` | `/api/scrobbling/listenbrainz/link` | Unlink ListenBrainz |
+| `PUT` | `/api/scrobbling/koito/link` | Configure Koito |
+| `DELETE` | `/api/scrobbling/koito/link` | Unlink Koito |
+| `GET` | `/api/play-events` | Read local play history |
+| `POST` | `/api/play-events` | Record a local play event |
 
 ## Onboarding
 
@@ -340,3 +375,14 @@ require authentication. After onboarding, Aurral requires an administrator
 credential for filesystem routes. Aurral accepts the instance API key. Do not
 expose an Aurral server directly to the public internet. Some `/api` routes do
 not require an API key.
+
+## Subsonic
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` or `POST` | `/rest/:method.view` | Authenticated Subsonic API methods |
+
+The Subsonic API supports XML and JSON responses. Use the account's Subsonic
+credentials or token authentication; the instance API key is not a Subsonic
+credential. See [Navidrome and Subsonic](/integrations/navidrome/) for the
+supported client behavior.

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -6,6 +6,10 @@ description: This page explains Aurral authentication and HTTP API use for scrip
 Aurral provides a JSON HTTP API. The web interface uses this API. You can also
 use the API for scripts, dashboards, and homepage widgets.
 
+The JSON API and the authenticated Subsonic API are separate interfaces. Use
+the JSON API for Aurral-specific automation. Use `/rest` for a Subsonic player
+or client.
+
 :::caution
 The API does not have version numbers. Routes and response formats can change
 between Aurral releases. Use the same Aurral version for each integration. If
@@ -52,6 +56,8 @@ same-origin proxy keeps it out of visitors' browsers.
 | `GET /api/health` | Aurral, library, discovery, and system status | None |
 | `GET /api/library/artists` | Library artists | `limit` (1-10000), `offset` |
 | `GET /api/library/artists/:mbid` | One library artist | MusicBrainz artist ID in the path |
+| `GET /api/library/canonical` | Canonical artists, albums, and tracks | Optional `source`, `availableOnly`, or page filters |
+| `GET /api/library/favorites` | Current user's favorites and library | None |
 | `GET /api/library/albums` | Albums for an artist | Required `artistId` |
 | `GET /api/library/albums/:id` | One library album | Lidarr album ID in the path |
 | `GET /api/library/tracks` | Tracks for an album | `albumId` or `releaseGroupMbid` |
@@ -103,4 +109,5 @@ the key.
 
 The API key gives access to administration routes and routes that change data.
 Before you give the key to a third-party integration, read the endpoint
-reference.
+reference. The API key is not a Subsonic credential; Subsonic clients use the
+account password or token authentication described in the integration guide.

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -56,7 +56,7 @@ same-origin proxy keeps it out of visitors' browsers.
 | `GET /api/health` | Aurral, library, discovery, and system status | None |
 | `GET /api/library/artists` | Library artists | `limit` (1-10000), `offset` |
 | `GET /api/library/artists/:mbid` | One library artist | MusicBrainz artist ID in the path |
-| `GET /api/library/canonical` | Canonical artists, albums, and tracks | Optional `source`, `availableOnly`, or page filters |
+| `GET /api/library/canonical` | Canonical artists, albums, and tracks | Optional `source` and `availableOnly`. Add `kind` to use `page`, `pageSize`, `query`, `genre`, `sort`, `direction`, `artistId`, or `albumId` filters. |
 | `GET /api/library/favorites` | Current user's favorites and library | None |
 | `GET /api/library/albums` | Albums for an artist | Required `artistId` |
 | `GET /api/library/albums/:id` | One library album | Lidarr album ID in the path |
@@ -66,6 +66,10 @@ same-origin proxy keeps it out of visitors' browsers.
 | `GET /api/requests` | Current artist and album requests | Optional `refresh=true` |
 | `GET /api/library/downloads/status/all` | All current download states | None |
 | `GET /api/search` | Search artists, albums, or tags | Required `q`. Optional `scope`, `limit`, and `offset` |
+
+`GET /api/library/canonical` returns the unpaged canonical library unless you
+provide `kind=artists`, `kind=albums`, or `kind=tracks`. The page filters apply
+only when `kind` is present.
 
 See the [endpoint reference](/api/endpoints/) for the complete current route
 index.

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -65,7 +65,7 @@ Non-stable channels also mark the sidebar.
 Nightly images currently support `linux/amd64` only. On ARM, use `latest` or a versioned stable tag.
 :::
 
-For the current Nightly scope, see the [GitHub issues](https://github.com/lklynet/aurral/issues). The latest **Release Readiness** issue is pinned at the top and lists what is currently in Nightly.
+For the current Nightly scope, see the [Release Readiness issues](https://github.com/lklynet/aurral/issues?q=is%3Aissue+label%3Arelease-readiness+sort%3Aupdated-desc). The latest issue is pinned at the top and lists the current Nightly candidate and included changes.
 
 ## Test a pull request preview
 

--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -27,9 +27,9 @@ services:
       - ./config:/config
 ```
 
-Replace `/srv/media` with the host directory that Lidarr already uses. Keep `:/data` as the container side of the mount if the other services use the recommended layout.
+Replace `/srv/media` with the host directory that Lidarr already uses. Keep `:/data` as the container side of the mount so every media service sees the same paths.
 
-For example, the host folder `/srv/media/downloads/aurral` is `/data/downloads/aurral` inside Aurral. Set the Downloads Folder to the container path in **Settings > Download Clients**, not to the host path.
+For example, the host folder `/srv/media/downloads/aurral` is `/data/downloads/aurral` inside Aurral. Set the Downloads Folder to the container path in **Settings > Download clients**, not to the host path.
 
 `/config` is only for Aurral. Do not share it with another service.
 
@@ -51,7 +51,7 @@ Continue with [First run](/getting-started/first-run/).
 | Tag | Contents | Use it when |
 | --- | --- | --- |
 | `latest` | The newest stable release | You want a tested release. |
-| `2.1.0`, `2.1`, `2` | An exact version, or the newest release in that line | You pin versions or need to roll back. |
+| `2.4.0`, `2.4`, `2` | An exact version, or the newest release in that line | You pin versions or need to roll back. |
 | `nightly` | Every change merged since the last release | You want fixes and features early and can report bugs. |
 | `pr-<number>` | The preview image for an open pull request | You were asked to test a proposed change. |
 
@@ -64,6 +64,8 @@ Non-stable channels also mark the sidebar.
 
 Nightly images currently support `linux/amd64` only. On ARM, use `latest` or a versioned stable tag.
 :::
+
+For the current Nightly scope, see the [GitHub issues](https://github.com/lklynet/aurral/issues). The latest **Release Readiness** issue is pinned at the top and lists what is currently in Nightly.
 
 ## Test a pull request preview
 

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -21,20 +21,21 @@ Complete [Filesystem and mounts](/getting-started/storage/) first. The short ver
 2. Open **Settings > Lidarr**.
 3. Enter the Lidarr URL that Aurral can reach. In one Docker Compose network this is often `http://lidarr:8686`.
 4. Enter the Lidarr API key and select **Test connection**.
-5. Open **Settings > Download Clients**.
+5. Open **Settings > Download clients**.
 6. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
-7. Open **Settings > System**, select **Run Checks** under **Storage Health**, and fix failed checks.
+7. Open **Settings > Storage health**, select **Run Checks**, and fix failed checks.
 8. Open **Settings > Lidarr** and select **Test library access**.
 9. Connect the download clients and playback server that you use. Navidrome and Plex are optional
-   destinations. Aurral can play indexed media in the app when the canonical file is readable.
+   destinations. Aurral can play indexed media in the built-in player when the canonical file is readable.
 
 The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral
 can read the files and write the Downloads Folder. The **Aurral-native playback** check reports
-whether indexed media is ready to play.
+whether indexed media is ready to play. The built-in Subsonic service is available at `/rest` for
+compatible external players.
 
 ## Configure the other services
 
-- **Download clients:** Open **Settings > Download Clients**. Connect slskd, SABnzbd, or NZBGet and make sure their completed path is under the shared media mount. The built-in yt-dlp source needs no separate service.
+- **Download clients:** Open **Settings > Download clients**. Connect slskd, SABnzbd, or NZBGet and make sure their completed path is under the shared media mount. The built-in yt-dlp source needs no separate service.
 - **Navidrome:** Open **Settings > Playback > Navidrome** and connect it. Aurral creates its playlist library when a flow or playlist produces output. See [Navidrome](/integrations/navidrome/).
 - **Plex:** Open **Settings > Playback > Plex**, connect Plex, and select **Sync to Plex now** after a flow downloads tracks. See [Plex](/integrations/plex/).
 

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -59,7 +59,7 @@ If a service uses a separate path for its own database or configuration, keep th
 1. Aurral asks a download client to find the track.
 2. The download client writes the completed file under `/data/downloads/...`.
 3. Aurral imports the file into its Downloads Folder. Permanent tracks use `artist/album/track`; flow tracks use `_flows/<flow-id>/artist/album/track`.
-4. Aurral stores playlist artwork and legacy sidecars under `aurral-weekly-flow/_playlists`. This folder is not part of the canonical Library.
+4. Aurral stores playlist artwork and sidecars under `aurral-weekly-flow/_playlists`. This folder is not part of the canonical Library.
 5. Navidrome scans the Downloads Folder and can play the tracks.
 
 If Aurral writes a file as `/data/downloads/aurral/track.flac` but Navidrome sees the same host folder as `/downloads/track.flac`, Navidrome cannot open the path in Aurral's playlist file. The API connection can still work, but the playlist will be empty or the tracks will not play. Use matching container paths, or follow [When paths cannot match](#when-paths-cannot-match).
@@ -198,10 +198,6 @@ Use these checks in order:
 4. **Playback check:** Navidrome or Plex must have the Downloads Folder in its own filesystem and must scan it.
 
 If the API check passes but the file check fails, do not change the API URL. Fix the volume mapping, permissions, or path mapping.
-
-:::note
-Upgrades from older Nightly builds migrate legacy playlist files into the canonical layout and move flow files from `.flows` to `_flows`. The migration does not change the Lidarr-owned root. Keep `/config` and the Downloads Folder backed up until the migration finishes.
-:::
 
 ## When paths cannot match
 

--- a/docs/src/content/docs/getting-started/storage.mdx
+++ b/docs/src/content/docs/getting-started/storage.mdx
@@ -59,7 +59,7 @@ If a service uses a separate path for its own database or configuration, keep th
 1. Aurral asks a download client to find the track.
 2. The download client writes the completed file under `/data/downloads/...`.
 3. Aurral imports the file into its Downloads Folder. Permanent tracks use `artist/album/track`; flow tracks use `_flows/<flow-id>/artist/album/track`.
-4. Aurral writes playlist sidecars under `aurral-weekly-flow/_playlists`.
+4. Aurral stores playlist artwork and legacy sidecars under `aurral-weekly-flow/_playlists`. This folder is not part of the canonical Library.
 5. Navidrome scans the Downloads Folder and can play the tracks.
 
 If Aurral writes a file as `/data/downloads/aurral/track.flac` but Navidrome sees the same host folder as `/downloads/track.flac`, Navidrome cannot open the path in Aurral's playlist file. The API connection can still work, but the playlist will be empty or the tracks will not play. Use matching container paths, or follow [When paths cannot match](#when-paths-cannot-match).
@@ -88,7 +88,7 @@ Choose one directory on the Docker host as the media root. The example uses `/sr
     \-- aurral/                     # Aurral Downloads Folder
         |-- Artist/Album/track      # permanent canonical tracks
         |-- _flows/flow-id/...      # temporary flow tracks
-        \-- aurral-weekly-flow/     # playlist sidecars
+        \-- aurral-weekly-flow/     # playlist sidecars and artwork
 ```
 
 Use the same host directory in every media-service mount:
@@ -158,7 +158,7 @@ After you add the mounts, use the container paths shown below.
 | Lidarr | Root folder | `/data/music` |
 | slskd | Completed download folder | `/data/downloads/slskd/complete` |
 | SABnzbd or NZBGet | Completed download folder | `/data/downloads/usenet/complete` |
-| Aurral | **Settings > Download Clients > Downloads Folder > Path** | `/data/downloads/aurral` |
+| Aurral | **Settings > Download clients > Downloads Folder > Path** | `/data/downloads/aurral` |
 | Navidrome | Aurral library | Aurral creates `/data/downloads/aurral` through the API. |
 | Plex | Aurral library | Aurral creates the library through the API at the path Plex uses for the Aurral Downloads Folder. |
 
@@ -170,16 +170,16 @@ The exact download-client folder names are not important. The important rules ar
 
 ## Setup order
 
-Follow this order. It makes each filesystem connection easy to check.
+Follow this order so you can check each filesystem connection separately.
 
 1. Choose the host media root, such as `/srv/media`.
 2. Mount that same host directory in Aurral, Lidarr, every download client, and the playback server you use.
 3. Use `/data/...` paths inside the containers. Set the Lidarr root folder and the completed download folders.
 4. Start the services.
 5. In Aurral, open **Settings > Lidarr**, enter the URL and API key, and select **Test connection**.
-6. In Aurral, open **Settings > Download Clients** and set **Downloads Folder > Path** to a writable folder under `/data`, such as `/data/downloads/aurral`.
+6. In Aurral, open **Settings > Download clients** and set **Downloads Folder > Path** to a writable folder under `/data`, such as `/data/downloads/aurral`.
 7. Connect and test each download client that you use.
-8. Open **Settings > System > Storage Health** and select **Run Checks**. Fix any failed library, download, or transfer check.
+8. Open **Settings > Storage health** and select **Run Checks**. Fix any failed library, download, or transfer check.
 9. Open **Settings > Playback**, connect Navidrome or Plex, and follow the path rules below.
 
 ## Verify the two connections
@@ -187,7 +187,7 @@ Follow this order. It makes each filesystem connection easy to check.
 Use these checks in order:
 
 1. **API check:** each integration's **Test connection** button must pass.
-2. **File check:** **Settings > Lidarr > Test library access** and **Settings > System > Storage Health** must be able to read the paths.
+2. **File check:** **Settings > Lidarr > Test library access** and **Settings > Storage health** must be able to read the paths.
 3. **Output check:** after a flow or playlist downloads a track, the file must exist under:
 
    ```text
@@ -199,13 +199,17 @@ Use these checks in order:
 
 If the API check passes but the file check fails, do not change the API URL. Fix the volume mapping, permissions, or path mapping.
 
+:::note
+Upgrades from older Nightly builds migrate legacy playlist files into the canonical layout and move flow files from `.flows` to `_flows`. The migration does not change the Lidarr-owned root. Keep `/config` and the Downloads Folder backed up until the migration finishes.
+:::
+
 ## When paths cannot match
 
 Different container paths can work, but each mismatch needs its own setting. A path mapping translates a path; it does not mount a folder or grant access to it.
 
 ### Paths reported by Lidarr or download clients
 
-Use **Settings > Download Clients > Remote Path Mappings**. Enter:
+Use **Settings > Download clients > Remote Path Mappings**. Enter:
 
 - **Remote Path**: the absolute path reported by the other application.
 - **Local Path**: the path for the same folder inside Aurral.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: Install, configure, and use Aurral.
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Aurral is a self-hosted companion for music discovery. It adds recommendations, requests, flows, and playlist downloads to a Lidarr-based music stack.
+Aurral is a self-hosted companion for music discovery and playback. It connects to Lidarr for library management, adds recommendations and requests, and downloads tracks for flows and imported playlists.
 
 ![Aurral Discover page](../../assets/screenshots/discover.webp)
 
@@ -16,11 +16,15 @@ Aurral is a self-hosted companion for music discovery. It adds recommendations, 
 3. [Complete first-run setup](/getting-started/first-run/).
 4. Connect the services that you use.
 
+:::note
+This release documents the Lidarr-connected workflow. Separate Aurral-only and split-root ownership modes are planned for a later release.
+:::
+
 ## How Aurral fits
 
 **Discover. Download. Listen.**
 
-Aurral manages discovery and generated playlists. Lidarr stores the permanent library state. Navidrome or Plex can play the audio files.
+Aurral reads your Lidarr library and keeps a canonical index of readable music. It manages flows and static playlists, and it can play canonical tracks in its built-in player. Navidrome, Plex, and Subsonic clients are optional playback destinations.
 
 ## Essential guides
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -3,7 +3,7 @@ title: Lidarr
 description: Connect Lidarr for library management, requests, and library file access.
 ---
 
-Aurral requires Lidarr. Aurral adds artists and albums, reads library state, and shows queue and history status through Lidarr.
+Aurral requires Lidarr in this release. Aurral adds artists and albums, reads library state, and shows queue and history status through Lidarr. Separate Aurral-only and split-root ownership modes are not part of this release.
 
 The Lidarr integration has two parts:
 
@@ -35,7 +35,9 @@ The check samples a track from an artist inside a root folder. It falls back to 
 
 After Lidarr imports a file, Aurral watches the configured Lidarr root folders
 and queues a canonical library scan. Aurral does not need a second import step
-in Lidarr. The file must still be readable at the path Lidarr reports.
+in Lidarr. The file must still be readable at the path Lidarr reports. The
+canonical Library uses the MusicBrainz and provider identities that Aurral reads
+from the file and from Lidarr.
 
 ## Request availability notifications
 
@@ -61,7 +63,7 @@ for a path mismatch.
 
 See [Library access fails on a folder that is not your root folder](/admin/troubleshooting/#library-access-fails-on-a-folder-that-is-not-your-root-folder).
 
-In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports. If that path differs from the path inside Aurral, add a mapping under **Settings > Download Clients > Remote Path Mappings** with **Source** set to **Lidarr**.
+In mixed Windows and Docker setups, **Test library access** shows the exact path that Lidarr reports. If that path differs from the path inside Aurral, add a mapping under **Settings > Download clients > Remote Path Mappings** with **Source** set to **Lidarr**.
 
 This mapping only helps Aurral read Lidarr files. Navidrome must scan the corresponding Lidarr music folder before Aurral can add a reused song to an API playlist. See [Path mismatches](/getting-started/storage/#when-paths-cannot-match).
 

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -1,11 +1,11 @@
 ---
-title: Navidrome
-description: Connect Navidrome to play Aurral downloads and generated playlists.
+title: Navidrome and Subsonic
+description: Use Aurral's native Subsonic service or connect Navidrome for playback and playlists.
 ---
 
-Navidrome is optional. Aurral can browse and play indexed media in the app without Navidrome when the canonical file is readable. Aurral
-also creates and updates Navidrome playlists through the Subsonic API when Navidrome is configured.
-Navidrome must be able to read and scan the Aurral download tree for that destination.
+Navidrome is optional. Aurral can browse and play indexed media in the built-in player when the canonical file is readable. Aurral also exposes its own authenticated Subsonic service for compatible clients.
+
+Connect Navidrome when you want Navidrome's server, scanner, or ecosystem. Aurral creates and updates Navidrome playlists through the Subsonic API when Navidrome is configured. Navidrome must be able to read and scan the Aurral download tree for that destination.
 
 This is a filesystem connection as well as an API connection. A successful **Test connection** only proves that Aurral can reach the Navidrome API.
 
@@ -13,7 +13,7 @@ Aurral also exposes an authenticated Subsonic server at `/rest/*.view`. It suppo
 
 When a Subsonic client adds a Flow or shared-playlist entry to a playlist, Aurral stores a reference to one canonical library acquisition job. The acquisition runs in the background. Multiple playlists that add the same track share that job. Removing a playlist entry removes only that playlist reference. It does not delete the canonical media file.
 
-Favoriting a Flow or shared-playlist entry uses the same canonical acquisition by default. To keep the favorite without acquiring the track, turn off **Favorite Flow tracks** in **Settings > System > Subsonic**. This setting does not change favorites for tracks that already exist in the canonical library.
+Favoriting a Flow or shared-playlist entry uses the same canonical acquisition by default. To keep the favorite without acquiring the track, turn off **Favorite Flow tracks** in **Settings > System > Subsonic**. This setting does not change favorites for tracks that already exist in the canonical Library.
 
 ## Connect a Subsonic client
 
@@ -31,7 +31,7 @@ Aurral exposes `scrobblingEnabled=true` from `getuser.view`. This reports that t
 
 The built-in Aurral player records completed library tracks through the same local play-event path. Aurral keeps local history when Last.fm, ListenBrainz, or Koito is unavailable.
 
-## Navidrome-compatible scrobbling
+## Scrobbling without Navidrome
 
 Open **Settings > Playback > Scrobbling** to connect Last.fm or ListenBrainz. Aurral copies
 Navidrome's provider flows directly, so a Navidrome connection is not required for scrobbling.
@@ -39,7 +39,7 @@ Navidrome's provider flows directly, so a Navidrome connection is not required f
 Aurral uses the Last.fm API key and API secret from **Settings > Connect > Last.fm**. It validates
 ListenBrainz tokens directly. Completed plays are submitted from Aurral to the selected provider.
 
-Navidrome remains an independent playback and playlist destination.
+Navidrome remains an independent playback and playlist destination. Aurral's built-in player and native Subsonic clients use the same local play history.
 
 See [Filesystem and mounts](/getting-started/storage/) for the complete layout. The recommended Docker setup mounts the same host media root at `/data` in Aurral and Navidrome:
 
@@ -57,7 +57,7 @@ volumes:
 ## Setup
 
 1. Mount the same media root in Aurral and Navidrome at the same container path.
-2. Set Aurral's **Settings > Download Clients > Downloads Folder > Path** to a folder under that path, for example `/data/downloads/aurral`.
+2. Set Aurral's **Settings > Download clients > Downloads Folder > Path** to a folder under that path, for example `/data/downloads/aurral`.
 3. Make sure Navidrome can read both `/data/music` and `/data/downloads/aurral` if you want to play reused Lidarr tracks as well as new Aurral downloads.
 4. Open **Settings > Playback > Navidrome** in Aurral.
 5. Enter the Navidrome URL, username, and password. Select **Test connection**, then save.
@@ -74,7 +74,7 @@ installations migrate the old `.flows` directory to `_flows` at startup.
 
 You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
 
-Navidrome must have permission to manage libraries through its API. If Aurral cannot create the library, use **Settings > System > Storage Health** for the exact path and error, then check the Navidrome account permissions and mount.
+Navidrome must have permission to manage libraries through its API. If Aurral cannot create the library, use **Settings > Storage health** for the exact path and error, then check the Navidrome account permissions and mount.
 
 ## Existing Lidarr library
 
@@ -119,7 +119,7 @@ To roll back, stop Aurral and deploy the previous exact image. Restore the previ
 
 ## Remove missing tracks
 
-For Weekly Flow, set this Navidrome environment variable:
+For Navidrome, set this environment variable if you want it to remove old files:
 
 ```bash
 ND_SCANNER_PURGEMISSING=always

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -33,8 +33,8 @@ The built-in Aurral player records completed library tracks through the same loc
 
 ## Scrobbling without Navidrome
 
-Open **Settings > Playback > Scrobbling** to connect Last.fm or ListenBrainz. Aurral copies
-Navidrome's provider flows directly, so a Navidrome connection is not required for scrobbling.
+Open **Settings > Playback > Scrobbling** to connect Last.fm or ListenBrainz. Aurral submits
+provider events directly, so a Navidrome connection is not required for scrobbling.
 
 Aurral uses the Last.fm API key and API secret from **Settings > Connect > Last.fm**. It validates
 ListenBrainz tokens directly. Completed plays are submitted from Aurral to the selected provider.
@@ -69,8 +69,7 @@ Aurral creates the **Aurral Playlists** library at the Downloads Folder root:
 /data/downloads/aurral
 ```
 
-Flow files live under `_flows`, which is visible to Navidrome scanners. Existing
-installations migrate the old `.flows` directory to `_flows` at startup.
+Flow files live under `_flows`, which is visible to Navidrome scanners.
 
 You do not normally need to create this library manually in Navidrome. The library can be empty until a track finishes downloading. Wait for the scan after the first completed track.
 
@@ -101,22 +100,6 @@ If a new track is not indexed, Aurral leaves it out until Navidrome scans it; it
 - run a Navidrome scan or save the Aurral Navidrome settings;
 - wait for the scan to finish.
 
-## Upgrade from M3U playlists
-
-Aurral adopts a matching Navidrome playlist that was imported from an old M3U file. It keeps the native playlist ID, updates its ordered tracks through the API, and then removes the legacy file. It also removes obsolete duplicate names.
-
-If the old file is already gone, Aurral can recover the imported playlist from Navidrome's import comment during its next playlist publish. It also rejects an imported playlist whose comment belongs to a different Aurral playlist.
-
-If migration does not finish:
-
-1. Keep the existing Navidrome playlist and M3U file.
-2. Make sure that Navidrome has indexed every track.
-3. Run a full Navidrome scan.
-4. Edit and save the Aurral playlist to retry migration.
-5. Confirm that the same Navidrome playlist updates and the legacy file disappears.
-
-To roll back, stop Aurral and deploy the previous exact image. Restore the previous Aurral data and legacy playlist files from the same backup. Do not delete or rename the Navidrome playlist before recovery completes.
-
 ## Remove missing tracks
 
 For Navidrome, set this environment variable if you want it to remove old files:
@@ -125,7 +108,7 @@ For Navidrome, set this environment variable if you want it to remove old files:
 ND_SCANNER_PURGEMISSING=always
 ```
 
-This removes old flow entries after a flow changes.
+This removes any missing Navidrome files, including flow entries, after a scan.
 
 :::caution
 `ND_SCANNER_PURGEMISSING=always` also removes other missing Navidrome files. It can remove their ratings, play counts, and playlist entries. Use it only when missing files will not return.

--- a/docs/src/content/docs/integrations/notifications.mdx
+++ b/docs/src/content/docs/integrations/notifications.mdx
@@ -3,13 +3,13 @@ title: Notifications (Gotify and webhooks)
 description: Get alerts when flows finish, discovery updates, and album requests change.
 ---
 
-Aurral can send a notification when a flow download completes. It can also send one when daily recommendations are ready, when a user requests an album, and when that album becomes available.
+Aurral can send a notification when a Flow download completes. It can also send one when daily recommendations are ready, when a user requests an album, and when that album becomes available.
 
 Two delivery methods are available. You can use one or both.
 
 ## Gotify
 
-Gotify is a self-hosted push notification server. Configure it in **Settings > Connect**.
+Gotify is a self-hosted push notification server. Configure it in **Settings > Connect**. Gotify and webhooks have separate event toggles, so configure each delivery method independently.
 
 Enter these values:
 - **Server URL**: the base URL Aurral can reach (for example, `http://gotify:8888` in Docker)

--- a/docs/src/content/docs/integrations/plex.mdx
+++ b/docs/src/content/docs/integrations/plex.mdx
@@ -57,7 +57,7 @@ Set **Plex Aurral Library path** if Plex uses a different mount prefix than Aurr
 
 Enter the Downloads Folder as Plex sees it. Aurral uses that path as the library root.
 
-Aurral also adds the `_flows` directory as an explicit second Plex library location. It keeps the legacy `.flows` location during migration.
+Aurral also adds the `_flows` directory as an explicit second Plex library location.
 
 | Aurral writes to            | Plex sees                      | Plex Aurral Library path |
 | --------------------------- | ------------------------------ | ------------------------- |

--- a/docs/src/content/docs/integrations/slskd.mdx
+++ b/docs/src/content/docs/integrations/slskd.mdx
@@ -10,22 +10,22 @@ slskd downloads flow and playlist tracks from Soulseek. Aurral can also use [Use
 ## Setup
 
 1. Mount the same media root in Aurral and slskd at the same container path. See [Filesystem and mounts](/getting-started/storage/).
-2. Connect slskd in **Settings > Download Clients > slskd**.
+2. Connect slskd in **Settings > Download clients > slskd**.
 
 Aurral uses the slskd API and reads the completed files from the path slskd reports. It then moves those files into your Downloads Folder path.
 
 If slskd runs on Windows and reports host paths, mount the parent folder into Aurral. For example, slskd can report `N:\...`.
 
-Then, add a path mapping under **Settings > Download Clients > Remote Path Mappings**.
+Then, add a path mapping under **Settings > Download clients > Remote Path Mappings**.
 
 ## Worker settings
 
-Open the **slskd** card in **Settings > Download Clients**. Set these options:
+Open the **slskd** card in **Settings > Download clients**. Set these options:
 
 - **Source priority**: order relative to Usenet (default `10`)
 - **Clean up after runs**: clear completed slskd jobs when a flow or playlist run finishes
 
-Use **Settings > Download Clients > Quality Profile** to select and order FLAC, MP3, and M4A quality tiers. Aurral uses this profile for new downloads and upgrades. See [Playlists: Quality profile](/using/playlists/#quality-profile).
+Use **Settings > Download clients > Quality profile** to select and order FLAC, MP3, and M4A quality tiers. Aurral uses this profile for new downloads and upgrades. See [Playlists: Quality profile](/using/playlists/#quality-profile).
 
 slskd can supply both missing tracks and upgrades. Aurral reads the completed file before it accepts the quality.
 

--- a/docs/src/content/docs/integrations/usenet.mdx
+++ b/docs/src/content/docs/integrations/usenet.mdx
@@ -9,7 +9,7 @@ Aurral treats each download client equally. You must configure only one download
 
 Enable and connect both components:
 
-- The download client in **Settings > Download Clients**
+- The download client in **Settings > Download clients**
 - Prowlarr in **Settings > Indexers**
 
 ## Setup overview
@@ -24,7 +24,7 @@ Enable and connect both components:
 8. Select **Refresh indexers**.
 9. Enable each indexer.
 10. Set the priority for each indexer.
-11. Open **Settings > Download Clients**.
+11. Open **Settings > Download clients**.
 12. Enable **SABnzbd** or **NZBGet**.
 13. Enter the URL and credentials.
 14. Select **Test connection**.
@@ -71,7 +71,7 @@ Aurral monitors NZBGet until the download is complete. Aurral then imports the b
 
 If NZBGet runs on Windows and reports host paths, mount the parent folder into Aurral.
 
-Then, add a path mapping under **Settings > Download Clients > Remote Path Mappings**.
+Then, add a path mapping under **Settings > Download clients > Remote Path Mappings**.
 
 Aurral can find a track with an incorrect duration. Aurral retains this track under **Activity > Queue**.
 
@@ -79,7 +79,7 @@ You can preview, approve, or deny the track.
 
 ## Quality and upgrades
 
-Use **Settings > Download Clients > Quality Profile** to set acceptable quality tiers and the preferred cutoff. Aurral reads the completed audio file before it accepts the quality. A quality rejection does not go to Queue review.
+Use **Settings > Download clients > Quality profile** to set acceptable quality tiers and the preferred cutoff. Aurral reads the completed audio file before it accepts the quality. A quality rejection does not go to Queue review.
 
 Usenet can supply both missing tracks and upgrades. Upgrade searches follow the normal source priority and have a lower queue priority than missing-track downloads. See [Playlists: Track upgrades](/using/playlists/#track-upgrades).
 

--- a/docs/src/content/docs/integrations/ytdlp.mdx
+++ b/docs/src/content/docs/integrations/ytdlp.mdx
@@ -7,7 +7,7 @@ yt-dlp is the built-in fallback download source. It searches YouTube for artist 
 
 yt-dlp extracts audio with ffmpeg. Aurral stages the audio outside your media paths, validates and tags it, and then imports it into your Downloads Folder.
 
-The default staging path is `/config/_staging`. To use another disk, mount it in the Aurral container and set **Settings > Download Clients > yt-dlp > Staging path**. Keep this path outside every media-server library.
+The default staging path is `/config/_staging`. To use another disk, mount it in the Aurral container and set **Settings > Download clients > yt-dlp > Staging path**. Keep this path outside every media-server library.
 
 You do not need a separate daemon. The Docker image includes `yt-dlp` and `ffmpeg`.
 
@@ -15,7 +15,7 @@ For a bare-metal installation, install both programs on the host. Make sure that
 
 ## Setup
 
-1. Open **Settings > Download Clients > yt-dlp**.
+1. Open **Settings > Download clients > yt-dlp**.
 2. Leave **Enable yt-dlp** on (default).
 3. If necessary, set **Source priority** or **Staging path**.
 4. Select **Test connection**.
@@ -33,7 +33,7 @@ Aurral ranks results by title, artist, duration, and noise filters. It skips kar
 
 Aurral validates downloaded audio with the same track validation that it uses for other sources.
 
-Aurral also applies the global Quality Profile. It rejects the final file if its measured M4A quality is not an enabled tier.
+Aurral also applies the global quality profile. It rejects the final file if its measured M4A quality is not an enabled tier.
 
 After validation, Aurral writes the playlist's title, artist, album, album artist, year, and track number into the audio file. This metadata lets tag-based libraries such as Navidrome organize yt-dlp downloads correctly.
 

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -16,7 +16,7 @@ those two filters.
 
 ![Aurral activity timeline](../../../assets/screenshots/history.webp)
 
-Use **Queue** to see active downloads and processes. Review items stay in this list because they are queued for your decision.
+Use **Queue** to see active downloads and processes. Review items stay in this list because they are queued for your decision. A duration or identity mismatch can remain here for preview, approval, or denial.
 
 Use the review controls in **Queue** when you must listen to a track before import. Use **History** to see completed and failed events.
 
@@ -36,6 +36,6 @@ for every cutoff-unmet track in the active Wanted view.
 Use the info action on any activity or Wanted row to inspect the operation
 details without leaving the page.
 
-Album requests store the requester. Activity can show the requester, and external tools can filter requests by user.
+Album requests store the requester. Activity can show the requester, and external tools can filter requests by user. A Lidarr import webhook can also mark a requested album as available as soon as Lidarr imports it.
 
 See [yt-dlp](/integrations/ytdlp/), [slskd](/integrations/slskd/), and [Usenet](/integrations/usenet/) for download client setup.

--- a/docs/src/content/docs/using/discover.mdx
+++ b/docs/src/content/docs/using/discover.mdx
@@ -9,7 +9,7 @@ When you configure Ticketmaster, Discover also shows nearby events.
 
 ![Aurral Discover page](../../../assets/screenshots/discover.webp)
 
-Discover uses your library data. Aurral tries to recommend artists that fit your taste but are not in your library.
+Discover uses your Lidarr library, listening history, and discovery data. Aurral tries to recommend artists that fit your taste but are not in your canonical Library.
 
 ## What shapes recommendations
 
@@ -44,11 +44,13 @@ When **News** is enabled in **Settings > RSS News**, Discover shows recent stori
 
 Select the arrow on the **Artist News** section, or **News** in the sidebar, to open the full news page. Aurral refreshes enabled RSS feeds in the background and keeps recent results in the local database. If a feed does not provide an article photo, Aurral uses the available image fallback. Select the disable icon beside an article's publisher to turn that RSS feed off in **Settings > RSS News**.
 
+Select a library artist or album from a Discover card to open its canonical Library page. From there, you can play available tracks, mark items as favorites, and open the full metadata page when you need release details.
+
 ## Discover playlists
 
 Aurral can generate playlists such as Release Radar from your listening context. These playlists appear in Discover.
 
-You can add them to your Playlists library for downloads and playback.
+You can adopt them as a Flow or a static playlist for downloads and playback. An adopted playlist belongs to the user who created it.
 
 ## Per-user listening history
 

--- a/docs/src/content/docs/using/flows.mdx
+++ b/docs/src/content/docs/using/flows.mdx
@@ -134,7 +134,7 @@ When a flow runs, Aurral:
 7. Builds a reserve pool from the same run for fast replacements
 8. Sends the primary playlist into the download worker
 
-Only flows can generate replacement tracks when downloads fail. See [Playlist imports](/using/playlist-imports/) for static playlist retry behavior.
+Only flows can generate replacement tracks when downloads fail. You can save a completed flow as a static playlist, or promote an individual flow track to the permanent Library from its action menu. See [Playlist imports](/using/playlist-imports/) for static playlist retry behavior.
 
 ## Lidarr import list
 

--- a/docs/src/content/docs/using/inbox.mdx
+++ b/docs/src/content/docs/using/inbox.mdx
@@ -3,7 +3,7 @@ title: Inbox
 description: Library-based releases, shows, news, and discoveries in Aurral.
 ---
 
-The Inbox is the bell-shaped icon beside your profile menu. It is a compact update feed, not a second Discover page.
+The Inbox is the bell icon beside your profile menu. It is a compact update feed for changes that need your attention.
 
 Inbox items are private to each Aurral user. The source library is shared, but read and dismissed state is not.
 
@@ -15,7 +15,7 @@ Inbox items are private to each Aurral user. The source library is shared, but r
 - Optional recommended-artist news from RSS feeds
 - Personalized artist discoveries from Discover
 
-The green Inbox icon shows that unread items exist. Select an item to mark it as read; it stays in the Inbox with reduced emphasis. Select the checkmark to remove it. Artist and release items open their full pages, where you can decide whether to add them to Lidarr. Use the filter button to show all notifications or one category. The dropdown scrolls when there are more updates than fit on screen.
+The green Inbox icon shows that unread items exist. Select an item to mark it as read; it stays in the Inbox with reduced emphasis. Use the item actions to save, dismiss, or mark it as added. Artist and release items open their full pages, where you can decide whether to add them to Lidarr. Use the filter button to show all notifications or one category. The dropdown scrolls when there are more updates than fit on screen.
 
 ## Settings
 

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -37,11 +37,6 @@ Static playlist membership is stored by Aurral's Subsonic model, so deleting a
 playlist does not delete a canonical track. A Subsonic favorite can also
 promote a Flow track when **Favorite Flow tracks** is enabled in **Settings > System > Subsonic**.
 
-When upgrading from an older Aurral installation, the one-time migration moves
-legacy playlist-folder files into this layout and moves `.flows` files to
-`_flows`. It resumes after a restart and keeps ambiguous, partial, or failed
-items for review. It never changes the Lidarr-owned root.
-
 ## When new files appear
 
 Aurral keeps the canonical library in its own database. It scans the Aurral
@@ -52,7 +47,7 @@ to them.
 When Lidarr imports a download, or a file changes in the Aurral root, Aurral's
 filesystem watcher queues a scan. The watcher waits briefly for a file move or
 rename to finish and ignores `_playlists`, `_staging`, `_fallback`, hidden
-folders, `_flows`, the legacy `.flows` tree, and the legacy `aurral-weekly-flow` tree.
+folders, `_flows`, and `aurral-weekly-flow`.
 
 When the scan completes, an open Library page reloads its canonical records
 automatically. The home page and **Newest** album or track sorting use the time

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -19,9 +19,11 @@ albums open listening-first library pages with their tracks, playback controls,
 and favorites. Those pages link to the full Discover artist or release page
 when a canonical identifier is available. Tracks without an available file
 stay visible but cannot play; missing album tracks are shown in a muted state.
-Use the track action menu to add a library track to a playlist. The page reports
-stale library data, partial or missing files, provider health problems, and empty
-results.
+Use the track action menu to add a library track to a playlist, remove it, or
+promote an Aurral-owned track into the permanent Library. Favorites are stored
+per user and work in both the built-in player and Subsonic clients. The page
+reports stale library data, partial or missing files, provider health problems,
+and empty results.
 
 Navidrome remains optional. Lidarr remains the library provider when it is
 configured.
@@ -30,14 +32,15 @@ configured.
 
 Permanent Aurral tracks use the canonical `artist/album/track` layout under
 the configured Aurral download folder. Flow media is temporary and lives under
-`_flows`; it is not added to the canonical Library. Static playlist membership
-is stored by Aurral's Subsonic model, so deleting a playlist does not delete a
-canonical track.
+`_flows`. It is not added to the canonical Library until you promote a track.
+Static playlist membership is stored by Aurral's Subsonic model, so deleting a
+playlist does not delete a canonical track. A Subsonic favorite can also
+promote a Flow track when **Favorite Flow tracks** is enabled in **Settings > System > Subsonic**.
 
 When upgrading from an older Aurral installation, the one-time migration moves
-legacy playlist-folder files into this layout. It resumes after a restart and
-keeps ambiguous, partial, or failed items for review. It never changes the
-Lidarr-owned root.
+legacy playlist-folder files into this layout and moves `.flows` files to
+`_flows`. It resumes after a restart and keeps ambiguous, partial, or failed
+items for review. It never changes the Lidarr-owned root.
 
 ## When new files appear
 

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -3,7 +3,7 @@ title: App overview
 description: Main sections of the Aurral interface.
 ---
 
-Aurral is a Lidarr companion for music discovery. It connects to your existing library.
+Aurral is a Lidarr companion for music discovery and playback. It connects to your existing library and keeps a canonical index of readable music.
 
 ## Main sections
 
@@ -23,11 +23,11 @@ The Inbox icon beside the profile menu collects library-based release updates, n
 
 ![Aurral search results](../../../assets/screenshots/search.webp)
 
-Use Search to find artists and albums. You can preview tracks, check library status, and add items to Lidarr.
+Use Search to find artists, albums, and tags. You can preview tracks, check library status, open a canonical Library page, and add items to Lidarr.
 
 ### Library
 
-Library shows the artists in Lidarr. It includes search, sort controls, artwork, monitoring status, and artist pages.
+Library shows the canonical music index built from readable Aurral and Lidarr files. It includes search, sort controls, artwork, favorites, playable tracks, missing-file states, and artist and album pages. Artist and album actions that change the managed library still go through Lidarr.
 
 ### Playlists and Flows
 
@@ -36,7 +36,7 @@ Library shows the artists in Lidarr. It includes search, sort controls, artwork,
 Library > Playlists contains static playlists, in-app playback, and their
 download status. Flows is a separate section for scheduled discovery mixes.
 
-Flows regenerate on a schedule. Static playlists keep fixed tracklists or synchronize with Spotify, Last.fm, or ListenBrainz.
+Flows regenerate on a schedule. Static playlists keep fixed tracklists or synchronize with Spotify, Last.fm, or ListenBrainz. You can play canonical Library tracks and accessible flow or playlist tracks in Aurral. Navidrome, Plex, and other Subsonic clients are optional destinations.
 
 ### Activity
 
@@ -77,15 +77,17 @@ Settings contains the admin configuration. The page has these tabs:
 
 | Tab                  | What it covers                                                      |
 | -------------------- | ------------------------------------------------------------------- |
-| **System**           | Runtime details, date and time format, and API access                |
-| **Tasks**            | Active and stale worker task management                             |
-| **Lidarr**           | Lidarr connection, profiles, tags, library access check             |
-| **Indexers**         | Prowlarr connection, indexer management, search priorities          |
-| **Download Clients** | yt-dlp, slskd, SABnzbd, NZBGet, source priority, format preferences |
-| **Playback**         | Navidrome and Plex                                                  |
+| **System**           | Runtime details, display format, Subsonic behavior, and API access |
+| **Storage health**   | Library, download, playback, and disk checks                       |
+| **Tasks**            | Scheduled jobs and worker management                                |
+| **Lidarr**           | Lidarr connection, profiles, tags, and library access               |
+| **Indexers**         | Prowlarr connection, indexer management, and search priorities     |
+| **Download clients** | yt-dlp, slskd, SABnzbd, NZBGet, source priority, and quality        |
+| **Playback**         | Navidrome, Plex, scrobbling, and cover art                          |
 | **Discover**         | Recommendation refresh, mode, and generated playlists              |
 | **Connect**          | Gotify, webhooks, Last.fm, Ticketmaster, and Inbox                  |
-| **Users**            | Accounts and permissions                                            |
+| **RSS news**         | RSS feeds and feed groups                                           |
+| **Users**            | Accounts, permissions, and Plex links                               |
 
 Settings and Profile changes save automatically after you edit them. Connection tests and sync
 actions remain separate actions.

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -227,6 +227,6 @@ Lidarr-aware reuse requires Aurral to read the files at the paths Lidarr reports
 
 If Lidarr runs on Windows and Aurral runs in Docker, run **Test library access** in **Settings > Lidarr**.
 
-Use the reported path to add a mapping under **Settings > Download Clients > Remote Path Mappings**.
+Use the reported path to add a mapping under **Settings > Download clients > Remote Path Mappings**.
 
 Navidrome must scan the corresponding Lidarr library before Aurral can add a reused track to a Navidrome API playlist. See [Navidrome](/integrations/navidrome/#different-navidrome-paths).

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -39,16 +39,8 @@ Static playlist membership is stored as canonical track references. Aurral-owned
 permanent tracks use the canonical `artist/album/track` layout under the
 configured Aurral download folder. Set this path in **Settings > Download clients**.
 
-Flow media is temporary and lives under `_flows` below that root. Usually, the
-legacy playlist folder was:
-
-```text
-/data/downloads/aurral/aurral-weekly-flow/
-```
-
-The one-time upgrade migration moves legacy Aurral files into the canonical
-layout and moves legacy `.flows` files to `_flows`. It keeps the Lidarr-owned
-root unchanged. Navidrome and Plex can use the roots they are configured to scan.
+Flow media is temporary and lives under `_flows` below that root. Navidrome and
+Plex can use the roots they are configured to scan.
 
 See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/) for playback setup.
 

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -35,9 +35,9 @@ Flows can expose a **Lidarr import URL** so Lidarr polls the current flow trackl
 
 ## Where files go
 
-Static playlist membership is stored as canonical track references. Permanent
-Aurral tracks use the canonical `artist/album/track` layout under the configured
-Aurral download folder. Set this path in **Settings > Download Clients**.
+Static playlist membership is stored as canonical track references. Aurral-owned
+permanent tracks use the canonical `artist/album/track` layout under the
+configured Aurral download folder. Set this path in **Settings > Download clients**.
 
 Flow media is temporary and lives under `_flows` below that root. Usually, the
 legacy playlist folder was:
@@ -47,8 +47,8 @@ legacy playlist folder was:
 ```
 
 The one-time upgrade migration moves legacy Aurral files into the canonical
-layout and keeps the Lidarr-owned root unchanged. Navidrome and Plex can use
-the roots they are configured to scan.
+layout and moves legacy `.flows` files to `_flows`. It keeps the Lidarr-owned
+root unchanged. Navidrome and Plex can use the roots they are configured to scan.
 
 See [Navidrome](/integrations/navidrome/) and [Plex](/integrations/plex/) for playback setup.
 
@@ -58,7 +58,7 @@ See [Filesystem and mounts](/getting-started/storage/) for storage setup.
 
 ## Quality profile
 
-Open **Settings > Download Clients > Quality Profile** to set the audio quality rules for flows and static playlists.
+Open **Settings > Download clients > Quality profile** to set the audio quality rules for flows and static playlists.
 
 The profile is global. Only an administrator can change it.
 
@@ -85,7 +85,7 @@ The **Quality** column on the Playlists page shows the measured tier and its pro
 
 ## Track upgrades
 
-Aurral can upgrade files that it owns under the flow and static playlist folder. It does not change files from Lidarr or another external library.
+Aurral can upgrade files that it owns in the canonical Library or under `_flows`. It does not change files from Lidarr or another external library.
 
 Existing Aurral files stay available when they are below the new quality floor. Aurral replaces one only after it downloads and validates a better file. If more than one playlist uses the same file, Aurral updates all playlist references together.
 
@@ -98,7 +98,7 @@ If an upgrade search is already in the queue for a track, Aurral reports that st
 
 A user who can open the playlist can start these searches. Manual searches work when automatic upgrades are off.
 
-To schedule upgrades, enable **Automatic upgrades** in the Quality Profile. The default is off. Set the interval from 1 to 365 days. The default is 2 days for each track.
+To schedule upgrades, enable **Automatic upgrades** in the quality profile. The default is off. Set the interval from 1 to 365 days. The default is 2 days for each track.
 
 Upgrade jobs have a lower priority than missing-track downloads. Aurral uses slskd and Usenet for upgrades, in the configured source-priority order. It stops after the first source provides a valid, strictly better file. It waits for the next interval before it tries another automatic improvement for that track.
 

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -107,6 +107,18 @@ body {
   padding-inline-start: 0.75rem;
 }
 
+site-search dialog .dialog-frame > div:not(.search-container) {
+  max-width: 36rem;
+  padding: 2rem;
+  color: var(--sl-color-gray-1);
+  line-height: 1.5;
+  text-align: center;
+}
+
+site-search dialog .dialog-frame > div:not(.search-container) p {
+  margin: 0;
+}
+
 main > .content-panel + .content-panel {
   border-top: 0;
 }


### PR DESCRIPTION
## What changed

Updated the documentation across administration, API, setup, integrations, and usage guides to reflect current Nightly behavior, including canonical library storage, built-in playback, Subsonic support, scrobbling, migration guidance, endpoint coverage, and current navigation labels.

## Why

The documentation had outdated workflows, paths, settings labels, release examples, and API coverage. These updates align the published guides with the current Nightly release and clarify supported integrations and migration expectations.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

Reviewed the documentation diff for consistency across setup, storage, integration, API, and usage guides. No automated tests were run because this change only updates documentation.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API endpoint reference, including authentication, library, favorites, playback, scrobbling, and Subsonic routes.
  * Clarified storage layouts, downloads, path mappings, backups, and storage-health checks.
  * Updated setup and integration guidance for Docker, Lidarr, Navidrome, Plex, download clients, notifications, and yt-dlp.
  * Added guidance for playback, canonical libraries, playlists, Flows, Discover, Inbox, favorites, and Activity.
  * Documented current settings labels, supported workflows, playlist handling, and library-management behavior.

* **Style**
  * Improved styling and readability for additional content in site search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->