### PR TITLE
fix: allow media data urls in content security policy

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -166,7 +166,7 @@ app.use(
           "https://*.fanart.tv",
         ],
         connectSrc: connectSrcDirectives,
-        mediaSrc: ["'self'", "https://*.dzcdn.net", "https://*.deezer.com"],
+        mediaSrc: ["'self'", "data:", "https://*.dzcdn.net", "https://*.deezer.com"],
         frameSrc: ["'self'", "https://www.youtube-nocookie.com", "https://www.youtube.com"],
         frameAncestors: null,
         upgradeInsecureRequests: null,


### PR DESCRIPTION
## What changed

Allow `data:` URLs in the media source Content Security Policy.

## Why

This prevents media loaded from data URLs from being blocked by the browser.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Not run; this is a one-line Content Security Policy configuration change.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated media security settings to allow supported media loaded through `data:` URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->