### PR TITLE
fix(playlists): verify migrated paths before cleanup

### DIFF
--- a/.tests/migration/aurral-download-folder-migration.test.js
+++ b/.tests/migration/aurral-download-folder-migration.test.js
@@ -37,6 +37,7 @@ test.beforeEach(async () => {
     sharedPlaylists: [],
     onboardingComplete: true,
   });
+  dbOps.setJSONSetting("aurralDownloadFolderMigration", null);
 });
 
 test.after(async () => {
@@ -206,6 +207,111 @@ test("migrates permanent tracks, isolates active flows, and removes unkept flow 
   await assert.rejects(() => fs.access(permanentSource));
   await assert.rejects(() => fs.access(flowSource));
   await assert.rejects(() => fs.access(unkeptFlowSource));
+});
+
+test("retains a permanent source when tracker updates are not persisted", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Unpersisted Permanent" });
+  const source = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Track.flac",
+  );
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.writeFile(source, "track audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Track" },
+    playlist.id,
+  );
+  downloadTracker.setDone(jobId, source);
+  mock.method(downloadTracker, "updateFinalPath", () => false);
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+    indexDestination: async () => {},
+    logger: { warn() {} },
+  });
+  const destination = path.join(root, "Artist", "Album", "Track.flac");
+
+  assert.equal(result.failed, 1);
+  assert.equal(result.status, "needs-review");
+  await assert.doesNotReject(() => fs.access(source));
+  await assert.doesNotReject(() => fs.access(destination));
+  assert.equal(downloadTracker.getJob(jobId).finalPath, source);
+});
+
+test("repairs stale tracker paths from a completed migration", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Repair Complete" });
+  const source = path.join(
+    root,
+    "aurral-weekly-flow",
+    playlist.id,
+    "Artist",
+    "Album",
+    "Track.flac",
+  );
+  const destination = path.join(root, "Artist", "Album", "Track.flac");
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, "migrated track");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", albumName: "Album", trackName: "Track" },
+    playlist.id,
+  );
+  downloadTracker.setDone(jobId, source);
+  dbOps.setJSONSetting("aurralDownloadFolderMigration", {
+    version: 1,
+    rootPath: path.resolve(root),
+    status: "complete",
+    items: {
+      [source]: {
+        status: "complete",
+        destination,
+        identity: { artistName: "Artist", albumName: "Album", trackName: "Track" },
+      },
+    },
+  });
+
+  const result = await migrateAurralDownloadFolder({ root });
+
+  assert.equal(result.status, "complete");
+  assert.equal(result.repaired, 1);
+  assert.equal(downloadTracker.getJob(jobId).finalPath, destination);
+});
+
+test("indexes permanent migrations in one library scan", async () => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Batch indexing" });
+  const jobs = [];
+  for (const trackName of ["Track One", "Track Two"]) {
+    const source = path.join(
+      root,
+      "aurral-weekly-flow",
+      playlist.id,
+      "Artist",
+      "Album",
+      `${trackName}.flac`,
+    );
+    await fs.mkdir(path.dirname(source), { recursive: true });
+    await fs.writeFile(source, trackName);
+    const jobId = downloadTracker.addJob(
+      { artistName: "Artist", albumName: "Album", trackName },
+      playlist.id,
+    );
+    downloadTracker.setDone(jobId, source);
+    jobs.push(jobId);
+  }
+
+  const result = await migrateAurralDownloadFolder({
+    root,
+    metadataReader: async () => ({
+      common: { albumartist: "Artist", album: "Album", title: "Track" },
+    }),
+  });
+
+  assert.equal(result.migrated, 2);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM library_scan_runs").get().count, 1);
+  assert.ok(jobs.every((jobId) => downloadTracker.getJob(jobId).finalPath.startsWith(root)));
 });
 
 test("retains a failed item and completes it safely on retry", async () => {

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -282,6 +282,48 @@ test("matches Navidrome-relative paths under the configured library root", async
   assert.equal(musicSong.id, "music-relative-match");
 });
 
+test("waits for and verifies a Navidrome library update", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  let libraryPath = "/data/downloads/aurral-weekly-flow";
+  const calls = [];
+  client._nativeRequest = async (method, requestPath, body) => {
+    calls.push({ method, requestPath, body });
+    if (method === "GET") {
+      return [{ id: "aurral-library", name: "Aurral Weekly Flow", path: libraryPath }];
+    }
+    if (method === "PUT") {
+      libraryPath = body.path;
+      return { id: "aurral-library", name: body.name, path: body.path };
+    }
+    throw new Error(`Unexpected Navidrome request: ${method} ${requestPath}`);
+  };
+
+  const library = await client.ensureWeeklyFlowLibrary("/data/downloads");
+
+  assert.equal(library.id, "aurral-library");
+  assert.equal(library.path, "/data/downloads");
+  assert.deepEqual(calls.map(({ method, requestPath }) => [method, requestPath]), [
+    ["GET", "/api/library"],
+    ["PUT", "/api/library/aurral-library"],
+    ["GET", "/api/library"],
+  ]);
+});
+
+test("fails when Navidrome keeps the old library path", async () => {
+  const client = new NavidromeClient("http://navidrome.test", "user", "password");
+  client._nativeRequest = async (method) => {
+    if (method === "GET") {
+      return [{ id: "aurral-library", name: "Aurral Playlists", path: "/data/downloads/aurral-weekly-flow" }];
+    }
+    return { ok: true };
+  };
+
+  await assert.rejects(
+    client.ensureWeeklyFlowLibrary("/data/downloads"),
+    /Navidrome library path verification failed/,
+  );
+});
+
 test("prefers an exact absolute path over an earlier relative match", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._libraryPaths = ["/data/music"];

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -450,6 +450,30 @@ test("refreshes a cached native token after a 401", async () => {
   assert.equal(requestCount, 2);
 });
 
+test("retries native Navidrome requests after a 429", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestCount = 0;
+  globalThis.fetch = async (url) => {
+    const request = new URL(url);
+    if (request.pathname === "/auth/login") return jsonResponse({ token: "native-token" });
+    requestCount += 1;
+    if (requestCount === 1) return new Response(null, {
+      status: 429,
+      headers: { "retry-after": "0" },
+    });
+    return jsonResponse({ ok: true });
+  };
+
+  try {
+    const client = new NavidromeClient("http://navidrome.test", "user", "password");
+    assert.deepEqual(await client._nativeRequest("GET", "/api/library"), { ok: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requestCount, 2);
+});
+
 test("refreshes a cached native token after a 401 during artwork upload", async () => {
   const originalFetch = globalThis.fetch;
   let loginCount = 0;

--- a/.tests/playback/plex-playback-destination.test.js
+++ b/.tests/playback/plex-playback-destination.test.js
@@ -369,3 +369,25 @@ test("keeps Navidrome and Plex failures isolated when both destinations are conf
   });
   await assert.doesNotReject(manager.ensurePlaylists());
 });
+
+test("does not publish playlists when a configured library cannot be verified", async (t) => {
+  t.mock.method(console, "warn", () => {});
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Blocked setup" });
+  const manager = new WeeklyFlowPlaylistManager(weeklyFlowRoot);
+  const published = [];
+  manager.navidromeDestination.isConfigured = () => true;
+  manager.navidromeDestination.ensureLibrary = async () => ({
+    ok: false,
+    error: { message: "Navidrome library path verification failed" },
+  });
+  manager.navidromeDestination.publishPlaylist = async () => {
+    published.push(playlist.id);
+    return { ok: true };
+  };
+
+  await assert.rejects(
+    manager.ensurePlaylists(),
+    /Navidrome: Navidrome library path verification failed/,
+  );
+  assert.deepEqual(published, []);
+});

--- a/backend/services/aurralDownloadFolderMigration.js
+++ b/backend/services/aurralDownloadFolderMigration.js
@@ -80,6 +80,13 @@ function saveMigrationState(state) {
   dbOps.setJSONSetting(AURRAL_DOWNLOAD_FOLDER_MIGRATION_SETTING, state);
 }
 
+function pathMatches(candidate, expected, rootPath) {
+  const resolved = path.resolve(String(candidate || ""));
+  const remapped = remapLegacyPath(resolved, rootPath);
+  const expectedPath = path.resolve(expected);
+  return resolved === expectedPath || remapped === expectedPath;
+}
+
 function pathsOverlap(left, right) {
   const a = path.resolve(left);
   const b = path.resolve(right);
@@ -337,8 +344,47 @@ export async function migrateLegacyFlowFolder(options = {}) {
 
 function updateJobPaths(jobs, destination) {
   for (const job of jobs) {
-    downloadTracker.updateFinalPath(job.id, destination);
+    if (!downloadTracker.updateFinalPath(job.id, destination)) {
+      throw new Error(`Could not update tracker path for job ${job.id}`);
+    }
+    const updated = downloadTracker.getJob(job.id);
+    if (
+      !updated
+      || updated.status !== "done"
+      || path.resolve(String(updated.finalPath || "")) !== path.resolve(destination)
+    ) {
+      throw new Error(`Tracker path was not persisted for job ${job.id}`);
+    }
   }
+}
+
+async function repairCompletedMigrationState(state, rootPath, jobs, logger) {
+  const result = { repaired: 0, failed: 0, failures: [] };
+  for (const [sourcePath, item] of Object.entries(state.items)) {
+    if (item?.status !== "complete" || !item.destination) continue;
+    const destination = path.resolve(String(item.destination));
+    const destinationStat = await fs.stat(destination).catch(() => null);
+    if (!isPathInsideRoot(destination, rootPath) || !destinationStat?.isFile()) {
+      const reason = "completed migration destination is missing";
+      retainItem(state, sourcePath, reason, logger);
+      result.failed += 1;
+      result.failures.push({ sourcePath, reason });
+      continue;
+    }
+    const staleJobs = jobs.filter(
+      (job) => job?.status === "done" && pathMatches(job.finalPath, sourcePath, rootPath),
+    );
+    if (!staleJobs.length) continue;
+    try {
+      updateJobPaths(staleJobs, destination);
+      result.repaired += staleJobs.length;
+    } catch (error) {
+      retainItem(state, sourcePath, error.message, logger);
+      result.failed += 1;
+      result.failures.push({ sourcePath, reason: error.message });
+    }
+  }
+  return result;
 }
 
 async function resolveIdentity(sourcePath, rootPath, playlistId, jobs, metadataReader) {
@@ -392,6 +438,21 @@ async function defaultIndexDestination({ rootPath, targetPath, metadataReader })
   return media;
 }
 
+async function defaultIndexDestinations({ rootPath, entries, metadataReader }) {
+  await scanMusicRoot({
+    rootPath,
+    source: "aurral",
+    filePaths: entries.map((entry) => entry.targetPath),
+    metadataReader,
+  });
+  const indexed = new Map();
+  for (const entry of entries) {
+    const media = getLibraryMediaFile({ source: "aurral", path: entry.targetPath });
+    if (media?.available) indexed.set(entry.targetPath, media);
+  }
+  return indexed;
+}
+
 function itemState(state, sourcePath) {
   return state.items[sourcePath] || {};
 }
@@ -405,6 +466,40 @@ function retainItem(state, sourcePath, reason, logger) {
   };
   saveMigrationState(state);
   log(logger, "warn", `[AurralMigration] Retained ${sourcePath}: ${reason}`);
+}
+
+async function commitIndexedMigrationItem({
+  state,
+  sourcePath,
+  committedPath,
+  jobs,
+  identity,
+  rootPath,
+}) {
+  state.items[sourcePath] = {
+    ...itemState(state, sourcePath),
+    status: "indexed",
+    destination: committedPath,
+    identity,
+    updatedAt: Date.now(),
+  };
+  saveMigrationState(state);
+  updateJobPaths(jobs, committedPath);
+  state.items[sourcePath] = {
+    ...itemState(state, sourcePath),
+    status: "referenced",
+    updatedAt: Date.now(),
+  };
+  saveMigrationState(state);
+  if (path.resolve(sourcePath) !== path.resolve(committedPath)) {
+    await removeSource(sourcePath, rootPath);
+  }
+  state.items[sourcePath] = {
+    ...itemState(state, sourcePath),
+    status: "complete",
+    updatedAt: Date.now(),
+  };
+  saveMigrationState(state);
 }
 
 function resolveOwnership(sourcePath, rootPath, jobs, knownIds) {
@@ -434,20 +529,24 @@ export async function migrateAurralDownloadFolder(options = {}) {
   }
 
   const state = loadMigrationState(rootPath);
+  const jobs = downloadTracker.getAll().filter((job) => job?.status === "done");
   if (state.status === "complete") {
+    const repair = await repairCompletedMigrationState(state, rootPath, jobs, logger);
+    if (repair.failed > 0) state.status = "needs-review";
+    if (repair.repaired > 0 || repair.failed > 0) saveMigrationState(state);
     return {
-      status: "complete",
+      status: state.status,
       rootPath,
       scanned: 0,
       migrated: 0,
       flowMigrated: 0,
       removed: 0,
       retained: 0,
-      failed: 0,
-      failures: [],
+      repaired: repair.repaired,
+      failed: repair.failed,
+      failures: repair.failures,
     };
   }
-  const jobs = downloadTracker.getAll().filter((job) => job?.status === "done");
   const knownIds = new Set([
     ...jobs.map(jobPlaylistId).filter(Boolean),
     ...flowPlaylistConfig.getFlows().map((flow) => String(flow.id)),
@@ -465,7 +564,9 @@ export async function migrateAurralDownloadFolder(options = {}) {
   }
 
   const metadataReader = options.metadataReader || parseFile;
+  const useBatchIndex = !options.indexDestination;
   const indexDestination = options.indexDestination || defaultIndexDestination;
+  const pendingPermanent = [];
   const result = {
     status: "complete",
     rootPath,
@@ -575,6 +676,15 @@ export async function migrateAurralDownloadFolder(options = {}) {
         };
         saveMigrationState(state);
       }
+      if (!flow && useBatchIndex) {
+        pendingPermanent.push({
+          sourcePath,
+          targetPath: committedPath,
+          jobs: jobsForSource,
+          identity,
+        });
+        continue;
+      }
       if (!flow) {
         await indexDestination({
           rootPath,
@@ -589,30 +699,14 @@ export async function migrateAurralDownloadFolder(options = {}) {
           throw new Error("Flow destination verification failed");
         }
       }
-      state.items[sourcePath] = {
-        ...itemState(state, sourcePath),
-        status: "indexed",
-        destination: committedPath,
+      await commitIndexedMigrationItem({
+        state,
+        sourcePath,
+        committedPath,
+        jobs: jobsForSource,
         identity,
-        updatedAt: Date.now(),
-      };
-      saveMigrationState(state);
-      updateJobPaths(jobsForSource, committedPath);
-      state.items[sourcePath] = {
-        ...itemState(state, sourcePath),
-        status: "referenced",
-        updatedAt: Date.now(),
-      };
-      saveMigrationState(state);
-      if (path.resolve(sourcePath) !== path.resolve(committedPath)) {
-        await removeSource(sourcePath, rootPath);
-      }
-      state.items[sourcePath] = {
-        ...itemState(state, sourcePath),
-        status: "complete",
-        updatedAt: Date.now(),
-      };
-      saveMigrationState(state);
+        rootPath,
+      });
       result.migrated += 1;
       if (flow) result.flowMigrated += 1;
     } catch (error) {
@@ -622,11 +716,47 @@ export async function migrateAurralDownloadFolder(options = {}) {
     }
   }
 
+  if (pendingPermanent.length) {
+    let indexed = new Map();
+    let batchError = null;
+    try {
+      indexed = await defaultIndexDestinations({
+        rootPath,
+        entries: pendingPermanent,
+        metadataReader,
+      });
+    } catch (error) {
+      batchError = error;
+    }
+    for (const entry of pendingPermanent) {
+      try {
+        if (batchError) throw batchError;
+        if (!indexed.has(entry.targetPath)) {
+          throw new Error("Destination was not indexed as available Aurral media");
+        }
+        await commitIndexedMigrationItem({
+          state,
+          sourcePath: entry.sourcePath,
+          committedPath: entry.targetPath,
+          jobs: entry.jobs,
+          identity: entry.identity,
+          rootPath,
+        });
+        result.migrated += 1;
+      } catch (error) {
+        retainItem(state, entry.sourcePath, `migration verification failed: ${error.message}`, logger);
+        result.failed += 1;
+        result.failures.push({ sourcePath: entry.sourcePath, reason: error.message });
+      }
+    }
+  }
+
   for (const [sourcePath, item] of Object.entries(state.items)) {
     if (item?.status !== "referenced" || fileSet.has(sourcePath)) continue;
     state.items[sourcePath] = { ...item, status: "complete", updatedAt: Date.now() };
   }
-  state.status = result.failed || result.retained ? "needs-review" : "complete";
+  const stateNeedsReview = Object.values(state.items).some((item) => item?.status === "retained");
+  state.status = result.failed || result.retained || stateNeedsReview ? "needs-review" : "complete";
   result.status = state.status;
   state.lastResult = {
     scanned: result.scanned,

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -266,7 +266,9 @@ export class NavidromeClient {
   async _nativeRequest(method, path, body = null) {
     const base = this.url;
     const url = path.startsWith("/") ? `${base}${path}` : `${base}/api/${path}`;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
+    let tokenRefreshes = 0;
+    let rateLimitRetries = 0;
+    for (;;) {
       let tokenPromise = this._nativeTokenPromise;
       if (!tokenPromise) {
         const token = await this._nativeLogin();
@@ -292,8 +294,23 @@ export class NavidromeClient {
         if (newToken) this._nativeTokenPromise = Promise.resolve(newToken);
         return response.data;
       } catch (error) {
-        if (error?.response?.status !== 401 || attempt > 0) throw error;
-        if (this._nativeTokenPromise === tokenPromise) this._nativeTokenPromise = null;
+        const status = error?.response?.status;
+        if (status === 401 && tokenRefreshes === 0) {
+          tokenRefreshes += 1;
+          if (this._nativeTokenPromise === tokenPromise) this._nativeTokenPromise = null;
+          continue;
+        }
+        if (status === 429 && rateLimitRetries < NAVIDROME_RATE_LIMIT_RETRIES) {
+          const retryAfterHeader = error.response.headers?.["retry-after"]?.trim();
+          const retryAfter = Number(retryAfterHeader);
+          const delay = retryAfterHeader && Number.isFinite(retryAfter) && retryAfter >= 0
+            ? Math.min(retryAfter * 1000, NAVIDROME_RATE_LIMIT_MAX_DELAY_MS)
+            : NAVIDROME_RATE_LIMIT_DELAY_MS;
+          rateLimitRetries += 1;
+          await wait(Math.max(0, delay));
+          continue;
+        }
+        throw error;
       }
     }
   }

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -396,6 +396,30 @@ export class NavidromeClient {
     const normalizedPath = normalizeLibraryPath(libraryPath);
     this._libraryPaths = [normalizedPath];
     try {
+      const verifyLibrary = async (libraryId) => {
+        const refreshed = await this.getLibraries();
+        const list = Array.isArray(refreshed) ? refreshed : [];
+        const byId = libraryId == null
+          ? null
+          : list.find((library) => String(library?.id || "") === String(libraryId));
+        const verified = byId || list.find(
+          (library) => normalizeLibraryPath(library?.path) === normalizedPath,
+        );
+        if (!verified || normalizeLibraryPath(verified.path) !== normalizedPath) {
+          throw new Error(
+            `Navidrome library path verification failed: expected ${normalizedPath}`,
+          );
+        }
+        this._libraryPaths = [...new Set([
+          normalizedPath,
+          ...list.map((library) => normalizeLibraryPath(library.path)).filter(Boolean),
+        ])];
+        return verified;
+      };
+      const updateAndVerify = async (library) => {
+        await this.updateLibrary(library.id, library);
+        return verifyLibrary(library.id);
+      };
       const libs = await this.getLibraries();
       const list = Array.isArray(libs) ? libs : [];
       this._libraryPaths = [...new Set([
@@ -405,7 +429,7 @@ export class NavidromeClient {
       const byPath = list.find((lib) => normalizeLibraryPath(lib.path) === normalizedPath);
       if (byPath) {
         if (byPath.name !== name) {
-          return this.updateLibrary(byPath.id, {
+          return updateAndVerify({
             ...byPath,
             name,
             path: normalizedPath,
@@ -417,7 +441,7 @@ export class NavidromeClient {
       const byName = list.find((lib) => lib.name === name || LEGACY_LIBRARY_NAMES.has(lib.name));
       if (byName) {
         if (normalizeLibraryPath(byName.path) !== normalizedPath) {
-          return this.updateLibrary(byName.id, {
+          return updateAndVerify({
             ...byName,
             name,
             path: normalizedPath,
@@ -428,14 +452,15 @@ export class NavidromeClient {
 
       const legacy = list.find((lib) => isLegacyPlaylistLibraryPath(lib.path));
       if (legacy) {
-        return this.updateLibrary(legacy.id, {
+        return updateAndVerify({
           ...legacy,
           name,
           path: normalizedPath,
         });
       }
 
-      return this.createLibrary(name, normalizedPath);
+      const created = await this.createLibrary(name, normalizedPath);
+      return verifyLibrary(created?.id);
     } catch (err) {
       const message = err?.response?.data?.error || err.message;
       if (err?.response?.status === 429) {
@@ -443,7 +468,7 @@ export class NavidromeClient {
       } else {
         logger.warn("navidrome", "Navidrome library setup failed", { message });
       }
-      return null;
+      throw err;
     }
   }
 }

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -99,6 +99,7 @@ async function processSystemTask(payload = {}) {
         legacyFlowResult = await migrateLegacyFlowFolder();
       } catch (error) {
         console.error(`[Playlists] Legacy flow folder migration failed: ${error.message}`);
+        throw error;
       }
       if (legacyFlowResult.migrated > 0) {
         console.log(`[Playlists] Migrated ${legacyFlowResult.migrated} legacy flow file(s)`);
@@ -112,6 +113,7 @@ async function processSystemTask(payload = {}) {
         result = await migrateAurralDownloadFolder();
       } catch (error) {
         console.error(`[Playlists] Aurral download folder migration failed: ${error.message}`);
+        throw error;
       }
       const flowMigrated = result.flowMigrated || 0;
       const permanentMigrated = (result.migrated || 0) - flowMigrated;
@@ -120,10 +122,16 @@ async function processSystemTask(payload = {}) {
           `[Playlists] Migrated ${permanentMigrated} permanent track(s) and ${flowMigrated} flow track(s), and removed ${result.removed} unkept flow file(s)`,
         );
       }
+      if (result.repaired > 0) {
+        console.log(`[Playlists] Repaired ${result.repaired} migrated tracker path(s)`);
+      }
       if (result.retained > 0 || result.failed > 0) {
         console.warn(
           `[Playlists] Retained ${result.retained} item(s) and failed ${result.failed} migration item(s) for review`,
         );
+      }
+      if (legacyFlowResult.failed > 0 || result.status === "blocked" || result.failed > 0) {
+        throw new Error("Playlist filesystem migration requires review before playlist rebuild");
       }
       const metadataRepair = await repairYtdlpMetadata(
         trackerModule.downloadTracker.getAll(),

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistManager.js
@@ -178,7 +178,15 @@ export class WeeklyFlowPlaylistManager {
   async _ensurePlaylistsInternal() {
     const flows = flowPlaylistConfig.getFlows();
     const sharedPlaylists = flowPlaylistConfig.getSharedPlaylists();
-    await this.destinationRegistry.run("ensureLibrary");
+    const libraryResults = await this.destinationRegistry.run("ensureLibrary");
+    const libraryFailures = libraryResults.filter((result) => !result.ok);
+    if (libraryFailures.length) {
+      throw new Error(
+        libraryFailures
+          .map((result) => `${result.destination}: ${result.error?.message || "library setup failed"}`)
+          .join("; "),
+      );
+    }
     for (const flow of flows) {
       if (flow.enabled) {
         await this._publishPlaylist(flow, "Flow");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration recovery when saved media paths become outdated or destination folders are missing.
  * Improved handling of migration failures so playlist rebuilding stops when setup requires attention.
  * Weekly Flow libraries are now verified after creation or updates, preventing continued use of incorrect paths.
  * Playlist publication is blocked when a playback library cannot be configured or verified.
  * Improved indexing of permanent media during migrations.
  * Improved handling of expired authentication and rate-limited service requests with automatic retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->