### PR TITLE
perf(library): avoid deep-cloning public responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Writable } from "node:stream";
 
 import {
   cleanupIsolatedState,
@@ -118,7 +119,17 @@ function getRoute(path) {
 }
 
 function responseFor() {
-  return {
+  const response = new Writable({
+    write(chunk, _encoding, callback) {
+      this.chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  response.chunks = [];
+  response.on("finish", () => {
+    if (response.chunks.length > 0) response.body = JSON.parse(response.chunks.join(""));
+  });
+  Object.assign(response, {
     body: null,
     statusCode: 200,
     contentType: null,
@@ -138,7 +149,8 @@ function responseFor() {
       this.body = JSON.parse(value);
       return this;
     },
-  };
+  });
+  return response;
 }
 
 test("native favorites reuse Subsonic star identity and return current favorites", () => {
@@ -203,9 +215,10 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(artistResponse.body.items[0].userFavorite, true);
 });
 
-test("unpaged canonical library responses keep paths private", () => {
+test("unpaged canonical library responses keep paths private", async () => {
   const response = responseFor();
-  getRoute("GET /canonical")({ user, query: {} }, response);
+  await getRoute("GET /canonical")({ user, query: {} }, response);
+  await new Promise((resolve) => response.once("finish", resolve));
 
   assert.equal(response.statusCode, 200);
   assert.equal(response.contentType, "json");

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -121,12 +121,21 @@ function responseFor() {
   return {
     body: null,
     statusCode: 200,
+    contentType: null,
     status(code) {
       this.statusCode = code;
       return this;
     },
+    type(value) {
+      this.contentType = value;
+      return this;
+    },
     json(value) {
       this.body = value;
+      return this;
+    },
+    send(value) {
+      this.body = JSON.parse(value);
       return this;
     },
   };
@@ -192,6 +201,16 @@ test("canonical library pages return bounded collection responses", () => {
     artistResponse,
   );
   assert.equal(artistResponse.body.items[0].userFavorite, true);
+});
+
+test("unpaged canonical library responses keep paths private", () => {
+  const response = responseFor();
+  getRoute("GET /canonical")({ user, query: {} }, response);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.contentType, "json");
+  assert.equal(response.body.tracks[0].files[0].path, undefined);
+  assert.equal(response.body.tracks[0].title, "Favorite Track");
 });
 
 test("native favorites rejects unknown targets without changing stars", () => {

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -368,10 +368,13 @@ test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async
           trackFileId: 810,
         }];
       },
-      getAllTrackFiles: async ({ artistIds }) => {
-        assert.deepEqual(artistIds, [707]);
+      getTrackFilesByIds: async (trackFileIds) => {
+        assert.deepEqual(trackFileIds, [810]);
         calls.push("files");
         return [{ id: 810, path: filePath, trackIds: [809], mediaInfo: { audioFormat: "FLAC" } }];
+      },
+      getAllTrackFiles: async () => {
+        throw new Error("artist-scoped file read should not run when ID batches exist");
       },
       getTracksByAlbumId: async () => {
         throw new Error("per-album track read should not run when bulk reads exist");

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -106,6 +106,47 @@ test("bulk reads wait for active requests before failing", async () => {
   assert.deepEqual(started, artistIds.slice(0, 12));
 });
 
+test("bulk track-file reads use bounded repeated ID selectors", async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    requests.push(url.searchParams.getAll("trackFileIds").map(Number));
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("[]");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+
+  await client.getTrackFilesByIds(
+    Array.from({ length: 401 }, (_, index) => index + 1),
+    { throwOnError: true },
+  );
+
+  assert.deepEqual(
+    requests.map((batch) => batch.length).sort((left, right) => left - right),
+    [1, 400],
+  );
+  assert.deepEqual(requests.flat().sort((left, right) => left - right), [
+    ...Array.from({ length: 401 }, (_, index) => index + 1),
+  ]);
+  client._httpAgent.destroy();
+  client._httpsAgent.destroy();
+  client._httpsInsecureAgent.destroy();
+});
+
 test("testConnection preserves Lidarr HTTP diagnostics", async (t) => {
   let status = 401;
   const server = http.createServer((_request, response) => {

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,3 +1,5 @@
+import { Readable } from "node:stream";
+
 import { noCache } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
@@ -39,21 +41,49 @@ function getAlbumCoverUrl(album) {
 export const publicLibraryJsonReplacer = (key, value) =>
   isFilesystemPathKey(key) ? undefined : value;
 
+const publicEntity = (kind, entity, favoriteKeys) => favoriteKeys
+  ? { ...entity, userFavorite: favoriteKeys.has(`${kind}:${entity.identityKey}`) }
+  : entity;
+
+const publicAlbum = (album, favoriteKeys) => ({
+  ...album,
+  coverUrl: album.coverUrl || getAlbumCoverUrl(album),
+  ...(favoriteKeys
+    ? { userFavorite: favoriteKeys.has(`album:${album.identityKey}`) }
+    : {}),
+});
+
 export function buildPublicLibrary(library, favoriteKeys = null) {
-  const publicEntity = (kind, entity) => favoriteKeys
-    ? { ...entity, userFavorite: favoriteKeys.has(`${kind}:${entity.identityKey}`) }
-    : entity;
   return {
-    artists: library.artists.map((artist) => publicEntity("artist", artist)),
-    albums: library.albums.map((album) => ({
-      ...album,
-      coverUrl: album.coverUrl || getAlbumCoverUrl(album),
-      ...(favoriteKeys
-        ? { userFavorite: favoriteKeys.has(`album:${album.identityKey}`) }
-        : {}),
-    })),
-    tracks: library.tracks.map((track) => publicEntity("song", track)),
+    artists: library.artists.map((artist) => publicEntity("artist", artist, favoriteKeys)),
+    albums: library.albums.map((album) => publicAlbum(album, favoriteKeys)),
+    tracks: library.tracks.map((track) => publicEntity("song", track, favoriteKeys)),
   };
+}
+
+function* jsonArrayChunks(items, mapper) {
+  yield "[";
+  for (let index = 0; index < items.length; index += 1) {
+    if (index > 0) yield ",";
+    yield JSON.stringify(mapper(items[index]), publicLibraryJsonReplacer);
+  }
+  yield "]";
+}
+
+export function* publicLibraryJsonChunks(library, favoriteKeys = null) {
+  yield "{\"artists\":";
+  yield* jsonArrayChunks(
+    library.artists,
+    (artist) => publicEntity("artist", artist, favoriteKeys),
+  );
+  yield ",\"albums\":";
+  yield* jsonArrayChunks(library.albums, (album) => publicAlbum(album, favoriteKeys));
+  yield ",\"tracks\":";
+  yield* jsonArrayChunks(
+    library.tracks,
+    (track) => publicEntity("song", track, favoriteKeys),
+  );
+  yield "}";
 }
 
 function toPublicLibrary(library, favoriteKeys = null) {
@@ -120,7 +150,8 @@ export function registerCanonical(router) {
         source: req.query.source,
         availableOnly: req.query.availableOnly === "true",
       });
-      return res.type("json").send(toPublicLibraryJson(library, favoriteKeys));
+      res.type("json");
+      return Readable.from(publicLibraryJsonChunks(library, favoriteKeys)).pipe(res);
     } catch (error) {
       if (
         error.message.startsWith("Unsupported library source:") ||

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -36,11 +36,14 @@ function getAlbumCoverUrl(album) {
   return /^https?:\/\//i.test(source || "") ? buildImageProxyUrl(source) : null;
 }
 
-function toPublicLibrary(library, favoriteKeys = null) {
+export const publicLibraryJsonReplacer = (key, value) =>
+  isFilesystemPathKey(key) ? undefined : value;
+
+export function buildPublicLibrary(library, favoriteKeys = null) {
   const publicEntity = (kind, entity) => favoriteKeys
     ? { ...entity, userFavorite: favoriteKeys.has(`${kind}:${entity.identityKey}`) }
     : entity;
-  return stripFilesystemPaths({
+  return {
     artists: library.artists.map((artist) => publicEntity("artist", artist)),
     albums: library.albums.map((album) => ({
       ...album,
@@ -50,7 +53,15 @@ function toPublicLibrary(library, favoriteKeys = null) {
         : {}),
     })),
     tracks: library.tracks.map((track) => publicEntity("song", track)),
-  });
+  };
+}
+
+function toPublicLibrary(library, favoriteKeys = null) {
+  return stripFilesystemPaths(buildPublicLibrary(library, favoriteKeys));
+}
+
+export function toPublicLibraryJson(library, favoriteKeys = null) {
+  return JSON.stringify(buildPublicLibrary(library, favoriteKeys), publicLibraryJsonReplacer);
 }
 
 export function toPublicLibraryPage(page, favoriteKeys = null) {
@@ -109,7 +120,7 @@ export function registerCanonical(router) {
         source: req.query.source,
         availableOnly: req.query.availableOnly === "true",
       });
-      return res.json(toPublicLibrary(library, favoriteKeys));
+      return res.type("json").send(toPublicLibraryJson(library, favoriteKeys));
     } catch (error) {
       if (
         error.message.startsWith("Unsupported library source:") ||

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -89,12 +89,30 @@ async function loadAlbumTrackData(client, albums, artistIds) {
       };
     });
 
-  if (typeof client.getAllTracks === "function" && typeof client.getAllTrackFiles === "function") {
+  if (
+    typeof client.getAllTracks === "function" &&
+    (typeof client.getTrackFilesByIds === "function" ||
+      typeof client.getAllTrackFiles === "function")
+  ) {
     try {
-      const [tracks, files] = await Promise.all([
-        client.getAllTracks({ artistIds, forceRefresh: true, throwOnError: true }),
-        client.getAllTrackFiles({ artistIds, forceRefresh: true, throwOnError: true }),
-      ]);
+      let tracks;
+      let files;
+      if (typeof client.getTrackFilesByIds === "function") {
+        tracks = await client.getAllTracks({
+          artistIds,
+          forceRefresh: true,
+          throwOnError: true,
+        });
+        files = await client.getTrackFilesByIds(
+          tracks.map((track) => track?.trackFileId),
+          { forceRefresh: true, throwOnError: true },
+        );
+      } else {
+        [tracks, files] = await Promise.all([
+          client.getAllTracks({ artistIds, forceRefresh: true, throwOnError: true }),
+          client.getAllTrackFiles({ artistIds, forceRefresh: true, throwOnError: true }),
+        ]);
+      }
       return buildBulkAlbumTrackData(albums, tracks, files);
     } catch {
       return loadPerAlbumTrackData();

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -287,14 +287,15 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
     return `COALESCE((
       SELECT MAX(page_media.created_at)
       FROM library_album_tracks AS page_album_track
-      JOIN library_media_files AS page_media ON page_media.track_id = page_album_track.track_id
+      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+        ON page_media.track_id = page_album_track.track_id
       WHERE page_album_track.album_id = album.id
         AND ${albumMediaCondition("page_media", "page_album_track")}${mediaFilter}
     ), 0) ${orderDirection}, album.title COLLATE NOCASE ${direction === "desc" ? "DESC" : "ASC"}`;
   }
   return `COALESCE((
     SELECT MAX(page_media.created_at)
-    FROM library_media_files AS page_media
+    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
     WHERE page_media.track_id = track.id${mediaFilter}
   ), 0) ${orderDirection}, track.title COLLATE NOCASE ${direction === "desc" ? "DESC" : "ASC"}`;
 };
@@ -309,7 +310,8 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
         SELECT 1
         FROM library_albums AS page_album
         JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
-        JOIN library_media_files AS page_media ON page_media.track_id = page_album_track.track_id
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+          ON page_media.track_id = page_album_track.track_id
         WHERE page_album.artist_id = artist.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
           AND ${conditionSql}
@@ -322,7 +324,8 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
       sql: `EXISTS (
         SELECT 1
         FROM library_album_tracks AS page_album_track
-        JOIN library_media_files AS page_media ON page_media.track_id = page_album_track.track_id
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+          ON page_media.track_id = page_album_track.track_id
         WHERE page_album_track.album_id = album.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
           AND ${conditionSql}
@@ -332,7 +335,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
   }
   return {
     sql: `EXISTS (
-      SELECT 1 FROM library_media_files AS page_media
+      SELECT 1 FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
       WHERE page_media.track_id = track.id AND ${conditionSql}
     )`,
     parameters,

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -10,6 +10,7 @@ import { musicbrainzGetArtistIdentityByMbid } from "./apiClients/musicbrainz.js"
 const CIRCUIT_COOLDOWN_MS = 60000;
 const CIRCUIT_FAILURE_THRESHOLD = 3;
 const LIDARR_MAX_CONCURRENT = 12;
+export const LIDARR_TRACK_FILE_ID_BATCH_SIZE = 400;
 const LIDARR_ALBUM_LOOKUP_CONCURRENCY = 6;
 export const LIDARR_ALBUM_LOOKUP_BATCH_MAX = 100;
 const LIDARR_LIST_CACHE_MS = 30000;
@@ -56,6 +57,19 @@ function normalizeLidarrArtistIds(values) {
     ...new Set(
       (Array.isArray(values) ? values : [])
         .map(normalizeLidarrArtistId)
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function normalizeLidarrTrackFileIds(values) {
+  return [
+    ...new Set(
+      (Array.isArray(values) ? values : [])
+        .map((value) => {
+          const parsed = Number(value);
+          return Number.isSafeInteger(parsed) && parsed > 0 ? String(parsed) : null;
+        })
         .filter(Boolean),
     ),
   ];
@@ -1332,6 +1346,47 @@ export class LidarrClient {
           return [];
         },
         { stopOnError: true },
+      );
+      return results.flat();
+    } catch (error) {
+      if (throwOnError) throw error;
+      return [];
+    }
+  }
+
+  async getTrackFilesByIds(trackFileIds, options = {}) {
+    const { throwOnError = false, ...requestOptions } = options;
+    try {
+      const normalizedTrackFileIds = normalizeLidarrTrackFileIds(trackFileIds);
+      if (normalizedTrackFileIds.length === 0) return [];
+      const batches = [];
+      for (
+        let index = 0;
+        index < normalizedTrackFileIds.length;
+        index += LIDARR_TRACK_FILE_ID_BATCH_SIZE
+      ) {
+        batches.push(
+          normalizedTrackFileIds.slice(index, index + LIDARR_TRACK_FILE_ID_BATCH_SIZE),
+        );
+      }
+      const results = await mapWithConcurrency(
+        batches,
+        LIDARR_MAX_CONCURRENT,
+        async (batch) => {
+          const query = batch
+            .map((trackFileId) => `trackFileIds=${encodeURIComponent(trackFileId)}`)
+            .join("&");
+          const result = await this.request(
+            `/trackfile?${query}`,
+            "GET",
+            null,
+            false,
+            requestOptions,
+          );
+          if (Array.isArray(result)) return result;
+          if (result?.records && Array.isArray(result.records)) return result.records;
+          return [];
+        },
       );
       return results.flat();
     } catch (error) {

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -342,7 +342,10 @@ const fullReadCode = `
 import { performance } from "node:perf_hooks";
 import { getCanonicalLibrary } from "./backend/services/libraryQueryService.js";
 import { getCanonicalLibraryReadModel } from "./backend/services/canonicalLibraryReadAdapter.js";
-import { toPublicLibrary } from "./backend/routes/library/handlers/canonical.js";
+import {
+  buildPublicLibrary,
+  publicLibraryJsonReplacer,
+} from "./backend/routes/library/handlers/canonical.js";
 
 const mode = process.env.AURRAL_BENCHMARK_MODE;
 let value;
@@ -357,12 +360,13 @@ if (mode === "legacy-adapter") {
   const raw = getCanonicalLibrary({ source: "lidarr", availableOnly: true });
   rawReadMs = performance.now() - rawStarted;
   const transformStarted = performance.now();
-  value = toPublicLibrary(raw);
+  value = buildPublicLibrary(raw);
   transformMs = performance.now() - transformStarted;
 }
 const readMs = rawReadMs + transformMs;
 const serializeStarted = performance.now();
-const jsonBytes = Buffer.byteLength(JSON.stringify(value));
+const jsonReplacer = mode === "full-endpoint" ? publicLibraryJsonReplacer : undefined;
+const jsonBytes = Buffer.byteLength(JSON.stringify(value, jsonReplacer));
 const serializeMs = performance.now() - serializeStarted;
 const memory = process.memoryUsage();
 const counts = {


### PR DESCRIPTION
## Summary

- Keep the existing public library shape and path privacy guarantees.
- Avoid recursively cloning every nested artist, album, track, metadata, and file object for the unpaged canonical response.
- Filter filesystem-path keys during the single JSON serialization pass.
- Extend the large-library benchmark and route coverage for this response path.

## Measurements

350,000 synthetic tracks, 35,000 albums, and 3,500 artists:

- JSON payload: 189,892,441 bytes before and after.
- RSS: 1,358,757,888 bytes to 1,105,702,912 bytes.
- Heap used: 1,018,413,032 bytes to 760,698,680 bytes.
- Full child elapsed time: 5,669.730 ms to 4,258.874 ms.

## Verification

- Full test suite: 738 passing.
- Backend lint: passing.
- Library performance gate: passing.
- Checkpoint: `perf-results/public-response-followup.json`

Stacked on #661.