### PR TITLE
fix(playlists): show Subsonic-managed tracks

### DIFF
--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -412,6 +412,9 @@ test("creates durable Subsonic playlists around one promoted library job", async
     const playlist = responseJson(await request("getPlaylist", { id: secondCreate.playlist.id })).playlist;
     return playlist.entry?.[0] ? playlist : null;
   });
+  const secondAurralPlaylistId = decodeURIComponent(
+    secondCreate.playlist.id.slice("shared:".length),
+  );
   assert.equal(jobIdFromSong(second.entry[0].id), canonicalJobId);
 
   await waitFor(() => db.prepare(
@@ -431,6 +434,20 @@ test("creates durable Subsonic playlists around one promoted library job", async
   ).all("library", "Flow Song");
   assert.equal(libraryJobs.length, 1);
 
+  const aurralPlaylistId = decodeURIComponent(firstId.slice("shared:".length));
+  const aurralJobsResponse = await apiFetch(
+    `/api/playlists/jobs/${encodeURIComponent(aurralPlaylistId)}`,
+  );
+  assert.equal(aurralJobsResponse.status, 200);
+  const aurralJobs = await aurralJobsResponse.json();
+  assert.equal(aurralJobs.length, 1);
+  assert.equal(aurralJobs[0].id, canonicalJobId);
+  assert.equal(aurralJobs[0].playlistType, aurralPlaylistId);
+  assert.equal(
+    (await apiFetch(`/api/playlists/stream/${encodeURIComponent(canonicalJobId)}`)).status,
+    200,
+  );
+
   const removed = responseJson(await request("updatePlaylist", {
     playlistId: first.id,
     songIndexToRemove: "0",
@@ -438,6 +455,18 @@ test("creates durable Subsonic playlists around one promoted library job", async
   assert.equal(removed.status, "ok");
   const secondEntry = responseJson(await request("getPlaylist", { id: second.id })).playlist.entry[0];
   assert.equal((await request("stream", { id: secondEntry.id })).response.status, 200);
+  const removeCanonicalResponse = await apiFetch(
+    `/api/playlists/shared-playlists/${encodeURIComponent(secondAurralPlaylistId)}/tracks/${encodeURIComponent(canonicalJobId)}`,
+    { method: "DELETE" },
+  );
+  assert.equal(removeCanonicalResponse.status, 200);
+  await waitFor(async () => {
+    const response = await apiFetch(
+      `/api/playlists/jobs/${encodeURIComponent(secondAurralPlaylistId)}`,
+    );
+    const jobs = await response.json();
+    return jobs.length === 0 ? true : null;
+  });
   await stat(libraryJobs[0].finalPath);
 
   assert.equal(responseJson(await request("deletePlaylist", { id: second.id })).status, "ok");

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -62,10 +62,29 @@ export function registerJobs(router) {
       rawLimit && Number.isFinite(parsedLimit) && parsedLimit > 0
         ? Math.floor(parsedLimit)
         : null;
-    let jobs = downloadTracker.getByPlaylistType(flowId, limit);
     const sharedPlaylist = flowPlaylistConfig.getSharedPlaylist(flowId);
-    if (sharedPlaylist?.tracks?.length && limit == null) {
-      jobs = orderJobsBySharedPlaylistTracks(jobs, sharedPlaylist.tracks);
+    const sharedTracks = sharedPlaylist?.tracks;
+    let jobs = downloadTracker.getByPlaylistType(
+      flowId,
+      sharedTracks?.length ? null : limit,
+    );
+    if (sharedTracks?.length) {
+      const referencedJobIds = new Set(
+        sharedTracks.map((track) => String(track?.canonicalJobId || "")).filter(Boolean),
+      );
+      const referencedJobs = [...referencedJobIds]
+        .map((jobId) => downloadTracker.getJob(jobId))
+        .filter(Boolean);
+      jobs = [...referencedJobs, ...jobs].filter(
+        (job, index, values) => values.findIndex((candidate) => candidate.id === job.id) === index,
+      );
+      jobs = orderJobsBySharedPlaylistTracks(jobs, sharedTracks);
+      if (limit != null) jobs = jobs.slice(0, limit);
+      jobs = jobs.map((job) =>
+        referencedJobIds.has(job.id) && job.playlistType !== flowId
+          ? { ...job, playlistId: flowId, playlistType: flowId }
+          : job,
+      );
     }
     const profile = getQualityProfile();
     res.json(filterJobsForUser(req.user, jobs).map((job) => decorateJobQuality(job, profile)));

--- a/backend/routes/weeklyFlow/handlers/sharedPlaylists.js
+++ b/backend/routes/weeklyFlow/handlers/sharedPlaylists.js
@@ -238,7 +238,10 @@ export function registerSharedPlaylists(router) {
           return res.status(404).json({ error: "Shared playlist not found" });
         }
         const job = downloadTracker.getJob(jobId);
-        if (!job || job.playlistType !== playlistId) {
+        const playlistReferencesJob = playlist.tracks?.some(
+          (track) => String(track?.canonicalJobId || "") === String(jobId || ""),
+        );
+        if (!job || (job.playlistType !== playlistId && !playlistReferencesJob)) {
           return res.status(404).json({ error: "Track not found" });
         }
         const result = await weeklyFlowOperationQueue.enqueuePayload({

--- a/backend/routes/weeklyFlow/handlers/stream.js
+++ b/backend/routes/weeklyFlow/handlers/stream.js
@@ -11,6 +11,15 @@ import {
   AUDIO_CONTENT_TYPES,
   canAccessPlaylistType,
 } from "./utils.js";
+import { flowPlaylistConfig } from "../../../services/weeklyFlow/weeklyFlowPlaylistConfig.js";
+
+const canAccessJob = (user, job) =>
+  canAccessPlaylistType(user, job.playlistType) ||
+  flowPlaylistConfig.getSharedPlaylistsForUser(user).some((playlist) =>
+    playlist.tracks?.some(
+      (track) => String(track?.canonicalJobId || "") === String(job.id || ""),
+    ),
+  );
 
 export function registerStream(router) {
   router.get("/stream/:jobId", noCache, async (req, res) => {
@@ -29,7 +38,7 @@ export function registerStream(router) {
     if (!job) {
       return res.status(404).json({ error: "Track not found" });
     }
-    if (!canAccessPlaylistType(req.user, job.playlistType)) {
+    if (!canAccessJob(req.user, job)) {
       return res.status(404).json({ error: "Track not found" });
     }
     if (job.status !== "done" || !job.finalPath) {

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -572,12 +572,24 @@ async function deleteSharedPlaylistTrack({ playlistId, jobId } = {}) {
   const playlist = flowPlaylistConfig.getSharedPlaylist(safePlaylistId);
   if (!playlist) return { missingPlaylist: true };
   const job = downloadTracker.getJob(safeJobId);
-  if (!job || job.playlistType !== safePlaylistId) {
+  const isCanonicalReference =
+    job?.playlistType !== safePlaylistId &&
+    playlist.tracks?.some((track) => String(track?.canonicalJobId || "") === safeJobId);
+  if (!job || (job.playlistType !== safePlaylistId && !isCanonicalReference)) {
     return { missingJob: true };
   }
   await withPlaylistMutation(
     safePlaylistId,
     async () => {
+      if (isCanonicalReference) {
+        const updated = flowPlaylistConfig.updateSharedPlaylist(safePlaylistId, {
+          tracks: playlist.tracks.filter(
+            (track) => String(track?.canonicalJobId || "") !== safeJobId,
+          ),
+        });
+        if (!updated) throw new Error("Failed to update shared playlist");
+        return;
+      }
       if (job.status === "done" && typeof job.finalPath === "string") {
         await removePlaylistLocalTrackFile(job, safePlaylistId);
       }


### PR DESCRIPTION
Subsonic playlist edits can leave a shared playlist with canonical library-job references instead of playlist-owned jobs. Aurral still showed the stored track count but returned no jobs, so the playlist appeared empty.

The playlist jobs route now resolves canonical references in the selected playlist context. Streaming and deletion accept those references without deleting the shared library job or file.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/subsonic/subsonic-canonical.int.test.js` (18 passed)
- `npm run lint:backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared playlists now support tracks linked to content managed by another playlist.
  * Authorized users can stream and remove these shared tracks seamlessly.
  * Job listings now include all relevant shared-playlist content, preserve track order, and honor result limits.

* **Bug Fixes**
  * Fixed shared-track deletion and cleanup behavior to prevent unintended removal of underlying files.
  * Added validation to ensure playlist jobs and streams remain accessible through valid shared-playlist references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->