### PR TITLE
feat(library): restore library item info

### DIFF
--- a/.tests/frontend/theme.test.js
+++ b/.tests/frontend/theme.test.js
@@ -26,7 +26,7 @@ test.afterEach(() => {
   invalidateThemeCaches();
 });
 
-test("Aurral keeps the original light and dark palettes", () => {
+test("Aurral keeps its neutral light and dark palettes", () => {
   const [aurral] = BUILT_IN_THEMES;
   assert.deepEqual(
     {
@@ -44,7 +44,7 @@ test("Aurral keeps the original light and dark palettes", () => {
       surfaceRaised: "#f1f1f1",
       surfacePopover: "#e4e4e4",
       surfaceHover: "#d0d0d0",
-      accent: "#4d7c0f",
+      accent: "#525252",
       text: "#171717",
     },
   );
@@ -64,7 +64,7 @@ test("Aurral keeps the original light and dark palettes", () => {
       surfaceRaised: "#202020",
       surfacePopover: "#2d2d2d",
       surfaceHover: "#424242",
-      accent: "#84cc16",
+      accent: "#b3b3b3",
       text: "#ffffff",
     },
   );

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -23,7 +23,8 @@ Use the track action menu to add a library track to a playlist, remove it, or
 promote an Aurral-owned track into the permanent Library. Favorites are stored
 per user and work in both the built-in player and Subsonic clients. The page
 reports stale library data, partial or missing files, provider health problems,
-and empty results.
+and empty results. Use **View info** in an artist, album, or track action menu
+to inspect the indexed metadata without leaving the Library.
 
 Navidrome remains optional. Lidarr remains the library provider when it is
 configured.

--- a/frontend/src/pages/LibraryInfoModal.jsx
+++ b/frontend/src/pages/LibraryInfoModal.jsx
@@ -1,0 +1,149 @@
+import { useId } from "react";
+import { X } from "lucide-react";
+import TooltipButton from "../components/TooltipButton";
+import { useModalDialog } from "../hooks/useModalDialog.js";
+
+const text = (value) => String(value ?? "").trim();
+
+const formatList = (value) =>
+  (Array.isArray(value) ? value : [value])
+    .map(text)
+    .filter(Boolean)
+    .filter((entry, index, values) => values.indexOf(entry) === index)
+    .join(", ");
+
+const metadataGenres = (entity) => {
+  const metadata = entity?.metadata || {};
+  return formatList([
+    ...(Array.isArray(metadata.genres) ? metadata.genres : [metadata.genres]),
+    ...(Array.isArray(metadata.genre) ? metadata.genre : [metadata.genre]),
+    ...(Array.isArray(metadata.common?.genre) ? metadata.common.genre : [metadata.common?.genre]),
+    ...(Array.isArray(metadata.tags?.genre) ? metadata.tags.genre : [metadata.tags?.genre]),
+  ]);
+};
+
+const firstFile = (track) =>
+  (track?.files || []).find((file) => file.available) || track?.files?.[0];
+
+const durationMs = (track, file) => {
+  if (Number(file?.durationMs) > 0) return Number(file.durationMs);
+  if (Number(track?.durationMs) > 0) return Number(track.durationMs);
+  if (Number(track?.metadata?.durationMs) > 0) return Number(track.metadata.durationMs);
+  const seconds = Number(track?.metadata?.duration);
+  return seconds > 0 ? Math.round(seconds * 1000) : 0;
+};
+
+const formatDuration = (duration) => {
+  const seconds = Math.floor(Number(duration || 0) / 1000);
+  return seconds
+    ? Math.floor(seconds / 60) + ":" + String(seconds % 60).padStart(2, "0")
+    : "";
+};
+
+const formatQuality = (quality) => {
+  if (!quality || typeof quality !== "object") return text(quality);
+  return [
+    quality.bitrate ? quality.bitrate + " kbps" : "",
+    quality.bitDepth ? quality.bitDepth + " bit" : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+};
+
+const getRows = ({ kind, entity, artist, album, trackNumber }) => {
+  const file = kind === "track" ? firstFile(entity) : null;
+  const title =
+    entity?.title || entity?.trackName || entity?.albumName || entity?.name || entity?.artistName;
+  const rows = [
+    ["Type", kind === "artist" ? "Artist" : kind === "album" ? "Album" : "Track"],
+    [kind === "artist" ? "Name" : kind === "album" ? "Album" : "Track", title],
+  ];
+
+  if (kind === "artist") {
+    rows.push(
+      ["Sort name", entity.sortName],
+      ["Albums", entity.albumIds?.length ?? entity.statistics?.albumCount],
+      ["Tracks", entity.statistics?.trackCount],
+    );
+  }
+  if (kind === "album") {
+    rows.push(
+      ["Artist", artist?.name || entity.artistName || entity.albumArtist],
+      ["Release date", entity.releaseDate],
+      ["Tracks", entity.trackCount ?? entity.statistics?.trackCount ?? entity.trackIds?.length],
+      ["Available tracks", entity.availableTrackCount ?? entity.statistics?.trackFileCount],
+    );
+  }
+  if (kind === "track") {
+    rows.push(
+      ["Artist", artist?.name || entity.artistName],
+      ["Album", album?.title || entity.albumName],
+      ["Track number", trackNumber],
+      ["Duration", formatDuration(durationMs(entity, file))],
+      ["Format", file?.format || entity.streamFormat],
+      ["Quality", formatQuality(file?.quality || entity.quality)],
+      ["Available", (entity.available ?? file?.available) ? "Yes" : "No"],
+    );
+  }
+
+  rows.push(
+    ["Genres", metadataGenres(entity)],
+    ["Sources", formatList(entity.sources)],
+    ["MusicBrainz ID", entity.mbid],
+    ...(kind === "album" ? [["Release group ID", entity.releaseGroupMbid]] : []),
+    ["Library ID", entity.id],
+  );
+  return rows.filter(([, value]) => text(value));
+};
+
+export default function LibraryInfoModal({ item, onClose }) {
+  const titleId = useId();
+  const { dialogRef, handleBackdropClick } = useModalDialog({
+    open: Boolean(item),
+    onClose,
+  });
+
+  if (!item) return null;
+
+  const title =
+    text(item.entity?.title || item.entity?.trackName || item.entity?.albumName || item.entity?.name) ||
+    "Library information";
+  const rows = getRows(item);
+
+  return (
+    <div className="artist-modal-backdrop" onClick={handleBackdropClick}>
+      <section
+        ref={dialogRef}
+        className="artist-modal activity-info-modal library-info-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <div className="artist-modal__header">
+          <div>
+            <p className="activity-info-modal__eyebrow">
+              {item.kind === "artist" ? "Artist" : item.kind === "album" ? "Album" : "Track"} information
+            </p>
+            <h2 id={titleId} className="artist-modal__title">{title}</h2>
+          </div>
+          <TooltipButton
+            className="btn btn-ghost btn-icon-square"
+            onClick={onClose}
+            label="Close information"
+          >
+            <X className="artist-icon-md" aria-hidden="true" />
+          </TooltipButton>
+        </div>
+        <dl className="activity-info-modal__rows">
+          {rows.map(([label, value]) => (
+            <div className="activity-info-modal__row" key={label}>
+              <dt>{label}</dt>
+              <dd>{text(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Grid3X3,
   Heart,
+  Info,
   List,
   ListFilter,
   Pause,
@@ -68,6 +69,7 @@ import {
 import { DeleteAlbumModal } from "./ArtistDetails/components/DeleteAlbumModal";
 import { DeleteArtistModal } from "./ArtistDetails/components/DeleteArtistModal";
 import { DeleteTrackModal } from "./ArtistDetails/components/DeleteTrackModal";
+import LibraryInfoModal from "./LibraryInfoModal";
 import {
   buildSharedPlaylistTrackPayload,
   reserveUniquePlaylistName,
@@ -396,6 +398,7 @@ function LibraryPage() {
   const [playlistSavingKey, setPlaylistSavingKey] = useState("");
   const [trackDownloadStates, setTrackDownloadStates] = useState({});
   const [libraryRemoval, setLibraryRemoval] = useState(null);
+  const [libraryInfo, setLibraryInfo] = useState(null);
   const [deleteFiles, setDeleteFiles] = useState(false);
   const [deletingLibraryEntity, setDeletingLibraryEntity] = useState(false);
   const [homeAlbumsGridRef, homeAlbumColumns] = useResponsiveReleaseLimit({
@@ -1489,6 +1492,10 @@ function LibraryPage() {
     navigate("/library/artist/" + encodeURIComponent(artist.id) + previewQuery);
   };
 
+  const openLibraryInfo = (kind, entity, context = {}) => {
+    setLibraryInfo({ kind, entity, ...context });
+  };
+
   const handleDiscoverArtistOpen = (artist) => {
     if (!artist?.mbid) return;
     navigate("/artist/" + encodeURIComponent(artist.mbid), {
@@ -1605,6 +1612,9 @@ function LibraryPage() {
             matchesSource(librarySource);
           const artistName = artist?.name || track.artistName || "Unknown Artist";
           const albumName = album?.title || "Unknown Album";
+          const trackNumber = track.albums?.find(
+            (entry) => String(entry.albumId) === String(album?.id),
+          )?.trackNumber;
           const isFavorite = favoriteIds.has(favoriteId("song", track));
           const trackMenuItems = [
             {
@@ -1613,6 +1623,12 @@ function LibraryPage() {
               icon: active && isPlaying ? Pause : Play,
               onSelect: () => playTrack(track, tracks),
               disabled: !file || (active && isLoading),
+            },
+            {
+              id: "info",
+              label: "View info",
+              icon: Info,
+              onSelect: () => openLibraryInfo("track", track, { artist, album, trackNumber }),
             },
             {
               id: "favorite",
@@ -1848,6 +1864,12 @@ function LibraryPage() {
                 onSelect: () => handleArtistOpen(artist),
               },
               {
+                id: "info",
+                label: "View info",
+                icon: Info,
+                onSelect: () => openLibraryInfo("artist", artist),
+              },
+              {
                 id: "favorite",
                 label: isFavorite ? "Remove from favorites" : "Add to favorites",
                 icon: Heart,
@@ -1963,6 +1985,12 @@ function LibraryPage() {
                 label: "Open album",
                 icon: ExternalLink,
                 onSelect: () => handleAlbumOpen(album),
+              },
+              {
+                id: "info",
+                label: "View info",
+                icon: Info,
+                onSelect: () => openLibraryInfo("album", album, { artist }),
               },
               {
                 id: "favorite",
@@ -2222,6 +2250,12 @@ function LibraryPage() {
                     disabled: !albumTracks.some((track) => firstAvailableFile(track)),
                   },
                   {
+                    id: "info",
+                    label: "View info",
+                    icon: Info,
+                    onSelect: () => openLibraryInfo("album", libraryAlbum, { artist }),
+                  },
+                  {
                     id: "favorite",
                     label: favoriteIds.has(favoriteId("album", libraryAlbum))
                       ? "Remove from favorites"
@@ -2347,6 +2381,12 @@ function LibraryPage() {
                     disabled: !artistTracks.some((track) => firstAvailableFile(track)),
                   },
                   {
+                    id: "info",
+                    label: "View info",
+                    icon: Info,
+                    onSelect: () => openLibraryInfo("artist", libraryArtist),
+                  },
+                  {
                     id: "favorite",
                     label: favoriteIds.has(favoriteId("artist", libraryArtist))
                       ? "Remove from favorites"
@@ -2461,6 +2501,7 @@ function LibraryPage() {
         onConfirm={handleLibraryRemovalConfirm}
         deleting={deletingLibraryEntity}
       />
+      <LibraryInfoModal item={libraryInfo} onClose={() => setLibraryInfo(null)} />
     </>
   );
 

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -164,7 +164,7 @@ export const BUILT_IN_THEMES = [
     id: DEFAULT_THEME_ID,
     label: "Aurral",
     appearance: "light",
-    colors: createThemeColors("light", "#ffffff", "#4d7c0f", {
+    colors: createThemeColors("light", "#ffffff", "#525252", {
       chrome: "#e5e7eb",
       surface: "#ffffff",
       surfaceRaised: "#f1f1f1",
@@ -187,7 +187,7 @@ export const BUILT_IN_THEMES = [
       scrim: "#e5e7ebb8",
     }),
     variants: {
-      dark: createThemeColors("dark", "#121212", "#84cc16", {
+      dark: createThemeColors("dark", "#121212", "#b3b3b3", {
         chrome: "#000000",
         surface: "#121212",
         surfaceRaised: "#202020",


### PR DESCRIPTION
## Problem

Library artist, album, and track menus no longer exposed indexed metadata. The default Aurral theme also reapplied a green accent at runtime, so common links and player controls drifted from the monochrome foundation.

## Solution

- Add **View info** to artist, album, and track kebab and right-click menus.
- Show type-specific indexed metadata in a reusable library information modal.
- Change the built-in light and dark Aurral accents to neutral grayscale values.
- Document the new **View info** action.

## Verification

- `node --test .tests/frontend/theme.test.js`
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`
- `npm run build --prefix docs`
- Live preview verified artist, album, and track info flows, right-click menus, Escape and close behavior, and grayscale player and link colors.
- `git diff --check`

The modal displays metadata already present in the library payloads. It does not add a new metadata request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **View info** actions for artists, albums, and tracks in the Library.
  * Added a metadata dialog showing details such as genre, duration, format, quality, availability, identifiers, and source.

* **Style**
  * Updated the built-in Aurral theme with neutral gray accent colors in light and dark modes.

* **Documentation**
  * Documented how to inspect indexed metadata from Library action menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->