### PR TITLE
fix: stabilize nightly library refreshes

### DIFF
--- a/.tests/frontend/library-album-cache.test.js
+++ b/.tests/frontend/library-album-cache.test.js
@@ -11,7 +11,7 @@ test("album track hydration does not rewrite unchanged library state", async (t)
   });
   t.after(() => vite.close());
 
-  const { mergeAlbumTrackPageIntoLibrary } = await vite.ssrLoadModule(
+  const { getCachedAlbumTracks, mergeAlbumTrackPageIntoLibrary } = await vite.ssrLoadModule(
     "/src/pages/LibraryPage.jsx?album-cache-test",
   );
   const album = { id: 7, title: "Album", trackCount: 0, availableTrackCount: 0 };
@@ -27,4 +27,32 @@ test("album track hydration does not rewrite unchanged library state", async (t)
     mergeAlbumTrackPageIntoLibrary(hydrated, page, album.id, [track]),
     hydrated,
   );
+});
+
+test("invalidated album track caches fall back to the current library tracks", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { getCachedAlbumTracks } = await vite.ssrLoadModule(
+    "/src/pages/LibraryPage.jsx?album-cache-removal-test",
+  );
+  const { queryClient, queryKeys } = await vite.ssrLoadModule("/src/queryClient.js");
+  const album = { id: 7, trackIds: [8, 9] };
+  const tracksById = new Map([
+    ["8", { id: 8 }],
+    ["9", { id: 9 }],
+  ]);
+  const queryKey = queryKeys.libraryAlbumTracks("7", null);
+  queryClient.setQueryData(queryKey, { tracks: [{ id: 8 }, { id: 9 }] });
+
+  queryClient.invalidateQueries({ queryKey, refetchType: "none" });
+  tracksById.delete("9");
+
+  assert.deepEqual(getCachedAlbumTracks(album, tracksById), [{ id: 8 }]);
+  queryClient.clear();
 });

--- a/.tests/frontend/library-query-invalidation.test.js
+++ b/.tests/frontend/library-query-invalidation.test.js
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "vite";
+
+test("canonical cache invalidation does not abort an active request", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { clearCanonicalLibraryPageCache } = await vite.ssrLoadModule(
+    "/src/utils/api/endpoints/library.js?canonical-invalidation-test",
+  );
+  const { queryClient, queryKeys } = await vite.ssrLoadModule("/src/queryClient.js");
+  const options = { kind: "artists", page: 1, pageSize: 100 };
+  const queryKey = queryKeys.libraryCanonical(options);
+  let resolveRequest;
+  let aborted = false;
+  const request = queryClient.fetchQuery({
+    queryKey,
+    staleTime: 0,
+    queryFn: ({ signal }) => new Promise((resolve, reject) => {
+      resolveRequest = resolve;
+      signal.addEventListener("abort", () => {
+        aborted = true;
+        reject(new Error("aborted"));
+      }, { once: true });
+    }),
+  });
+
+  while (!resolveRequest) await new Promise((resolve) => setImmediate(resolve));
+  await clearCanonicalLibraryPageCache();
+  assert.equal(aborted, false);
+  resolveRequest({ artists: [] });
+  await request;
+
+  assert.notDeepEqual(queryKeys.libraryCanonical(options), queryKey);
+  queryClient.clear();
+});
+
+test("library requests forward caller cancellation", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { getCanonicalLibraryPage, getLibraryFavorites } = await vite.ssrLoadModule(
+    "/src/utils/api/endpoints/library.js?library-request-cancellation-test",
+  );
+  const { queryClient } = await vite.ssrLoadModule("/src/queryClient.js");
+
+  const assertForwardedCancellation = async (load) => {
+    const originalFetch = globalThis.fetch;
+    let requestSignal;
+    const controller = new AbortController();
+    globalThis.fetch = (_url, init) => new Promise((_resolve, reject) => {
+      requestSignal = init.signal;
+      init.signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    });
+    try {
+      const request = load(controller.signal);
+      while (!requestSignal) await new Promise((resolve) => setImmediate(resolve));
+      controller.abort();
+      await assert.rejects(request, /aborted/);
+      assert.equal(requestSignal.aborted, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  };
+
+  await assertForwardedCancellation((signal) =>
+    getCanonicalLibraryPage({ kind: "artists", page: 1, pageSize: 100 }, { signal }),
+  );
+  await assertForwardedCancellation((signal) => getLibraryFavorites({ signal }));
+  queryClient.clear();
+});

--- a/.tests/library/library-refresh.test.js
+++ b/.tests/library/library-refresh.test.js
@@ -7,7 +7,12 @@ const { registerCanonical } = await import(
   "../../backend/routes/library/handlers/canonical.js"
 );
 const {
+  claimScheduledLibraryScanJob,
   clearScheduledLibraryScan,
+  getScheduledLibraryScanJobId,
+  onLibraryScanFinalFailure,
+  onLibraryScanSuccess,
+  scheduleLibraryScan,
   stopLibraryScanWorker,
 } = await import("../../backend/services/libraryScanWorker.js");
 const { dbOps } = await import("../../backend/db/helpers/index.js");
@@ -64,6 +69,48 @@ test("library refresh queues a forced scan and exposes its queue status", async 
     clearScheduledLibraryScan();
     await new Promise((resolve) => setImmediate(resolve));
     await stopLibraryScanWorker();
+  }
+});
+
+test("library scan scheduling keeps one live job and recovers stale registry entries", () => {
+  const queue = getLibraryScanQueue();
+  clearScheduledLibraryScan();
+  let firstJob;
+  let secondJob;
+  try {
+    firstJob = scheduleLibraryScan();
+    const claimed = queue.claimOne("library-scan-test");
+    assert.equal(claimed?.id, firstJob);
+    assert.equal(claimScheduledLibraryScanJob(firstJob), true);
+    assert.equal(scheduleLibraryScan(), firstJob);
+
+    queue.cancel(firstJob);
+    secondJob = scheduleLibraryScan();
+    assert.notEqual(secondJob, firstJob);
+    assert.equal(getScheduledLibraryScanJobId(), secondJob);
+  } finally {
+    if (firstJob) queue.cancel(firstJob);
+    if (secondJob) queue.cancel(secondJob);
+    clearScheduledLibraryScan();
+  }
+});
+
+test("terminal library scan outcomes clear the persistent registry", () => {
+  const queue = getLibraryScanQueue();
+  let successJob;
+  let failedJob;
+  try {
+    successJob = scheduleLibraryScan();
+    onLibraryScanSuccess(null, { id: successJob });
+    assert.equal(getScheduledLibraryScanJobId(), null);
+
+    failedJob = scheduleLibraryScan();
+    onLibraryScanFinalFailure({ id: failedJob });
+    assert.equal(getScheduledLibraryScanJobId(), null);
+  } finally {
+    if (successJob) queue.cancel(successJob);
+    if (failedJob) queue.cancel(failedJob);
+    clearScheduledLibraryScan();
   }
 });
 

--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -58,6 +58,57 @@ test("creates flows with normalized scheduling and enforces unique names", () =>
   );
 });
 
+test("normalizes invalid playlist owners to null", () => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Unowned Flow", ownerUserId: 0 });
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Unowned Playlist",
+    ownerUserId: "0",
+  });
+  const fractional = flowPlaylistConfig.createFlow({
+    name: "Fractional Owner",
+    ownerUserId: 7.9,
+  });
+  const unsafe = flowPlaylistConfig.createFlow({
+    name: "Unsafe Owner",
+    ownerUserId: Number.MAX_SAFE_INTEGER + 1,
+  });
+  const unowned = flowPlaylistConfig.createFlow({ name: "Invalid Owner Conflict" });
+  const unownedPlaylist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Invalid Playlist Owner Conflict",
+  });
+  const owned = flowPlaylistConfig.createFlow({ name: "Owned Flow", ownerUserId: 7 });
+
+  assert.equal(flow.ownerUserId, null);
+  assert.equal(playlist.ownerUserId, null);
+  assert.equal(fractional.ownerUserId, null);
+  assert.equal(unsafe.ownerUserId, null);
+  assert.equal(owned.ownerUserId, 7);
+  assert.throws(
+    () =>
+      flowPlaylistConfig.createFlow({
+        name: "Invalid Owner Conflict",
+        ownerUserId: "not-a-user",
+      }),
+    /already exists/,
+  );
+  assert.throws(
+    () =>
+      flowPlaylistConfig.createSharedPlaylist({
+        name: "Invalid Playlist Owner Conflict",
+        ownerUserId: "not-a-user",
+      }),
+    /already exists/,
+  );
+
+  flowPlaylistConfig.deleteFlow(flow.id);
+  flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+  flowPlaylistConfig.deleteFlow(fractional.id);
+  flowPlaylistConfig.deleteFlow(unsafe.id);
+  flowPlaylistConfig.deleteFlow(unowned.id);
+  flowPlaylistConfig.deleteSharedPlaylist(unownedPlaylist.id);
+  flowPlaylistConfig.deleteFlow(owned.id);
+});
+
 test("defaults listening history on and persists a flow opt-out", () => {
   const flow = flowPlaylistConfig.createFlow({
     name: "No History",

--- a/backend/services/libraryScanWorker.js
+++ b/backend/services/libraryScanWorker.js
@@ -17,9 +17,17 @@ function setScanRegistry(registry) {
   dbOps.setJSONSetting(LIBRARY_SCAN_REGISTRY_KEY, registry);
 }
 
+function normalizeJobId(value) {
+  const jobId = Number(value);
+  return Number.isSafeInteger(jobId) && jobId > 0 ? jobId : null;
+}
+
+function hasLiveScanJob(jobId) {
+  return Boolean(getLibraryScanQueue().getJob(jobId));
+}
+
 export function getScheduledLibraryScanJobId() {
-  const jobId = Number(getScanRegistry().jobId);
-  return Number.isFinite(jobId) ? jobId : null;
+  return normalizeJobId(getScanRegistry().jobId);
 }
 
 export function clearScheduledLibraryScan(jobId = null) {
@@ -32,13 +40,34 @@ export function clearScheduledLibraryScan(jobId = null) {
 
 export function scheduleLibraryScan({ force = false } = {}) {
   const registry = getScanRegistry();
-  const existingJobId = Number(registry.jobId);
-  if (Number.isFinite(existingJobId)) {
+  const existingJobId = normalizeJobId(registry.jobId);
+  if (existingJobId != null && hasLiveScanJob(existingJobId)) {
     return existingJobId;
   }
+  if (existingJobId != null) clearScheduledLibraryScan(existingJobId);
   const jobId = enqueueLibraryScanJob({ force: force === true });
   setScanRegistry({ jobId });
   return jobId;
+}
+
+export function claimScheduledLibraryScanJob(jobId) {
+  const normalizedJobId = normalizeJobId(jobId);
+  if (normalizedJobId == null) return false;
+  const scheduledJobId = getScheduledLibraryScanJobId();
+  if (scheduledJobId != null && scheduledJobId !== normalizedJobId) {
+    if (hasLiveScanJob(scheduledJobId)) return false;
+    clearScheduledLibraryScan(scheduledJobId);
+  }
+  setScanRegistry({ jobId: normalizedJobId });
+  return true;
+}
+
+export function onLibraryScanSuccess(_payload, job) {
+  clearScheduledLibraryScan(job.id);
+}
+
+export function onLibraryScanFinalFailure(job) {
+  clearScheduledLibraryScan(job.id);
 }
 
 export function getLibraryScanStatus(jobId) {
@@ -83,12 +112,7 @@ const {
   idlePollS: 10,
   retryDelayS: 60,
   filterJob(job) {
-    const scheduledJobId = getScheduledLibraryScanJobId();
-    if (scheduledJobId != null && scheduledJobId !== job.id) {
-      return false;
-    }
-    clearScheduledLibraryScan(job.id);
-    return true;
+    return claimScheduledLibraryScanJob(job.id);
   },
   processJob: async () => {
     const { lidarrClient } = await import("./lidarrClient.js");
@@ -106,6 +130,8 @@ const {
     setScanRegistry({ jobId: job.id });
     return { action: "retry", delayS: 60, message };
   },
+  onJobSuccess: onLibraryScanSuccess,
+  onFinalFailure: onLibraryScanFinalFailure,
   onLoopError(error) {
     databaseClosed = isHonkerDatabaseClosedError(error);
     if (!databaseClosed) {

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js
@@ -24,6 +24,12 @@ const clampSize = (value) => {
   return Math.max(Math.round(n), 1);
 };
 
+const normalizeOwnerUserId = (value) => {
+  if (value == null) return null;
+  const userId = Number(value);
+  return Number.isSafeInteger(userId) && userId > 0 ? userId : null;
+};
+
 export const normalizeYearBound = (value) => {
   if (value == null || value === "") return null;
   const parsed = Number(value);
@@ -242,10 +248,7 @@ const normalizeFlow = (flow) => {
   return {
     id: flow?.id || randomUUID(),
     name: name || "Flow",
-    ownerUserId:
-      flow?.ownerUserId != null && Number.isFinite(Number(flow.ownerUserId))
-        ? Math.trunc(Number(flow.ownerUserId))
-        : null,
+    ownerUserId: normalizeOwnerUserId(flow?.ownerUserId),
     enabled: flow?.enabled === true,
     recordHistory: flow?.recordHistory !== false,
     scheduleDays: normalizeScheduleDays(flow?.scheduleDays),
@@ -475,10 +478,7 @@ const normalizeSharedPlaylist = (playlist) => {
   return {
     id: playlist?.id || randomUUID(),
     name: name || "Shared Playlist",
-    ownerUserId:
-      playlist?.ownerUserId != null && Number.isFinite(Number(playlist.ownerUserId))
-        ? Math.trunc(Number(playlist.ownerUserId))
-        : null,
+    ownerUserId: normalizeOwnerUserId(playlist?.ownerUserId),
     sourceName: String(playlist?.sourceName || "").trim() || null,
     sourceFlowId: String(playlist?.sourceFlowId || "").trim() || null,
     discoverPresetId: String(playlist?.discoverPresetId || "").trim() || null,
@@ -718,9 +718,12 @@ export const flowPlaylistConfig = {
     description = null,
   }) {
     const flows = getStoredFlows();
+    const normalizedOwnerUserId = normalizeOwnerUserId(ownerUserId);
     assertUniqueFlowName(
-      entitiesRelevantForNameCheck(flows, { ownerUserId }),
-      entitiesRelevantForNameCheck(getStoredSharedPlaylists(), { ownerUserId }),
+      entitiesRelevantForNameCheck(flows, { ownerUserId: normalizedOwnerUserId }),
+      entitiesRelevantForNameCheck(getStoredSharedPlaylists(), {
+        ownerUserId: normalizedOwnerUserId,
+      }),
       name,
     );
     const flow = normalizeFlow({
@@ -740,7 +743,7 @@ export const flowPlaylistConfig = {
       recordHistory,
       scheduleDays,
       scheduleTime,
-      ownerUserId,
+      ownerUserId: normalizedOwnerUserId,
       enabled: false,
       nextRunAt: null,
       lastRunAt: null,
@@ -898,15 +901,18 @@ export const flowPlaylistConfig = {
     description = null,
   }) {
     const playlists = getStoredSharedPlaylists();
+    const normalizedOwnerUserId = normalizeOwnerUserId(ownerUserId);
     assertUniqueSharedPlaylistName(
-      entitiesRelevantForNameCheck(playlists, { ownerUserId }),
-      entitiesRelevantForNameCheck(getStoredFlows(), { ownerUserId }),
+      entitiesRelevantForNameCheck(playlists, { ownerUserId: normalizedOwnerUserId }),
+      entitiesRelevantForNameCheck(getStoredFlows(), {
+        ownerUserId: normalizedOwnerUserId,
+      }),
       name,
     );
     const playlist = normalizeSharedPlaylist({
       id: String(id || "").trim() || randomUUID(),
       name,
-      ownerUserId,
+      ownerUserId: normalizedOwnerUserId,
       sourceName,
       sourceFlowId,
       discoverPresetId,

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -186,6 +186,14 @@ export const mergeAlbumTrackPageIntoLibrary = (current, page, albumId, tracks) =
   };
 };
 
+export const getCachedAlbumTracks = (album, tracksById) => {
+  const queryKey = queryKeys.libraryAlbumTracks(String(album?.id), album?.releaseGroupMbid);
+  const cached = queryClient.getQueryState(queryKey)?.isInvalidated
+    ? null
+    : queryClient.getQueryData(queryKey)?.tracks;
+  return cached || album?.trackIds?.map((id) => tracksById.get(String(id))).filter(Boolean) || [];
+};
+
 const trackDurationMs = (track) => {
   const fileDurationMs = (track?.files || []).find((file) => Number(file?.durationMs) > 0)
     ?.durationMs;
@@ -393,7 +401,10 @@ function LibraryPage() {
   const handleLibraryScanMessage = useCallback((message) => {
     if (message?.type !== "library_scan_completed") return;
     clearCanonicalLibraryPageCache();
-    queryClient.removeQueries({ queryKey: queryKeys.libraryAlbumTracksPrefix });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.libraryAlbumTracksPrefix,
+      refetchType: "none",
+    });
     void queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
     void queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
   }, []);
@@ -423,7 +434,10 @@ function LibraryPage() {
         if (refreshAttemptRef.current !== attempt) return;
         if (status.status === "completed") {
           clearCanonicalLibraryPageCache();
-          queryClient.removeQueries({ queryKey: queryKeys.libraryAlbumTracksPrefix });
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.libraryAlbumTracksPrefix,
+            refetchType: "none",
+          });
           void queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
           void queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
           showSuccess("Library refreshed");
@@ -502,24 +516,21 @@ function LibraryPage() {
               albumId: routeAlbumId,
               page: 1,
               pageSize,
-              signal,
-            })
+            }, { signal })
           : await Promise.all([
               getCanonicalLibraryPage({
                 kind: "albums",
                 artistId: routeArtistId,
                 page: 1,
                 pageSize,
-                signal,
-              }),
+              }, { signal }),
               getCanonicalLibraryPage({
                 kind: "tracks",
                 artistId: routeArtistId,
                 page: 1,
                 pageSize,
                 availableOnly: true,
-                signal,
-              }),
+              }, { signal }),
             ])
         : section === "favorites"
           ? await getLibraryFavorites({ signal })
@@ -530,16 +541,14 @@ function LibraryPage() {
                   page: 1,
                   pageSize,
                   sort: "newest",
-                  signal,
-                }),
+                }, { signal }),
                 getCanonicalLibraryPage({
                   kind: "tracks",
                   page: 1,
                   pageSize: 12,
                   sort: "newest",
                   availableOnly: true,
-                  signal,
-                }),
+                }, { signal }),
               ])
             : await getCanonicalLibraryPage({
                 kind: tab,
@@ -550,8 +559,7 @@ function LibraryPage() {
                 sort: sortMode,
                 direction: sortDirection,
                 availableOnly: tab === "tracks",
-                signal,
-              });
+              }, { signal });
       const pageResults = section === "favorites"
         ? [nextData?.library || EMPTY_LIBRARY]
         : Array.isArray(nextData) ? nextData : [nextData];
@@ -609,6 +617,7 @@ function LibraryPage() {
   }, [isDetail, isPreviewLibrary, queryData, section]);
   const setLibrary = useCallback((updater) => {
     queryClient.setQueryData(libraryQueryKey, (current) => {
+      if (!current && !forcePreview) return current;
       const previous = current?.library || (forcePreview ? libraryPreviewData : EMPTY_LIBRARY);
       const next = typeof updater === "function" ? updater(previous) : updater;
       if (current && next === previous) return current;
@@ -641,12 +650,7 @@ function LibraryPage() {
   );
 
   const getAlbumTracks = useCallback(
-    (album) => {
-      const cached = queryClient.getQueryData(
-        queryKeys.libraryAlbumTracks(String(album?.id), album?.releaseGroupMbid),
-      )?.tracks;
-      return cached || album?.trackIds?.map((id) => tracksById.get(String(id))).filter(Boolean) || [];
-    },
+    (album) => getCachedAlbumTracks(album, tracksById),
     [tracksById],
   );
 
@@ -661,8 +665,7 @@ function LibraryPage() {
           albumId: album.id,
           page: 1,
           pageSize,
-          signal,
-        });
+        }, { signal });
         const ownedTracks = Array.isArray(page?.items) ? page.items : [];
         const pageArtist = page?.artists?.[0] || null;
         if (!releaseGroupMbid) return { tracks: ownedTracks, page };
@@ -852,7 +855,10 @@ function LibraryPage() {
       };
     });
     clearCanonicalLibraryPageCache();
-    queryClient.removeQueries({ queryKey: queryKeys.libraryAlbumTracksPrefix });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.libraryAlbumTracksPrefix,
+      refetchType: "none",
+    });
   }, [setLibrary]);
 
   const handleLibraryRemovalConfirm = useCallback(async () => {
@@ -1214,6 +1220,9 @@ function LibraryPage() {
   const homeTracks = ownedLibraryTracks.slice(0, 12);
   const libraryAlbum = routeAlbumId ? albumsById.get(String(routeAlbumId)) || null : null;
   const libraryArtist = routeArtistId ? artistsById.get(String(routeArtistId)) || null : null;
+  const hasMissingAlbumTracks = Boolean(
+    libraryAlbum && getAlbumTracks(libraryAlbum).some((track) => !firstAvailableFile(track)),
+  );
   const activityQueryKey = useMemo(
     () => queryKeys.libraryActivityRequests(user?.id),
     [user?.id],
@@ -1227,7 +1236,7 @@ function LibraryPage() {
   const activityQuery = useQuery({
     queryKey: activityQueryKey,
     queryFn: ({ signal }) => getRequests({ refresh: true, signal }),
-    enabled: Boolean(libraryAlbum && !isPreviewLibrary),
+    enabled: Boolean(libraryAlbum && !isPreviewLibrary && hasMissingAlbumTracks),
     staleTime: 0,
     refetchInterval: hasTrackDownloadPolling ? 4000 : false,
     refetchIntervalInBackground: false,

--- a/frontend/src/queryClient.js
+++ b/frontend/src/queryClient.js
@@ -3,6 +3,11 @@ import { QueryClient } from "@tanstack/react-query";
 const LIBRARY_CANONICAL_QUERY_KEY = ["library", "canonical"];
 const LIBRARY_VIEW_QUERY_KEY = ["library", "view"];
 const LIBRARY_ALBUM_TRACKS_QUERY_KEY = ["library", "tracks"];
+let libraryCanonicalGeneration = 0;
+
+export const bumpLibraryCanonicalGeneration = () => {
+  libraryCanonicalGeneration += 1;
+};
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,7 +39,11 @@ export const queryKeys = {
   libraryLookupBatch: (ids) => ["library", "lookup-batch", [...ids].sort()],
   libraryViewPrefix: LIBRARY_VIEW_QUERY_KEY,
   libraryCanonicalPrefix: LIBRARY_CANONICAL_QUERY_KEY,
-  libraryCanonical: (options) => [...LIBRARY_CANONICAL_QUERY_KEY, options],
+  libraryCanonical: (options) => [
+    ...LIBRARY_CANONICAL_QUERY_KEY,
+    libraryCanonicalGeneration,
+    options,
+  ],
   libraryAlbumLookup: (ids) => ["library", "album-lookup", [...ids].sort()],
   libraryAlbumTracksPrefix: LIBRARY_ALBUM_TRACKS_QUERY_KEY,
   libraryAlbumTracks: (albumId, releaseGroupMbid) => [

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -5,7 +5,11 @@ import {
   deleteData,
   buildAuthenticatedApiUrl,
 } from "../core.js";
-import { queryClient, queryKeys } from "../../../queryClient.js";
+import {
+  bumpLibraryCanonicalGeneration,
+  queryClient,
+  queryKeys,
+} from "../../../queryClient.js";
 
 const buildStreamUrl = (path) => buildAuthenticatedApiUrl(path);
 const SLOW_LIBRARY_REQUEST_TIMEOUT_MS = 90000;
@@ -22,7 +26,7 @@ export const getCanonicalLibrary = (options = {}) =>
     signal: options.signal,
   });
 
-export const getCanonicalLibraryPage = (options = {}) => {
+export const getCanonicalLibraryPage = (options = {}, { signal } = {}) => {
   const params = Object.fromEntries(
     Object.entries({
       kind: options.kind,
@@ -42,14 +46,18 @@ export const getCanonicalLibraryPage = (options = {}) => {
     queryKey: queryKeys.libraryCanonical(params),
     queryFn: ({ signal: querySignal }) => getData("/library/canonical", {
       params,
-      signal: querySignal,
+      signal: signal ?? querySignal,
     }),
     staleTime: 15_000,
   });
 };
 
 export const clearCanonicalLibraryPageCache = () => {
-  queryClient.removeQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
+  bumpLibraryCanonicalGeneration();
+  return queryClient.removeQueries({
+    queryKey: queryKeys.libraryCanonicalPrefix,
+    predicate: (query) => query.state.fetchStatus !== "fetching",
+  });
 };
 
 export const requestLibraryRefresh = () => postData("/library/refresh", {});
@@ -63,11 +71,11 @@ let latestLibraryFavorites = null;
 export const fetchLibraryFavorites = ({ signal } = {}) =>
   getData("/library/favorites", { signal });
 
-export const getLibraryFavorites = () => {
+export const getLibraryFavorites = ({ signal } = {}) => {
   const generation = libraryFavoritesGeneration;
   return queryClient.fetchQuery({
     queryKey: queryKeys.libraryFavorites,
-    queryFn: ({ signal: querySignal }) => fetchLibraryFavorites({ signal: querySignal }),
+    queryFn: ({ signal: querySignal }) => fetchLibraryFavorites({ signal: signal ?? querySignal }),
     staleTime: 30_000,
   }).then((data) => {
     if (generation !== libraryFavoritesGeneration && latestLibraryFavorites) {


### PR DESCRIPTION
Nightly users with larger libraries are seeing repeated scans, high CPU usage, empty or partial library views, aborted operations, and owner identity errors.

This PR coalesces live library scans and recovers stale queue state, makes library cache refreshes non-destructive so active requests survive, ignores expected query cancellations, and normalizes invalid owner IDs before playback.

Verification:
- `npm test` — 747 tests passed
- `npm run lint -- --no-fix`
- `npm run build`
- `npm run perf:library -- --check`

Known limitation: this does not replace the existing full Lidarr/library scan with an incremental index. It prevents duplicate work and request aborts; further indexing changes should follow profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented canceled library requests from displaying load errors.
  * Improved library scan scheduling to avoid duplicate or stale jobs.
  * Ensured completed and failed scans properly release their scheduled jobs.
  * Corrected playlist owner ID validation for invalid values.

* **Improvements**
  * Library updates now refresh album and track data without unnecessarily removing cached results.
  * Cache invalidation now reliably refreshes canonical library queries.
  * Improved loading and background refresh behavior for library activity and downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->