### PR TITLE
perf(library): optimize large Lidarr library scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -356,7 +356,8 @@ test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async
         foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
         path: path.join(root, "Bulk Artist", "Bulk Album"),
       }],
-      getAllTracks: async () => {
+      getAllTracks: async ({ artistIds }) => {
+        assert.deepEqual(artistIds, [707]);
         calls.push("tracks");
         return [{
           id: 809,
@@ -367,7 +368,8 @@ test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async
           trackFileId: 810,
         }];
       },
-      getAllTrackFiles: async () => {
+      getAllTrackFiles: async ({ artistIds }) => {
+        assert.deepEqual(artistIds, [707]);
         calls.push("files");
         return [{ id: 810, path: filePath, trackIds: [809], mediaInfo: { audioFormat: "FLAC" } }];
       },

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -336,6 +336,66 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
   }
 });
 
+test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-bulk-index-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Bulk Artist/Bulk Album/01 Bulk Track.flac");
+    const calls = [];
+    const client = {
+      isConfigured: () => true,
+      request: async () => [{
+        id: 707,
+        artistName: "Bulk Artist",
+        foreignArtistId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }],
+      getAllAlbums: async () => [{
+        id: 808,
+        artistId: 707,
+        title: "Bulk Album",
+        foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        path: path.join(root, "Bulk Artist", "Bulk Album"),
+      }],
+      getAllTracks: async () => {
+        calls.push("tracks");
+        return [{
+          id: 809,
+          albumId: 808,
+          title: "Bulk Track",
+          trackNumber: 1,
+          foreignRecordingId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          trackFileId: 810,
+        }];
+      },
+      getAllTrackFiles: async () => {
+        calls.push("files");
+        return [{ id: 810, path: filePath, trackIds: [809], mediaInfo: { audioFormat: "FLAC" } }];
+      },
+      getTracksByAlbumId: async () => {
+        throw new Error("per-album track read should not run when bulk reads exist");
+      },
+      getTrackFilesByAlbumId: async () => {
+        throw new Error("per-album file read should not run when bulk reads exist");
+      },
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    const result = await indexLidarrLibrary({ client });
+    const snapshot = getLibrarySnapshot();
+    const file = snapshot.files.find((entry) => entry.path === filePath);
+
+    assert.deepEqual(calls, ["tracks", "files"]);
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(file?.source, "lidarr");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
 test("indexLidarrLibrary does not reuse a file from another album", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-album-scope-"));
   const artistId = 10000 + (process.pid % 1000);

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -396,6 +396,68 @@ test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async
   }
 });
 
+test("indexLidarrLibrary falls back when a bulk track read fails", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-bulk-fallback-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Fallback Artist/Fallback Album/01 Fallback Track.flac");
+    const calls = [];
+    const client = {
+      isConfigured: () => true,
+      request: async () => [{
+        id: 717,
+        artistName: "Fallback Artist",
+        foreignArtistId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }],
+      getAllAlbums: async () => [{
+        id: 818,
+        artistId: 717,
+        title: "Fallback Album",
+        foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        path: path.join(root, "Fallback Artist", "Fallback Album"),
+      }],
+      getAllTracks: async () => {
+        calls.push("bulk-tracks");
+        throw new Error("bulk track read failed");
+      },
+      getAllTrackFiles: async () => {
+        calls.push("bulk-files");
+        return [];
+      },
+      getTracksByAlbumId: async (albumId) => {
+        calls.push(`tracks:${albumId}`);
+        return [{
+          id: 819,
+          albumId,
+          title: "Fallback Track",
+          trackNumber: 1,
+          foreignRecordingId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          trackFileId: 820,
+        }];
+      },
+      getTrackFilesByAlbumId: async (albumId) => {
+        calls.push(`files:${albumId}`);
+        return [{ id: 820, path: filePath, trackIds: [819], mediaInfo: { audioFormat: "FLAC" } }];
+      },
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    const result = await indexLidarrLibrary({ client });
+    const snapshot = getLibrarySnapshot();
+    const file = snapshot.files.find((entry) => entry.path === filePath);
+
+    assert.deepEqual(calls, ["bulk-tracks", "bulk-files", "tracks:818", "files:818"]);
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(file?.source, "lidarr");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
 test("indexLidarrLibrary does not reuse a file from another album", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-album-scope-"));
   const artistId = 10000 + (process.pid % 1000);

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -458,6 +458,68 @@ test("indexLidarrLibrary falls back when a bulk track read fails", async () => {
   }
 });
 
+test("indexLidarrLibrary falls back when a bulk track-file read fails", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-bulk-file-fallback-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "File Fallback Artist/File Fallback Album/01 File Fallback Track.flac");
+    const calls = [];
+    const client = {
+      isConfigured: () => true,
+      request: async () => [{
+        id: 727,
+        artistName: "File Fallback Artist",
+        foreignArtistId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }],
+      getAllAlbums: async () => [{
+        id: 828,
+        artistId: 727,
+        title: "File Fallback Album",
+        foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        path: path.join(root, "File Fallback Artist", "File Fallback Album"),
+      }],
+      getAllTracks: async () => {
+        calls.push("bulk-tracks");
+        return [{ id: 829, albumId: 828 }];
+      },
+      getAllTrackFiles: async () => {
+        calls.push("bulk-files");
+        throw new Error("bulk track-file read failed");
+      },
+      getTracksByAlbumId: async (albumId) => {
+        calls.push(`tracks:${albumId}`);
+        return [{
+          id: 829,
+          albumId,
+          title: "File Fallback Track",
+          trackNumber: 1,
+          foreignRecordingId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          trackFileId: 830,
+        }];
+      },
+      getTrackFilesByAlbumId: async (albumId) => {
+        calls.push(`files:${albumId}`);
+        return [{ id: 830, path: filePath, trackIds: [829], mediaInfo: { audioFormat: "FLAC" } }];
+      },
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    const result = await indexLidarrLibrary({ client });
+    const snapshot = getLibrarySnapshot();
+    const file = snapshot.files.find((entry) => entry.path === filePath);
+
+    assert.deepEqual(calls, ["bulk-tracks", "bulk-files", "tracks:828", "files:828"]);
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(file?.source, "lidarr");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
 test("indexLidarrLibrary does not reuse a file from another album", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-album-scope-"));
   const artistId = 10000 + (process.pid % 1000);

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -59,6 +59,53 @@ test("bulk track reads use Lidarr artist selectors", async (t) => {
   client._httpsInsecureAgent.destroy();
 });
 
+test("bulk reads wait for active requests before failing", async () => {
+  const client = new LidarrClient();
+  const artistIds = Array.from({ length: 14 }, (_, index) => index + 1);
+  const started = [];
+  let releaseFailure;
+  let releasePending;
+  let resolveInitialRequests;
+  const failure = new Promise((resolve) => {
+    releaseFailure = resolve;
+  });
+  const pending = new Promise((resolve) => {
+    releasePending = resolve;
+  });
+  const initialRequests = new Promise((resolve) => {
+    resolveInitialRequests = resolve;
+  });
+
+  client.request = async (endpoint) => {
+    const artistId = Number(new URL(`http://localhost${endpoint}`).searchParams.get("artistId"));
+    started.push(artistId);
+    if (started.length === 12) resolveInitialRequests();
+    if (artistId === 1) {
+      await failure;
+      throw new Error("bulk track read failed");
+    }
+    if (artistId <= 12) await pending;
+    return [];
+  };
+
+  const read = client.getAllTracks({ artistIds, throwOnError: true });
+  await initialRequests;
+  releaseFailure();
+
+  let settled = false;
+  const rejection = read.catch((error) => {
+    settled = true;
+    throw error;
+  });
+  await delay(10);
+  assert.equal(settled, false);
+
+  releasePending();
+  await assert.rejects(rejection, /bulk track read failed/);
+  await delay(0);
+  assert.deepEqual(started, artistIds.slice(0, 12));
+});
+
 test("testConnection preserves Lidarr HTTP diagnostics", async (t) => {
   let status = 401;
   const server = http.createServer((_request, response) => {

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -22,6 +22,43 @@ test("isCircuitOpen returns stale GET cache instead of throwing", async () => {
   assert.equal(artists[0].artistName, "Test");
 });
 
+test("bulk track reads use Lidarr artist selectors", async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify([{ id: 1, albumId: 2 }]));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+
+  await client.getAllTracks({ artistIds: [7, 8], throwOnError: true });
+  await client.getAllTrackFiles({ artistIds: [7, 8], throwOnError: true });
+
+  assert.deepEqual(requests.sort(), [
+    "/api/v1/track?artistId=7",
+    "/api/v1/track?artistId=8",
+    "/api/v1/trackfile?artistId=7",
+    "/api/v1/trackfile?artistId=8",
+  ]);
+  client._httpAgent.destroy();
+  client._httpsAgent.destroy();
+  client._httpsInsecureAgent.destroy();
+});
+
 test("testConnection preserves Lidarr HTTP diagnostics", async (t) => {
   let status = 401;
   const server = http.createServer((_request, response) => {

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -13,8 +13,8 @@ const recordMatches = (record, reference) => {
   );
 };
 
-const buildArtist = (artist, albums) => {
-  const artistAlbums = albums.filter((album) => album.artistId === artist.id);
+const buildArtist = (artist, albumsByArtistId) => {
+  const artistAlbums = albumsByArtistId.get(artist.id) || [];
   const trackCount = artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
   const sizeOnDisk = artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
   const providerId = artist.metadata?.id ?? null;
@@ -45,10 +45,10 @@ const buildArtist = (artist, albums) => {
   };
 };
 
-const buildAlbum = (album, artists, tracks) => {
-  const artist = artists.find((candidate) => candidate.id === album.artistId);
+const buildAlbum = (album, artistsById, tracksById) => {
+  const artist = artistsById.get(album.artistId);
   const albumTracks = album.trackIds
-    .map((trackId) => tracks.find((track) => track.id === trackId))
+    .map((trackId) => tracksById.get(trackId))
     .filter(Boolean);
   const sizeOnDisk = albumTracks.reduce((total, track) => {
     const file = firstAvailableFile(track);
@@ -79,7 +79,7 @@ const buildAlbum = (album, artists, tracks) => {
       percentOfTracks:
         albumTracks.length > 0 && albumTracks.every((track) => track.available) ? 100 : 0,
     },
-    trackIds: album.trackIds,
+    trackIds: [...album.trackIds],
     sources: album.sources,
     available: album.available,
   };
@@ -109,21 +109,20 @@ const buildTrack = (track, album) => {
 };
 
 export function buildCanonicalLibraryReadModel(library) {
-  const artists = library.artists.map((artist) => ({ ...artist }));
-  const albums = library.albums.map((album) => ({
-    ...album,
-    trackIds: [...album.trackIds],
-  }));
-  const tracks = library.tracks.map((track) => ({
-    ...track,
-    albums: [...track.albums],
-    files: [...track.files],
-  }));
-  const readAlbums = albums.map((album) => buildAlbum(album, artists, tracks));
-  const readArtists = artists.map((artist) => buildArtist(artist, readAlbums));
+  const { artists, albums, tracks } = library;
+  const artistsById = new Map(artists.map((artist) => [artist.id, artist]));
+  const tracksById = new Map(tracks.map((track) => [track.id, track]));
+  const readAlbums = albums.map((album) => buildAlbum(album, artistsById, tracksById));
+  const albumsByArtistId = new Map();
+  for (const album of readAlbums) {
+    const artistAlbums = albumsByArtistId.get(album.artistId) || [];
+    artistAlbums.push(album);
+    albumsByArtistId.set(album.artistId, artistAlbums);
+  }
+  const readArtists = artists.map((artist) => buildArtist(artist, albumsByArtistId));
   const readTracks = readAlbums.flatMap((album) =>
     album.trackIds
-      .map((trackId) => tracks.find((track) => track.id === trackId))
+      .map((trackId) => tracksById.get(trackId))
       .filter(Boolean)
       .map((track) => buildTrack(track, album)),
   );

--- a/backend/services/discovery/helpers.js
+++ b/backend/services/discovery/helpers.js
@@ -243,23 +243,39 @@ export const wait = (delayMs) =>
       })
     : Promise.resolve();
 
-export const mapWithConcurrency = async (items, concurrency, worker) => {
+export const mapWithConcurrency = async (
+  items,
+  concurrency,
+  worker,
+  { stopOnError = false } = {},
+) => {
   const list = Array.isArray(items) ? items : [];
   const limit = Math.max(1, Number(concurrency) || 1);
   if (list.length === 0) return [];
   const results = new Array(list.length);
   let nextIndex = 0;
+  let failed = false;
+  let firstError;
   const runners = Array.from(
     { length: Math.min(limit, list.length) },
     async () => {
-      while (nextIndex < list.length) {
+      while (!failed && nextIndex < list.length) {
         const index = nextIndex;
         nextIndex += 1;
-        results[index] = await worker(list[index], index);
+        try {
+          results[index] = await worker(list[index], index);
+        } catch (error) {
+          if (!stopOnError) throw error;
+          if (!failed) {
+            failed = true;
+            firstError = error;
+          }
+        }
       }
     },
   );
   await Promise.all(runners);
+  if (failed) throw firstError;
   return results;
 };
 

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -75,26 +75,33 @@ function buildBulkAlbumTrackData(albums, tracks, files) {
 }
 
 async function loadAlbumTrackData(client, albums) {
+  const loadPerAlbumTrackData = () =>
+    mapWithConcurrency(albums, 4, async (album) => {
+      if (!album?.id) return { albumId: null, tracks: [], files: [] };
+      const [tracks, files] = await Promise.all([
+        client.getTracksByAlbumId(album.id),
+        client.getTrackFilesByAlbumId(album.id),
+      ]);
+      return {
+        albumId: String(album.id),
+        tracks: Array.isArray(tracks) ? tracks : [],
+        files: Array.isArray(files) ? files : [],
+      };
+    });
+
   if (typeof client.getAllTracks === "function" && typeof client.getAllTrackFiles === "function") {
-    const [tracks, files] = await Promise.all([
-      client.getAllTracks({ forceRefresh: true }),
-      client.getAllTrackFiles({ forceRefresh: true }),
-    ]);
-    return buildBulkAlbumTrackData(albums, tracks, files);
+    try {
+      const [tracks, files] = await Promise.all([
+        client.getAllTracks({ forceRefresh: true, throwOnError: true }),
+        client.getAllTrackFiles({ forceRefresh: true, throwOnError: true }),
+      ]);
+      return buildBulkAlbumTrackData(albums, tracks, files);
+    } catch {
+      return loadPerAlbumTrackData();
+    }
   }
 
-  return mapWithConcurrency(albums, 4, async (album) => {
-    if (!album?.id) return { albumId: null, tracks: [], files: [] };
-    const [tracks, files] = await Promise.all([
-      client.getTracksByAlbumId(album.id),
-      client.getTrackFilesByAlbumId(album.id),
-    ]);
-    return {
-      albumId: String(album.id),
-      tracks: Array.isArray(tracks) ? tracks : [],
-      files: Array.isArray(files) ? files : [],
-    };
-  });
+  return loadPerAlbumTrackData();
 }
 
 function resolveTrackFile(track, fileIndex, album) {

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -33,6 +33,70 @@ function buildFileIndex(files) {
   return index;
 }
 
+function buildBulkAlbumTrackData(albums, tracks, files) {
+  const tracksByAlbumId = new Map();
+  const albumIdsByTrackId = new Map();
+  for (const track of Array.isArray(tracks) ? tracks : []) {
+    if (track?.albumId == null) continue;
+    const albumId = String(track.albumId);
+    const albumTracks = tracksByAlbumId.get(albumId) || [];
+    albumTracks.push(track);
+    tracksByAlbumId.set(albumId, albumTracks);
+    const trackAlbums = albumIdsByTrackId.get(String(track.id)) || new Set();
+    trackAlbums.add(albumId);
+    albumIdsByTrackId.set(String(track.id), trackAlbums);
+  }
+
+  const filesByAlbumId = new Map();
+  const addFile = (albumId, file) => {
+    const key = String(albumId);
+    const albumFiles = filesByAlbumId.get(key) || new Map();
+    const fileKey = file?.id != null ? `id:${file.id}` : `path:${file?.path || ""}`;
+    albumFiles.set(fileKey, file);
+    filesByAlbumId.set(key, albumFiles);
+  };
+  for (const file of Array.isArray(files) ? files : []) {
+    const albumIds = new Set();
+    if (file?.albumId != null) albumIds.add(String(file.albumId));
+    for (const trackId of [file?.trackId, ...(Array.isArray(file?.trackIds) ? file.trackIds : [])]) {
+      for (const albumId of albumIdsByTrackId.get(String(trackId)) || []) albumIds.add(albumId);
+    }
+    for (const albumId of albumIds) addFile(albumId, file);
+  }
+
+  return (Array.isArray(albums) ? albums : []).map((album) => {
+    const albumId = String(album?.id);
+    return {
+      albumId,
+      tracks: tracksByAlbumId.get(albumId) || [],
+      files: [...(filesByAlbumId.get(albumId)?.values() || [])],
+    };
+  });
+}
+
+async function loadAlbumTrackData(client, albums) {
+  if (typeof client.getAllTracks === "function" && typeof client.getAllTrackFiles === "function") {
+    const [tracks, files] = await Promise.all([
+      client.getAllTracks({ forceRefresh: true }),
+      client.getAllTrackFiles({ forceRefresh: true }),
+    ]);
+    return buildBulkAlbumTrackData(albums, tracks, files);
+  }
+
+  return mapWithConcurrency(albums, 4, async (album) => {
+    if (!album?.id) return { albumId: null, tracks: [], files: [] };
+    const [tracks, files] = await Promise.all([
+      client.getTracksByAlbumId(album.id),
+      client.getTrackFilesByAlbumId(album.id),
+    ]);
+    return {
+      albumId: String(album.id),
+      tracks: Array.isArray(tracks) ? tracks : [],
+      files: Array.isArray(files) ? files : [],
+    };
+  });
+}
+
 function resolveTrackFile(track, fileIndex, album) {
   if (track?.albumId != null && String(track.albumId) !== String(album?.id)) return null;
   const file =
@@ -82,18 +146,7 @@ export async function indexLidarrLibrary({ client } = {}) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
   const artistById = new Map((Array.isArray(artists) ? artists : []).map((item) => [String(item.id), item]));
-  const albumTrackData = await mapWithConcurrency(albums, 4, async (album) => {
-    if (!album?.id) return { albumId: null, tracks: [], files: [] };
-    const [tracks, files] = await Promise.all([
-      client.getTracksByAlbumId(album.id),
-      client.getTrackFilesByAlbumId(album.id),
-    ]);
-    return {
-      albumId: String(album.id),
-      tracks: Array.isArray(tracks) ? tracks : [],
-      files: Array.isArray(files) ? files : [],
-    };
-  });
+  const albumTrackData = await loadAlbumTrackData(client, albums);
   const tracksByAlbumId = new Map();
   const filesByAlbumId = new Map();
   for (const albumData of albumTrackData) {

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -74,7 +74,7 @@ function buildBulkAlbumTrackData(albums, tracks, files) {
   });
 }
 
-async function loadAlbumTrackData(client, albums) {
+async function loadAlbumTrackData(client, albums, artistIds) {
   const loadPerAlbumTrackData = () =>
     mapWithConcurrency(albums, 4, async (album) => {
       if (!album?.id) return { albumId: null, tracks: [], files: [] };
@@ -92,8 +92,8 @@ async function loadAlbumTrackData(client, albums) {
   if (typeof client.getAllTracks === "function" && typeof client.getAllTrackFiles === "function") {
     try {
       const [tracks, files] = await Promise.all([
-        client.getAllTracks({ forceRefresh: true, throwOnError: true }),
-        client.getAllTrackFiles({ forceRefresh: true, throwOnError: true }),
+        client.getAllTracks({ artistIds, forceRefresh: true, throwOnError: true }),
+        client.getAllTrackFiles({ artistIds, forceRefresh: true, throwOnError: true }),
       ]);
       return buildBulkAlbumTrackData(albums, tracks, files);
     } catch {
@@ -153,7 +153,11 @@ export async function indexLidarrLibrary({ client } = {}) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
   const artistById = new Map((Array.isArray(artists) ? artists : []).map((item) => [String(item.id), item]));
-  const albumTrackData = await loadAlbumTrackData(client, albums);
+  const albumTrackData = await loadAlbumTrackData(
+    client,
+    albums,
+    (Array.isArray(artists) ? artists : []).map((artist) => artist?.id),
+  );
   const tracksByAlbumId = new Map();
   const filesByAlbumId = new Map();
   for (const albumData of albumTrackData) {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -221,16 +221,14 @@ export function getCanonicalLibrary({ source = null, availableOnly = false, favo
     conditions.push(`media.track_id IN (${targetQueries.join(" UNION ")})`);
   }
 
-  const rows = db
-    .prepare(
-      `${CANONICAL_SELECT}
-      ${CANONICAL_FROM}
-      ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
-      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
-        album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
-        track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
-    )
-    .all(...parameters);
+  const rows = db.prepare(
+    `${CANONICAL_SELECT}
+    ${CANONICAL_FROM}
+    ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
+    ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
+      album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
+      track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
+  ).iterate(...parameters);
   const library = buildLibraryFromRows(rows);
   if (!favoriteTargets) libraryCache.set(cacheKey, library);
   return library;
@@ -247,23 +245,12 @@ const metadataGenres = (entity) => {
     .filter((value, index, values) => values.indexOf(value) === index);
 };
 
-const genreStatsFor = (library) => {
-  const stats = new Map();
-  const add = (genre, kind) => {
+const addGenreStats = (stats, metadata, kind) => {
+  metadataGenres({ metadata }).forEach((genre) => {
     const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
     entry[kind] += 1;
     stats.set(genre, entry);
-  };
-  library.artists.forEach((artist) =>
-    metadataGenres(artist).forEach((genre) => add(genre, "artists")),
-  );
-  library.albums.forEach((album) =>
-    metadataGenres(album).forEach((genre) => add(genre, "albums")),
-  );
-  library.tracks.forEach((track) =>
-    metadataGenres(track).forEach((genre) => add(genre, "tracks")),
-  );
-  return [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+  });
 };
 
 const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
@@ -480,25 +467,28 @@ function getCanonicalGenreStats({ sourceFilter, availableOnly }) {
   const artistMedia = pageMediaExists("artists", sourceFilter, availableOnly);
   const albumMedia = pageMediaExists("albums", sourceFilter, availableOnly);
   const trackMedia = pageMediaExists("tracks", sourceFilter, availableOnly);
-  const artists = db.prepare(
+  const stats = new Map();
+  for (const row of db.prepare(
     `SELECT artist.metadata_json FROM library_artists AS artist WHERE ${artistMedia.sql}`,
-  ).all(...artistMedia.parameters);
-  const albums = db.prepare(
+  ).iterate(...artistMedia.parameters)) {
+    addGenreStats(stats, parseJson(row.metadata_json), "artists");
+  }
+  for (const row of db.prepare(
     `SELECT album.metadata_json
      FROM library_albums AS album
      JOIN library_artists AS artist ON artist.id = album.artist_id
      WHERE ${albumMedia.sql}`,
-  ).all(...albumMedia.parameters);
-  const tracks = db.prepare(
+  ).iterate(...albumMedia.parameters)) {
+    addGenreStats(stats, parseJson(row.metadata_json), "albums");
+  }
+  for (const row of db.prepare(
     `SELECT track.metadata_json FROM library_tracks AS track WHERE ${trackMedia.sql}`,
-  ).all(...trackMedia.parameters);
-  const stats = genreStatsFor({
-    artists: artists.map((row) => ({ metadata: parseJson(row.metadata_json) })),
-    albums: albums.map((row) => ({ metadata: parseJson(row.metadata_json) })),
-    tracks: tracks.map((row) => ({ metadata: parseJson(row.metadata_json) })),
-  });
-  genreStatsCache.set(cacheKey, stats);
-  return stats;
+  ).iterate(...trackMedia.parameters)) {
+    addGenreStats(stats, parseJson(row.metadata_json), "tracks");
+  }
+  const sortedStats = [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+  genreStatsCache.set(cacheKey, sortedStats);
+  return sortedStats;
 }
 
 function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) {
@@ -522,7 +512,7 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) 
      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE,
        album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number,
        track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
-  ).all(...parameters);
+  ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 
@@ -581,7 +571,7 @@ function getAlbumTrackLibrary(
      WHERE ${conditions.join(" AND ")}
      ORDER BY ${orderBy}, album_track.disc_number, album_track.track_number,
        media.path COLLATE NOCASE`,
-  ).all(...parameters);
+  ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -51,6 +51,16 @@ function normalizeLidarrArtistId(value) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? String(parsed) : null;
 }
 
+function normalizeLidarrArtistIds(values) {
+  return [
+    ...new Set(
+      (Array.isArray(values) ? values : [])
+        .map(normalizeLidarrArtistId)
+        .filter(Boolean),
+    ),
+  ];
+}
+
 function isMetadataProviderIdError(error) {
   const message = String(error?.message || "").toLowerCase();
   return message.includes("input string") && message.includes("correct format");
@@ -1269,12 +1279,29 @@ export class LidarrClient {
   }
 
   async getAllTracks(options = {}) {
-    const { throwOnError = false, ...requestOptions } = options;
+    const { artistIds, throwOnError = false, ...requestOptions } = options;
     try {
-      const result = await this.request("/track", "GET", null, false, requestOptions);
-      if (Array.isArray(result)) return result;
-      if (result?.records && Array.isArray(result.records)) return result.records;
-      return [];
+      const normalizedArtistIds = normalizeLidarrArtistIds(artistIds);
+      if (normalizedArtistIds.length === 0) {
+        throw new Error("Lidarr artist IDs are required for bulk track reads");
+      }
+      const results = await mapWithConcurrency(
+        normalizedArtistIds,
+        LIDARR_MAX_CONCURRENT,
+        async (artistId) => {
+          const result = await this.request(
+            `/track?artistId=${artistId}`,
+            "GET",
+            null,
+            false,
+            requestOptions,
+          );
+          if (Array.isArray(result)) return result;
+          if (result?.records && Array.isArray(result.records)) return result.records;
+          return [];
+        },
+      );
+      return results.flat();
     } catch (error) {
       if (throwOnError) throw error;
       return [];
@@ -1282,12 +1309,29 @@ export class LidarrClient {
   }
 
   async getAllTrackFiles(options = {}) {
-    const { throwOnError = false, ...requestOptions } = options;
+    const { artistIds, throwOnError = false, ...requestOptions } = options;
     try {
-      const result = await this.request("/trackfile", "GET", null, false, requestOptions);
-      if (Array.isArray(result)) return result;
-      if (result?.records && Array.isArray(result.records)) return result.records;
-      return [];
+      const normalizedArtistIds = normalizeLidarrArtistIds(artistIds);
+      if (normalizedArtistIds.length === 0) {
+        throw new Error("Lidarr artist IDs are required for bulk track-file reads");
+      }
+      const results = await mapWithConcurrency(
+        normalizedArtistIds,
+        LIDARR_MAX_CONCURRENT,
+        async (artistId) => {
+          const result = await this.request(
+            `/trackfile?artistId=${artistId}`,
+            "GET",
+            null,
+            false,
+            requestOptions,
+          );
+          if (Array.isArray(result)) return result;
+          if (result?.records && Array.isArray(result.records)) return result.records;
+          return [];
+        },
+      );
+      return results.flat();
     } catch (error) {
       if (throwOnError) throw error;
       return [];

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1300,6 +1300,7 @@ export class LidarrClient {
           if (result?.records && Array.isArray(result.records)) return result.records;
           return [];
         },
+        { stopOnError: true },
       );
       return results.flat();
     } catch (error) {
@@ -1330,6 +1331,7 @@ export class LidarrClient {
           if (result?.records && Array.isArray(result.records)) return result.records;
           return [];
         },
+        { stopOnError: true },
       );
       return results.flat();
     } catch (error) {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1269,23 +1269,27 @@ export class LidarrClient {
   }
 
   async getAllTracks(options = {}) {
+    const { throwOnError = false, ...requestOptions } = options;
     try {
-      const result = await this.request("/track", "GET", null, false, options);
+      const result = await this.request("/track", "GET", null, false, requestOptions);
       if (Array.isArray(result)) return result;
       if (result?.records && Array.isArray(result.records)) return result.records;
       return [];
-    } catch {
+    } catch (error) {
+      if (throwOnError) throw error;
       return [];
     }
   }
 
   async getAllTrackFiles(options = {}) {
+    const { throwOnError = false, ...requestOptions } = options;
     try {
-      const result = await this.request("/trackfile", "GET", null, false, options);
+      const result = await this.request("/trackfile", "GET", null, false, requestOptions);
       if (Array.isArray(result)) return result;
       if (result?.records && Array.isArray(result.records)) return result.records;
       return [];
-    } catch {
+    } catch (error) {
+      if (throwOnError) throw error;
       return [];
     }
   }

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1268,9 +1268,9 @@ export class LidarrClient {
     }
   }
 
-  async getAllTracks() {
+  async getAllTracks(options = {}) {
     try {
-      const result = await this.request("/track");
+      const result = await this.request("/track", "GET", null, false, options);
       if (Array.isArray(result)) return result;
       if (result?.records && Array.isArray(result.records)) return result.records;
       return [];
@@ -1279,9 +1279,9 @@ export class LidarrClient {
     }
   }
 
-  async getAllTrackFiles() {
+  async getAllTrackFiles(options = {}) {
     try {
-      const result = await this.request("/trackfile");
+      const result = await this.request("/trackfile", "GET", null, false, options);
       if (Array.isArray(result)) return result;
       if (result?.records && Array.isArray(result.records)) return result.records;
       return [];

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "node --test --import ./.tests/setup-env.js --test-concurrency=4 $(find .tests -name '*.test.js' -not -name '*.int.test.js' -print)",
     "test:integration": "node --test --import ./.tests/setup-env.js --test-concurrency=1 $(find .tests -name '*.int.test.js' -print)",
     "test:coverage": "node --experimental-test-coverage --test --import ./.tests/setup-env.js --test-concurrency=4 --test-coverage-include='backend/**' --test-coverage-lines=30 $(find .tests -name '*.test.js' -not -name '*.int.test.js' -print)",
+    "perf:library": "node scripts/benchmark-library.mjs",
     "dev": "node scripts/dev.mjs",
     "wait-and-dev:frontend": "while ! curl -s http://localhost:3001/api/health; do sleep 1; done && npm run dev --workspace frontend",
     "dev:backend": "node --watch --env-file=backend/.env backend/server.js",

--- a/perf-results/.gitignore
+++ b/perf-results/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+!baseline.json

--- a/perf-results/README.md
+++ b/perf-results/README.md
@@ -1,0 +1,12 @@
+# Library performance results
+
+Run the synthetic 350,000-track benchmark with:
+
+```sh
+npm run perf:library -- --check
+```
+
+Each run writes a JSON file containing seed size, SQLite page timings, full
+canonical and legacy read timings, JSON size, memory samples, and the Lidarr
+indexer call probe. Pass `--output perf-results/baseline.json` when a result
+should be kept under a stable name. Timestamped result files stay untracked.

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -1,0 +1,548 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const commit = (() => {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+})();
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+function readOption(args, name, fallback) {
+  const index = args.indexOf(`--${name}`);
+  if (index < 0) return fallback;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Missing value for --${name}`);
+  return value;
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseOptions(args) {
+  if (args.includes("--help")) {
+    console.log(`Usage: npm run perf:library -- [options]
+
+Options:
+  --tracks N                  Synthetic tracks, default 350000
+  --tracks-per-album N        Synthetic tracks per album, default 10
+  --repeats N                 Page samples per cold/warm group, default 3
+  --indexer-albums N          Albums in the Lidarr call probe, default 1000
+  --full-read-timeout-ms N    Timeout for full-read child probes, default 30000
+  --output PATH               JSON result path, default perf-results/library-<timestamp>.json
+  --check                     Exit nonzero when the regression gate fails
+`);
+    process.exit(0);
+  }
+  const tracks = positiveInteger(readOption(args, "tracks", 350000), "tracks");
+  const tracksPerAlbum = positiveInteger(
+    readOption(args, "tracks-per-album", 10),
+    "tracks-per-album",
+  );
+  const repeats = positiveInteger(readOption(args, "repeats", 3), "repeats");
+  const indexerAlbums = positiveInteger(
+    readOption(args, "indexer-albums", 1000),
+    "indexer-albums",
+  );
+  const fullReadTimeoutMs = positiveInteger(
+    readOption(args, "full-read-timeout-ms", 30000),
+    "full-read-timeout-ms",
+  );
+  const output = readOption(
+    args,
+    "output",
+    path.join(repoRoot, "perf-results", `library-${timestamp}-${commit}.json`),
+  );
+  return {
+    tracks,
+    tracksPerAlbum,
+    repeats,
+    indexerAlbums,
+    fullReadTimeoutMs,
+    output: path.isAbsolute(output) ? output : path.join(repoRoot, output),
+    check: args.includes("--check"),
+  };
+}
+
+function memoryStats() {
+  const memory = process.memoryUsage();
+  return {
+    rssBytes: memory.rss,
+    heapUsedBytes: memory.heapUsed,
+    heapTotalBytes: memory.heapTotal,
+    externalBytes: memory.external,
+  };
+}
+
+function summarizeSamples(samples) {
+  const values = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
+  return {
+    samples,
+    minMs: values[0],
+    medianMs: percentile(0.5),
+    p95Ms: percentile(0.95),
+    maxMs: values[values.length - 1],
+  };
+}
+
+function measure(operation) {
+  const before = memoryStats();
+  const started = performance.now();
+  const value = operation();
+  const elapsedMs = performance.now() - started;
+  const after = memoryStats();
+  return {
+    elapsedMs: Number(elapsedMs.toFixed(3)),
+    memoryBefore: before,
+    memoryAfter: after,
+    rssDeltaBytes: after.rssBytes - before.rssBytes,
+    value,
+  };
+}
+
+function pageSummary(page) {
+  return {
+    total: page.total,
+    page: page.page,
+    pageSize: page.pageSize,
+    hasMore: page.hasMore,
+    itemCount: Array.isArray(page.items) ? page.items.length : 0,
+    genreCount: Array.isArray(page.genres) ? page.genres.length : 0,
+  };
+}
+
+function seedDatabase(database, { tracks, tracksPerAlbum }) {
+  const albumCount = Math.ceil(tracks / tracksPerAlbum);
+  const artistCount = Math.ceil(albumCount / 10);
+  const metadata = JSON.stringify({ genres: ["Rock"], tags: ["benchmark"] });
+  const now = Date.now();
+  const insertArtist = database.prepare(
+    `INSERT INTO library_artists
+      (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const insertAlbum = database.prepare(
+    `INSERT INTO library_albums
+      (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const insertTrack = database.prepare(
+    `INSERT INTO library_tracks
+      (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const insertRelation = database.prepare(
+    `INSERT INTO library_album_tracks
+      (album_id, track_id, disc_number, track_number, created_at)
+     VALUES (?, ?, 1, ?, ?)`,
+  );
+  const insertFile = database.prepare(
+    `INSERT INTO library_media_files
+      (track_id, album_id, source, path, format, size, mtime_ms, duration_ms, quality_json, available, created_at, updated_at)
+     VALUES (?, ?, 'lidarr', ?, 'flac', 1000, ?, 180000, ?, 1, ?, ?)`,
+  );
+  const artistIds = [];
+  const albumIds = [];
+  const transaction = database.transaction(() => {
+    for (let artistIndex = 0; artistIndex < artistCount; artistIndex += 1) {
+      const name = `Benchmark Artist ${String(artistIndex).padStart(5, "0")}`;
+      artistIds.push(
+        Number(
+          insertArtist.run(
+            `benchmark:artist:${artistIndex}`,
+            `00000000-0000-4000-8000-${String(artistIndex).padStart(12, "0")}`,
+            name,
+            name,
+            metadata,
+            now,
+            now,
+          ).lastInsertRowid,
+        ),
+      );
+    }
+    for (let albumIndex = 0; albumIndex < albumCount; albumIndex += 1) {
+      const artistId = artistIds[Math.floor(albumIndex / 10)];
+      const title = `Benchmark Album ${String(albumIndex).padStart(6, "0")}`;
+      albumIds.push(
+        Number(
+          insertAlbum.run(
+            `benchmark:album:${albumIndex}`,
+            `10000000-0000-4000-8000-${String(albumIndex).padStart(12, "0")}`,
+            `20000000-0000-4000-8000-${String(albumIndex).padStart(12, "0")}`,
+            artistId,
+            title,
+            `Benchmark Artist ${String(Math.floor(albumIndex / 10)).padStart(5, "0")}`,
+            "2020-01-01",
+            metadata,
+            now,
+            now,
+          ).lastInsertRowid,
+        ),
+      );
+    }
+    for (let trackIndex = 0; trackIndex < tracks; trackIndex += 1) {
+      const albumIndex = Math.floor(trackIndex / tracksPerAlbum);
+      const albumId = albumIds[albumIndex];
+      const artistIndex = Math.floor(albumIndex / 10);
+      const artistName = `Benchmark Artist ${String(artistIndex).padStart(5, "0")}`;
+      const trackId = Number(
+        insertTrack.run(
+          `benchmark:track:${trackIndex}`,
+          `30000000-0000-4000-8000-${String(trackIndex).padStart(12, "0")}`,
+          `Benchmark Track ${String(trackIndex).padStart(7, "0")}`,
+          artistName,
+          metadata,
+          now,
+          now,
+        ).lastInsertRowid,
+      );
+      insertRelation.run(albumId, trackId, (trackIndex % tracksPerAlbum) + 1, now);
+      insertFile.run(
+        trackId,
+        albumId,
+        `/synthetic/Benchmark Artist ${String(artistIndex).padStart(5, "0")}/${
+          `Benchmark Album ${String(albumIndex).padStart(6, "0")}`
+        }/${String((trackIndex % tracksPerAlbum) + 1).padStart(2, "0")}.flac`,
+        now,
+        JSON.stringify({ format: "FLAC", bitrate: 1000 }),
+        now,
+        now,
+      );
+    }
+  });
+  database.pragma("synchronous = OFF");
+  transaction();
+  const pageCount = Number(database.pragma("page_count", { simple: true }));
+  const pageSize = Number(database.pragma("page_size", { simple: true }));
+  return {
+    artists: artistCount,
+    albums: albumCount,
+    tracks,
+    mediaFiles: tracks,
+    databaseBytes: pageCount * pageSize,
+  };
+}
+
+function collectPageSamples(getPage, invalidate, repeats) {
+  const coldSamples = [];
+  const warmSamples = [];
+  let shape;
+  for (let index = 0; index < repeats; index += 1) {
+    invalidate();
+    const result = measure(() => getPage());
+    shape ||= pageSummary(result.value);
+    coldSamples.push(result);
+  }
+  for (let index = 0; index < repeats; index += 1) {
+    const result = measure(() => getPage());
+    warmSamples.push(result);
+  }
+  const strip = ({ value: _value, ...sample }) => sample;
+  return {
+    shape,
+    cold: summarizeSamples(coldSamples.map(strip)),
+    warm: summarizeSamples(warmSamples.map(strip)),
+  };
+}
+
+function runChild({ dataDir, dbPath, code, timeoutMs, env = {} }) {
+  return new Promise((resolve) => {
+    const started = performance.now();
+    const child = spawn(
+      process.execPath,
+      ["--max-old-space-size=2048", "--input-type=module", "-e", code],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          AURRAL_DATA_DIR: dataDir,
+          AURRAL_DB_PATH: dbPath,
+          ...env,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (codeValue, signal) => {
+      clearTimeout(timer);
+      const elapsedMs = Number((performance.now() - started).toFixed(3));
+      if (timedOut) {
+        resolve({ status: "timeout", elapsedMs, timeoutMs });
+        return;
+      }
+      const lines = stdout.trim().split("\n").filter(Boolean);
+      let value = null;
+      try {
+        value = JSON.parse(lines.at(-1) || "null");
+      } catch {
+        value = null;
+      }
+      if (codeValue !== 0 || !value) {
+        resolve({
+          status: "failed",
+          elapsedMs,
+          exitCode: codeValue,
+          signal,
+          error: stderr.trim().split("\n").at(-1) || "child produced no JSON result",
+        });
+        return;
+      }
+      resolve({ status: "completed", elapsedMs, ...value });
+    });
+  });
+}
+
+const fullReadCode = `
+import { performance } from "node:perf_hooks";
+import { getCanonicalLibrary } from "./backend/services/libraryQueryService.js";
+import { getCanonicalLibraryReadModel } from "./backend/services/canonicalLibraryReadAdapter.js";
+import { toPublicLibrary } from "./backend/routes/library/handlers/canonical.js";
+
+const mode = process.env.AURRAL_BENCHMARK_MODE;
+let value;
+let rawReadMs = 0;
+let transformMs = 0;
+if (mode === "legacy-adapter") {
+  const started = performance.now();
+  value = getCanonicalLibraryReadModel({ source: "lidarr", availableOnly: true });
+  rawReadMs = performance.now() - started;
+} else {
+  const rawStarted = performance.now();
+  const raw = getCanonicalLibrary({ source: "lidarr", availableOnly: true });
+  rawReadMs = performance.now() - rawStarted;
+  const transformStarted = performance.now();
+  value = toPublicLibrary(raw);
+  transformMs = performance.now() - transformStarted;
+}
+const readMs = rawReadMs + transformMs;
+const serializeStarted = performance.now();
+const jsonBytes = Buffer.byteLength(JSON.stringify(value));
+const serializeMs = performance.now() - serializeStarted;
+const memory = process.memoryUsage();
+const counts = {
+  artists: Array.isArray(value.artists) ? value.artists.length : 0,
+  albums: Array.isArray(value.albums) ? value.albums.length : 0,
+  tracks: Array.isArray(value.tracks) ? value.tracks.length : 0,
+};
+console.log(JSON.stringify({
+  rawReadMs: Number(rawReadMs.toFixed(3)),
+  transformMs: Number(transformMs.toFixed(3)),
+  readMs: Number(readMs.toFixed(3)),
+  serializeMs: Number(serializeMs.toFixed(3)),
+  jsonBytes,
+  counts,
+  rssBytes: memory.rss,
+  heapUsedBytes: memory.heapUsed,
+}));
+`;
+
+const indexerProbeCode = `
+import { performance } from "node:perf_hooks";
+import { indexLidarrLibrary } from "./backend/services/libraryLidarrIndexer.js";
+
+const albumCount = Number(process.env.AURRAL_BENCHMARK_INDEXER_ALBUMS);
+const mode = process.env.AURRAL_BENCHMARK_INDEXER_MODE;
+const calls = [];
+const activeAlbums = new Set();
+let maxActiveAlbums = 0;
+const albums = Array.from({ length: albumCount }, (_, index) => ({
+  id: index + 1,
+  artistId: 1,
+  title: \`Benchmark Album \${index}\`,
+  statistics: { sizeOnDisk: 1 },
+}));
+const artists = [{ id: 1, artistName: "Benchmark Artist", foreignArtistId: "lidarr-artist-1" }];
+const albumCall = async (albumId, kind) => {
+  if (kind === "tracks") activeAlbums.add(String(albumId));
+  maxActiveAlbums = Math.max(maxActiveAlbums, activeAlbums.size);
+  await Promise.resolve();
+  if (kind === "files") activeAlbums.delete(String(albumId));
+  return [];
+};
+const client = {
+  isConfigured: () => true,
+  request: async (...args) => {
+    calls.push({ method: "request", path: args[0] });
+    return artists;
+  },
+  getAllAlbums: async () => {
+    calls.push({ method: "getAllAlbums" });
+    return albums;
+  },
+  getRootFolders: async () => {
+    calls.push({ method: "getRootFolders" });
+    return [];
+  },
+};
+if (mode === "bulk") {
+  client.getAllTracks = async () => {
+    calls.push({ method: "getAllTracks" });
+    return [];
+  };
+  client.getAllTrackFiles = async () => {
+    calls.push({ method: "getAllTrackFiles" });
+    return [];
+  };
+} else {
+  client.getTracksByAlbumId = async (albumId) => {
+    calls.push({ method: "getTracksByAlbumId", albumId });
+    return albumCall(albumId, "tracks");
+  };
+  client.getTrackFilesByAlbumId = async (albumId) => {
+    calls.push({ method: "getTrackFilesByAlbumId", albumId });
+    return albumCall(albumId, "files");
+  };
+}
+const started = performance.now();
+const result = await indexLidarrLibrary({ client });
+console.log(JSON.stringify({
+  elapsedMs: Number((performance.now() - started).toFixed(3)),
+  calls,
+  callCount: calls.length,
+  maxActiveAlbums,
+  result,
+}));
+`;
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const dataDir = await mkdtemp(path.join(tmpdir(), "aurral-library-perf-"));
+  const indexerDataDir = await mkdtemp(path.join(tmpdir(), "aurral-indexer-perf-"));
+  const fallbackIndexerDataDir = await mkdtemp(path.join(tmpdir(), "aurral-indexer-fallback-perf-"));
+  const dbPath = path.join(dataDir, "aurral.db");
+  const started = performance.now();
+  let database;
+  let output;
+  try {
+    process.env.AURRAL_DATA_DIR = dataDir;
+    process.env.AURRAL_DB_PATH = dbPath;
+    const imported = await import("../backend/config/db-sqlite.js");
+    database = imported.db;
+    const queryService = await import("../backend/services/libraryQueryService.js");
+    const seedStarted = performance.now();
+    const seed = seedDatabase(database, options);
+    const seedElapsedMs = Number((performance.now() - seedStarted).toFixed(3));
+    const pageCases = [
+      ["artists", { kind: "artists", page: 1, pageSize: 100 }],
+      ["albums", { kind: "albums", page: 1, pageSize: 100, sort: "newest" }],
+      ["tracks", { kind: "tracks", page: 1, pageSize: 100 }],
+      ["tracks-search", { kind: "tracks", page: 1, pageSize: 100, query: String(options.tracks - 1) }],
+      ["genres", { kind: "genres", page: 1, pageSize: 100 }],
+    ];
+    const pages = {};
+    for (const [name, pageOptions] of pageCases) {
+      pages[name] = collectPageSamples(
+        () => queryService.getCanonicalLibraryPage(pageOptions),
+        queryService.invalidateCanonicalLibraryCache,
+        options.repeats,
+      );
+    }
+    database.close();
+    database = null;
+    const fullReads = {};
+    for (const mode of ["full-endpoint", "legacy-adapter"]) {
+      fullReads[mode] = await runChild({
+        dataDir,
+        dbPath,
+        timeoutMs: options.fullReadTimeoutMs,
+        code: fullReadCode,
+        env: { AURRAL_BENCHMARK_MODE: mode },
+      });
+    }
+    const indexerProbes = {};
+    for (const [mode, probeDir] of [
+      ["bulk", indexerDataDir],
+      ["fallback", fallbackIndexerDataDir],
+    ]) {
+      indexerProbes[mode] = await runChild({
+        dataDir: probeDir,
+        dbPath: path.join(probeDir, "aurral.db"),
+        timeoutMs: options.fullReadTimeoutMs,
+        code: indexerProbeCode,
+        env: {
+          AURRAL_BENCHMARK_INDEXER_ALBUMS: String(options.indexerAlbums),
+          AURRAL_BENCHMARK_INDEXER_MODE: mode,
+        },
+      });
+    }
+    const expectedBulkIndexerCalls = 5;
+    const expectedFallbackIndexerCalls = 3 + options.indexerAlbums * 2;
+    const adapter = fullReads["legacy-adapter"];
+    const pageP95 = Object.fromEntries(
+      Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
+    );
+    const checks = {
+      legacyReadCompleted: adapter.status === "completed",
+      bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
+        && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
+      fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
+        && indexerProbes.fallback.callCount === expectedFallbackIndexerCalls,
+      pageWarmP95Under5s: Object.values(pageP95).every((value) => value < 5000),
+    };
+    output = {
+      benchmark: "aurral-library",
+      version: 1,
+      timestamp: new Date().toISOString(),
+      commit,
+      node: process.version,
+      options,
+      elapsedMs: Number((performance.now() - started).toFixed(3)),
+      seed: { ...seed, elapsedMs: seedElapsedMs },
+      pages,
+      fullReads,
+      indexer: {
+        requestedAlbums: options.indexerAlbums,
+        expectedBulkCalls: expectedBulkIndexerCalls,
+        expectedFallbackCalls: expectedFallbackIndexerCalls,
+        bulkProbe: indexerProbes.bulk,
+        fallbackProbe: indexerProbes.fallback,
+      },
+      checks,
+      verdict: Object.values(checks).every(Boolean) ? "pass" : "fail",
+    };
+  } finally {
+    if (database) database.close();
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(indexerDataDir, { recursive: true, force: true });
+    await rm(fallbackIndexerDataDir, { recursive: true, force: true });
+  }
+  await mkdir(path.dirname(options.output), { recursive: true });
+  await writeFile(options.output, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(JSON.stringify({ output: options.output, verdict: output.verdict, checks: output.checks }, null, 2));
+  if (options.check && output.verdict !== "pass") process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -46,6 +46,7 @@ Options:
   --repeats N                 Page samples per cold/warm group, default 3
   --indexer-albums N          Albums in the Lidarr call probe, default 1000
   --full-read-timeout-ms N    Timeout for full-read child probes, default 30000
+  --child-heap-mb N           Child heap cap in megabytes, default 2048
   --output PATH               JSON result path, default perf-results/library-<timestamp>.json
   --check                     Exit nonzero when the regression gate fails
 `);
@@ -65,6 +66,7 @@ Options:
     readOption(args, "full-read-timeout-ms", 30000),
     "full-read-timeout-ms",
   );
+  const childHeapMb = positiveInteger(readOption(args, "child-heap-mb", 2048), "child-heap-mb");
   const output = readOption(
     args,
     "output",
@@ -76,6 +78,7 @@ Options:
     repeats,
     indexerAlbums,
     fullReadTimeoutMs,
+    childHeapMb,
     output: path.isAbsolute(output) ? output : path.join(repoRoot, output),
     check: args.includes("--check"),
   };
@@ -263,12 +266,12 @@ function collectPageSamples(getPage, invalidate, repeats) {
   };
 }
 
-function runChild({ dataDir, dbPath, code, timeoutMs, env = {} }) {
+function runChild({ dataDir, dbPath, code, timeoutMs, heapMb, env = {} }) {
   return new Promise((resolve) => {
     const started = performance.now();
     const child = spawn(
       process.execPath,
-      ["--max-old-space-size=2048", "--input-type=module", "-e", code],
+      [`--max-old-space-size=${heapMb}`, "--input-type=module", "-e", code],
       {
         cwd: repoRoot,
         env: {
@@ -283,10 +286,21 @@ function runChild({ dataDir, dbPath, code, timeoutMs, env = {} }) {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let settled = false;
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGKILL");
     }, timeoutMs);
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        status: "failed",
+        elapsedMs: Number((performance.now() - started).toFixed(3)),
+        error: error.message,
+      });
+    });
     child.stdout.on("data", (chunk) => {
       stdout += chunk;
     });
@@ -294,6 +308,8 @@ function runChild({ dataDir, dbPath, code, timeoutMs, env = {} }) {
       stderr += chunk;
     });
     child.on("close", (codeValue, signal) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       const elapsedMs = Number((performance.now() - started).toFixed(3));
       if (timedOut) {
@@ -475,6 +491,7 @@ async function main() {
         dataDir,
         dbPath,
         timeoutMs: options.fullReadTimeoutMs,
+        heapMb: options.childHeapMb,
         code: fullReadCode,
         env: { AURRAL_BENCHMARK_MODE: mode },
       });
@@ -488,6 +505,7 @@ async function main() {
         dataDir: probeDir,
         dbPath: path.join(probeDir, "aurral.db"),
         timeoutMs: options.fullReadTimeoutMs,
+        heapMb: options.childHeapMb,
         code: indexerProbeCode,
         env: {
           AURRAL_BENCHMARK_INDEXER_ALBUMS: String(options.indexerAlbums),
@@ -502,11 +520,14 @@ async function main() {
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
     );
     const checks = {
+      fullEndpointReadCompleted: fullReads["full-endpoint"].status === "completed",
       legacyReadCompleted: adapter.status === "completed",
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
         && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
       fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
         && indexerProbes.fallback.callCount === expectedFallbackIndexerCalls,
+      fallbackIndexerConcurrency: indexerProbes.fallback.status === "completed"
+        && indexerProbes.fallback.maxActiveAlbums <= 4,
       pageWarmP95Under5s: Object.values(pageP95).every((value) => value < 5000),
     };
     output = {

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -430,6 +430,14 @@ if (mode === "bulk") {
     return [];
   };
 } else {
+  client.getAllTracks = async () => {
+    calls.push({ method: "getAllTracks" });
+    return [{ id: 1, albumId: 1 }];
+  };
+  client.getAllTrackFiles = async () => {
+    calls.push({ method: "getAllTrackFiles" });
+    throw new Error("bulk track-file read failed");
+  };
   client.getTracksByAlbumId = async (albumId) => {
     calls.push({ method: "getTracksByAlbumId", albumId });
     return albumCall(albumId, "tracks");
@@ -514,7 +522,7 @@ async function main() {
       });
     }
     const expectedBulkIndexerCalls = 5;
-    const expectedFallbackIndexerCalls = 3 + options.indexerAlbums * 2;
+    const expectedFallbackIndexerCalls = 5 + options.indexerAlbums * 2;
     const adapter = fullReads["legacy-adapter"];
     const pageP95 = Object.fromEntries(
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),


### PR DESCRIPTION
Large Lidarr libraries could spend most of a refresh making one track and one track-file request per album, while canonical reads repeatedly scanned large in-memory collections. That made a 350,000-track library vulnerable to long refreshes and timeouts.

This change:
- Uses Lidarr's bulk track and track-file reads when available, retaining the existing four-album concurrent fallback for compatible clients.
- Replaces full-collection adapter scans with indexed lookups.
- Streams canonical and genre SQL reads instead of materializing intermediate row arrays.
- Adds a repeatable synthetic 350,000-track benchmark with page latency, read/transform/serialization timings, JSON size, RSS, and provider call counts.
- Adds regression coverage proving bulk reads do not fall back to per-album calls.

Verification:
- `npm test` — 735 passing
- `npm run lint:backend`
- `npm run lint --workspace frontend`
- `npm run build`
- `npm run perf:library -- --check`

Benchmark checkpoint:
- 1,000 albums: 5 bulk calls vs. 2,003 fallback calls.
- Warm paged reads remain below 0.5 seconds at 350,000 tracks.
- The full public response is still about 190 MB JSON and 1.36 GB RSS; that is the next stacked optimization PR, not hidden by this change.

Redis/Valkey is not introduced; this first pass removes measured call and allocation costs in the existing SQLite path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved browsing and indexing performance for large libraries.
  - Reduced memory usage during library queries and genre aggregation.
  - Added configurable benchmarks for measuring performance and detecting regressions.

- **Bug Fixes**
  - Improved bulk library loading reliability with per-album fallback when retrieval fails.

- **Documentation**
  - Added instructions and baseline metrics for library performance benchmarks.

- **Testing**
  - Added coverage for bulk indexing, fallback behavior, artist-specific requests, and file indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->