### PR TITLE
perf(library): replace unbounded canonical reads

### DIFF
--- a/.tests/frontend/library-favorites-cache.test.js
+++ b/.tests/frontend/library-favorites-cache.test.js
@@ -87,7 +87,7 @@ test("a favorites read waits when it completes before the mutation refresh", asy
   await mutation;
 });
 
-test("an older favorites refresh cannot overwrite a newer mutation", async (t) => {
+test("favorite writes serialize and the final refresh includes both mutations", async (t) => {
   const { updateLibraryFavorites, queryClient, queryKeys, requests, waitForRequests } =
     await openFavoritesHarness(t, "favorites-refresh-generation-test");
   const initial = { version: "initial" };
@@ -99,21 +99,24 @@ test("an older favorites refresh cannot overwrite a newer mutation", async (t) =
   await waitForRequests(2);
 
   const secondMutation = updateLibraryFavorites(["song:2"], true);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(requests.length, 2);
+
+  requests[1].resolve(jsonResponse({ version: "first" }));
   await waitForRequests(3);
   requests[2].resolve(jsonResponse({ changedIds: ["song:2"] }));
   await waitForRequests(4);
 
-  requests[1].resolve(jsonResponse({ version: "old" }));
   await firstMutation;
   assert.deepEqual(queryClient.getQueryData(queryKeys.libraryFavorites), initial);
 
-  const freshFavorites = { version: "new" };
+  const freshFavorites = { version: "both" };
   requests[3].resolve(jsonResponse(freshFavorites));
   await secondMutation;
   assert.deepEqual(queryClient.getQueryData(queryKeys.libraryFavorites), freshFavorites);
 });
 
-test("an older failed refresh cannot invalidate a newer mutation", async (t) => {
+test("a failed favorite refresh does not block the next queued mutation", async (t) => {
   const { updateLibraryFavorites, queryClient, queryKeys, requests, waitForRequests } =
     await openFavoritesHarness(t, "favorites-refresh-failure-test");
   const initial = { version: "initial" };
@@ -125,16 +128,14 @@ test("an older failed refresh cannot invalidate a newer mutation", async (t) => 
   await waitForRequests(2);
 
   const secondMutation = updateLibraryFavorites(["song:2"], true);
-  await waitForRequests(3);
-  requests[2].resolve(jsonResponse({ changedIds: ["song:2"] }));
-  await waitForRequests(4);
-
   requests[1].resolve(new Response(JSON.stringify({ error: "refresh failed" }), {
     status: 500,
     headers: { "content-type": "application/json" },
   }));
   await firstMutation;
-  assert.equal(queryClient.getQueryState(queryKeys.libraryFavorites)?.isInvalidated, false);
+  await waitForRequests(3);
+  requests[2].resolve(jsonResponse({ changedIds: ["song:2"] }));
+  await waitForRequests(4);
 
   const freshFavorites = { version: "new" };
   requests[3].resolve(jsonResponse(freshFavorites));

--- a/.tests/frontend/library-favorites-cache.test.js
+++ b/.tests/frontend/library-favorites-cache.test.js
@@ -7,29 +7,36 @@ const jsonResponse = (value) => new Response(JSON.stringify(value), {
   headers: { "content-type": "application/json" },
 });
 
-test("an older favorites read cannot overwrite a newer mutation cache", async (t) => {
+const openFavoritesHarness = async (t, suffix) => {
   const vite = await createServer({
     root: "frontend",
     server: { middlewareMode: true },
     appType: "custom",
     optimizeDeps: { noDiscovery: true },
   });
-  t.after(() => vite.close());
 
-  const { getLibraryFavorites, updateLibraryFavorites } = await vite.ssrLoadModule(
-    "/src/utils/api/endpoints/library.js?favorites-race-test",
-  );
+  const favorites = await vite.ssrLoadModule(`/src/utils/api/endpoints/library.js?${suffix}`);
+  const { queryClient, queryKeys } = await vite.ssrLoadModule("/src/queryClient.js");
   const originalFetch = globalThis.fetch;
   const requests = [];
   t.after(() => {
     globalThis.fetch = originalFetch;
+    queryClient.clear();
   });
+  t.after(() => vite.close());
   globalThis.fetch = async (_url, init = {}) => new Promise((resolve) => {
     requests.push({ method: init.method || "GET", resolve });
   });
   const waitForRequests = async (count) => {
     while (requests.length < count) await new Promise((resolve) => setImmediate(resolve));
   };
+
+  return { ...favorites, queryClient, queryKeys, requests, waitForRequests };
+};
+
+test("an older favorites read cannot overwrite a newer mutation cache", async (t) => {
+  const { getLibraryFavorites, updateLibraryFavorites, requests, waitForRequests } =
+    await openFavoritesHarness(t, "favorites-race-test");
 
   const staleFavorites = { artist: [], album: [], song: [], library: { tracks: [] } };
   const mutationResponse = {
@@ -52,4 +59,85 @@ test("an older favorites read cannot overwrite a newer mutation cache", async (t
   assert.deepEqual(await read, freshFavorites);
   assert.deepEqual(await getLibraryFavorites(), freshFavorites);
   assert.equal(requests.length, 3);
+});
+
+test("a favorites read waits when it completes before the mutation refresh", async (t) => {
+  const { getLibraryFavorites, updateLibraryFavorites, requests, waitForRequests } =
+    await openFavoritesHarness(t, "favorites-read-before-refresh-test");
+  const read = getLibraryFavorites();
+  await waitForRequests(1);
+  const mutation = updateLibraryFavorites(["song:1"], true);
+  await waitForRequests(2);
+
+  let readSettled = false;
+  const pendingRead = read.then((value) => {
+    readSettled = true;
+    return value;
+  });
+  requests[0].resolve(jsonResponse({ version: "stale" }));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(readSettled, false);
+
+  requests[1].resolve(jsonResponse({ changedIds: ["song:1"] }));
+  await waitForRequests(3);
+  const freshFavorites = { version: "fresh" };
+  requests[2].resolve(jsonResponse(freshFavorites));
+
+  assert.deepEqual(await pendingRead, freshFavorites);
+  await mutation;
+});
+
+test("an older favorites refresh cannot overwrite a newer mutation", async (t) => {
+  const { updateLibraryFavorites, queryClient, queryKeys, requests, waitForRequests } =
+    await openFavoritesHarness(t, "favorites-refresh-generation-test");
+  const initial = { version: "initial" };
+  queryClient.setQueryData(queryKeys.libraryFavorites, initial);
+
+  const firstMutation = updateLibraryFavorites(["song:1"], true);
+  await waitForRequests(1);
+  requests[0].resolve(jsonResponse({ changedIds: ["song:1"] }));
+  await waitForRequests(2);
+
+  const secondMutation = updateLibraryFavorites(["song:2"], true);
+  await waitForRequests(3);
+  requests[2].resolve(jsonResponse({ changedIds: ["song:2"] }));
+  await waitForRequests(4);
+
+  requests[1].resolve(jsonResponse({ version: "old" }));
+  await firstMutation;
+  assert.deepEqual(queryClient.getQueryData(queryKeys.libraryFavorites), initial);
+
+  const freshFavorites = { version: "new" };
+  requests[3].resolve(jsonResponse(freshFavorites));
+  await secondMutation;
+  assert.deepEqual(queryClient.getQueryData(queryKeys.libraryFavorites), freshFavorites);
+});
+
+test("an older failed refresh cannot invalidate a newer mutation", async (t) => {
+  const { updateLibraryFavorites, queryClient, queryKeys, requests, waitForRequests } =
+    await openFavoritesHarness(t, "favorites-refresh-failure-test");
+  const initial = { version: "initial" };
+  queryClient.setQueryData(queryKeys.libraryFavorites, initial);
+
+  const firstMutation = updateLibraryFavorites(["song:1"], true);
+  await waitForRequests(1);
+  requests[0].resolve(jsonResponse({ changedIds: ["song:1"] }));
+  await waitForRequests(2);
+
+  const secondMutation = updateLibraryFavorites(["song:2"], true);
+  await waitForRequests(3);
+  requests[2].resolve(jsonResponse({ changedIds: ["song:2"] }));
+  await waitForRequests(4);
+
+  requests[1].resolve(new Response(JSON.stringify({ error: "refresh failed" }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  }));
+  await firstMutation;
+  assert.equal(queryClient.getQueryState(queryKeys.libraryFavorites)?.isInvalidated, false);
+
+  const freshFavorites = { version: "new" };
+  requests[3].resolve(jsonResponse(freshFavorites));
+  await secondMutation;
+  assert.deepEqual(queryClient.getQueryData(queryKeys.libraryFavorites), freshFavorites);
 });

--- a/.tests/frontend/library-favorites-cache.test.js
+++ b/.tests/frontend/library-favorites-cache.test.js
@@ -32,16 +32,24 @@ test("an older favorites read cannot overwrite a newer mutation cache", async (t
   };
 
   const staleFavorites = { artist: [], album: [], song: [], library: { tracks: [] } };
+  const mutationResponse = {
+    artist: [],
+    album: [],
+    song: [{ id: "song:1" }],
+    changedIds: ["song:1"],
+  };
   const freshFavorites = { artist: [], album: [], song: ["song:1"], library: { tracks: ["fresh"] } };
   const read = getLibraryFavorites();
   await waitForRequests(1);
   const mutation = updateLibraryFavorites(["song:1"], true);
   await waitForRequests(2);
 
-  requests[1].resolve(jsonResponse(freshFavorites));
-  assert.deepEqual(await mutation, freshFavorites);
+  requests[1].resolve(jsonResponse(mutationResponse));
+  await waitForRequests(3);
+  requests[2].resolve(jsonResponse(freshFavorites));
+  assert.deepEqual(await mutation, mutationResponse);
   requests[0].resolve(jsonResponse(staleFavorites));
   assert.deepEqual(await read, freshFavorites);
   assert.deepEqual(await getLibraryFavorites(), freshFavorites);
-  assert.equal(requests.length, 2);
+  assert.equal(requests.length, 3);
 });

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -153,7 +153,7 @@ function responseFor() {
   return response;
 }
 
-test("native favorites reuse Subsonic star identity and return current favorites", () => {
+test("native favorites return changed identities and reuse Subsonic star identity", () => {
   const target = `artist:${encodeURIComponent(artist.identity_key)}`;
   const postResponse = responseFor();
   getRoute("POST /favorites")(
@@ -162,7 +162,8 @@ test("native favorites reuse Subsonic star identity and return current favorites
   );
 
   assert.equal(postResponse.statusCode, 200);
-  assert.equal(postResponse.body.artist[0].id, target);
+  assert.deepEqual(postResponse.body.changedIds, [target]);
+  assert.equal(postResponse.body.library, undefined);
 
   const getResponse = responseFor();
   getRoute("GET /favorites")({ user }, getResponse);
@@ -179,6 +180,7 @@ test("native favorites include the canonical favorite subset", () => {
     "Favorite Track",
     "Favorite Track Two",
   ]);
+  assert.equal(response.body.library.tracks[0].files[0].path, undefined);
 });
 
 test("canonical library pages return bounded collection responses", () => {
@@ -198,6 +200,7 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.albums[0].trackCount, 2);
   assert.equal(response.body.albums[0].availableTrackCount, 1);
   assert.equal(response.body.hasMore, true);
+  assert.equal(response.body.items[0].files[0].path, undefined);
 
   const availableResponse = responseFor();
   getRoute("GET /canonical")(
@@ -215,15 +218,12 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(artistResponse.body.items[0].userFavorite, true);
 });
 
-test("unpaged canonical library responses keep paths private", async () => {
+test("canonical library rejects unbounded requests", () => {
   const response = responseFor();
-  await getRoute("GET /canonical")({ user, query: {} }, response);
-  await new Promise((resolve) => response.once("finish", resolve));
+  getRoute("GET /canonical")({ user, query: { kind: "tracks" } }, response);
 
-  assert.equal(response.statusCode, 200);
-  assert.equal(response.contentType, "json");
-  assert.equal(response.body.tracks[0].files[0].path, undefined);
-  assert.equal(response.body.tracks[0].title, "Favorite Track");
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error, "kind and pageSize (1-100) are required");
 });
 
 test("native favorites rejects unknown targets without changing stars", () => {

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -1,12 +1,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { db } from "../../backend/config/db-sqlite.js";
 import { registerTracks } from "../../backend/routes/library/handlers/tracks.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
+
+test("bounded backend callers do not materialize the compatibility library", async () => {
+  const boundedCallers = [
+    new URL("../../backend/routes/library/handlers/canonical.js", import.meta.url),
+    new URL("../../backend/routes/library/handlers/downloads.js", import.meta.url),
+    new URL("../../backend/services/libraryManager.js", import.meta.url),
+    new URL("../../backend/services/storageHealthService.js", import.meta.url),
+  ];
+
+  for (const caller of boundedCallers) {
+    const source = await readFile(caller, "utf8");
+    assert.doesNotMatch(source, /\bgetCanonicalLibrary(?:ReadModel)?\s*\(/);
+    assert.doesNotMatch(source, /\bbuildCanonicalLibraryReadModel\s*\(/);
+  }
+});
 
 test("canonical track reads remove nested filesystem paths", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-canonical-route-"));

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -13,7 +13,11 @@ import {
   getCanonicalLibraryForAlbumReferences,
   getCanonicalLibraryForArtists,
   getCanonicalLibraryPage,
+  getCanonicalTrack,
+  getCanonicalTrackCount,
+  getCanonicalTrackOwnership,
   getCanonicalTrackPath,
+  getCanonicalTrackSample,
   invalidateCanonicalLibraryCache,
 } from "../../backend/services/libraryQueryService.js";
 import { toPublicLibrary } from "../../backend/routes/library/handlers/canonical.js";
@@ -110,6 +114,96 @@ test("getCanonicalTrackPath keeps shared tracks scoped to the requested album", 
     db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
     db.prepare("DELETE FROM library_albums WHERE artist_id = ?").run(artist.id);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("focused track, ownership, count, and sample queries stay bounded", () => {
+  const key = `query-focused-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "Focused Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: artist.id,
+    title: "Focused Album",
+  });
+  const ownedTrack = upsertLibraryTrack({
+    identityKey: `${key}:owned`,
+    mbid: `${key}-owned-mbid`,
+    title: "Focused Track",
+    artistName: artist.name,
+  });
+  const unavailableTrack = upsertLibraryTrack({
+    identityKey: `${key}:unavailable`,
+    mbid: `${key}-unavailable-mbid`,
+    title: "Unavailable Track",
+    artistName: artist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: ownedTrack.id, trackNumber: 1 });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: unavailableTrack.id, trackNumber: 2 });
+  const ownedPath = `/tmp/${key}/owned.flac`;
+  const unavailablePath = `/tmp/${key}/unavailable.flac`;
+  upsertLibraryMediaFile({
+    trackId: ownedTrack.id,
+    albumId: album.id,
+    source: "aurral",
+    path: ownedPath,
+    available: true,
+  });
+  upsertLibraryMediaFile({
+    trackId: unavailableTrack.id,
+    albumId: album.id,
+    source: "aurral",
+    path: unavailablePath,
+    available: false,
+  });
+
+  try {
+    const focused = getCanonicalTrack({
+      trackId: ownedTrack.id,
+      source: "aurral",
+      availableOnly: true,
+      albumId: album.id,
+    });
+    assert.deepEqual(focused.tracks.map((track) => track.id), [ownedTrack.id]);
+    assert.deepEqual(focused.albums.map((entry) => entry.id), [album.id]);
+    assert.deepEqual(focused.tracks[0].files.map((file) => file.path), [ownedPath]);
+
+    const stale = getCanonicalTrack({
+      trackId: unavailableTrack.id,
+      source: "aurral",
+      availableOnly: false,
+    });
+    assert.deepEqual(stale.tracks.map((track) => track.id), [unavailableTrack.id]);
+    assert.equal(stale.tracks[0].files[0].available, false);
+
+    assert.equal(
+      getCanonicalTrackOwnership({ trackMbid: ownedTrack.mbid }),
+      true,
+    );
+    assert.equal(
+      getCanonicalTrackOwnership({ artistName: artist.name, trackName: ownedTrack.title }),
+      true,
+    );
+    assert.equal(
+      getCanonicalTrackOwnership({ trackMbid: unavailableTrack.mbid }),
+      false,
+    );
+
+    const countBefore = getCanonicalTrackCount({ source: "aurral" });
+    const availableCountBefore = getCanonicalTrackCount({ source: "aurral", availableOnly: true });
+    assert.equal(countBefore >= 2, true);
+    assert.equal(availableCountBefore >= 1, true);
+    const sample = getCanonicalTrackSample({ source: "aurral", availableOnly: true, limit: 1 });
+    assert.ok(sample.tracks.length <= 1);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(ownedPath, unavailablePath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(ownedTrack.id, unavailableTrack.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    invalidateCanonicalLibraryCache();
   }
 });
 

--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -599,7 +599,7 @@ test("streams canonical files through the authenticated native route", async () 
   const { token } = await login.json();
   const headers = { Authorization: `Bearer ${token}` };
   const canonical = await fetch(
-    `http://127.0.0.1:${aurral.port}/api/library/canonical?source=lidarr&availableOnly=true`,
+    `http://127.0.0.1:${aurral.port}/api/library/canonical?source=lidarr&availableOnly=true&kind=tracks&page=1&pageSize=100`,
     { headers },
   );
   const library = await canonical.json();

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,10 +1,8 @@
-import { Readable } from "node:stream";
-
 import { noCache } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import {
-  getCanonicalLibrary,
+  getCanonicalFavoriteTargetKeys,
   getCanonicalLibraryPage,
 } from "../../../services/libraryQueryService.js";
 import {
@@ -61,37 +59,8 @@ export function buildPublicLibrary(library, favoriteKeys = null) {
   };
 }
 
-function* jsonArrayChunks(items, mapper) {
-  yield "[";
-  for (let index = 0; index < items.length; index += 1) {
-    if (index > 0) yield ",";
-    yield JSON.stringify(mapper(items[index]), publicLibraryJsonReplacer);
-  }
-  yield "]";
-}
-
-export function* publicLibraryJsonChunks(library, favoriteKeys = null) {
-  yield "{\"artists\":";
-  yield* jsonArrayChunks(
-    library.artists,
-    (artist) => publicEntity("artist", artist, favoriteKeys),
-  );
-  yield ",\"albums\":";
-  yield* jsonArrayChunks(library.albums, (album) => publicAlbum(album, favoriteKeys));
-  yield ",\"tracks\":";
-  yield* jsonArrayChunks(
-    library.tracks,
-    (track) => publicEntity("song", track, favoriteKeys),
-  );
-  yield "}";
-}
-
 function toPublicLibrary(library, favoriteKeys = null) {
   return stripFilesystemPaths(buildPublicLibrary(library, favoriteKeys));
-}
-
-export function toPublicLibraryJson(library, favoriteKeys = null) {
-  return JSON.stringify(buildPublicLibrary(library, favoriteKeys), publicLibraryJsonReplacer);
 }
 
 export function toPublicLibraryPage(page, favoriteKeys = null) {
@@ -131,27 +100,33 @@ export function registerCanonical(router) {
   router.get("/canonical", noCache, (req, res) => {
     try {
       const favoriteKeys = req.user ? getStarredIdentityKeys(req.user) : null;
-      if (req.query.kind) {
-        return res.json(toPublicLibraryPage(getCanonicalLibraryPage({
-          source: req.query.source,
-          availableOnly: req.query.availableOnly === "true",
-          kind: req.query.kind,
-          page: req.query.page,
-          pageSize: req.query.pageSize,
-          query: req.query.query,
-          genre: req.query.genre,
-          sort: req.query.sort,
-          direction: req.query.direction,
-          artistId: req.query.artistId,
-          albumId: req.query.albumId,
-        }), favoriteKeys));
+      const kind = typeof req.query.kind === "string" ? req.query.kind.trim() : "";
+      const requestedPageSize = typeof req.query.pageSize === "string"
+        ? Number(req.query.pageSize)
+        : NaN;
+      if (
+        !kind ||
+        !Number.isSafeInteger(requestedPageSize) ||
+        requestedPageSize < 1 ||
+        requestedPageSize > 100
+      ) {
+        return res.status(400).json({
+          error: "kind and pageSize (1-100) are required",
+        });
       }
-      const library = getCanonicalLibrary({
+      return res.json(toPublicLibraryPage(getCanonicalLibraryPage({
         source: req.query.source,
         availableOnly: req.query.availableOnly === "true",
-      });
-      res.type("json");
-      return Readable.from(publicLibraryJsonChunks(library, favoriteKeys)).pipe(res);
+        kind,
+        page: req.query.page,
+        pageSize: requestedPageSize,
+        query: req.query.query,
+        genre: req.query.genre,
+        sort: req.query.sort,
+        direction: req.query.direction,
+        artistId: req.query.artistId,
+        albumId: req.query.albumId,
+      }), favoriteKeys));
     } catch (error) {
       if (
         error.message.startsWith("Unsupported library source:") ||
@@ -181,12 +156,21 @@ export function registerCanonical(router) {
       });
     }
 
-    const changed = req.body.starred ? starMany(req.user, ids) : unstarMany(req.user, ids);
+    if (req.body.starred) {
+      const canonicalIds = ids.filter((id) => /^(artist|album|song):.+/.test(id));
+      const validTargets = getCanonicalFavoriteTargetKeys(canonicalIds);
+      if (canonicalIds.some((id) => !validTargets.has(id))) {
+        return res.status(400).json({ error: "Invalid favorite target" });
+      }
+    }
+
+    const changed = req.body.starred
+      ? starMany(req.user, ids, { skipCanonicalValidation: true })
+      : unstarMany(req.user, ids);
     if (!changed) {
       return res.status(400).json({ error: "Invalid favorite target" });
     }
-    const { starred, library } = getStarredWithLibrary(req.user);
-    return res.json({ ...starred, library: toPublicLibrary(library) });
+    return res.json({ changedIds: ids });
   });
 }
 

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -8,7 +8,7 @@ import {
   albumHasTrackFiles,
 } from "../../../services/albumSearchState.js";
 import { logger } from "../../../services/logger.js";
-import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
+import { getCanonicalTrackOwnership } from "../../../services/libraryQueryService.js";
 
 const STALE_GRABBED_MS = 15 * 60 * 1000;
 const DOWNLOAD_STATUS_CACHE_MS = 5000;
@@ -329,14 +329,10 @@ export function registerDownloads(router) {
     }
 
     try {
-      const canonical = getCanonicalLibrary({ source: "all", availableOnly: false });
-      const alreadyOwned = canonical.tracks.some((candidate) => {
-        if (!candidate.files.some((file) => file.available)) return false;
-        if (track.trackMbid) return candidate.mbid === track.trackMbid;
-        return (
-          candidate.artistName?.toLocaleLowerCase() === track.artistName.toLocaleLowerCase() &&
-          candidate.title?.toLocaleLowerCase() === track.trackName.toLocaleLowerCase()
-        );
+      const alreadyOwned = getCanonicalTrackOwnership({
+        trackMbid: track.trackMbid,
+        artistName: track.artistName,
+        trackName: track.trackName,
       });
       if (alreadyOwned) return res.json({ success: true, alreadyOwned: true, queued: false });
 

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -77,7 +77,10 @@ export function registerTracks(router) {
 
   router.get("/playback-queue", cacheMiddleware(120), async (req, res) => {
     try {
-      const tracks = await libraryManager.getPlaybackQueue();
+      const tracks = await libraryManager.getPlaybackQueue({
+        page: Number.parseInt(req.query.page, 10) || 1,
+        pageSize: Number.parseInt(req.query.pageSize, 10) || 100,
+      });
       res.json(tracks);
     } catch (error) {
       res.status(500).json({

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -3,7 +3,8 @@ import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
 import {
-  getCanonicalLibrary,
+  getCanonicalLibraryPage,
+  getCanonicalTrack,
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
 const normalizeTypeName = (value) =>
@@ -1551,7 +1552,11 @@ export class LibraryManager {
       return { success: false, code: "lidarr_unavailable", error: "Lidarr is not configured" };
     }
     try {
-      const library = getCanonicalLibrary({ source: "lidarr", availableOnly: false });
+      const library = getCanonicalTrack({
+        trackId: id,
+        source: "lidarr",
+        availableOnly: false,
+      });
       const track = library.tracks.find((entry) => String(entry.id) === String(id));
       if (!track) return { success: false, code: "not_found", error: "Track not found" };
 
@@ -1740,9 +1745,15 @@ export class LibraryManager {
     }
   }
 
-  async getPlaybackQueue() {
+  async getPlaybackQueue({ page = 1, pageSize = 100 } = {}) {
     return buildPlaybackQueueFromCanonicalLibrary(
-      getCanonicalLibrary({ source: "lidarr", availableOnly: true }),
+      getCanonicalLibraryPage({
+        source: "lidarr",
+        availableOnly: true,
+        kind: "tracks",
+        page,
+        pageSize,
+      }),
     );
   }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -257,6 +257,163 @@ export function getCanonicalTrackPath(albumReference, trackReference) {
   ).get(album.id, track.id, album.id, album.id)?.path || null;
 }
 
+export function getCanonicalTrack({
+  trackId,
+  source = null,
+  availableOnly = false,
+  albumId = null,
+} = {}) {
+  const reference = String(trackId ?? "").trim();
+  if (!reference) return { artists: [], albums: [], tracks: [] };
+
+  const numericId = /^\d+$/.test(reference) ? Number(reference) : null;
+  const conditions = [];
+  const parameters = [];
+  if (Number.isSafeInteger(numericId) && numericId > 0) {
+    conditions.push("track.id = ?");
+    parameters.push(numericId);
+  } else {
+    conditions.push("(track.identity_key = ? OR track.mbid = ?)");
+    parameters.push(reference, reference);
+  }
+  if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
+    conditions.push("album.id = ?");
+    parameters.push(Number(albumId));
+  }
+
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions,
+    parameters,
+  });
+}
+
+export function getCanonicalTrackOwnership({
+  trackMbid = null,
+  artistName = null,
+  trackName = null,
+  source = null,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const conditions = ["media.available = 1"];
+  const parameters = [];
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+
+  const mbid = String(trackMbid || "").trim();
+  if (mbid) {
+    conditions.push("track.mbid = ?");
+    parameters.push(mbid);
+  } else {
+    const artist = String(artistName || "").trim();
+    const title = String(trackName || "").trim();
+    if (!artist || !title) return false;
+    conditions.push("lower(coalesce(track.artist_name, '')) = lower(?)");
+    conditions.push("lower(track.title) = lower(?)");
+    parameters.push(artist, title);
+  }
+
+  return Boolean(db.prepare(
+    `SELECT EXISTS (
+       SELECT 1
+       ${CANONICAL_FROM}
+       WHERE ${conditions.join(" AND ")}
+     ) AS owned`,
+  ).get(...parameters)?.owned);
+}
+
+export function getCanonicalTrackCount({ source = null, availableOnly = false } = {}) {
+  const sourceFilter = normalizeSource(source);
+  const conditions = [];
+  const parameters = [];
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+  const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  return Number(db.prepare(
+    `SELECT COUNT(DISTINCT track.id) AS total
+     ${CANONICAL_FROM}
+     ${where}`,
+  ).get(...parameters)?.total || 0);
+}
+
+export function getCanonicalTrackSample({
+  source = null,
+  availableOnly = false,
+  limit = 100,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const conditions = [];
+  const parameters = [];
+  if (sourceFilter) {
+    conditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) conditions.push("media.available = 1");
+  const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  const boundedLimit = Math.min(500, Math.max(1, Number.parseInt(limit, 10) || 100));
+  const rows = db.prepare(
+    `${CANONICAL_SELECT}
+     ${CANONICAL_FROM}
+     ${where}
+     ${canonicalOrder}
+     LIMIT ?`,
+  ).iterate(...parameters, boundedLimit);
+  return buildLibraryFromRows(rows);
+}
+
+const CANONICAL_FAVORITE_TABLES = {
+  artist: "library_artists",
+  album: "library_albums",
+  song: "library_tracks",
+};
+
+function parseCanonicalFavoriteId(value) {
+  const input = String(value || "").trim();
+  const separator = input.indexOf(":");
+  if (separator <= 0) return null;
+  const kind = input.slice(0, separator);
+  if (!CANONICAL_FAVORITE_TABLES[kind]) return null;
+  const rawKey = input.slice(separator + 1);
+  if (!rawKey) return null;
+  try {
+    const key = decodeURIComponent(rawKey).trim();
+    return key ? { kind, key, rawKey } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getCanonicalFavoriteTargetKeys(values = []) {
+  const targets = (Array.isArray(values) ? values : [])
+    .map(parseCanonicalFavoriteId)
+    .filter(Boolean);
+  const found = new Set();
+  for (const [kind, table] of Object.entries(CANONICAL_FAVORITE_TABLES)) {
+    const keys = [...new Set(
+      targets.filter((target) => target.kind === kind).map((target) => target.key),
+    )];
+    if (!keys.length) continue;
+    const rows = db.prepare(
+      `SELECT identity_key FROM ${table}
+       WHERE identity_key IN (${keys.map(() => "?").join(",")})`,
+    ).all(...keys);
+    for (const row of rows) {
+      for (const target of targets) {
+        if (target.kind !== kind || target.key !== row.identity_key) continue;
+        found.add(`${kind}:${target.rawKey}`);
+        found.add(`${kind}:${encodeURIComponent(target.key)}`);
+      }
+    }
+  }
+  return found;
+}
+
 export function getCanonicalLibraryForArtists({
   source = null,
   availableOnly = false,

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -2,7 +2,10 @@ import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { dbOps } from "../db/helpers/index.js";
-import { getCanonicalLibrary } from "./libraryQueryService.js";
+import {
+  getCanonicalTrackCount,
+  getCanonicalTrackSample,
+} from "./libraryQueryService.js";
 import { lidarrClient } from "./lidarrClient.js";
 import { slskdClient } from "./slskdClient.js";
 import { nzbgetClient } from "./nzbgetClient.js";
@@ -821,9 +824,8 @@ async function checkNavidromeSection() {
 }
 
 async function checkNativePlaybackSection() {
-  const library = getCanonicalLibrary({ availableOnly: true });
-  const tracks = Array.isArray(library.tracks) ? library.tracks : [];
-  if (tracks.length === 0) {
+  const trackCount = getCanonicalTrackCount({ availableOnly: true });
+  if (trackCount === 0) {
     return buildSection("native-playback", "Aurral-native playback", [
       healthStep("indexed", "warn", "Canonical media is ready for native playback", {
         fix: "Connect Lidarr, let the library index refresh, then run Storage Health again.",
@@ -831,7 +833,10 @@ async function checkNativePlaybackSection() {
     ]);
   }
 
-  const sample = tracks.slice(0, MEDIA_HEALTH_SAMPLE_LIMIT);
+  const sample = getCanonicalTrackSample({
+    availableOnly: true,
+    limit: MEDIA_HEALTH_SAMPLE_LIMIT,
+  }).tracks;
   const missing = [];
   for (const track of sample) {
     let readable = false;
@@ -846,7 +851,7 @@ async function checkNativePlaybackSection() {
     }
   }
 
-  const detail = `${tracks.length} canonical track${tracks.length === 1 ? "" : "s"} indexed`;
+  const detail = `${trackCount} canonical track${trackCount === 1 ? "" : "s"} indexed`;
   if (missing.length > 0) {
     return buildSection("native-playback", "Aurral-native playback", [
       healthStep("indexed", "fail", "Aurral-native playback can read indexed media", {

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -792,10 +792,10 @@ export function star(user, value) {
   return starMany(user, [value]);
 }
 
-export function starMany(user, values) {
+export function starMany(user, values, { skipCanonicalValidation = false } = {}) {
   const parsed = values.map(starTarget);
   if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
-  const library = readLibrary();
+  const library = skipCanonicalValidation ? null : readLibrary();
   const playlistSongs = parsed.map((target) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? resolvePlaylistSong(user, idFor(target.kind, target.key))
@@ -804,7 +804,7 @@ export function starMany(user, values) {
   if (parsed.some((target, index) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? !playlistSongs[index]
-      : !findCanonical(library, target),
+      : !skipCanonicalValidation && !findCanonical(library, target),
   )) return false;
   if (favoriteAutoKeepEnabled()) {
     const createdJobIds = [];

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -83,10 +83,10 @@ instance API key for WebSocket connections.
 | `GET` | `/api/library/tracks` | List album tracks |
 | `POST` | `/api/library/refresh` | Queue a canonical library scan |
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
-| `GET` | `/api/library/canonical` | Read the canonical artists, albums, and tracks |
+| `GET` | `/api/library/canonical` | Read a bounded canonical page; provide `kind` and `pageSize` |
 | `GET` | `/api/library/favorites` | Read the current user's library favorites |
 | `POST` | `/api/library/favorites` | Add or remove a library favorite |
-| `GET` | `/api/library/playback-queue` | Build the playback queue |
+| `GET` | `/api/library/playback-queue` | Build a bounded playback queue page; optional `page` and `pageSize` (1-100) |
 | `GET` | `/api/library/stream/:songId` | Stream a library song |
 | `GET` | `/api/library/canonical-stream/:trackId` | Stream a canonical library track |
 | `GET` | `/api/library/file-stream/:albumId/:trackId` | Stream an album track file |

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -83,7 +83,7 @@ instance API key for WebSocket connections.
 | `GET` | `/api/library/tracks` | List album tracks |
 | `POST` | `/api/library/refresh` | Queue a canonical library scan |
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
-| `GET` | `/api/library/canonical` | Read a bounded canonical page; provide `kind` and `pageSize` |
+| `GET` | `/api/library/canonical` | Read a bounded canonical page; provide a supported `kind` and `pageSize` (1-100) |
 | `GET` | `/api/library/favorites` | Read the current user's library favorites |
 | `POST` | `/api/library/favorites` | Add or remove a library favorite |
 | `GET` | `/api/library/playback-queue` | Build a bounded playback queue page; optional `page` and `pageSize` (1-100) |

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -56,7 +56,7 @@ same-origin proxy keeps it out of visitors' browsers.
 | `GET /api/health` | Aurral, library, discovery, and system status | None |
 | `GET /api/library/artists` | Library artists | `limit` (1-10000), `offset` |
 | `GET /api/library/artists/:mbid` | One library artist | MusicBrainz artist ID in the path |
-| `GET /api/library/canonical` | Canonical artists, albums, and tracks | Optional `source` and `availableOnly`. Add `kind` to use `page`, `pageSize`, `query`, `genre`, `sort`, `direction`, `artistId`, or `albumId` filters. |
+| `GET /api/library/canonical` | A bounded canonical page | Required `kind` and `pageSize` (1-100). Optional `source`, `availableOnly`, `page`, `query`, `genre`, `sort`, `direction`, `artistId`, or `albumId`. |
 | `GET /api/library/favorites` | Current user's favorites and library | None |
 | `GET /api/library/albums` | Albums for an artist | Required `artistId` |
 | `GET /api/library/albums/:id` | One library album | Lidarr album ID in the path |
@@ -67,9 +67,9 @@ same-origin proxy keeps it out of visitors' browsers.
 | `GET /api/library/downloads/status/all` | All current download states | None |
 | `GET /api/search` | Search artists, albums, or tags | Required `q`. Optional `scope`, `limit`, and `offset` |
 
-`GET /api/library/canonical` returns the unpaged canonical library unless you
-provide `kind=artists`, `kind=albums`, or `kind=tracks`. The page filters apply
-only when `kind` is present.
+`GET /api/library/canonical` rejects requests without a supported `kind` and a
+bounded `pageSize`. Use separate requests for artists, albums, tracks, or
+genres.
 
 See the [endpoint reference](/api/endpoints/) for the complete current route
 index.

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1440,16 +1440,17 @@ function LibraryPage() {
         return next;
       });
       try {
-        const starred = await updateLibraryFavorites([id], nextStarred);
-        setFavoriteIds(
-          new Set(
-            ["artist", "album", "song"].flatMap((group) =>
-              (Array.isArray(starred?.[group]) ? starred[group] : []).map(
-                (entry) => entry.id,
-              ),
-            ),
-          ),
-        );
+        const result = await updateLibraryFavorites([id], nextStarred);
+        if (Array.isArray(result?.changedIds)) {
+          setFavoriteIds((current) => {
+            const next = new Set(current);
+            for (const changedId of result.changedIds) {
+              if (nextStarred) next.add(changedId);
+              else next.delete(changedId);
+            }
+            return next;
+          });
+        }
       } catch (requestError) {
         setFavoriteIds(previous);
         showError(requestError.response?.data?.message || "Failed to update favorites");

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -22,15 +22,6 @@ const mergeSignals = (callerSignal, querySignal) => {
 export const getLibraryArtists = (options = {}) =>
   getData("/library/artists", options);
 
-export const getCanonicalLibrary = (options = {}) =>
-  getData("/library/canonical", {
-    params: {
-      source: options.source || "all",
-      availableOnly: options.availableOnly === true ? "true" : "false",
-    },
-    signal: options.signal,
-  });
-
 export const getCanonicalLibraryPage = (options = {}, { signal } = {}) => {
   const params = Object.fromEntries(
     Object.entries({
@@ -101,8 +92,13 @@ export const updateLibraryFavorites = async (ids, starred) => {
   const generation = ++libraryFavoritesGeneration;
   const data = await postData("/library/favorites", { ids, starred });
   if (generation === libraryFavoritesGeneration) {
-    latestLibraryFavorites = data;
-    queryClient.setQueryData(queryKeys.libraryFavorites, data);
+    try {
+      latestLibraryFavorites = await fetchLibraryFavorites();
+      queryClient.setQueryData(queryKeys.libraryFavorites, latestLibraryFavorites);
+    } catch {
+      latestLibraryFavorites = null;
+      queryClient.invalidateQueries({ queryKey: queryKeys.libraryFavorites });
+    }
   }
   clearCanonicalLibraryPageCache();
   return data;

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -63,24 +63,33 @@ export const getLibraryRefreshStatus = (jobId) =>
 
 let libraryFavoritesGeneration = 0;
 let latestLibraryFavorites = null;
+let libraryFavoritesRefresh = null;
 
 export const fetchLibraryFavorites = ({ signal } = {}) =>
   getData("/library/favorites", { signal });
 
-export const getLibraryFavorites = ({ signal } = {}) => {
+const waitForLibraryFavoritesRefresh = async () => {
+  let waited = false;
+  while (libraryFavoritesRefresh) {
+    waited = true;
+    const pending = libraryFavoritesRefresh;
+    await pending;
+  }
+  return waited;
+};
+
+export const getLibraryFavorites = async ({ signal } = {}) => {
   const generation = libraryFavoritesGeneration;
-  return queryClient.fetchQuery({
+  const data = await queryClient.fetchQuery({
     queryKey: queryKeys.libraryFavorites,
     queryFn: ({ signal: querySignal }) => fetchLibraryFavorites({ signal: mergeSignals(signal, querySignal) }),
     staleTime: 30_000,
-  }).then((data) => {
-    if (generation !== libraryFavoritesGeneration && latestLibraryFavorites) {
-      const repaired = latestLibraryFavorites;
-      queryClient.setQueryData(queryKeys.libraryFavorites, repaired);
-      return repaired;
-    }
-    return data;
   });
+  const waitedForRefresh = await waitForLibraryFavoritesRefresh();
+  if (generation === libraryFavoritesGeneration && !waitedForRefresh) return data;
+  const repaired = latestLibraryFavorites || queryClient.getQueryData(queryKeys.libraryFavorites) || data;
+  queryClient.setQueryData(queryKeys.libraryFavorites, repaired);
+  return repaired;
 };
 
 export const clearLibraryFavoritesCache = () => {
@@ -90,18 +99,31 @@ export const clearLibraryFavoritesCache = () => {
 
 export const updateLibraryFavorites = async (ids, starred) => {
   const generation = ++libraryFavoritesGeneration;
-  const data = await postData("/library/favorites", { ids, starred });
-  if (generation === libraryFavoritesGeneration) {
+  let settleRefresh;
+  const refresh = new Promise((resolve) => {
+    settleRefresh = resolve;
+  });
+  libraryFavoritesRefresh = refresh;
+  try {
+    const data = await postData("/library/favorites", { ids, starred });
+    if (generation !== libraryFavoritesGeneration) return data;
     try {
-      latestLibraryFavorites = await fetchLibraryFavorites();
-      queryClient.setQueryData(queryKeys.libraryFavorites, latestLibraryFavorites);
+      const refreshed = await fetchLibraryFavorites();
+      if (generation !== libraryFavoritesGeneration) return data;
+      latestLibraryFavorites = refreshed;
+      queryClient.setQueryData(queryKeys.libraryFavorites, refreshed);
     } catch {
-      latestLibraryFavorites = null;
-      queryClient.invalidateQueries({ queryKey: queryKeys.libraryFavorites });
+      if (generation === libraryFavoritesGeneration) {
+        latestLibraryFavorites = null;
+        queryClient.invalidateQueries({ queryKey: queryKeys.libraryFavorites });
+      }
     }
+    return data;
+  } finally {
+    clearCanonicalLibraryPageCache();
+    settleRefresh();
+    if (libraryFavoritesRefresh === refresh) libraryFavoritesRefresh = null;
   }
-  clearCanonicalLibraryPageCache();
-  return data;
 };
 
 const normalizeLibraryArtist = (artist) =>

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -64,6 +64,7 @@ export const getLibraryRefreshStatus = (jobId) =>
 let libraryFavoritesGeneration = 0;
 let latestLibraryFavorites = null;
 let libraryFavoritesRefresh = null;
+let libraryFavoritesWrite = Promise.resolve();
 
 export const fetchLibraryFavorites = ({ signal } = {}) =>
   getData("/library/favorites", { signal });
@@ -97,33 +98,35 @@ export const clearLibraryFavoritesCache = () => {
   latestLibraryFavorites = null;
 };
 
-export const updateLibraryFavorites = async (ids, starred) => {
+export const updateLibraryFavorites = (ids, starred) => {
   const generation = ++libraryFavoritesGeneration;
-  let settleRefresh;
-  const refresh = new Promise((resolve) => {
-    settleRefresh = resolve;
-  });
-  libraryFavoritesRefresh = refresh;
-  try {
-    const data = await postData("/library/favorites", { ids, starred });
-    if (generation !== libraryFavoritesGeneration) return data;
+  const write = libraryFavoritesWrite.then(async () => {
     try {
-      const refreshed = await fetchLibraryFavorites();
+      const data = await postData("/library/favorites", { ids, starred });
       if (generation !== libraryFavoritesGeneration) return data;
-      latestLibraryFavorites = refreshed;
-      queryClient.setQueryData(queryKeys.libraryFavorites, refreshed);
-    } catch {
-      if (generation === libraryFavoritesGeneration) {
-        latestLibraryFavorites = null;
-        queryClient.invalidateQueries({ queryKey: queryKeys.libraryFavorites });
+      try {
+        const refreshed = await fetchLibraryFavorites();
+        if (generation !== libraryFavoritesGeneration) return data;
+        latestLibraryFavorites = refreshed;
+        queryClient.setQueryData(queryKeys.libraryFavorites, refreshed);
+      } catch {
+        if (generation === libraryFavoritesGeneration) {
+          latestLibraryFavorites = null;
+          queryClient.invalidateQueries({ queryKey: queryKeys.libraryFavorites });
+        }
       }
+      return data;
+    } finally {
+      clearCanonicalLibraryPageCache();
     }
-    return data;
-  } finally {
-    clearCanonicalLibraryPageCache();
-    settleRefresh();
-    if (libraryFavoritesRefresh === refresh) libraryFavoritesRefresh = null;
-  }
+  });
+  const pending = write.catch(() => {});
+  libraryFavoritesWrite = pending;
+  libraryFavoritesRefresh = pending;
+  pending.then(() => {
+    if (libraryFavoritesRefresh === pending) libraryFavoritesRefresh = null;
+  });
+  return write;
 };
 
 const normalizeLibraryArtist = (artist) =>


### PR DESCRIPTION
Canonical page requests and several backend paths could materialize the entire SQLite library before returning a small result. At large library sizes, bounded work inherited full-library latency and memory use.

This PR makes the first in-scope paths read only the records they need:

- The canonical endpoint now requires a supported kind and pageSize from 1 through 100.
- Playback queues use a bounded canonical track page.
- Track deletion reads one track, its album relationship, and matching files.
- Download ownership uses SQL EXISTS.
- Storage health uses SQL COUNT plus a bounded readable-file sample.
- Native favorite mutations validate canonical identities with focused queries and return changedIds; the frontend refreshes the existing scoped favorites view.
- Public canonical responses continue to strip filesystem paths.
- No dependency, schema, cache, repository abstraction, or file ownership behavior was added or changed.

Known scope: hosted Subsonic full-library reads and the legacy /artists, /albums, and /tracks compatibility conversion remain intentionally deferred to TASK-2.1.10.2. The direct full-read benchmark probes remain so this PR can document the current behavior; benchmark redesign is deferred to TASK-2.1.10.6. This PR does not claim to remove every full canonical read.

## Caller inventory

| Production caller | Classification | Result |
| --- | --- | --- |
| GET /api/library/canonical | Bounded page, with related artist/album records | Changed to getCanonicalLibraryPage; unpaged requests are rejected |
| GET /api/library/favorites | Favorite relationship subset | Existing favorite-key-scoped query retained; it is not an unfiltered library read |
| POST /api/library/favorites | Identity validation and favorite mutation | Changed to focused identity queries and changedIds response |
| LibraryManager.getPlaybackQueue | Bounded page | Changed to a bounded available track page |
| LibraryManager.deleteTrack | One track, album relation, and relevant files | Changed to getCanonicalTrack |
| Download ownership check | Existence check | Changed to SQL EXISTS over available matching media |
| Native storage-health playback check | Count and bounded sample | Changed to SQL COUNT and a sample capped at 500 |
| Canonical stream path lookup | One album/track relationship and file | Existing focused query retained |
| Artist and album lookup batches | Bounded relationship/existence checks | Existing focused query methods retained |
| Canonical artist stream lookup | One artist relationship | Existing focused query retained |
| Subsonic readLibrary and hosted favorite reads | True hosted export | Deferred to TASK-2.1.10.2 |
| Legacy /artists canonical conversion | Compatibility export | Deferred to TASK-2.1.10.2 |
| Legacy /albums canonical conversion | Compatibility export | Deferred to TASK-2.1.10.2 |
| Legacy /tracks?readPath=canonical conversion | Compatibility export | Deferred to TASK-2.1.10.2 |
| Direct benchmark full reads | Measurement of deferred behavior | Retained for this task; redesign deferred to TASK-2.1.10.6 |

Changed callers are the native canonical route, native favorite mutation path, playback queue, track deletion, download ownership, and storage health. The existing focused artist/album relationship queries were reused instead of adding another abstraction.

## Measurements

The required probes were run at 100,000 and 350,000 synthetic tracks with three repeats. Page measurements below are warm track-page results; each page contains 100 items. RSS deltas are per sample from the benchmark JSON.

| Probe | Before | After |
| --- | ---: | ---: |
| 100k bounded track page warm p95 | 63.950 ms | 65.193 ms |
| 350k bounded track page warm p95 | 415.401 ms | 247.462 ms |
| 100k full endpoint read | 1389.837 ms; 55,313,881 bytes; RSS 403,673,088; heap 228,768,064 | 1372.620 ms; 55,313,881 bytes; RSS 400,584,704; heap 228,389,288 |
| 350k full endpoint read | 4308.171 ms; 195,381,381 bytes; RSS 1,117,126,656; heap 769,210,216 | 4504.359 ms; 195,381,381 bytes; RSS 1,107,038,208; heap 761,701,464 |
| 100k legacy compatibility read | 1314.957 ms; 48,877,459 bytes; RSS 421,879,808; heap 247,876,544 | 1295.234 ms; 48,877,459 bytes; RSS 421,736,448; heap 247,948,336 |
| 350k legacy compatibility read | 3847.872 ms; 172,297,459 bytes; RSS 1,197,518,848; heap 852,244,304 | 4069.287 ms; 172,297,459 bytes; RSS 1,194,885,120; heap 844,811,088 |

The current benchmark records serialized bytes for the retained full-read probes, and page shape, latency, RSS, and heap deltas for bounded pages. Bounded-page RSS deltas stayed at 0 bytes for the 100k warm samples and 28,672–110,592 bytes for the 350k warm samples; allocation samples were about 0.4 MB heap growth, with one GC sample negative. The full-read numbers remain intentionally large because those deferred paths are still being measured.

## Verification

Passed:

- Focused suite: 43 tests
- npm run lint
- npm test: 773 tests passed
- npm run build
- npm run docs:build
- Docker compose validation
- Disposable candidate image build and run
- Candidate health before and after restart
- Authenticated /api/auth/me
- Unpaged canonical request rejected with 400
- Bounded artist, album, track, favorites, and playback requests returned successfully in the candidate's empty-library state
- Public response path scan found no filesystem paths
- Candidate logs had no uncaught, unhandled, worker-failure, or exception lines

The candidate had no indexed library roots/data available, so live provider-backed populated responses were not available; the Docker checks covered empty-state behavior. Interactive browser navigation was blocked because the candidate port was not reachable from the available browser session; direct authenticated route checks completed.

The integration suite ran 54 tests: 53 passed and one pre-existing Navidrome onboarding test failed because its mock library response remains empty after settings update, causing the expected weekly-flow path verification to reject. No unrelated Navidrome change was included.

Surface status:

- Backend/API: passed
- Frontend: passed automated checks; interactive browser: inconclusive
- Persistence: passed; no migration or schema change
- Lidarr integration: inconclusive for populated live-stack data; focused/indexer coverage passed
- Hosted Subsonic: deferred to TASK-2.1.10.2
- Tests: passed for focused/full suites; integration inconclusive for the unrelated Navidrome mock failure
- Documentation: passed
- Docker and release behavior: passed candidate build/health/restart checks; no release artifact published

Task: TASK-2.1.10.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded pagination for canonical library and playback-queue requests.
  * Added “View info” actions for tracks, artists, and albums.
  * Improved track lookup, ownership checks, filtering, counts, and samples.
  * Favorite updates now return changed IDs and refresh data reliably.
* **Bug Fixes**
  * Prevented file paths from appearing in library responses.
  * Improved favorite validation and concurrent cache handling.
  * Rejected unbounded or invalid library requests with clear errors.
* **Documentation**
  * Updated API guidance for required filters and pagination limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->