### PR TITLE
fix(playback): preserve playlists during nightly refresh

### DIFF
--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -336,6 +336,33 @@ test("loads the complete indexed song list in pages", async () => {
   ]);
 });
 
+test("reuses one native login while paging the song index", async () => {
+  const originalFetch = globalThis.fetch;
+  let loginCount = 0;
+  globalThis.fetch = async (url) => {
+    const request = new URL(url);
+    if (request.pathname === "/auth/login") {
+      loginCount += 1;
+      return jsonResponse({ token: "native-token" });
+    }
+    const start = Number(request.searchParams.get("_start"));
+    return jsonResponse(start < 5_000
+      ? Array.from({ length: 1_000 }, (_, index) => ({ id: `song-${start + index}` }))
+      : [{ id: "last-song" }]);
+  };
+
+  let songs;
+  try {
+    songs = await new NavidromeClient("http://navidrome.test", "user", "password")
+      ._getIndexedSongs();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(songs.length, 5_001);
+  assert.equal(loginCount, 1);
+});
+
 test("uploads playlist artwork through the native API", async () => {
   const originalFetch = globalThis.fetch;
   const requests = [];

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -255,6 +255,33 @@ test("uses an indexed path without metadata matching", async () => {
   assert.equal(song.id, "path-match");
 });
 
+test("matches Navidrome-relative paths under the configured library root", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._nativeRequest = async () => [
+    { id: "music-library", name: "Music Library", path: "/data/music" },
+    { id: "aurral-song", name: "Aurral Playlists", path: "/data/downloads/aurral" },
+  ];
+  await client.ensureWeeklyFlowLibrary("/data/downloads/aurral");
+  client._getIndexedSongs = async () => [{
+    id: "relative-match",
+    path: "The Rapture/Echoes/Echoes.flac",
+  }, {
+    id: "music-relative-match",
+    path: "Black Lips/Good Bad Not Evil/Black Lips_Good Bad Not Evil_08_Bad Kids.flac",
+  }];
+
+  const song = await client.findSong("Echoes", "The Rapture", {
+    path: "/data/downloads/aurral/The Rapture/Echoes/Echoes.flac",
+  });
+
+  assert.equal(song.id, "relative-match");
+  const musicSong = await client.findSong("Bad Kids", "Black Lips", {
+    path: "/data/music/Black Lips/Good Bad Not Evil/Black Lips_Good Bad Not Evil_08_Bad Kids.flac",
+  });
+
+  assert.equal(musicSong.id, "music-relative-match");
+});
+
 test("does not match a path suffix from another library", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [{

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -381,6 +381,60 @@ test("reuses one native login while paging the song index", async () => {
   assert.equal(loginCount, 1);
 });
 
+test("refreshes a cached native token after a 401", async () => {
+  const originalFetch = globalThis.fetch;
+  let loginCount = 0;
+  let requestCount = 0;
+  globalThis.fetch = async (url, options = {}) => {
+    const request = new URL(url);
+    if (request.pathname === "/auth/login") {
+      loginCount += 1;
+      return jsonResponse({ token: loginCount === 1 ? "stale-token" : "fresh-token" });
+    }
+    requestCount += 1;
+    if (requestCount === 1) return new Response(null, { status: 401 });
+    assert.equal(options.headers["X-ND-Authorization"], "Bearer fresh-token");
+    return jsonResponse({ ok: true });
+  };
+
+  try {
+    const client = new NavidromeClient("http://navidrome.test", "user", "password");
+    assert.deepEqual(await client._nativeRequest("GET", "/api/library"), { ok: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(loginCount, 2);
+  assert.equal(requestCount, 2);
+});
+
+test("refreshes a cached native token after a 401 during artwork upload", async () => {
+  const originalFetch = globalThis.fetch;
+  let loginCount = 0;
+  let artworkAttempts = 0;
+  globalThis.fetch = async (url, options = {}) => {
+    const request = new URL(url);
+    if (request.pathname === "/auth/login") {
+      loginCount += 1;
+      return jsonResponse({ token: loginCount === 1 ? "stale-token" : "fresh-token" });
+    }
+    artworkAttempts += 1;
+    if (artworkAttempts === 1) return new Response(null, { status: 401 });
+    assert.equal(options.headers["X-ND-Authorization"], "Bearer fresh-token");
+    return new Response(null, { status: 204 });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .uploadPlaylistArtwork("playlist-1", Buffer.from("image"));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(loginCount, 2);
+  assert.equal(artworkAttempts, 2);
+});
+
 test("uploads playlist artwork through the native API", async () => {
   const originalFetch = globalThis.fetch;
   const requests = [];

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -282,6 +282,24 @@ test("matches Navidrome-relative paths under the configured library root", async
   assert.equal(musicSong.id, "music-relative-match");
 });
 
+test("prefers an exact absolute path over an earlier relative match", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._libraryPaths = ["/data/music"];
+  client._getIndexedSongs = async () => [{
+    id: "relative-match",
+    path: "Artist/Album/track.flac",
+  }, {
+    id: "exact-match",
+    path: "/data/music/Artist/Album/track.flac",
+  }];
+
+  const song = await client.findSong("Track", "Artist", {
+    path: "/data/music/Artist/Album/track.flac",
+  });
+
+  assert.equal(song.id, "exact-match");
+});
+
 test("does not match a path suffix from another library", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [{

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -702,14 +702,20 @@ test("publishes resolved songs and catches up when Navidrome indexes the rest", 
       { path: "/music/missing.flac", title: "Missing", artist: "Artist" },
     ],
   });
+  const scheduleCatchup = destination._scheduleCatchup.bind(destination);
+  let scheduleCalls = 0;
+  destination._scheduleCatchup = () => {
+    scheduleCalls += 1;
+  };
 
   await destination.publishPlaylist(snapshot);
   await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
+  assert.equal(scheduleCalls, 1);
   assert.deepEqual(client.calls.created, [
     { name: "Catch-up", songIds: ["ready-song"] },
   ]);
   songs.Missing = { id: "missing-song" };
-  destination._scheduleCatchup([0]);
+  scheduleCatchup([0]);
   while (destination._catchupRunning) await new Promise((resolve) => setTimeout(resolve, 1));
 
   assert.deepEqual(client.calls.updated, [

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -307,7 +307,7 @@ test("creates an empty API playlist without waiting for a scan", async () => {
   assert.deepEqual(client.calls.created, [{ name: "Empty", songIds: [] }]);
 });
 
-test("clears an existing API playlist while a new run has no indexed tracks", async () => {
+test("preserves an existing API playlist while a new run has no indexed tracks", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Refreshing" });
   const client = createClient({
     playlists: [{ id: "saved-id", name: "Refreshing" }],
@@ -322,13 +322,11 @@ test("clears an existing API playlist while a new run has no indexed tracks", as
     createPlaybackPlaylistSnapshot({
       entityId: playlist.id,
       displayName: playlist.name,
-      tracks: [],
+      tracks: [{ path: "/music/song.flac", title: "Song", artist: "Artist" }],
     }),
   );
 
-  assert.deepEqual(client.calls.updated, [
-    { id: "saved-id", name: "Refreshing", songIds: [] },
-  ]);
+  assert.deepEqual(client.calls.updated, []);
   assert.deepEqual(client.calls.created, []);
 });
 
@@ -519,7 +517,7 @@ test("replaces a pointer whose imported source belongs to another entity", async
   assert.equal(navidromePlaylistPointerStore.getPointer(original.id, "global"), null);
 });
 
-test("clears a stored playlist during rename cleanup until tracks resolve", async () => {
+test("preserves a stored playlist during rename cleanup until tracks resolve", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed" });
   const client = createClient({
     playlists: [{ id: "imported-id", name: "Legacy Rename Fixture" }],
@@ -551,7 +549,6 @@ test("clears a stored playlist during rename cleanup until tracks resolve", asyn
   await destination.publishPlaylist(snapshot);
 
   assert.deepEqual(client.calls.updated, [
-    { id: "imported-id", name: "Renamed", songIds: [] },
     { id: "imported-id", name: "Renamed", songIds: ["song-1"] },
   ]);
   assert.equal(
@@ -560,7 +557,7 @@ test("clears a stored playlist during rename cleanup until tracks resolve", asyn
   );
 });
 
-test("clears an unclaimed imported playlist during rename cleanup until tracks resolve", async () => {
+test("preserves an unclaimed imported playlist during rename cleanup until tracks resolve", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed without pointer" });
   const client = createClient({
     playlists: [{ id: "unclaimed-id", name: "Legacy Unclaimed Fixture" }],
@@ -584,7 +581,6 @@ test("clears an unclaimed imported playlist during rename cleanup until tracks r
   await destination.publishPlaylist(snapshot);
 
   assert.deepEqual(client.calls.updated, [
-    { id: "unclaimed-id", name: "Renamed without pointer", songIds: [] },
     { id: "unclaimed-id", name: "Renamed without pointer", songIds: ["song-1"] },
   ]);
   assert.equal(
@@ -593,7 +589,7 @@ test("clears an unclaimed imported playlist during rename cleanup until tracks r
   );
 });
 
-test("renames and clears an imported playlist before unresolved tracks are ready", async () => {
+test("renames but preserves an imported playlist before unresolved tracks are ready", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Renamed immediately" });
   const client = createClient({
     playlists: [{ id: "rename-first-id", name: "Legacy Rename First" }],
@@ -616,9 +612,7 @@ test("renames and clears an imported playlist before unresolved tracks are ready
   assert.deepEqual(client.calls.renamed, [
     { id: "rename-first-id", name: "Renamed immediately" },
   ]);
-  assert.deepEqual(client.calls.updated, [
-    { id: "rename-first-id", name: "Renamed immediately", songIds: [] },
-  ]);
+  assert.deepEqual(client.calls.updated, []);
   assert.equal(
     navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
     "rename-first-id",

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -724,6 +724,72 @@ test("publishes resolved songs and catches up when Navidrome indexes the rest", 
   await assert.rejects(fs.access(path.join(destination.libraryRoot, "Catch-up.m3u")));
 });
 
+test("serializes playlist deletion behind an in-flight catch-up", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Delete during catch-up" });
+  const songs = { Ready: { id: "ready-song" } };
+  const client = createClient({ songs });
+  const events = [];
+  const updatePlaylist = client.updatePlaylist.bind(client);
+  const deletePlaylist = client.deletePlaylist.bind(client);
+  client.updatePlaylist = async (...args) => {
+    events.push("update");
+    return updatePlaylist(...args);
+  };
+  client.deletePlaylist = async (...args) => {
+    events.push("delete");
+    return deletePlaylist(...args);
+  };
+  let releaseLookup;
+  const lookupGate = new Promise((resolve) => {
+    releaseLookup = resolve;
+  });
+  let lookupStartedResolve;
+  const lookupStarted = new Promise((resolve) => {
+    lookupStartedResolve = resolve;
+  });
+  let lookupStartedDone = false;
+  lookupStarted.then(() => {
+    lookupStartedDone = true;
+  });
+  let blockMissing = false;
+  client.findSong = async (title) => {
+    if (title === "Missing" && blockMissing) {
+      blockMissing = false;
+      lookupStartedResolve();
+      await lookupGate;
+    }
+    return songs[title] || null;
+  };
+  const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  const scheduleCatchup = destination._scheduleCatchup.bind(destination);
+  destination._scheduleCatchup = () => {};
+  const snapshot = createPlaybackPlaylistSnapshot({
+    entityId: playlist.id,
+    displayName: playlist.name,
+    tracks: [
+      { path: "/music/ready.flac", title: "Ready", artist: "Artist" },
+      { path: "/music/missing.flac", title: "Missing", artist: "Artist" },
+    ],
+  });
+
+  await destination.publishPlaylist(snapshot);
+  destination._scheduleCatchup = scheduleCatchup;
+  songs.Missing = { id: "missing-song" };
+  blockMissing = true;
+  scheduleCatchup([0]);
+  while (!lookupStartedDone) await new Promise((resolve) => setTimeout(resolve, 1));
+
+  const deletePromise = destination.deletePlaylist(snapshot);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(events, []);
+  releaseLookup();
+
+  assert.deepEqual(await deletePromise, { ok: true });
+  while (destination._catchupRunning) await new Promise((resolve) => setTimeout(resolve, 1));
+  assert.deepEqual(events, ["update", "delete"]);
+  assert.equal(navidromePlaylistPointerStore.getPointer(playlist.id, "global"), null);
+});
+
 test("updates a stored playlist ID without relying on the playlist list", async () => {
   const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Stored" });
   const client = createClient({ songs: { Song: { id: "song-1" } } });

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -106,12 +106,17 @@ export class NavidromeClient {
       .filter((libraryPath) => normalizedPath.startsWith(`${libraryPath}/`))
       .map((libraryPath) => normalizedPath.slice(libraryPath.length + 1));
     const indexedSongs = await this._getIndexedSongs();
-    const matchesPath = (song) => {
-      const songPath = normalizeLibraryPath(song.path).toLowerCase();
-      return songPath && (normalizedPath === songPath || relativePaths.includes(songPath));
-    };
-    const pathMatch = normalizedPath ? indexedSongs.find(matchesPath) : null;
-    if (pathMatch) return pathMatch;
+    const normalizeSongPath = (song) => normalizeLibraryPath(song.path).toLowerCase();
+    const exactPathMatch = normalizedPath
+      ? indexedSongs.find((song) => normalizeSongPath(song) === normalizedPath)
+      : null;
+    if (exactPathMatch) return exactPathMatch;
+
+    const relativeMatches = indexedSongs.filter((song) => {
+      const songPath = normalizeSongPath(song);
+      return songPath && relativePaths.includes(songPath);
+    });
+    if (relativeMatches.length === 1) return relativeMatches[0];
 
     const mbid = String(track.mbid || "").trim().toLowerCase();
     if (!mbid) return null;

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -31,6 +31,7 @@ export class NavidromeClient {
     this.user = user;
     this.password = password;
     this._libraryPaths = [];
+    this._nativeTokenPromise = null;
     this._indexedSongsPromise = null;
   }
 
@@ -240,14 +241,21 @@ export class NavidromeClient {
 
   async _nativeLogin() {
     if (!this.isConfigured()) throw new Error("Navidrome not configured");
-    const { data } = await axios.post(
-      `${this.url}/auth/login`,
-      { username: this.user, password: this.password },
-      { headers: { "Content-Type": "application/json" } },
-    );
-    const token = data.token || data.Token;
-    if (!token) throw new Error("No token in login response");
-    return token;
+    if (!this._nativeTokenPromise) {
+      this._nativeTokenPromise = axios.post(
+        `${this.url}/auth/login`,
+        { username: this.user, password: this.password },
+        { headers: { "Content-Type": "application/json" } },
+      ).then(({ data }) => {
+        const token = data.token || data.Token;
+        if (!token) throw new Error("No token in login response");
+        return token;
+      }).catch((error) => {
+        this._nativeTokenPromise = null;
+        throw error;
+      });
+    }
+    return this._nativeTokenPromise;
   }
 
   async _nativeRequest(method, path, body = null) {
@@ -269,7 +277,7 @@ export class NavidromeClient {
       throw new Error(`Unsupported method: ${method}`);
     }
     const newToken = response.headers["x-nd-authorization"];
-    if (newToken) token = newToken;
+    if (newToken) this._nativeTokenPromise = Promise.resolve(newToken);
     return response.data;
   }
 

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -264,26 +264,69 @@ export class NavidromeClient {
   }
 
   async _nativeRequest(method, path, body = null) {
-    let token = await this._nativeLogin();
     const base = this.url;
     const url = path.startsWith("/") ? `${base}${path}` : `${base}/api/${path}`;
-    const headers = {
-      "Content-Type": "application/json",
-      "X-ND-Authorization": `Bearer ${token}`,
-    };
-    let response;
-    if (method === "GET") {
-      response = await axios.get(url, { headers });
-    } else if (method === "POST") {
-      response = await axios.post(url, body, { headers });
-    } else if (method === "PUT") {
-      response = await axios.put(url, body, { headers });
-    } else {
-      throw new Error(`Unsupported method: ${method}`);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      let tokenPromise = this._nativeTokenPromise;
+      if (!tokenPromise) {
+        const token = await this._nativeLogin();
+        tokenPromise = this._nativeTokenPromise || Promise.resolve(token);
+      }
+      const token = await tokenPromise;
+      const headers = {
+        "Content-Type": "application/json",
+        "X-ND-Authorization": `Bearer ${token}`,
+      };
+      try {
+        let response;
+        if (method === "GET") {
+          response = await axios.get(url, { headers });
+        } else if (method === "POST") {
+          response = await axios.post(url, body, { headers });
+        } else if (method === "PUT") {
+          response = await axios.put(url, body, { headers });
+        } else {
+          throw new Error(`Unsupported method: ${method}`);
+        }
+        const newToken = response.headers["x-nd-authorization"];
+        if (newToken) this._nativeTokenPromise = Promise.resolve(newToken);
+        return response.data;
+      } catch (error) {
+        if (error?.response?.status !== 401 || attempt > 0) throw error;
+        if (this._nativeTokenPromise === tokenPromise) this._nativeTokenPromise = null;
+      }
     }
-    const newToken = response.headers["x-nd-authorization"];
-    if (newToken) this._nativeTokenPromise = Promise.resolve(newToken);
-    return response.data;
+  }
+
+  async _requestPlaylistArtwork(method, playlistId, data, filename, contentType) {
+    const url = `${this.url}/api/playlist/${encodeURIComponent(playlistId)}/image`;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      let tokenPromise = this._nativeTokenPromise;
+      if (!tokenPromise) {
+        const token = await this._nativeLogin();
+        tokenPromise = this._nativeTokenPromise || Promise.resolve(token);
+      }
+      const token = await tokenPromise;
+      const options = {
+        method,
+        headers: { "X-ND-Authorization": `Bearer ${token}` },
+      };
+      if (method === "POST") {
+        const form = new FormData();
+        form.append("image", new Blob([data], { type: contentType }), filename);
+        options.body = form;
+      }
+      const response = await fetch(url, options);
+      if (response.status === 401 && attempt === 0) {
+        if (this._nativeTokenPromise === tokenPromise) this._nativeTokenPromise = null;
+        continue;
+      }
+      if (!response.ok) {
+        const action = method === "POST" ? "upload" : "deletion";
+        throw new Error(`Playlist artwork ${action} failed with status ${response.status}`);
+      }
+      return;
+    }
   }
 
   async _getIndexedSongs() {
@@ -311,34 +354,17 @@ export class NavidromeClient {
   }
 
   async uploadPlaylistArtwork(playlistId, data, filename = "cover.webp", contentType = "image/webp") {
-    const token = await this._nativeLogin();
-    const form = new FormData();
-    form.append("image", new Blob([data], { type: contentType }), filename);
-    const response = await fetch(
-      `${this.url}/api/playlist/${encodeURIComponent(playlistId)}/image`,
-      {
-        method: "POST",
-        headers: { "X-ND-Authorization": `Bearer ${token}` },
-        body: form,
-      },
+    return this._requestPlaylistArtwork(
+      "POST",
+      playlistId,
+      data,
+      filename,
+      contentType,
     );
-    if (!response.ok) {
-      throw new Error(`Playlist artwork upload failed with status ${response.status}`);
-    }
   }
 
   async deletePlaylistArtwork(playlistId) {
-    const token = await this._nativeLogin();
-    const response = await fetch(
-      `${this.url}/api/playlist/${encodeURIComponent(playlistId)}/image`,
-      {
-        method: "DELETE",
-        headers: { "X-ND-Authorization": `Bearer ${token}` },
-      },
-    );
-    if (!response.ok) {
-      throw new Error(`Playlist artwork deletion failed with status ${response.status}`);
-    }
+    return this._requestPlaylistArtwork("DELETE", playlistId);
   }
 
   async getLibraries() {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -30,6 +30,7 @@ export class NavidromeClient {
     this.url = url ? url.replace(/\/+$/, "") : null;
     this.user = user;
     this.password = password;
+    this._libraryPaths = [];
     this._indexedSongsPromise = null;
   }
 
@@ -98,11 +99,15 @@ export class NavidromeClient {
   }
 
   async findSong(_title, _artist, track = {}) {
-    const normalizedPath = String(track.path || "").replace(/\\/g, "/").toLowerCase();
+    const normalizedPath = normalizeLibraryPath(track.path).toLowerCase();
+    const relativePaths = this._libraryPaths
+      .map((libraryPath) => normalizeLibraryPath(libraryPath).toLowerCase())
+      .filter((libraryPath) => normalizedPath.startsWith(`${libraryPath}/`))
+      .map((libraryPath) => normalizedPath.slice(libraryPath.length + 1));
     const indexedSongs = await this._getIndexedSongs();
     const matchesPath = (song) => {
-      const songPath = String(song.path || "").replace(/\\/g, "/").toLowerCase();
-      return songPath && normalizedPath === songPath;
+      const songPath = normalizeLibraryPath(song.path).toLowerCase();
+      return songPath && (normalizedPath === songPath || relativePaths.includes(songPath));
     };
     const pathMatch = normalizedPath ? indexedSongs.find(matchesPath) : null;
     if (pathMatch) return pathMatch;
@@ -350,9 +355,14 @@ export class NavidromeClient {
     if (!this.isConfigured()) return null;
     const name = PLAYLIST_LIBRARY_NAME;
     const normalizedPath = normalizeLibraryPath(libraryPath);
+    this._libraryPaths = [normalizedPath];
     try {
       const libs = await this.getLibraries();
       const list = Array.isArray(libs) ? libs : [];
+      this._libraryPaths = [...new Set([
+        normalizedPath,
+        ...list.map((lib) => normalizeLibraryPath(lib.path)).filter(Boolean),
+      ])];
       const byPath = list.find((lib) => normalizeLibraryPath(lib.path) === normalizedPath);
       if (byPath) {
         if (byPath.name !== name) {

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -507,18 +507,22 @@ export class NavidromePlaybackDestination {
     return playbackOperationSuccess();
   }
 
+  async _runPlaylistOperation(key, operation) {
+    const previous = this._publishInFlight.get(key) || Promise.resolve();
+    const queued = previous.catch(() => {}).then(operation);
+    this._publishInFlight.set(key, queued);
+    try {
+      return await queued;
+    } finally {
+      if (this._publishInFlight.get(key) === queued) this._publishInFlight.delete(key);
+    }
+  }
+
   async publishPlaylist(value) {
     try {
       const snapshot = createPlaybackPlaylistSnapshot(value);
       const key = `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`;
-      const previous = this._publishInFlight.get(key) || Promise.resolve();
-      const operation = previous.catch(() => {}).then(() => this._publishPlaylist(snapshot));
-      this._publishInFlight.set(key, operation);
-      try {
-        return await operation;
-      } finally {
-        if (this._publishInFlight.get(key) === operation) this._publishInFlight.delete(key);
-      }
+      return await this._runPlaylistOperation(key, () => this._publishPlaylist(snapshot));
     } catch (error) {
       return playbackOperationFailure({
         code: "PLAYLIST_PUBLISH_FAILED",
@@ -534,32 +538,35 @@ export class NavidromePlaybackDestination {
       const names = this._getNamesForIdentity(identity);
       if (!names) return playbackOperationSuccess();
       const targetKey = this._targetKey(identity.ownerUserId);
-      const pointer = navidromePlaylistPointerStore.getPointer(identity.entityId, targetKey);
-      let pointerError = null;
-      let pointerResolved = !pointer;
-      if (pointer && this.isConfigured()) {
-        try {
-          await this.client.deletePlaylist(pointer.playlistId);
-          pointerResolved = true;
-        } catch (error) {
-          pointerError = error;
+      const key = `${identity.entityId}:${targetKey}`;
+      return await this._runPlaylistOperation(key, async () => {
+        const pointer = navidromePlaylistPointerStore.getPointer(identity.entityId, targetKey);
+        let pointerError = null;
+        let pointerResolved = !pointer;
+        if (pointer && this.isConfigured()) {
+          try {
+            await this.client.deletePlaylist(pointer.playlistId);
+            pointerResolved = true;
+          } catch (error) {
+            pointerError = error;
+          }
         }
-      }
-      if (pointerResolved) {
-        navidromePlaylistPointerStore.deletePointer(identity.entityId, targetKey);
-      }
-      this._pendingSnapshots.delete(`${identity.entityId}:${targetKey}`);
-      this._syncHashes.delete(`${identity.entityId}:${targetKey}`);
-      this._playlists = null;
-      await this._deleteNativePlaylists([names.current, ...names.legacy]);
-      await this._deleteFiles([names.current], PLAYLIST_FILE_EXTENSIONS);
-      await this._deleteFiles(names.legacy, [
-        ...PLAYLIST_FILE_EXTENSIONS,
-        ...ARTWORK_FILE_EXTENSIONS,
-        ARTWORK_SUPPRESS_SUFFIX,
-      ]);
-      if (pointerError) throw pointerError;
-      return playbackOperationSuccess();
+        if (pointerResolved) {
+          navidromePlaylistPointerStore.deletePointer(identity.entityId, targetKey);
+        }
+        this._pendingSnapshots.delete(key);
+        this._syncHashes.delete(key);
+        this._playlists = null;
+        await this._deleteNativePlaylists([names.current, ...names.legacy]);
+        await this._deleteFiles([names.current], PLAYLIST_FILE_EXTENSIONS);
+        await this._deleteFiles(names.legacy, [
+          ...PLAYLIST_FILE_EXTENSIONS,
+          ...ARTWORK_FILE_EXTENSIONS,
+          ARTWORK_SUPPRESS_SUFFIX,
+        ]);
+        if (pointerError) throw pointerError;
+        return playbackOperationSuccess();
+      });
     } catch (error) {
       return playbackOperationFailure({
         code: "PLAYLIST_DELETE_FAILED",
@@ -593,6 +600,8 @@ export class NavidromePlaybackDestination {
           await wait(delayMs, undefined, { ref: false });
           if (!this.isConfigured() || !this._pendingSnapshots.size) break;
           for (const snapshot of [...this._pendingSnapshots.values()]) {
+            const key = `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`;
+            if (this._pendingSnapshots.get(key) !== snapshot) continue;
             await this.publishPlaylist(snapshot);
           }
         }

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -442,6 +442,10 @@ export class NavidromePlaybackDestination {
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
       return playbackOperationSuccess();
     }
+    if (pointer && hasUnresolvedSongs) {
+      this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      return playbackOperationSuccess();
+    }
 
     let playlist = null;
     let artworkNeedsUpload = false;

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -440,10 +440,12 @@ export class NavidromePlaybackDestination {
         "utf8",
       );
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      this._scheduleCatchup();
       return playbackOperationSuccess();
     }
     if (pointer && hasUnresolvedSongs) {
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      this._scheduleCatchup();
       return playbackOperationSuccess();
     }
 
@@ -488,6 +490,7 @@ export class NavidromePlaybackDestination {
     if (artworkNeedsUpload) await this._uploadPlaylistArtwork(snapshot, playlist.id);
     if (hasUnresolvedSongs) {
       this._pendingSnapshots.set(`${snapshot.entityId}:${targetKey}`, snapshot);
+      this._scheduleCatchup();
       return playbackOperationSuccess();
     }
     this._pendingSnapshots.delete(`${snapshot.entityId}:${targetKey}`);


### PR DESCRIPTION
## What changed

Preserve existing Navidrome playlists while refreshed tracks are still unresolved, instead of temporarily clearing them. Pending snapshots are retained until track resolution completes.

## Why

Nightly refreshes could briefly clear existing playlists when indexed tracks were unavailable, causing unnecessary playlist disruption. This keeps the current playlist contents intact until the updated tracks are ready.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Updated Navidrome playback destination tests to verify existing playlists are preserved during unresolved-track and rename-cleanup flows.
- Automated tests were not run in the provided change details.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing or imported playlists when tracks cannot yet be resolved.
  * Prevented playlists from being cleared or updated with incomplete track lists.
  * Applied deferred playlist updates once all tracks become available.
  * Improved rename and cleanup behavior to avoid unnecessary empty playlist updates.
  * Improved song matching across configured music library locations.
  * Reduced repeated authentication requests during large library and playlist operations.
  * Improved handling of refreshed authentication credentials during playback and library access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->