### PR TITLE
refactor(frontend): unify loading indicators

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import { AudioQueueProvider } from "./contexts/AudioQueueProvider";
 import { AlertTriangle, XCircle } from "lucide-react";
 import ReloadPrompt from "./components/ReloadPrompt";
 import UpdateIndicator from "./components/UpdateIndicator";
+import { DotLoader } from "./components/DotLoader";
 import { useWebSocketChannel } from "./hooks/useWebSocket";
 import { buildActivityPath, DEFAULT_ACTIVITY_VIEW } from "./navigation/activityNavConfig";
 import { getBootstrapPollIntervalMs } from "./utils/requestScheduling.js";
@@ -52,13 +53,13 @@ const NewsPage = lazy(() => import("./pages/NewsPage"));
 
 const PageLoader = () => (
   <div className="app-loading">
-    <div className="app-loading__spinner" />
+    <DotLoader size="xl" />
   </div>
 );
 
 const ScreenLoader = () => (
   <div className="app-loading app-loading--screen">
-    <div className="app-loading__spinner app-loading__spinner--lg" />
+    <DotLoader size="2xl" />
   </div>
 );
 

--- a/frontend/src/components/AddActionButton.jsx
+++ b/frontend/src/components/AddActionButton.jsx
@@ -1,6 +1,7 @@
 import { forwardRef } from "react";
-import { Loader, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import TooltipButton from "./TooltipButton";
+import { DotLoader } from "./DotLoader";
 
 const AddActionButton = forwardRef(function AddActionButton(
   {
@@ -27,7 +28,7 @@ const AddActionButton = forwardRef(function AddActionButton(
     >
       <span className="btn-add-action__icon">
         {isLoading ? (
-          <Loader className="animate-spin" aria-hidden="true" />
+          <DotLoader size="sm" label={null} />
         ) : (
           <Icon aria-hidden="true" />
         )}

--- a/frontend/src/components/ArtistContextMenu.jsx
+++ b/frontend/src/components/ArtistContextMenu.jsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Ban, Library, Loader2, MoreVertical, ThumbsDown, ThumbsUp } from "lucide-react";
+import { Ban, Library, MoreVertical, ThumbsDown, ThumbsUp } from "lucide-react";
 import { getDiscoveryFeedbackLabel } from "../utils/discoveryFeedback";
 import TooltipButton from "./TooltipButton";
+import { DotLoader } from "./DotLoader";
 
 const getMenuHorizontalAnchorRect = (button) => {
   const discoverCard = button.closest(".artist-discover-card");
@@ -212,7 +213,7 @@ export function ArtistContextMenu({
             className={`btn btn-icon-square artist-context-menu__inline-action${isInLibrary ? " is-selected" : ""}`}
           >
             {pendingAction === "library" ? (
-              <Loader2 className="artist-icon-sm animate-spin" />
+              <DotLoader size="sm" label={null} />
             ) : (
               <Library className="artist-icon-sm" />
             )}
@@ -227,7 +228,7 @@ export function ArtistContextMenu({
               className={`btn btn-icon-square artist-context-menu__inline-action${feedbackUsed.more_like_this ? " is-selected" : ""}`}
             >
               {pendingAction === "more_like_this" ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <ThumbsUp className="artist-icon-sm" />
               )}
@@ -239,7 +240,7 @@ export function ArtistContextMenu({
               className={`btn btn-icon-square artist-context-menu__inline-action${feedbackUsed.less_like_this ? " is-selected" : ""}`}
             >
               {pendingAction === "less_like_this" ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <ThumbsDown className="artist-icon-sm" />
               )}
@@ -251,7 +252,7 @@ export function ArtistContextMenu({
               className={`btn btn-icon-square artist-context-menu__inline-action artist-context-menu__inline-action--danger${feedbackUsed.block_artist ? " is-selected" : ""}`}
             >
               {pendingAction === "block_artist" ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <Ban className="artist-icon-sm" />
               )}
@@ -305,7 +306,7 @@ export function ArtistContextMenu({
                 >
                   <div className="artist-menu-item__main--discover">
                     {pendingAction === "library" ? (
-                      <Loader2 className="artist-icon-sm animate-spin" />
+                      <DotLoader size="sm" label={null} />
                     ) : (
                       <Library className="artist-icon-sm" />
                     )}
@@ -327,7 +328,7 @@ export function ArtistContextMenu({
                   >
                     <div className="artist-menu-item__main--discover">
                       {pendingAction === "more_like_this" ? (
-                        <Loader2 className="artist-icon-sm animate-spin" />
+                        <DotLoader size="sm" label={null} />
                       ) : (
                         <ThumbsUp className="artist-icon-sm" />
                       )}
@@ -346,7 +347,7 @@ export function ArtistContextMenu({
                   >
                     <div className="artist-menu-item__main--discover">
                       {pendingAction === "less_like_this" ? (
-                        <Loader2 className="artist-icon-sm animate-spin" />
+                        <DotLoader size="sm" label={null} />
                       ) : (
                         <ThumbsDown className="artist-icon-sm" />
                       )}
@@ -365,7 +366,7 @@ export function ArtistContextMenu({
                   >
                     <div className="artist-menu-item__main--discover">
                       {pendingAction === "block_artist" ? (
-                        <Loader2 className="artist-icon-sm animate-spin" />
+                        <DotLoader size="sm" label={null} />
                       ) : (
                         <Ban className="artist-icon-sm" />
                       )}

--- a/frontend/src/components/ArtistImage.jsx
+++ b/frontend/src/components/ArtistImage.jsx
@@ -3,7 +3,8 @@ import { getArtistCover } from "../utils/api/endpoints/artists.js";
 import { normalizeMediaUrl } from "../utils/normalizeMediaUrl";
 import { useArtistPreviewPlayback } from "../hooks/useArtistPreviewPlayback";
 
-import { Music, Loader, Play } from "lucide-react";
+import { Music, Play } from "lucide-react";
+import { DotLoader } from "./DotLoader";
 const queue = [];
 let active = 0;
 const MAX_CONCURRENT = 4;
@@ -214,7 +215,7 @@ const ArtistImage = ({
       title={`Play ${artistName || "artist"} top tracks`}
     >
       {isLoadingPreview ? (
-        <Loader className="artist-image-preview-button__icon animate-spin" />
+        <DotLoader size="md" label={null} className="artist-image-preview-button__icon" />
       ) : (
         <Play className="artist-image-preview-button__icon" fill="currentColor" />
       )}
@@ -242,15 +243,16 @@ const ArtistImage = ({
       >
         <div className="artist-image-overlay">
           {isLoading ? (
-            <Loader
-              className={`artist-image-loader${showLoading ? " animate-spin" : " is-dim"}`}
+            <DotLoader
+              size="md"
+              label={null}
+              className={`artist-image-loader${showLoading ? "" : " is-dim"}`}
             />
           ) : (
             <Music className="artist-image-icon" />
           )}
         </div>
         {previewButton}
-        {isLoading && <div className="artist-image-shimmer" />}
       </div>
     );
   }
@@ -265,7 +267,7 @@ const ArtistImage = ({
           className="artist-image-overlay"
           style={{ backgroundColor: "var(--aurral-surface-raised)" }}
         >
-          <Loader className="artist-image-loader animate-spin" />
+          <DotLoader size="md" label={null} className="artist-image-loader" />
         </div>
       )}
       {currentSrc && (

--- a/frontend/src/components/DiscoverPlaylistContextMenu.jsx
+++ b/frontend/src/components/DiscoverPlaylistContextMenu.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ListMusic, Loader2, MoreVertical, Plus, RefreshCw } from "lucide-react";
+import { ListMusic, MoreVertical, Plus, RefreshCw } from "lucide-react";
+import { DotLoader } from "./DotLoader";
 
 const getMenuHorizontalAnchorRect = (button) => {
   const discoverCard = button.closest(".artist-discover-card");
@@ -213,7 +214,7 @@ export function DiscoverPlaylistContextMenu({
       >
         {triggerVariant === "add" ? (
           isBusy ? (
-            <Loader2 className="artist-icon-md animate-spin" />
+            <DotLoader size="md" label={null} />
           ) : (
             <Plus className="artist-icon-md" />
           )
@@ -240,7 +241,7 @@ export function DiscoverPlaylistContextMenu({
               >
                 <div className="artist-menu-item__main--discover">
                   {pendingAction === "flow" || isAdoptingFlow ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
+                    <DotLoader size="sm" label={null} />
                   ) : (
                     <RefreshCw className="artist-icon-sm" />
                   )}
@@ -255,7 +256,7 @@ export function DiscoverPlaylistContextMenu({
               >
                 <div className="artist-menu-item__main--discover">
                   {pendingAction === "playlist" || isAdoptingPlaylist ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
+                    <DotLoader size="sm" label={null} />
                   ) : (
                     <ListMusic className="artist-icon-sm" />
                   )}

--- a/frontend/src/components/DiscoveryStatusPill.jsx
+++ b/frontend/src/components/DiscoveryStatusPill.jsx
@@ -1,5 +1,6 @@
-import { Loader, Clock } from "lucide-react";
+import { Clock } from "lucide-react";
 import { formatDate } from "../utils/dateTime.js";
+import { DotLoader } from "./DotLoader";
 
 export default function DiscoveryStatusPill({
   isUpdating = false,
@@ -11,7 +12,7 @@ export default function DiscoveryStatusPill({
   if (isUpdating) {
     return (
       <span className="artist-discover-hero__updated artist-discover-hero__updated--refreshing">
-        <Loader className="artist-discover-hero__updated-icon animate-spin" />
+        <DotLoader size="sm" label={null} className="artist-discover-hero__updated-icon" />
         {updateProgressMessage || "Refreshing discovery..."}
       </span>
     );
@@ -20,7 +21,7 @@ export default function DiscoveryStatusPill({
   if (playlistsUpdating) {
     return (
       <span className="artist-discover-hero__updated artist-discover-hero__updated--refreshing">
-        <Loader className="artist-discover-hero__updated-icon animate-spin" />
+        <DotLoader size="sm" label={null} className="artist-discover-hero__updated-icon" />
         {playlistsUpdateMessage || "Updating playlists..."}
       </span>
     );

--- a/frontend/src/components/DotLoader.jsx
+++ b/frontend/src/components/DotLoader.jsx
@@ -1,0 +1,40 @@
+const COARSE_TILE_SIZE = 16;
+const COARSE_GAP = 7;
+const COARSE_FOOTPRINT = 3 * COARSE_TILE_SIZE + 2 * COARSE_GAP;
+const DOT_COUNT = 9;
+
+const LOADER_FOOTPRINTS = {
+  xs: 14,
+  sm: 16,
+  md: 20,
+  lg: 28,
+  xl: 32,
+  "2xl": 62,
+};
+
+export function DotLoader({ size = "sm", label = "Loading", className = "" }) {
+  const classes = ["aurral-dot-loader", className].filter(Boolean).join(" ");
+  const footprint = LOADER_FOOTPRINTS[size] || LOADER_FOOTPRINTS.sm;
+  const tileSize = (footprint * COARSE_TILE_SIZE) / COARSE_FOOTPRINT;
+  const gap = (footprint * COARSE_GAP) / COARSE_FOOTPRINT;
+  const style = {
+    width: `${footprint}px`,
+    height: `${footprint}px`,
+    "--aurral-dot-loader-tile-size": `${tileSize}px`,
+    "--aurral-dot-loader-gap": `${gap}px`,
+  };
+
+  return (
+    <span
+      className={classes}
+      style={style}
+      role={label === null ? undefined : "status"}
+      aria-label={label === null ? undefined : label}
+      aria-hidden={label === null ? "true" : undefined}
+    >
+      {Array.from({ length: DOT_COUNT }, (_, index) => (
+        <span key={index} className="aurral-dot-loader__dot" aria-hidden="true" />
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/components/DownloadFolderPickerModal.jsx
+++ b/frontend/src/components/DownloadFolderPickerModal.jsx
@@ -4,6 +4,7 @@ import { browseFilesystem, ensureFilesystemPath } from "../utils/api/endpoints/a
 import { createPortal } from "react-dom";
 import { ArrowUp, Folder, X } from "lucide-react";
 import { useModalDialog } from "../hooks/useModalDialog.js";
+import { DotLoader } from "./DotLoader";
 function normalizeConfirmedPath(pathValue, browsePath) {
   const raw = String(pathValue ?? "").trim() || browsePath || "/";
   if (raw === "/") return "/";
@@ -206,7 +207,11 @@ export default function DownloadFolderPickerModal({
               ))}
             </tbody>
           </table>
-          {loading ? <p className="file-browser-modal__status">Loading folders...</p> : null}
+          {loading ? (
+            <p className="file-browser-modal__status">
+              <DotLoader size="sm" label={null} /> Loading folders...
+            </p>
+          ) : null}
           {!loading && !parentPath && entries.length === 0 ? (
             <p className="file-browser-modal__status">No subfolders here.</p>
           ) : null}

--- a/frontend/src/components/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch.jsx
@@ -38,7 +38,8 @@ import { getAlbumAddButtonLabel, shouldTriggerAlbumSearch } from "../utils/album
 import { useDebouncedTask } from "../hooks/useDebouncedTask";
 import { useSharedPlaylists } from "../hooks/useSharedPlaylists";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Clock, Loader2, Search } from "lucide-react";
+import { Clock, Search } from "lucide-react";
+import { DotLoader } from "./DotLoader";
 import AddActionButton from "./AddActionButton";
 import SearchLibraryCheck from "./SearchLibraryCheck";
 import { TrackPlaylistMenu } from "../pages/ArtistDetails/components/TrackPlaylistMenu";
@@ -627,7 +628,7 @@ function GlobalSearch({ settingsMode = false }) {
           )}
           {loadingSuggestions && (
             <div className="global-search__loader">
-              <Loader2 className="artist-icon-md animate-spin" />
+              <DotLoader size="md" label={null} />
             </div>
           )}
         </div>

--- a/frontend/src/components/InboxMenu.jsx
+++ b/frontend/src/components/InboxMenu.jsx
@@ -19,6 +19,7 @@ import { readStoredNearbyLocation } from "../pages/discoverUtils.js";
 import { useAuth } from "../contexts/AuthContext.jsx";
 import { useToast } from "../contexts/ToastContext";
 import TooltipButton from "./TooltipButton";
+import { DotLoader } from "./DotLoader";
 import { queryClient, queryKeys } from "../queryClient.js";
 
 const ITEM_ICONS = {
@@ -339,7 +340,9 @@ function InboxMenu() {
             ) : null}
           </div>
           {(inboxQuery.isPending || (serverRefreshing && items.length === 0)) ? (
-            <div className="app-inbox-menu__empty">Loading…</div>
+            <div className="app-inbox-menu__empty">
+              <DotLoader size="sm" label={null} /> Loading…
+            </div>
           ) : items.length === 0 ? (
             <div className="app-inbox-menu__empty">Nothing to see here yet</div>
           ) : visibleItems.length === 0 ? (

--- a/frontend/src/components/LibraryItemMenu.jsx
+++ b/frontend/src/components/LibraryItemMenu.jsx
@@ -1,7 +1,8 @@
 import { createPortal } from "react-dom";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from "react";
-import { ChevronRight, Loader2, MoreVertical } from "lucide-react";
+import { ChevronRight, MoreVertical } from "lucide-react";
 import TooltipButton from "./TooltipButton";
+import { DotLoader } from "./DotLoader";
 
 let activeMenuCloser = null;
 
@@ -69,7 +70,7 @@ export function LibraryItemSubmenu({
             >
               <span className="artist-menu-item__main">
                 {isPending ? (
-                  <Loader2 className="artist-icon-sm animate-spin" />
+                  <DotLoader size="sm" label={null} />
                 ) : ItemIcon ? (
                   <ItemIcon className="artist-icon-sm" />
                 ) : null}
@@ -268,7 +269,7 @@ export const LibraryItemMenu = forwardRef(function LibraryItemMenu(
             >
               <span className="artist-menu-item__main">
                 {isPending ? (
-                  <Loader2 className="artist-icon-sm animate-spin" />
+                  <DotLoader size="sm" label={null} />
                 ) : Icon ? (
                   <Icon className="artist-icon-sm" />
                 ) : null}

--- a/frontend/src/components/PlaylistModals.jsx
+++ b/frontend/src/components/PlaylistModals.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { Check, Loader2, MoreVertical, Plus, Sparkles, Trash2, Upload, X } from "lucide-react";
+import { Check, MoreVertical, Plus, Sparkles, Trash2, Upload, X } from "lucide-react";
 import { useModalDialog } from "../hooks/useModalDialog.js";
+import { DotLoader } from "./DotLoader";
 
 export function ModalShell({
   open,
@@ -116,7 +117,7 @@ export function CreatePlaylistModal({
             disabled={saving}
           >
             {saving ? (
-              <Loader2 className="artist-icon-sm animate-spin" />
+              <DotLoader size="sm" label={null} />
             ) : (
               <Plus className="artist-icon-sm" />
             )}
@@ -354,7 +355,7 @@ export function RenamePlaylistModal({
                     >
                       <span className="artist-menu-item__main">
                         {coverBusy ? (
-                          <Loader2 className="artist-icon-sm animate-spin" />
+                          <DotLoader size="sm" label={null} />
                         ) : (
                           <Sparkles className="artist-icon-sm" />
                         )}
@@ -418,7 +419,7 @@ export function RenamePlaylistModal({
               disabled={busy}
             >
               {saving ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <Check className="artist-icon-sm" />
               )}

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -3,17 +3,17 @@ import {
   AlertCircle,
   CheckCircle,
   Info,
-  LoaderCircle,
   TriangleAlert,
   X,
 } from "lucide-react";
+import { DotLoader } from "./DotLoader";
 
 const TOAST_ICONS = {
   success: CheckCircle,
   error: AlertCircle,
   info: Info,
   warning: TriangleAlert,
-  loading: LoaderCircle,
+  loading: DotLoader,
 };
 
 const TOAST_EXIT_DURATION = 180;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,3 @@
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
-}
-
 :root {
   color-scheme: dark;
   --font-sans: ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
@@ -755,14 +746,93 @@ textarea {
   display: none;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
+.aurral-dot-loader {
+  display: inline-grid;
+  grid-template-columns: repeat(3, var(--aurral-dot-loader-tile-size));
+  grid-template-rows: repeat(3, var(--aurral-dot-loader-tile-size));
+  gap: var(--aurral-dot-loader-gap);
+  flex: 0 0 auto;
+  vertical-align: middle;
+  color: var(--aurral-text-muted);
+}
+
+.aurral-dot-loader__dot {
+  width: var(--aurral-dot-loader-tile-size);
+  height: var(--aurral-dot-loader-tile-size);
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.1;
+  animation: aurral-dot-loader-helix 2.6s ease-in-out infinite;
+}
+
+.aurral-dot-loader__dot:nth-child(1) {
+  animation-delay: -2.275s;
+}
+
+.aurral-dot-loader__dot:nth-child(2) {
+  animation-delay: 0s;
+}
+
+.aurral-dot-loader__dot:nth-child(3) {
+  animation-delay: -0.325s;
+}
+
+.aurral-dot-loader__dot:nth-child(4) {
+  animation-delay: -1.95s;
+}
+
+.aurral-dot-loader__dot:nth-child(5),
+.aurral-dot-loader__dot:nth-child(6) {
+  animation-delay: -0.65s;
+}
+
+.aurral-dot-loader__dot:nth-child(7) {
+  animation-delay: -1.625s;
+}
+
+.aurral-dot-loader__dot:nth-child(8) {
+  animation-delay: -1.3s;
+}
+
+.aurral-dot-loader__dot:nth-child(9) {
+  animation-delay: -0.975s;
+}
+
+@keyframes aurral-dot-loader-helix {
+  0%,
+  100% {
+    opacity: 0.1;
+  }
+
+  30% {
+    opacity: 0.95;
+  }
+
+  50% {
+    opacity: 0.3;
+  }
+
+  80% {
+    opacity: 0.95;
   }
 }
 
-.animate-spin {
-  animation: spin 1s linear infinite;
+@media (prefers-reduced-motion: reduce) {
+  .aurral-dot-loader__dot {
+    animation: aurral-dot-loader-pulse 3s ease-in-out infinite;
+    animation-delay: 0s !important;
+  }
+}
+
+@keyframes aurral-dot-loader-pulse {
+  0%,
+  100% {
+    opacity: 0.22;
+  }
+
+  50% {
+    opacity: 0.9;
+  }
 }
 
 .artist-details-page button.btn-round-lg {
@@ -2183,10 +2253,6 @@ textarea {
   height: 1rem;
 }
 
-.app-toast--loading .app-toast__icon svg {
-  animation: spin 1s linear infinite;
-}
-
 .app-toast__content {
   display: flex;
   min-width: 0;
@@ -2743,17 +2809,6 @@ textarea {
   justify-content: center;
   align-items: center;
   padding: 5rem 0;
-}
-
-.artist-spinner {
-  width: 2rem;
-  height: 2rem;
-  color: var(--aurral-text-muted);
-}
-
-.artist-spinner--large {
-  width: 3rem;
-  height: 3rem;
 }
 
 .artist-empty-panel,
@@ -4903,8 +4958,7 @@ textarea {
   padding: 4rem 1.5rem;
 }
 
-.discover-recommended-status__icon,
-.discover-recommended-status__spinner {
+.discover-recommended-status__icon {
   display: flex;
   width: 4.5rem;
   height: 4.5rem;
@@ -4919,9 +4973,8 @@ textarea {
   border-radius: var(--aurral-radius-round);
 }
 
-.discover-recommended-status__spinner {
-  width: 2.5rem;
-  height: 2.5rem;
+.discover-recommended-status__loader {
+  margin-bottom: 1.25rem;
 }
 
 .discover-recommended-status__heading {
@@ -6082,12 +6135,6 @@ textarea {
   border-radius: var(--aurral-radius);
 }
 
-.artist-nearby-status__spinner {
-  width: 2rem;
-  height: 2rem;
-  color: var(--aurral-text-muted);
-}
-
 /* Nearby Configuration */
 
 .artist-nearby-location {
@@ -6392,11 +6439,8 @@ textarea {
   text-align: center;
 }
 
-.artist-spinner--discover {
-  width: 3rem;
-  height: 3rem;
+.aurral-dot-loader--discover {
   margin-bottom: 1rem;
-  color: var(--aurral-text-muted);
 }
 
 .artist-error-title--discover {
@@ -6791,14 +6835,9 @@ textarea {
 
   .sidebar-link__activity,
   .sidebar-subnav-link__alert,
-  .artist-image-shimmer,
   .onboarding-card-shell,
   .onboarding-card-shell::after {
     animation: none !important;
-  }
-
-  .artist-image-shimmer {
-    background-position: 50% 0;
   }
 
   .app-toast,
@@ -12765,19 +12804,6 @@ button.native-library-genre-row:focus-visible {
   min-height: 100vh;
 }
 
-.app-loading__spinner {
-  width: 2rem;
-  height: 2rem;
-  border-bottom: 2px solid var(--aurral-text-muted);
-  border-radius: var(--aurral-radius-round);
-  animation: spin 1s linear infinite;
-}
-
-.app-loading__spinner--lg {
-  width: 3rem;
-  height: 3rem;
-}
-
 .app-status-banner {
   display: flex;
   align-items: flex-start;
@@ -13405,19 +13431,6 @@ button.native-library-genre-row:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.artist-image-shimmer {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    110deg,
-    color-mix(in srgb, var(--aurral-text) 2%, transparent) 8%,
-    color-mix(in srgb, var(--aurral-text) 8%, transparent) 18%,
-    color-mix(in srgb, var(--aurral-text) 2%, transparent) 33%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.6s linear infinite;
 }
 
 .artist-image-media {

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -26,7 +26,8 @@ import ActivityMissingPage from "./activity/ActivityMissingPage";
 import ActivityInfoModal from "./activity/ActivityInfoModal";
 
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
-import { Loader, AlertCircle, Music } from "lucide-react";
+import { AlertCircle, Music } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import { queryClient, queryKeys } from "../queryClient.js";
 const ACTIVITY_PAGE_SIZE = 25;
 
@@ -412,7 +413,7 @@ function ActivityPage() {
           refreshing={refreshing}
         />
         <div className="artist-loading">
-          <Loader className="artist-spinner artist-spinner--large animate-spin" />
+          <DotLoader size="2xl" label={null} />
         </div>
       </div>
     );

--- a/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistDetailsPage.jsx
@@ -25,7 +25,8 @@ import { useSharedPlaylists } from "../../hooks/useSharedPlaylists";
 
 import { useParams, useLocation } from "react-router-dom";
 import { useDiscoverNavigation } from "../../hooks/useDiscoverNavigation";
-import { Loader, Music, X } from "lucide-react";
+import { Music, X } from "lucide-react";
+import { DotLoader } from "../../components/DotLoader";
 import { useToast } from "../../contexts/ToastContext";
 import { useAuth } from "../../contexts/AuthContext";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
@@ -451,7 +452,7 @@ function ArtistDetailsPage() {
   if (loading) {
     return (
       <div className="artist-loading">
-        <Loader className="artist-spinner artist-spinner--large animate-spin" />
+        <DotLoader size="2xl" label={null} />
       </div>
     );
   }
@@ -798,6 +799,7 @@ function EditArtistIdsModal({
             onClick={onSave}
             disabled={loading || saving}
           >
+            {saving ? <DotLoader size="sm" label={null} /> : null}
             {saving ? "Saving..." : "Save IDs"}
           </button>
         </div>

--- a/frontend/src/pages/ArtistDetails/ArtistReleaseListPage.jsx
+++ b/frontend/src/pages/ArtistDetails/ArtistReleaseListPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import { useDiscoverNavigation } from "../../hooks/useDiscoverNavigation";
+import { DotLoader } from "../../components/DotLoader";
 import {
   ArrowDown,
   ArrowUp,
@@ -8,7 +9,6 @@ import {
   CornerUpLeft,
   LayoutGrid,
   List,
-  Loader,
   Music,
   Search,
   Star,
@@ -326,7 +326,7 @@ function ArtistReleaseListPage({ mode = "releases" }) {
   if (loading) {
     return (
       <div className="artist-loading">
-        <Loader className="artist-spinner animate-spin" />
+        <DotLoader size="xl" label={null} />
       </div>
     );
   }
@@ -484,7 +484,7 @@ function ArtistReleaseListPage({ mode = "releases" }) {
           </Link>
           {loadingReleases && (
             <p className="artist-meta-line">
-              <Loader className="artist-icon-sm animate-spin" />
+              <DotLoader size="sm" label={null} />
               {isAppearsOn ? "Loading appearances" : "Loading releases"}
             </p>
           )}
@@ -621,7 +621,7 @@ function ArtistReleaseListPage({ mode = "releases" }) {
             disabled={loadingMoreAppearances}
           >
             {loadingMoreAppearances ? (
-              <Loader className="artist-icon-sm animate-spin" />
+              <DotLoader size="sm" label={null} />
             ) : null}
             Load more
           </button>

--- a/frontend/src/pages/ArtistDetails/components/AddArtistCustomizeModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/AddArtistCustomizeModal.jsx
@@ -1,5 +1,5 @@
 import { useId } from "react";
-import { Loader } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
 export function AddArtistCustomizeModal({
@@ -54,7 +54,7 @@ export function AddArtistCustomizeModal({
 
         {loading ? (
           <div className="artist-loading">
-            <Loader className="artist-spinner animate-spin" />
+            <DotLoader size="xl" label={null} />
           </div>
         ) : (
           <div className="artist-modal__fields">
@@ -144,6 +144,7 @@ export function AddArtistCustomizeModal({
             className="btn btn-primary"
             disabled={loading || !configured || confirming}
           >
+            {confirming ? <DotLoader size="sm" label={null} /> : null}
             {confirming ? "Adding..." : "Add Artist"}
           </button>
         </div>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsActionBar.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsActionBar.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import {
   Ban,
   ChevronDown,
-  Loader,
   MoreHorizontal,
   Pause,
   Pencil,
@@ -13,6 +12,7 @@ import {
   ThumbsUp,
   Trash2,
 } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import AddActionButton from "../../../components/AddActionButton";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import { getDiscoveryFeedbackLabel } from "../../../utils/discoveryFeedback";
@@ -51,7 +51,7 @@ export function ArtistDetailsActionBar({
     if (loadingLibrary) {
       return (
         <div className="btn btn-secondary btn--bold btn-min-h">
-          <Loader className="artist-icon-sm animate-spin" />
+          <DotLoader size="sm" label={null} />
           {existsInLibrary ? "Loading library" : "Checking Lidarr"}
         </div>
       );
@@ -175,7 +175,7 @@ export function ArtistDetailsActionBar({
             title={isPreviewPlaying ? "Pause playback" : "Play artist"}
           >
             {buildingQueue ? (
-              <Loader className="artist-icon-md animate-spin" />
+              <DotLoader size="md" label={null} />
             ) : isPreviewPlaying ? (
               <Pause className="artist-icon-md" />
             ) : (
@@ -196,7 +196,7 @@ export function ArtistDetailsActionBar({
               title="Refresh artist"
             >
               {library.refreshingArtist ? (
-                <Loader className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <RefreshCw className="artist-icon-sm" />
               )}
@@ -235,7 +235,7 @@ export function ArtistDetailsActionBar({
                       >
                         <span className="artist-menu-item__main">
                           {tasteActionPending === "more_like_this" ? (
-                            <Loader className="artist-icon-sm animate-spin" />
+                            <DotLoader size="sm" label={null} />
                           ) : (
                             <ThumbsUp className="artist-icon-sm" />
                           )}
@@ -253,7 +253,7 @@ export function ArtistDetailsActionBar({
                       >
                         <span className="artist-menu-item__main">
                           {tasteActionPending === "less_like_this" ? (
-                            <Loader className="artist-icon-sm animate-spin" />
+                            <DotLoader size="sm" label={null} />
                           ) : (
                             <ThumbsDown className="artist-icon-sm" />
                           )}
@@ -271,7 +271,7 @@ export function ArtistDetailsActionBar({
                       >
                         <span className="artist-menu-item__main">
                           {tasteActionPending === "block_artist" ? (
-                            <Loader className="artist-icon-sm animate-spin" />
+                            <DotLoader size="sm" label={null} />
                           ) : (
                             <Ban className="artist-icon-sm" />
                           )}

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsAppearsOn.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsAppearsOn.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useDiscoverNavigation } from "../../../hooks/useDiscoverNavigation";
-import { ArrowRight, Loader, Music, Star } from "lucide-react";
+import { ArrowRight, Music, Star } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import AddActionButton from "../../../components/AddActionButton";
 import { navigateToReleaseGroup } from "../../../utils/searchNavigation";
@@ -60,7 +61,7 @@ export function ArtistDetailsAppearsOn({
         <div className="artist-min-0">
           <div className="artist-controls-row">
             <h2 className="artist-section-title">Appears On</h2>
-            {loadingAppearsOn && <Loader className="artist-icon-sm animate-spin" />}
+            {loadingAppearsOn && <DotLoader size="sm" label={null} />}
           </div>
         </div>
         {onViewAll ? (

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsDownloadTargets.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader, Music, Star } from "lucide-react";
+import { Music, Star } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import AddActionButton from "../../../components/AddActionButton";
 import { getReleaseGroupTracks } from "../../../utils/api/endpoints/artists.js";
 import { buildAurralPick, getReleaseGroupCoverUrl, getReleaseMetric } from "../utils";
@@ -231,7 +232,7 @@ export function ArtistDetailsDownloadTargets({
           <div className="artist-pick-panel__tracks artist-min-0">
             {loadingTracks ? (
               <div className="artist-loading">
-                <Loader className="artist-spinner animate-spin" />
+                <DotLoader size="xl" label={null} />
               </div>
             ) : tracks.length ? (
               <>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsLibraryAlbums.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDiscoverNavigation } from "../../../hooks/useDiscoverNavigation";
 import {
-  Loader,
   Music,
   ChevronLeft,
   ChevronRight,
@@ -10,6 +9,7 @@ import {
   Trash2,
   RefreshCw,
 } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { navigateToLibraryAlbum } from "../../../utils/searchNavigation";
 import { isVisibleLibraryAlbum } from "../utils";
 
@@ -271,7 +271,7 @@ export function ArtistDetailsLibraryAlbums({
               disabled={reSearchingMissingAlbums || incompleteAlbumCount === 0}
             >
               {reSearchingMissingAlbums ? (
-                <Loader className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <RefreshCw className="artist-icon-sm" />
               )}
@@ -349,7 +349,7 @@ export function ArtistDetailsLibraryAlbums({
 
                 <div className="artist-library-card__status">
                   {requestingAlbum === rgId || reSearchingAlbum === libraryAlbum.id ? (
-                    <Loader className="artist-icon-xs animate-spin" />
+                    <DotLoader size="xs" label={null} />
                   ) : hasDownloadedStatus ? (
                     <span
                       className="artist-status-dot artist-status-dot--complete"
@@ -442,7 +442,7 @@ export function ArtistDetailsLibraryAlbums({
                               >
                                 <span className="artist-menu-item__main">
                                   {reSearchingAlbum === libraryAlbum.id ? (
-                                    <Loader className="artist-icon-sm animate-spin" />
+                                    <DotLoader size="sm" label={null} />
                                   ) : (
                                     <RefreshCw className="artist-icon-sm" />
                                   )}

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsPreviewTracks.jsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { getArtistTopSongVideo } from "../../../utils/api/endpoints/artists.js";
 import { TrackPlaylistMenu } from "./TrackPlaylistMenu";
 
-import { Loader, Pause, Play } from "lucide-react";
+import { Pause, Play } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 export function ArtistDetailsPreviewTracks({
   mbid,
   artistName,
@@ -75,7 +76,7 @@ export function ArtistDetailsPreviewTracks({
       <h2 className="artist-section-title">Popular</h2>
       {loadingPreview ? (
         <div className="artist-loading">
-          <Loader className="artist-spinner animate-spin" />
+          <DotLoader size="xl" label={null} />
         </div>
       ) : (
         <div
@@ -149,7 +150,7 @@ export function ArtistDetailsPreviewTracks({
                   />
                 ) : (
                   <div className="artist-loading">
-                    <Loader className="artist-spinner animate-spin" />
+                    <DotLoader size="xl" label={null} />
                   </div>
                 )}
               </div>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseGroups.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useDiscoverNavigation } from "../../../hooks/useDiscoverNavigation";
-import { ArrowRight, Loader, Music, Star } from "lucide-react";
+import { ArrowRight, Music, Star } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import AddActionButton from "../../../components/AddActionButton";
 import { navigateToReleaseGroup } from "../../../utils/searchNavigation";
@@ -97,7 +98,7 @@ export function ArtistDetailsReleaseGroups({
         <div className="artist-min-0">
           <div className="artist-controls-row">
             <h2 className="artist-section-title">Discography</h2>
-            {loadingReleases && <Loader className="artist-icon-sm animate-spin" />}
+            {loadingReleases && <DotLoader size="sm" label={null} />}
           </div>
           <div className="artist-tabs">
             {viewModes.map((mode) => (

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsReleaseTrackList.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Loader } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import { TrackPlayButton } from "./TrackPlayButton";
 import { TrackPlaylistMenu } from "./TrackPlaylistMenu";
@@ -134,7 +134,7 @@ export function ArtistDetailsReleaseTrackList({
     <div className="artist-release-track-list">
       {loading ? (
         <div className="artist-loading">
-          <Loader className="artist-spinner animate-spin" />
+        <DotLoader size="xl" label={null} />
         </div>
       ) : tracks?.length ? (
         <>

--- a/frontend/src/pages/ArtistDetails/components/ArtistDetailsSimilar.jsx
+++ b/frontend/src/pages/ArtistDetails/components/ArtistDetailsSimilar.jsx
@@ -3,7 +3,8 @@ import { lookupArtistsInLibraryBatch, readLibraryLookupCache } from "../../../ut
 import { getArtistFeedbackFlags } from "../../../utils/discoveryFeedback";
 import { getArtistRecordId } from "../../../utils/artistTaste";
 
-import { Loader, ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import ArtistImage from "../../../components/ArtistImage";
 import { ArtistContextMenu } from "../../../components/ArtistContextMenu";
@@ -89,7 +90,7 @@ export function ArtistDetailsSimilar({
       <div className="artist-similar-header">
         <h2 className="artist-section-title">
           Fans Also Like
-          {loadingSimilar && <Loader className="artist-icon-sm animate-spin" />}
+          {loadingSimilar && <DotLoader size="sm" label={null} />}
         </h2>
         <div className="artist-scroll-controls">
           <button
@@ -116,7 +117,7 @@ export function ArtistDetailsSimilar({
       </div>
       {loadingSimilar ? (
         <div className="artist-loading">
-          <Loader className="artist-spinner animate-spin" />
+          <DotLoader size="xl" label={null} />
         </div>
       ) : similarArtists.length > 0 ? (
         <div>

--- a/frontend/src/pages/ArtistDetails/components/DeleteAlbumModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/DeleteAlbumModal.jsx
@@ -1,5 +1,5 @@
 import { useId } from "react";
-import { Loader } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
 export function DeleteAlbumModal({
@@ -61,7 +61,7 @@ export function DeleteAlbumModal({
           <button onClick={onConfirm} disabled={!!removing} className="btn btn-danger">
             {removing ? (
               <>
-                <Loader className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
                 Deleting...
               </>
             ) : (

--- a/frontend/src/pages/ArtistDetails/components/DeleteArtistModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/DeleteArtistModal.jsx
@@ -1,5 +1,5 @@
 import { useId } from "react";
-import { Loader } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
 export function DeleteArtistModal({
@@ -63,7 +63,7 @@ export function DeleteArtistModal({
           <button onClick={onConfirm} disabled={deleting} className="btn btn-danger">
             {deleting ? (
               <>
-                <Loader className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
                 Removing...
               </>
             ) : (

--- a/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
@@ -1,5 +1,5 @@
 import { useId } from "react";
-import { Loader } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
 export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting }) {
@@ -35,7 +35,7 @@ export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting })
           <button onClick={onConfirm} disabled={deleting} className="btn btn-danger">
             {deleting ? (
               <>
-                <Loader className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
                 Deleting...
               </>
             ) : (

--- a/frontend/src/pages/ArtistDetails/components/TrackPlayButton.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlayButton.jsx
@@ -1,4 +1,5 @@
-import { Loader, Pause, Play } from "lucide-react";
+import { Pause, Play } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { getTrackPlayAccessibilityLabel, isLibraryPlaybackTrack } from "../utils";
 
 export function TrackPlayButton({ track, isPlaying, isLoading, onClick, size = "default" }) {
@@ -15,7 +16,7 @@ export function TrackPlayButton({ track, isPlaying, isLoading, onClick, size = "
       title={playLabel}
     >
       {isLoading ? (
-        <Loader className="artist-icon-xs animate-spin" />
+        <DotLoader size="xs" label={null} />
       ) : isPlaying ? (
         <Pause className="artist-icon-xs" />
       ) : (

--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { ChevronRight, Loader, MoreHorizontal, Plus, Trash2 } from "lucide-react";
+import { ChevronRight, MoreHorizontal, Plus, Trash2 } from "lucide-react";
 import AddActionButton from "../../../components/AddActionButton";
+import { DotLoader } from "../../../components/DotLoader";
 import SearchLibraryCheck from "../../../components/SearchLibraryCheck";
 import TooltipButton from "../../../components/TooltipButton";
 
@@ -104,7 +105,7 @@ export function TrackPlaylistPickerContent({
   if (loading) {
     return (
       <div className="artist-menu-item">
-        <Loader className="artist-icon-sm animate-spin" />
+        <DotLoader size="sm" label={null} />
         Loading playlists
       </div>
     );
@@ -415,7 +416,7 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
             disabled={saving || disabled}
           >
             {saving ? (
-              <Loader className="artist-icon-xs animate-spin" />
+              <DotLoader size="xs" label={null} />
             ) : isKebab ? (
               <MoreHorizontal className="artist-icon-xs" />
             ) : (

--- a/frontend/src/pages/BlocklistPage.jsx
+++ b/frontend/src/pages/BlocklistPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Ban, Loader2, Search, X } from "lucide-react";
+import { Ban, Search, X } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import { useArtistTasteFeedback } from "../hooks/useArtistTasteFeedback";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { searchUnified } from "../utils/api/endpoints/search.js";
@@ -107,7 +108,7 @@ export default function BlocklistPage() {
             placeholder="Search for an artist"
             aria-label="Search for an artist to block"
           />
-          {searching ? <Loader2 className="artist-icon-sm animate-spin" aria-hidden="true" /> : null}
+          {searching ? <DotLoader size="sm" label={null} /> : null}
         </form>
         {suggestions.length > 0 ? (
           <div className="blocklist-page__suggestions">
@@ -123,7 +124,7 @@ export default function BlocklistPage() {
                 >
                   <span>{artist.name}</span>
                   {pendingKey === key ? (
-                    <Loader2 className="artist-icon-xs animate-spin" />
+                    <DotLoader size="xs" label={null} />
                   ) : (
                     <Ban className="artist-icon-xs" />
                   )}
@@ -154,7 +155,7 @@ export default function BlocklistPage() {
                     title="Unblock artist"
                   >
                     {pendingKey === key ? (
-                      <Loader2 className="artist-icon-xs animate-spin" />
+                      <DotLoader size="xs" label={null} />
                     ) : (
                       <X className="artist-icon-xs" />
                     )}

--- a/frontend/src/pages/DiscoverLayoutModal.jsx
+++ b/frontend/src/pages/DiscoverLayoutModal.jsx
@@ -18,6 +18,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { GripVertical, X } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import { useModalDialog } from "../hooks/useModalDialog.js";
 
 const FALLBACK_GENRE_SECTION_PREFIX = "fallbackGenre:";
@@ -213,6 +214,7 @@ export function DiscoverLayoutModal({
               className="btn btn-secondary btn-sm artist-customize-modal__save"
               disabled={isSaving}
             >
+              {isSaving ? <DotLoader size="sm" label={null} /> : null}
               {isSaving ? "Saving..." : "Save Layout"}
             </button>
           </div>

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -8,11 +8,11 @@ import { getMyDiscoverLayout, updateMyDiscoverLayout } from "../utils/api/endpoi
 
 import { useDiscoverNavigation } from "../hooks/useDiscoverNavigation";
 import {
-  Loader,
   Music,
   Sparkles,
   LayoutTemplate,
 } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import DiscoveryStatusPill from "../components/DiscoveryStatusPill";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAuth } from "../contexts/AuthContext";
@@ -596,7 +596,7 @@ function DiscoverPage() {
         >
           {newsLoading && newsArticles.length === 0 ? (
             <div className="discover-news-rail-status artist-discover-shelf-card--news-status">
-              Checking recent stories…
+              <DotLoader size="sm" label={null} /> Checking recent stories…
             </div>
           ) : newsArticles.length > 0 ? (
             newsArticles.slice(0, 12).map((article) => (
@@ -658,7 +658,7 @@ function DiscoverPage() {
             className={`discover-recommended-status${isUpdating ? " discover-recommended-status--loading" : ""}`}
           >
             {isUpdating ? (
-              <Loader className="discover-recommended-status__spinner animate-spin" />
+              <DotLoader size="2xl" label={null} className="discover-recommended-status__loader" />
             ) : (
               <div className="discover-recommended-status__icon" aria-hidden="true">
                 <Music className="artist-icon-lg" />
@@ -752,7 +752,7 @@ function DiscoverPage() {
         return (
           <section key="recommendedShows" className="artist-discover-section">
             <div className="artist-nearby-status artist-nearby-status--loading">
-              <Loader className="artist-nearby-status__spinner animate-spin" />
+              <DotLoader size="xl" label={null} />
             </div>
           </section>
         );
@@ -910,7 +910,7 @@ function DiscoverPage() {
   if (data === null && !error) {
     return (
       <div className="artist-loading--discover">
-        <Loader className="artist-spinner--discover animate-spin" />
+        <DotLoader size="2xl" label={null} className="aurral-dot-loader--discover" />
         <h2 className="artist-error-title--discover">Loading recommendations...</h2>
         <p className="artist-error-copy--discover">Recommendations will appear as they load.</p>
       </div>
@@ -920,7 +920,7 @@ function DiscoverPage() {
   if (isActuallyUpdating) {
     return (
       <div className="artist-loading--discover">
-        <Loader className="artist-spinner--discover animate-spin" />
+        <DotLoader size="2xl" label={null} className="aurral-dot-loader--discover" />
         <h2 className="artist-error-title--discover">
           {isListenBrainzFallback
             ? "Loading ListenBrainz discovery..."

--- a/frontend/src/pages/DiscoverPlaylistsPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistsPage.jsx
@@ -6,7 +6,8 @@ import {
 } from "../utils/api/endpoints/discovery.js";
 import { useToast } from "../contexts/ToastContext";
 import { useAuth } from "../contexts/AuthContext";
-import { Crosshair, Loader, Music } from "lucide-react";
+import { Crosshair, Music } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 
 import { Link } from "react-router-dom";
 import { useDiscoverData } from "./useDiscoverData";
@@ -158,7 +159,7 @@ export default function DiscoverPlaylistsPage() {
         </header>
         {isUpdating || playlistsUpdating ? (
           <div className="search-empty-panel">
-            <Loader className="artist-icon-lg animate-spin" />
+            <DotLoader size="lg" label={null} />
             <h2 className="search-empty-panel__title">
               {playlistsUpdating ? "Building playlists" : "Refreshing discovery"}
             </h2>

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Check, Loader2, Play, FilePlus2, Download, Trash2, Search, RefreshCw, ClipboardCopy, ListMusic } from "lucide-react";
+import { Check, Play, FilePlus2, Download, Trash2, Search, RefreshCw, ClipboardCopy, ListMusic } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
   getFlowJobs,
@@ -1436,7 +1437,7 @@ function FlowPage({ mode = "all" }) {
   if (loading && !status) {
     return (
       <div className="flow-page__loading">
-        <Loader2 className="artist-spinner artist-spinner--large" />
+        <DotLoader size="2xl" label={null} />
       </div>
     );
   }
@@ -1568,7 +1569,7 @@ function FlowPage({ mode = "all" }) {
           >
             <span className="artist-menu-item__main">
               {searchingUpgradePlaylistId === selectedFlow.id ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <Search className="artist-icon-sm" />
               )}
@@ -1583,7 +1584,7 @@ function FlowPage({ mode = "all" }) {
           >
             <span className="artist-menu-item__main">
               {rerunningId === selectedFlow.id ? (
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
               ) : (
                 <Play className="artist-icon-sm" />
               )}
@@ -1658,7 +1659,7 @@ function FlowPage({ mode = "all" }) {
               >
                 <span className="artist-menu-item__main">
                   {syncingImportPlaylistId === selectedPlaylist.id ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
+                    <DotLoader size="sm" label={null} />
                   ) : (
                     <RefreshCw className="artist-icon-sm" />
                   )}
@@ -1896,7 +1897,7 @@ function FlowPage({ mode = "all" }) {
                   onClick={() => handleApplySimple(selectedFlow)}
                 >
                   {applyingFlowId === selectedFlow.id ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
+                    <DotLoader size="sm" label={null} />
                   ) : null}
                   Save recipe
                 </button>

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 
 import ArtistImage from "../components/ArtistImage";
+import { DotLoader } from "../components/DotLoader";
 import { LibraryItemMenu, LibraryItemSubmenu } from "../components/LibraryItemMenu";
 import TooltipButton from "../components/TooltipButton";
 import { useAuth } from "../contexts/AuthContext";
@@ -1724,7 +1725,7 @@ function LibraryPage() {
                 aria-label={downloadLabel}
               >
                 {downloadPending ? (
-                  <RefreshCw className="animate-spin" aria-hidden="true" />
+                  <DotLoader size="sm" label={null} />
                 ) : (
                   <Download aria-hidden="true" />
                 )}
@@ -2442,7 +2443,8 @@ function LibraryPage() {
       )}
       {loading && (
         <div className="native-library-state" role="status">
-          Loading library…
+          <DotLoader size="xl" label={null} />
+          <span>Loading library…</span>
         </div>
       )}
       {!loading && error && (
@@ -2455,6 +2457,7 @@ function LibraryPage() {
             onClick={refreshLibrary}
             disabled={refreshing}
           >
+            {refreshing ? <DotLoader size="sm" label={null} /> : null}
             {refreshing ? "Refreshing…" : "Refresh library"}
           </button>
         </div>
@@ -2580,7 +2583,7 @@ function LibraryPage() {
                 label={refreshing ? "Refreshing library…" : "Refresh"}
                 aria-label="Refresh library"
               >
-                <RefreshCw aria-hidden="true" />
+                {refreshing ? <DotLoader size="sm" label={null} /> : <RefreshCw aria-hidden="true" />}
               </TooltipButton>
             )}
           </div>
@@ -2670,7 +2673,7 @@ function LibraryPage() {
                 label={refreshing ? "Refreshing library…" : "Refresh"}
                 aria-label="Refresh library"
               >
-                <RefreshCw aria-hidden="true" />
+                {refreshing ? <DotLoader size="sm" label={null} /> : <RefreshCw aria-hidden="true" />}
               </TooltipButton>
               <span className="native-library-toolbar-spacer" aria-hidden="true" />
               {(tab === "artists" || tab === "albums") && (

--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { Newspaper, RefreshCw } from "lucide-react";
+import { Newspaper } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useLibraryNews } from "../hooks/useLibraryNews";
 import { NewsArticleCard } from "../components/NewsArticleCard";
+import { DotLoader } from "../components/DotLoader";
 
 export default function NewsPage() {
   useDocumentTitle("Artist News");
@@ -73,7 +74,7 @@ export default function NewsPage() {
         </section>
       ) : loading && articles.length === 0 ? (
         <section className="discover-news-page__status">
-          <RefreshCw className="animate-spin" aria-hidden="true" />
+          <DotLoader size="2xl" label={null} />
           <h2>Loading artist news</h2>
           <p>Checking recent stories for your library artists.</p>
         </section>
@@ -102,7 +103,7 @@ export default function NewsPage() {
           ) : null}
           {hasMore ? (
             <div ref={loadMoreRef} className="discover-news-page__load-more" aria-live="polite">
-              {loadingMore ? "Loading more stories…" : "Loading more stories…"}
+              {loadingMore ? <DotLoader size="sm" label={null} /> : "Loading more stories…"}
             </div>
           ) : null}
         </>

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -11,6 +11,7 @@ import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { SettingsInput } from "./Settings/components/SettingsField";
 import { OnboardingStep, OnboardingStepHeader, OnboardingHint } from "./onboardingUtils.jsx";
 import PillToggle from "../components/PillToggle";
+import { DotLoader } from "../components/DotLoader";
 import {
   getApiErrorMessage,
   ONBOARDING_HERO_LOGO_SIZE,
@@ -343,7 +344,10 @@ function Onboarding() {
                   <ChevronRight className="artist-icon-xs" />
                 </>
               ) : (
-                primaryLabel
+                <>
+                  {testingLidarr || submitting ? <DotLoader size="sm" label={null} /> : null}
+                  {primaryLabel}
+                </>
               )}
             </button>
           </div>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { useToast } from "../contexts/ToastContext";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAccountSettings } from "./Settings/hooks/useAccountSettings";
 import { SettingsAccountTab } from "./Settings/components/SettingsAccountTab";
+import { DotLoader } from "../components/DotLoader";
 import {
   getSidebarStageBackdropEnabled,
   resolveSidebarStageBackdropVariant,
@@ -36,7 +37,7 @@ function ProfilePage() {
           aria-busy={account.saving}
           aria-hidden={!account.saving}
         >
-          {account.saving ? "Saving…" : null}
+          {account.saving ? <><DotLoader size="sm" label={null} /> Saving…</> : null}
         </span>
       </div>
 

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -10,6 +10,7 @@ import {
   createSharedPlaylist,
 } from "../utils/api/endpoints/playlists.js";
 import { getDiscovery } from "../utils/api/endpoints/discovery.js";
+import { DotLoader } from "../components/DotLoader";
 import { getArtistCover, getReleaseGroupCover } from "../utils/api/endpoints/artists.js";
 import { searchCatalog, searchUnified } from "../utils/api/endpoints/search.js";
 import SearchAlbumResults from "../components/SearchAlbumResults";
@@ -58,7 +59,6 @@ import {
   Grid3X3,
   LayoutGrid,
   List,
-  Loader,
   Music,
   Search,
   SlidersHorizontal,
@@ -1685,7 +1685,7 @@ function SearchResultsPage() {
 
       {loading && (
         <div className="artist-loading">
-          <Loader className="artist-spinner artist-spinner--large animate-spin" />
+          <DotLoader size="2xl" label={null} />
         </div>
       )}
 
@@ -1810,7 +1810,7 @@ function SearchResultsPage() {
               {showLoadMore && (
                 <div ref={sentinelRef} className="search-load-more">
                   <span className="search-load-more__inner">
-                    <Loader className="artist-spinner animate-spin" />
+                    <DotLoader size="xl" label={null} />
                     Loading...
                   </span>
                 </div>

--- a/frontend/src/pages/Settings/SettingsPage.jsx
+++ b/frontend/src/pages/Settings/SettingsPage.jsx
@@ -20,6 +20,7 @@ import { SettingsRssNewsTab } from "./components/SettingsRssNewsTab";
 import { SettingsDiscoverTab } from "./components/SettingsDiscoverTab";
 import { SettingsUsersTab } from "./components/SettingsUsersTab";
 import { SettingsMetadataTab } from "./components/SettingsMetadataTab";
+import { DotLoader } from "../../components/DotLoader";
 import { DEFAULT_SETTINGS_TAB, normalizeSettingsTabId } from "./settingsTabsConfig";
 import "./settingsArr.css";
 
@@ -307,7 +308,7 @@ function SettingsPage() {
                 aria-busy={data.saving}
                 aria-hidden={!data.saving}
               >
-                {data.saving ? "Saving…" : null}
+                {data.saving ? <><DotLoader size="sm" label={null} /> Saving…</> : null}
               </div>
             ) : null}
 

--- a/frontend/src/pages/Settings/components/AdminPlexLinkField.jsx
+++ b/frontend/src/pages/Settings/components/AdminPlexLinkField.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { SettingsSelect } from "./SettingsField";
+import { DotLoader } from "../../../components/DotLoader";
 import {
   getPlexHomeUsersForAdmin,
   linkManagedPlexUser,
@@ -120,7 +121,11 @@ export function AdminPlexLinkField({ user, onChanged, showSuccess, showError }) 
         onClick={loadHomeUsers}
         disabled={loadingHomeUsers}
       >
-        {loadingHomeUsers ? "Loading Plex Home users…" : "Link managed Plex user"}
+        {loadingHomeUsers ? (
+          <>
+            <DotLoader size="sm" label={null} /> Loading Plex Home users…
+          </>
+        ) : "Link managed Plex user"}
       </button>
     );
   }

--- a/frontend/src/pages/Settings/components/LidarrSettingsModalContent.jsx
+++ b/frontend/src/pages/Settings/components/LidarrSettingsModalContent.jsx
@@ -10,6 +10,7 @@ import {
 import { Link } from "react-router-dom";
 import { RefreshCw } from "lucide-react";
 import PillToggle from "../../../components/PillToggle";
+import { DotLoader } from "../../../components/DotLoader";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { SettingsArrFieldSet, SettingsArrFormGroup } from "./arr/SettingsArrLayout";
 export function LidarrSettingsSection({
@@ -216,9 +217,11 @@ export function LidarrSettingsSection({
               }
               className="arr-btn"
             >
-              <RefreshCw
-                className={`artist-icon-sm${refreshingProfilesTags ? " animate-spin" : ""}`}
-              />
+              {refreshingProfilesTags ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {refreshingProfilesTags ? "Refreshing..." : "Refresh profiles/tags"}
             </button>
             <button
@@ -231,6 +234,7 @@ export function LidarrSettingsSection({
               }
               className="arr-btn"
             >
+              {testingLidarr ? <DotLoader size="sm" label={null} /> : null}
               {testingLidarr ? "Testing..." : "Test connection"}
             </button>
             {lidarrTestStatus ? (
@@ -464,6 +468,7 @@ export function LidarrSettingsSection({
           disabled={applyingCommunityGuide || !health?.lidarrConfigured}
           className="arr-btn arr-btn--primary"
         >
+          {applyingCommunityGuide ? <DotLoader size="sm" label={null} /> : null}
           {applyingCommunityGuide ? "Applying..." : "Apply recommended settings"}
         </button>
         <p className="arr-form-help arr-form-help--spaced">

--- a/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsAccountTab.jsx
@@ -7,6 +7,7 @@ import { ThemeSettings } from "./ThemeSettings";
 
 import { Link } from "react-router-dom";
 import { RotateCcw } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 export function SettingsAccountTab({
   listenHistoryProvider,
   setListenHistoryProvider,
@@ -53,7 +54,9 @@ export function SettingsAccountTab({
   if (loading) {
     return (
       <div className={profileVariant ? "profile-settings" : "settings-page__panel"}>
-        <p className="settings-page__muted-copy">Loading…</p>
+        <p className="settings-page__muted-copy">
+          <DotLoader size="sm" label={null} /> Loading…
+        </p>
       </div>
     );
   }
@@ -280,7 +283,11 @@ export function SettingsAccountTab({
               disabled={resettingTastes}
               className="btn btn-secondary btn-sm"
             >
-              <RotateCcw className={`artist-icon-xs${resettingTastes ? " animate-spin" : ""}`} />
+              {resettingTastes ? (
+                <DotLoader size="xs" label={null} />
+              ) : (
+                <RotateCcw className="artist-icon-xs" aria-hidden />
+              )}
               {resettingTastes ? "Resetting…" : "Reset discovery tastes"}
             </button>
           </div>

--- a/frontend/src/pages/Settings/components/SettingsConnectTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsConnectTab.jsx
@@ -18,6 +18,7 @@ import {
   SettingsModalToggleGroup,
 } from "./SettingsModalLayout";
 import PillToggle from "../../../components/PillToggle";
+import { DotLoader } from "../../../components/DotLoader";
 import { getConfiguredStatus } from "../utils/integrationStatus";
 export function SettingsConnectTab({
   settings,
@@ -503,6 +504,7 @@ export function SettingsConnectTab({
               disabled={testingGotify || !gotify.url || !gotify.token}
               className="btn btn-secondary"
             >
+              {testingGotify ? <DotLoader size="sm" label={null} /> : null}
               {testingGotify ? "Sending..." : "Test notification"}
             </button>
           }

--- a/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDiscoverTab.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { RefreshCw, Trash2, X } from "lucide-react";
 import PillToggle from "../../../components/PillToggle";
+import { DotLoader } from "../../../components/DotLoader";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { SettingsArrFieldSet, SettingsArrFormGroup } from "./arr/SettingsArrLayout";
 import { formatDateTime } from "../../../utils/dateTime.js";
@@ -225,10 +226,11 @@ export function SettingsDiscoverTab({
                 onClick={handleRefreshDiscovery}
                 disabled={refreshingDiscovery}
               >
-                <RefreshCw
-                  className={`artist-icon-xs${refreshingDiscovery ? " animate-spin" : ""}`}
-                  aria-hidden
-                />
+                {refreshingDiscovery ? (
+                  <DotLoader size="xs" label={null} />
+                ) : (
+                  <RefreshCw className="artist-icon-xs" aria-hidden />
+                )}
                 {refreshingDiscovery ? "Refreshing…" : "Refresh discovery"}
               </button>
               <button
@@ -237,10 +239,11 @@ export function SettingsDiscoverTab({
                 onClick={handleClearCache}
                 disabled={clearingCache}
               >
-                <Trash2
-                  className={`artist-icon-xs${clearingCache ? " animate-spin" : ""}`}
-                  aria-hidden
-                />
+                {clearingCache ? (
+                  <DotLoader size="xs" label={null} />
+                ) : (
+                  <Trash2 className="artist-icon-xs" aria-hidden />
+                )}
                 {clearingCache ? "Clearing…" : "Clear image cache"}
               </button>
             </>
@@ -274,7 +277,7 @@ export function SettingsDiscoverTab({
           {showProgress ? (
             <div className="arr-progress">
               <p className="arr-progress__line">
-                <RefreshCw className="artist-icon-xs animate-spin" aria-hidden />
+                <DotLoader size="xs" label={null} />
                 <span>{progressMessage}</span>
                 {typeof activeProgress === "number" ? (
                   <span className="arr-progress__pct">{activeProgress}%</span>

--- a/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { testNzbgetConnection, testSabnzbdConnection, testSlskdConnection, testYtdlpConnection } from "../../../utils/api/endpoints/settings.js";
 
 import { Plus, RefreshCw, Trash2, Wrench } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import DownloadFolderField from "../../../components/DownloadFolderField";
 import { SettingsInput } from "./SettingsField";
 import { IntegrationCard, SettingsIntegrationModal } from "./SettingsIntegrationCards";
@@ -441,7 +442,11 @@ export function SettingsDownloadClientsSection({
               disabled={testingSlskd}
               onClick={handleTestSlskd}
             >
-              <RefreshCw className={`artist-icon-sm${testingSlskd ? " animate-spin" : ""}`} />
+              {testingSlskd ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingSlskd ? "Testing..." : "Test connection"}
             </button>
           }
@@ -511,7 +516,11 @@ export function SettingsDownloadClientsSection({
               disabled={testingYtdlp}
               onClick={handleTestYtdlp}
             >
-              <RefreshCw className={`artist-icon-sm${testingYtdlp ? " animate-spin" : ""}`} />
+              {testingYtdlp ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingYtdlp ? "Testing..." : "Test connection"}
             </button>
           }
@@ -567,7 +576,11 @@ export function SettingsDownloadClientsSection({
               disabled={testingNzbget}
               onClick={handleTestNzbget}
             >
-              <RefreshCw className={`artist-icon-sm${testingNzbget ? " animate-spin" : ""}`} />
+              {testingNzbget ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingNzbget ? "Testing..." : "Test connection"}
             </button>
           }
@@ -693,7 +706,11 @@ export function SettingsDownloadClientsSection({
               disabled={testingSabnzbd}
               onClick={handleTestSabnzbd}
             >
-              <RefreshCw className={`artist-icon-sm${testingSabnzbd ? " animate-spin" : ""}`} />
+              {testingSabnzbd ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingSabnzbd ? "Testing..." : "Test connection"}
             </button>
           }

--- a/frontend/src/pages/Settings/components/SettingsIndexersSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsIndexersSection.jsx
@@ -4,6 +4,7 @@ import { getProwlarrIndexers, testProwlarrConnection } from "../../../utils/api/
 import { queryClient, queryKeys } from "../../../queryClient.js";
 
 import { RefreshCw } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { SettingsInput } from "./SettingsField";
 import { IntegrationCard, SettingsIntegrationModal } from "./SettingsIntegrationCards";
 import {
@@ -155,7 +156,7 @@ export function SettingsIndexersSection({
           </div>
           {loadingProwlarrIndexers && (
             <span className="settings-page__status">
-              <RefreshCw className="settings-page__status-icon animate-spin" />
+              <DotLoader size="sm" label={null} className="settings-page__status-icon" />
               Loading
             </span>
           )}
@@ -208,7 +209,11 @@ export function SettingsIndexersSection({
               disabled={testingProwlarr || loadingProwlarrIndexers}
               onClick={handleTestProwlarr}
             >
-              <RefreshCw className={`artist-icon-sm${testingProwlarr ? " animate-spin" : ""}`} />
+              {testingProwlarr ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingProwlarr ? "Testing..." : "Test connection"}
             </button>
           }
@@ -274,9 +279,11 @@ export function SettingsIndexersSection({
                 disabled={loadingProwlarrIndexers || !health?.prowlarrConfigured}
                 onClick={() => loadProwlarrIndexers()}
               >
-                <RefreshCw
-                  className={`artist-icon-sm${loadingProwlarrIndexers ? " animate-spin" : ""}`}
-                />
+                {loadingProwlarrIndexers ? (
+                  <DotLoader size="sm" label={null} />
+                ) : (
+                  <RefreshCw className="artist-icon-sm" aria-hidden />
+                )}
                 {loadingProwlarrIndexers ? "Refreshing..." : "Refresh indexers"}
               </button>
             </SettingsModalActions>

--- a/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsPlaybackSection.jsx
@@ -24,6 +24,7 @@ import {
   Folder,
   RefreshCw,
 } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import DownloadFolderPickerModal from "../../../components/DownloadFolderPickerModal";
 import { SettingsInput, SettingsSelect } from "./SettingsField";
 import { SettingsAdapterFields } from "./SettingsAdapterFields";
@@ -585,7 +586,11 @@ export function SettingsPlaybackSection({
               onClick={handleTestNavidrome}
               disabled={testingNavidrome || !navidrome.url || !navidrome.username || !navidrome.password}
             >
-              <RefreshCw className={`artist-icon-sm${testingNavidrome ? " animate-spin" : ""}`} />
+              {testingNavidrome ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingNavidrome ? "Testing…" : "Test connection"}
             </button>
           }
@@ -612,7 +617,11 @@ export function SettingsPlaybackSection({
               onClick={handleTestPlex}
               disabled={testingPlex || !plex.url || !plex.token}
             >
-              <RefreshCw className={`artist-icon-sm${testingPlex ? " animate-spin" : ""}`} />
+              {testingPlex ? (
+                <DotLoader size="sm" label={null} />
+              ) : (
+                <RefreshCw className="artist-icon-sm" aria-hidden />
+              )}
               {testingPlex ? "Testing…" : "Test connection"}
             </button>
           }
@@ -753,7 +762,7 @@ export function SettingsPlaybackSection({
 
             {plex.mainLibrarySectionId && libraryAccessCheck?.checking ? (
               <p className="settings-modal__hint">
-                <RefreshCw className="artist-icon-xs" aria-hidden /> Checking whether Aurral can
+                <DotLoader size="xs" label={null} /> Checking whether Aurral can
                 already read this library…
               </p>
             ) : null}
@@ -828,6 +837,7 @@ export function SettingsPlaybackSection({
                 onClick={handleSyncPlex}
                 disabled={syncingPlex || !plex.url || !plex.token}
               >
+                {syncingPlex ? <DotLoader size="sm" label={null} /> : null}
                 {syncingPlex ? "Syncing…" : "Sync to Plex now"}
               </button>
             </SettingsModalActions>

--- a/frontend/src/pages/Settings/components/SettingsStorageSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsStorageSection.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { RefreshCw } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { StorageHealthDashboard, StorageHealthSummary } from "./StorageHealthDashboard";
 import {
   refreshStorageHealth,
@@ -176,7 +177,11 @@ export function SettingsStorageHealthSection({
             onClick={() => runHealthCheck({ notify: true })}
             disabled={checkingHealth}
           >
-            <RefreshCw className={`artist-icon-sm${checkingHealth ? " animate-spin" : ""}`} />
+            {checkingHealth ? (
+              <DotLoader size="sm" label={null} />
+            ) : (
+              <RefreshCw className="artist-icon-sm" aria-hidden />
+            )}
             {checkingHealth ? "Checking…" : "Run checks"}
           </button>
         </div>
@@ -202,7 +207,11 @@ export function SettingsSystemSection({ health }) {
           <h1 className="settings-system__title">System</h1>
         </div>
         <div className={`settings-system__status${runtimeReady ? " is-ready" : ""}`}>
-          <span className="settings-system__status-dot" aria-hidden />
+          {runtimeReady ? (
+            <span className="settings-system__status-dot" aria-hidden />
+          ) : (
+            <DotLoader size="xs" label={null} />
+          )}
           {runtimeReady ? "Running" : "Loading"}
         </div>
       </div>

--- a/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsSystemTab.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { AlertCircle, Check, Copy, RotateCcw } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { getApiKey, rotateApiKey } from "../../../utils/api/endpoints/auth";
 import { SettingsSystemSection } from "./SettingsStorageSection";
 import { SettingsSelect } from "./SettingsField";
@@ -138,7 +139,9 @@ export function SettingsSystemTab({ health, settings, updateSettings, showSucces
               <div className="settings-system__copy">
                 <div className="settings-system__label">API key</div>
               </div>
-              <div className="settings-system__value">Loading…</div>
+              <div className="settings-system__value">
+                <DotLoader size="sm" label={null} /> Loading…
+              </div>
             </div>
           ) : apiKey ? (
             <div className="settings-system__row">
@@ -171,9 +174,11 @@ export function SettingsSystemTab({ health, settings, updateSettings, showSucces
                   title="Rotate API key"
                   aria-label="Rotate API key"
                 >
-                  <RotateCcw
-                    className={"artist-icon-xs" + (rotating ? " animate-spin" : "")}
-                  />
+                  {rotating ? (
+                    <DotLoader size="xs" label={null} />
+                  ) : (
+                    <RotateCcw className="artist-icon-xs" aria-hidden />
+                  )}
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/Settings/components/SettingsTasksTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsTasksTab.jsx
@@ -4,7 +4,8 @@ import { getSettingsTasks, clearSettingsStaleTasks } from "../../../utils/api/en
 import { queryClient, queryKeys } from "../../../queryClient.js";
 import { SettingsArrFieldSet } from "./arr/SettingsArrLayout";
 
-import { AlertCircle, Check, Clock, Loader2, XCircle } from "lucide-react";
+import { AlertCircle, Check, Clock, XCircle } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 const POLL_INTERVAL_MS = 5000;
 
 const relativeFormatter = new Intl.RelativeTimeFormat(undefined, {
@@ -27,7 +28,7 @@ const STATUS_META = {
   running: {
     label: "Running",
     tone: "active",
-    icon: Loader2,
+    spinning: true,
     title: null,
   },
   queued: {
@@ -118,16 +119,17 @@ function StatusBadge({ status }) {
     icon: AlertCircle,
     title: null,
   };
-  const Icon = meta.icon;
+  const Icon = meta.icon || AlertCircle;
   return (
     <span
       className={`arr-task-status arr-task-status--${meta.tone}`}
       title={meta.title || undefined}
     >
-      <Icon
-        className={`arr-task-status__icon${status === "running" ? " animate-spin" : ""}`}
-        aria-hidden
-      />
+      {meta.spinning ? (
+        <DotLoader size="sm" label={null} className="arr-task-status__icon" />
+      ) : (
+        <Icon className="arr-task-status__icon" aria-hidden />
+      )}
       {meta.label}
     </span>
   );
@@ -144,14 +146,20 @@ function EmptyRows({ colSpan }) {
 function LoadingRows({ colSpan }) {
   return (
     <tr className="arr-table__empty-row">
-      <td colSpan={colSpan}>Loading task data...</td>
+      <td colSpan={colSpan}>
+        <DotLoader size="sm" label={null} /> Loading task data...
+      </td>
     </tr>
   );
 }
 
 function TasksHealthSummary({ summary, loading, clearing = false, onClearStale }) {
   if (loading || !summary) {
-    return <div className="arr-info arr-info--tasks">Loading background task status...</div>;
+    return (
+      <div className="arr-info arr-info--tasks">
+        <DotLoader size="sm" label={null} /> Loading background task status...
+      </div>
+    );
   }
 
   const { healthy, activeCount, staleCount, failedCount, workersFailedCount, completedCount } =
@@ -199,6 +207,7 @@ function TasksHealthSummary({ summary, loading, clearing = false, onClearStale }
             onClick={onClearStale}
             disabled={clearing}
           >
+            {clearing ? <DotLoader size="sm" label={null} /> : null}
             {clearing ? "Clearing stuck jobs…" : "Clear stuck jobs"}
           </button>
         </div>

--- a/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
+++ b/frontend/src/pages/Settings/components/SettingsUsersTab.jsx
@@ -10,6 +10,7 @@ import { GRANULAR_PERMISSIONS, granularPerms } from "../constants";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 import { AdminPlexLinkField } from "./AdminPlexLinkField";
 import { PlexSelfLinkSection } from "./PlexSelfLinkSection";
+import { DotLoader } from "../../../components/DotLoader";
 function getLocalBypassStatus(status) {
   if (!status) {
     return {
@@ -268,6 +269,7 @@ export function SettingsUsersTab({
                   changePwNew !== changePwConfirm
                 }
               >
+                {changingPassword ? <DotLoader size="sm" label={null} /> : null}
                 {changingPassword ? "Changing…" : "Change password"}
               </button>
             </div>
@@ -331,7 +333,9 @@ export function SettingsUsersTab({
                 <tbody>
                   {loadingUsers ? (
                     <tr className="arr-table__empty-row">
-                      <td colSpan={4}>Loading users…</td>
+                      <td colSpan={4}>
+                        <DotLoader size="sm" label={null} /> Loading users…
+                      </td>
                     </tr>
                   ) : usersList.length === 0 ? (
                     <tr className="arr-table__empty-row">
@@ -457,6 +461,7 @@ export function SettingsUsersTab({
                             }
                           }}
                         >
+                          {deletingUser ? <DotLoader size="sm" label={null} /> : null}
                           {deletingUser ? "Deleting…" : "Delete"}
                         </button>
                       </div>
@@ -571,6 +576,7 @@ export function SettingsUsersTab({
                             className="arr-btn arr-btn--primary"
                             disabled={creatingUser}
                           >
+                            {creatingUser ? <DotLoader size="sm" label={null} /> : null}
                             {creatingUser ? "Creating…" : "Create user"}
                           </button>
                         </div>
@@ -743,6 +749,7 @@ export function SettingsUsersTab({
                             className="arr-btn arr-btn--primary"
                             disabled={savingEdit}
                           >
+                            {savingEdit ? <DotLoader size="sm" label={null} /> : null}
                             {savingEdit ? "Saving…" : "Save"}
                           </button>
                         </div>

--- a/frontend/src/pages/Settings/components/StorageHealthDashboard.jsx
+++ b/frontend/src/pages/Settings/components/StorageHealthDashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { formatDateTime } from "../../../utils/dateTime.js";
+import { DotLoader } from "../../../components/DotLoader";
 
 const STATUS_LABELS = {
   pass: "PASS",
@@ -40,6 +41,7 @@ export function StorageHealthSummary({ result, loading = false }) {
             {loading ? "Checking" : "Pending"}
           </span>
           <span className="arr-health__summary-text">
+            {loading ? <DotLoader size="sm" label={null} /> : null}
             {loading ? "Checking storage access…" : "Run checks to review storage access."}
           </span>
         </div>
@@ -101,7 +103,9 @@ export function StorageHealthDashboard({ result, loading = false, showSummary = 
     if (loading) {
       return (
         <div className="arr-health" role="status">
-          <p className="arr-health__loading">Running storage checks…</p>
+          <p className="arr-health__loading">
+            <DotLoader size="sm" label={null} /> Running storage checks…
+          </p>
         </div>
       );
     }

--- a/frontend/src/pages/Settings/components/ThemeSettings.jsx
+++ b/frontend/src/pages/Settings/components/ThemeSettings.jsx
@@ -1,7 +1,8 @@
 import { createPortal } from "react-dom";
 import { useEffect, useId, useRef, useState } from "react";
-import { Check, Loader2, Monitor, Moon, Palette, Plus, Search, Sun, Trash2, X } from "lucide-react";
+import { Check, Monitor, Moon, Palette, Plus, Search, Sun, Trash2, X } from "lucide-react";
 import TooltipButton from "../../../components/TooltipButton.jsx";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 import {
   applyThemePreview,
@@ -102,7 +103,9 @@ function ThemeSwatch({ colors, loading = false }) {
       style={colors ? { background: colors.surface, borderColor: colors.border } : undefined}
       aria-hidden="true"
     >
-      {colors ? (
+      {loading ? (
+        <DotLoader size="xs" label={null} />
+      ) : colors ? (
         <>
           <span className="theme-settings__swatch-bar" style={{ background: colors.chrome }} />
           <span className="theme-settings__swatch-line" style={{ background: colors.text }} />
@@ -176,7 +179,7 @@ function SchemeCard({ scheme, theme, mode, active, loading, installing, installB
           disabled={loading || installing || installBusy || installed}
           onClick={onAdd}
         >
-          {loading || installing ? <Loader2 className="theme-settings__spin" aria-hidden="true" /> : installed ? <Check aria-hidden="true" /> : <Plus aria-hidden="true" />}
+          {loading || installing ? <DotLoader size="sm" label={null} /> : installed ? <Check aria-hidden="true" /> : <Plus aria-hidden="true" />}
           {loading ? "Loading…" : installing ? "Adding…" : installed ? "Added" : "Add"}
         </button>
       </div>
@@ -244,12 +247,12 @@ function SchemeSearchModal({
             onChange={(event) => onQueryChange(event.target.value)}
           />
           <button type="submit" className="btn btn-secondary" disabled={!query.trim() || searching || Boolean(installing)}>
-            {searching ? <Loader2 className="theme-settings__spin" aria-hidden="true" /> : <Search aria-hidden="true" />} Search
+            {searching ? <DotLoader size="sm" label={null} /> : <Search aria-hidden="true" />} Search
           </button>
         </form>
         {previewing ? <p className="theme-settings__preview-note" role="status">Previewing {previewing.label}. Add it to keep this theme.</p> : null}
         {error ? <p className="theme-settings__error" role="alert">{error}</p> : null}
-        {searching ? <p className="theme-settings__status" role="status"><Loader2 className="theme-settings__spin" aria-hidden="true" /> Finding schemes…</p> : null}
+        {searching ? <p className="theme-settings__status" role="status"><DotLoader size="sm" label={null} /> Finding schemes…</p> : null}
         {results ? (
           results.length ? (
             <div className="theme-settings__grid">
@@ -544,7 +547,7 @@ export function ThemeSettings({ showSuccess, showError }) {
         <div className="theme-settings__section-heading">
           <h4 id="theme-themes-heading">Themes</h4>
           <div className="theme-settings__section-actions">
-            {featuredThemes === null ? <span className="theme-settings__section-status" role="status">Loading schemes…</span> : null}
+            {featuredThemes === null ? <span className="theme-settings__section-status" role="status"><DotLoader size="sm" label={null} /> Loading schemes…</span> : null}
             <button type="button" className="btn btn-secondary" onClick={openSearch}>
               <Search aria-hidden="true" /> Find a scheme
             </button>

--- a/frontend/src/pages/Settings/components/themeSettings.css
+++ b/frontend/src/pages/Settings/components/themeSettings.css
@@ -323,11 +323,6 @@
 
 .theme-settings__swatch.is-loading {
   background: var(--aurral-surface-hover);
-  animation: theme-settings-pulse 1.4s ease-in-out infinite;
-}
-
-@keyframes theme-settings-pulse {
-  50% { opacity: 0.45; }
 }
 
 .theme-settings__card-copy {
@@ -431,14 +426,6 @@
   color: var(--aurral-accent);
 }
 
-.theme-settings__spin {
-  animation: theme-settings-spin 0.9s linear infinite;
-}
-
-@keyframes theme-settings-spin {
-  to { transform: rotate(360deg); }
-}
-
 .theme-settings__empty,
 .theme-settings__error {
   margin: 0;
@@ -535,8 +522,7 @@
   .theme-settings__mode-card,
   .theme-settings__card,
   .theme-settings__scheme-card,
-  .theme-settings__swatch.is-loading,
-  .theme-settings__spin {
+  .theme-settings__swatch.is-loading {
     animation: none;
     transition: none;
   }

--- a/frontend/src/pages/Settings/settingsArr.css
+++ b/frontend/src/pages/Settings/settingsArr.css
@@ -98,10 +98,6 @@
   height: 1.125rem;
 }
 
-.settings-arr__toolbar-icon--spin {
-  animation: spin 1s linear infinite;
-}
-
 .settings-arr__toolbar-label {
   margin-top: 0.125rem;
   font-size: 0.6875rem;

--- a/frontend/src/pages/ShowsPage.jsx
+++ b/frontend/src/pages/ShowsPage.jsx
@@ -1,6 +1,7 @@
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
-import { Loader, Music, MapPin, AlertCircle } from "lucide-react";
+import { Music, MapPin, AlertCircle } from "lucide-react";
+import { DotLoader } from "../components/DotLoader";
 import NearbyLocationControl from "../components/NearbyLocationControl";
 import ShowCard from "../components/ShowCard";
 import { PageSectionMobileNav } from "../components/PageSectionMobileNav";
@@ -114,7 +115,7 @@ function ShowsPage() {
         </div>
       ) : showsLoading ? (
         <div className="artist-loading">
-          <Loader className="artist-spinner artist-spinner--large animate-spin" />
+          <DotLoader size="2xl" label={null} />
         </div>
       ) : showsError ? (
         <div className="artist-error-panel" role="alert">

--- a/frontend/src/pages/SsoComplete.jsx
+++ b/frontend/src/pages/SsoComplete.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { setStoredAuth } from "../utils/api/core.js";
 import { exchangeOidcCode } from "../utils/api/endpoints/auth.js";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import { DotLoader } from "../components/DotLoader";
 
 const readHashParams = () => {
   const hash = String(window.location.hash || "").replace(/^#/, "");
@@ -83,7 +84,7 @@ const SsoComplete = () => {
 
   return (
     <div className="app-loading app-loading--screen">
-      <div className="app-loading__spinner app-loading__spinner--lg" />
+      <DotLoader size="2xl" />
     </div>
   );
 };

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -5,10 +5,10 @@ import {
   ArrowUpCircle,
   CheckCircle2,
   Info,
-  Loader,
   RotateCcw,
   Search,
 } from "lucide-react";
+import { DotLoader } from "../../components/DotLoader";
 import TooltipButton from "../../components/TooltipButton";
 import { useToast } from "../../contexts/ToastContext";
 import { formatDateTime } from "../../utils/dateTime.js";
@@ -120,7 +120,7 @@ function MissingJobRow({ job, playlist, actionState, onAction, onInfo }) {
           }
         >
           {isWorking ? (
-            <Loader className="animate-spin" aria-hidden="true" />
+            <DotLoader size="sm" label={null} />
           ) : isMissing ? (
             <RotateCcw aria-hidden="true" />
           ) : (
@@ -308,7 +308,7 @@ export default function ActivityMissingPage() {
       }
     >
       {searchingAll ? (
-        <Loader className="animate-spin" aria-hidden="true" />
+        <DotLoader size="sm" label={null} />
       ) : showingCutoff ? (
         <ArrowUpCircle aria-hidden="true" />
       ) : (
@@ -327,7 +327,7 @@ export default function ActivityMissingPage() {
           placeholder={filterPlaceholder}
         />
         <div className="activity-page__loading">
-          <Loader className="artist-spinner artist-spinner--large animate-spin" />
+        <DotLoader size="2xl" label={null} />
         </div>
       </div>
     );

--- a/frontend/src/pages/activity/ActivityRequestRow.jsx
+++ b/frontend/src/pages/activity/ActivityRequestRow.jsx
@@ -4,13 +4,13 @@ import {
   Clock,
   Eye,
   Info,
-  Loader,
   Pause,
   Play,
   RotateCcw,
   XCircle,
 } from "lucide-react";
 import TooltipButton from "../../components/TooltipButton";
+import { DotLoader } from "../../components/DotLoader";
 import { formatReviewReasonSummary, formatTimelineTime } from "./activityListUtils";
 
 function getStatusMeta(request) {
@@ -25,7 +25,6 @@ function getStatusMeta(request) {
   }
   if (request.status === "processing" || request.status === "pending") {
     return {
-      icon: Loader,
       label: request.statusLabel || "In progress",
       tone: "active",
       spinning: true,
@@ -123,7 +122,11 @@ export default function ActivityRequestRow({
         title={status.label}
         aria-label={status.label}
       >
-        <StatusIcon className={status.spinning ? "animate-spin" : ""} aria-hidden="true" />
+        {status.spinning ? (
+          <DotLoader size="sm" label={null} />
+        ) : (
+          <StatusIcon aria-hidden="true" />
+        )}
       </span>
       <div className="activity-row__details">
         <h2 className="activity-row__title">
@@ -176,7 +179,7 @@ export default function ActivityRequestRow({
               disabled={isApproving || isDenying}
               label="Approve track"
             >
-              {isApproving ? <Loader className="animate-spin" aria-hidden="true" /> : <CheckCircle2 aria-hidden="true" />}
+              {isApproving ? <DotLoader size="sm" label={null} /> : <CheckCircle2 aria-hidden="true" />}
             </TooltipButton>
             <TooltipButton
               className="native-library-icon-button"
@@ -184,7 +187,7 @@ export default function ActivityRequestRow({
               disabled={isApproving || isDenying}
               label="Deny track"
             >
-              {isDenying ? <Loader className="animate-spin" aria-hidden="true" /> : <XCircle aria-hidden="true" />}
+              {isDenying ? <DotLoader size="sm" label={null} /> : <XCircle aria-hidden="true" />}
             </TooltipButton>
           </>
         ) : null}
@@ -195,7 +198,11 @@ export default function ActivityRequestRow({
             disabled={isReSearching}
             label={isReSearching ? "Re-searching" : "Re-search"}
           >
-            <RotateCcw className={isReSearching ? "animate-spin" : ""} aria-hidden="true" />
+            {isReSearching ? (
+              <DotLoader size="sm" label={null} />
+            ) : (
+              <RotateCcw aria-hidden="true" />
+            )}
           </TooltipButton>
         ) : null}
         <TooltipButton

--- a/frontend/src/pages/activity/ActivityToolbar.jsx
+++ b/frontend/src/pages/activity/ActivityToolbar.jsx
@@ -1,6 +1,7 @@
 import { RefreshCw, Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import TooltipButton from "../../components/TooltipButton";
+import { DotLoader } from "../../components/DotLoader";
 
 export default function ActivityToolbar({
   filterValue,
@@ -32,7 +33,11 @@ export default function ActivityToolbar({
             label={refreshing ? "Refreshing" : "Refresh"}
             aria-label="Refresh activity"
           >
-            <RefreshCw className={refreshing ? "animate-spin" : ""} aria-hidden="true" />
+            {refreshing ? (
+              <DotLoader size="sm" label={null} />
+            ) : (
+              <RefreshCw aria-hidden="true" />
+            )}
           </TooltipButton>
         </div>
       ) : null}

--- a/frontend/src/pages/flows/FlowPlaylistUI.jsx
+++ b/frontend/src/pages/flows/FlowPlaylistUI.jsx
@@ -3,13 +3,13 @@ import {
   Clock,
   ChevronDown,
   ListMusic,
-  Loader2,
   Plus,
   Sparkles,
   Upload,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import PillToggle from "../../components/PillToggle";
+import { DotLoader } from "../../components/DotLoader";
 import TooltipButton from "../../components/TooltipButton";
 import { PlaylistArtworkThumb } from "./flowComponents/PlaylistArtworkThumb.jsx";
 import {
@@ -144,7 +144,11 @@ export function FlowLibraryCreateMenu({
                 }}
               >
                 <span className="flow-page__library-create-action-icon" aria-hidden="true">
-                  <ListMusic className="flow-page__library-create-action-glyph" />
+                  {creatingPlaylist ? (
+                    <DotLoader size="sm" label={null} />
+                  ) : (
+                    <ListMusic className="flow-page__library-create-action-glyph" />
+                  )}
                 </span>
                 <span className="flow-page__library-create-action-copy">
                   <span className="flow-page__library-create-action-title">
@@ -167,7 +171,11 @@ export function FlowLibraryCreateMenu({
                     className="flow-page__library-create-action-icon flow-page__library-create-action-icon--flow"
                     aria-hidden="true"
                   >
-                    <Sparkles className="flow-page__library-create-action-glyph" />
+                    {creatingFlow ? (
+                      <DotLoader size="sm" label={null} />
+                    ) : (
+                      <Sparkles className="flow-page__library-create-action-glyph" />
+                    )}
                   </span>
                   <span className="flow-page__library-create-action-copy">
                     <span className="flow-page__library-create-action-title">
@@ -277,7 +285,7 @@ export function PlaylistLibraryItem({
                 title={activityHint}
                 aria-label={activityHint}
               >
-                <Loader2 className="artist-icon-xs animate-spin" aria-hidden="true" />
+                <DotLoader size="xs" label={null} />
               </span>
             ) : null}
           </div>
@@ -391,7 +399,7 @@ export function PlaylistDetailHero({
             ) : null}
             {activityHint ? (
               <p className="flow-page__detail-meta flow-page__detail-activity">
-                <Loader2 className="artist-icon-xs animate-spin" aria-hidden="true" />
+                <DotLoader size="xs" label={null} />
                 <span>{activityHint}</span>
               </p>
             ) : null}

--- a/frontend/src/pages/flows/flowComponents/ConfirmModal.jsx
+++ b/frontend/src/pages/flows/flowComponents/ConfirmModal.jsx
@@ -1,4 +1,5 @@
 import { useId } from "react";
+import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
 export function ConfirmModal({
@@ -48,6 +49,7 @@ export function ConfirmModal({
             className="btn btn-secondary flow-page__btn--destructive"
             disabled={busy}
           >
+            {busy ? <DotLoader size="sm" label={null} /> : null}
             {busy ? busyLabel : confirmLabel}
           </button>
         </div>

--- a/frontend/src/pages/flows/flowComponents/FlowEmptyState.jsx
+++ b/frontend/src/pages/flows/flowComponents/FlowEmptyState.jsx
@@ -1,5 +1,6 @@
 import { ListMusic, Sparkles, Upload } from "lucide-react";
 import { Link } from "react-router-dom";
+import { DotLoader } from "../../../components/DotLoader";
 
 function getFlowEmptyCopy(libraryFilter, canCreate) {
   if (libraryFilter === "playlists") {
@@ -74,7 +75,7 @@ export function FlowEmptyState({
               disabled={creatingPlaylist}
               className="btn btn-primary btn--bold btn-min-h"
             >
-              <ListMusic className="artist-icon-sm" />
+              {creatingPlaylist ? <DotLoader size="sm" label={null} /> : <ListMusic className="artist-icon-sm" />}
               {creatingPlaylist ? "Creating…" : "New playlist"}
             </button>
           ) : null}
@@ -85,7 +86,7 @@ export function FlowEmptyState({
               disabled={creatingFlow}
               className="btn btn-secondary btn--bold btn-min-h"
             >
-              <Sparkles className="artist-icon-sm" />
+              {creatingFlow ? <DotLoader size="sm" label={null} /> : <Sparkles className="artist-icon-sm" />}
               {creatingFlow ? "Creating…" : "New flow"}
             </button>
           ) : null}

--- a/frontend/src/pages/flows/flowComponents/MixSlider.jsx
+++ b/frontend/src/pages/flows/flowComponents/MixSlider.jsx
@@ -5,7 +5,8 @@ import { TAG_COLORS } from "../../discoverUtils";
 import { getTagColor } from "../../ArtistDetails/utils";
 import { useDebouncedTask } from "../../../hooks/useDebouncedTask";
 
-import { Loader2, Search } from "lucide-react";
+import { Search } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 const SOURCE_MIX_COLORS = {
   discover: TAG_COLORS[10],
   mix: TAG_COLORS[4],
@@ -600,7 +601,7 @@ export function CommaTokenInput({
         >
           {loadingSuggestions && suggestions.length === 0 ? (
             <div className="flow-page__token-suggestion flow-page__token-suggestion--loading">
-              <Loader2 className="artist-icon-sm animate-spin" />
+              <DotLoader size="sm" label={null} />
               Searching
             </div>
           ) : null}

--- a/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
+++ b/frontend/src/pages/flows/flowComponents/flowTrackComponents.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useMemo, useState, useCallback } from "react";
 import {
   ExternalLink,
   Heart,
-  Loader2,
   ListMusic,
   Play,
   Pause,
@@ -15,6 +14,7 @@ import {
   Pencil,
   UserRound,
 } from "lucide-react";
+import { DotLoader } from "../../../components/DotLoader";
 import { getFlowTrackDisplayNumber, sortFlowTracks } from "../../../utils/flowTrackSort";
 import { Link } from "react-router-dom";
 import { useAudioQueue } from "../../../contexts/audioQueueContext";
@@ -708,7 +708,7 @@ export function FlowTracksPanel({
       <div className="flow-page__tracks-body">
         {loading && (
           <div className="flow-page__tracks-loading">
-            <Loader2 className="artist-icon-sm animate-spin" />
+            <DotLoader size="sm" label={null} />
             Loading tracks...
           </div>
         )}
@@ -719,7 +719,7 @@ export function FlowTracksPanel({
           <div className="flow-page__tracks-empty">
             {activityHint ? (
               <>
-                <Loader2 className="artist-icon-sm animate-spin" />
+                <DotLoader size="sm" label={null} />
                 <span>{activityHint}</span>
               </>
             ) : (
@@ -1017,7 +1017,7 @@ export function FlowTracksPanel({
                                     disabled={isReSearching}
                                   >
                                     {isReSearching ? (
-                                      <Loader2 className="artist-icon-xs animate-spin" />
+                                      <DotLoader size="xs" label={null} />
                                     ) : (
                                       <Search className="artist-icon-xs" />
                                     )}
@@ -1033,7 +1033,7 @@ export function FlowTracksPanel({
                                     disabled={isDeleting}
                                   >
                                     {isDeleting ? (
-                                      <Loader2 className="artist-icon-xs animate-spin" />
+                                      <DotLoader size="xs" label={null} />
                                     ) : (
                                       <Trash2 className="artist-icon-xs" />
                                     )}

--- a/frontend/src/pages/flows/import/PlaylistImportModal.jsx
+++ b/frontend/src/pages/flows/import/PlaylistImportModal.jsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FileJson, Loader2, Music2, Upload } from "lucide-react";
+import { FileJson, Music2, Upload } from "lucide-react";
 import { Link } from "react-router-dom";
 import { ModalShell } from "../../../components/PlaylistModals";
+import { DotLoader } from "../../../components/DotLoader";
 import {
   completeSpotifyOAuth,
   disconnectSpotify,
@@ -579,7 +580,7 @@ export function PlaylistImportModal({
               className="btn btn-primary btn-sm"
               disabled={importing || !canImportExternal}
             >
-              {importing ? <Loader2 className="artist-icon-sm animate-spin" /> : <Music2 className="artist-icon-sm" />}
+              {importing ? <DotLoader size="sm" label={null} /> : <Music2 className="artist-icon-sm" />}
               Import playlist
             </button>
           ) : (
@@ -589,7 +590,7 @@ export function PlaylistImportModal({
               className="btn btn-primary btn-sm"
               disabled={importing || !canImportJson}
             >
-              {importing ? <Loader2 className="artist-icon-sm animate-spin" /> : <Upload className="artist-icon-sm" />}
+              {importing ? <DotLoader size="sm" label={null} /> : <Upload className="artist-icon-sm" />}
               Import JSON
             </button>
           )}
@@ -637,7 +638,7 @@ export function PlaylistImportModal({
                   onClick={handleConnectSpotify}
                   disabled={spotifyLoading || importing}
                 >
-                  {spotifyLoading ? <Loader2 className="artist-icon-sm animate-spin" /> : null}
+                  {spotifyLoading ? <DotLoader size="sm" label={null} /> : null}
                   Connect Spotify
                 </button>
               </div>
@@ -693,7 +694,7 @@ export function PlaylistImportModal({
                   disabled={lastfmProfileLoading || lastfmLoading || !lastfmUsernameInput.trim() || importing}
                 >
                   {lastfmProfileLoading || lastfmLoading ? (
-                    <Loader2 className="artist-icon-sm animate-spin" />
+                    <DotLoader size="sm" label={null} />
                   ) : null}
                   Load stations
                 </button>
@@ -775,7 +776,7 @@ export function PlaylistImportModal({
                           ? listenBrainzLoading
                           : lastfmLoading) && playlists.length === 0 ? (
                         <div className="playlist-import__list-status">
-                          <Loader2 className="artist-icon-sm animate-spin" />
+                          <DotLoader size="sm" label={null} />
                           <span>Loading playlists…</span>
                         </div>
                       ) : filteredPlaylists.length === 0 ? (
@@ -860,7 +861,7 @@ export function PlaylistImportModal({
                     <div className="playlist-import__summary">
                       {previewLoading ? (
                         <div className="playlist-import__list-status playlist-import__list-status--inline">
-                          <Loader2 className="artist-icon-sm animate-spin" />
+                          <DotLoader size="sm" label={null} />
                           <span>Counting importable tracks…</span>
                         </div>
                       ) : (


### PR DESCRIPTION
## What changed

Replaced scattered spinner, shimmer, and loading animation implementations across the frontend with a shared `DotLoader` component and unified styling. Added reduced-motion behavior and accessibility labels for loading states.

## Why

This consolidates loading indicators into one consistent visual system, removes duplicated loader CSS, and makes loading states easier to maintain across the application.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

This changes loading indicator visuals throughout the frontend. Before-and-after screenshots were not included.

## Testing

Automated tests were not run. Manual validation should verify loading states across the affected pages, actions, modals, menus, image previews, and reduced-motion settings.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a consistent animated nine-dot loading indicator across the application.
  - Added size-appropriate loaders to page loads, buttons, menus, modals, searches, settings, imports, downloads, and background actions.
  - Loading states now provide clearer visual feedback alongside existing status text.
  - Added reduced-motion behavior and improved accessibility semantics for loading indicators.
- **Style**
  - Replaced legacy spinning, shimmer, and pulsing loading animations with the unified loader design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->