### PR TITLE
perf(library): move stable reads to canonical projections

### DIFF
--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -219,7 +219,7 @@ test("canonical recent releases exclude owned albums without loading old albums"
       "Missing Current",
     ]);
 
-    const scopedReleases = await getRecentMissingReleases(10, {
+    const scopedReleases = await getRecentMissingReleases(1, {
       artists: [projectedArtist],
       now: "2026-08-22T12:00:00Z",
     });

--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -178,6 +178,23 @@ test("canonical recent releases exclude owned albums without loading old albums"
   try {
     addAlbum({ suffix: 1, title: "Missing Current", releaseDate: "2026-08-20" });
     addAlbum({ suffix: 2, title: "Owned Current", releaseDate: "2026-08-19", available: true });
+    const unrelatedArtist = upsertLibraryArtist({
+      identityKey: `${key}:unrelated-artist`,
+      name: "Unrelated Release Artist",
+    });
+    const unrelatedAlbum = upsertLibraryAlbum({
+      identityKey: `${key}:unrelated-album`,
+      artistId: unrelatedArtist.id,
+      title: "Unrelated Newer Release",
+      releaseDate: "2026-08-21",
+    });
+    const unrelatedTrack = upsertLibraryTrack({
+      identityKey: `${key}:unrelated-track`,
+      title: "Unrelated Track",
+      artistName: "Unrelated Release Artist",
+    });
+    trackIds.push(unrelatedTrack.id);
+    linkLibraryAlbumTrack({ albumId: unrelatedAlbum.id, trackId: unrelatedTrack.id });
     for (let index = 0; index < 125; index += 1) {
       addAlbum({ suffix: index + 100, title: `Old Album ${index}`, releaseDate: "2000-01-01" });
     }
@@ -188,13 +205,25 @@ test("canonical recent releases exclude owned albums without loading old albums"
       to: "2026-08-22",
       limit: 10,
     });
-    assert.equal(projectedAlbums[0]?.artistId, projectedArtist?.id);
+    assert.equal(
+      projectedAlbums.find((album) => album.title === "Missing Current")?.artistId,
+      projectedArtist?.id,
+    );
 
     const releases = await getRecentMissingReleases(10, {
       now: "2026-08-22T12:00:00Z",
     });
 
-    assert.deepEqual(releases.map((album) => album.title), ["Missing Current"]);
+    assert.deepEqual(releases.map((album) => album.title), [
+      "Unrelated Newer Release",
+      "Missing Current",
+    ]);
+
+    const scopedReleases = await getRecentMissingReleases(10, {
+      artists: [projectedArtist],
+      now: "2026-08-22T12:00:00Z",
+    });
+    assert.deepEqual(scopedReleases.map((album) => album.title), ["Missing Current"]);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(canonicalArtist.id);

--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -2,9 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
+import { db } from "../../backend/config/db-sqlite.js";
 import { dbOps } from "../../backend/db/helpers/index.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
+import {
+  getCanonicalAlbumsByReleaseDate,
+  getCanonicalArtistProjection,
+} from "../../backend/services/libraryQueryService.js";
+import {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} from "../../backend/services/libraryMediaStore.js";
 
 const artist = {
   id: 1,
@@ -125,5 +137,71 @@ test("recent missing releases backfill direct Lidarr artists before mapping", as
   } finally {
     lidarrClient.isConfigured = originalIsConfigured;
     dbOps.deleteLidarrArtistIdMap(canonicalMbid);
+  }
+});
+
+test("canonical recent releases exclude owned albums without loading old albums", async () => {
+  const key = `recent-canonical-${process.pid}-${Date.now()}`;
+  const canonicalArtist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: "45454545-4545-4454-8454-454545454545",
+    name: "Canonical Release Artist",
+    metadata: { id: 4545 },
+  });
+  const trackIds = [];
+  const addAlbum = ({ suffix, title, releaseDate, available = false }) => {
+    const album = upsertLibraryAlbum({
+      identityKey: `${key}:album:${suffix}`,
+      releaseGroupMbid: `56565656-5656-4565-8565-${String(suffix).padStart(12, "0")}`,
+      artistId: canonicalArtist.id,
+      title,
+      releaseDate,
+    });
+    const track = upsertLibraryTrack({
+      identityKey: `${key}:track:${suffix}`,
+      title: `${title} Track`,
+      artistName: "Canonical Release Artist",
+    });
+    trackIds.push(track.id);
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+    if (available) {
+      upsertLibraryMediaFile({
+        trackId: track.id,
+        albumId: album.id,
+        source: "lidarr",
+        path: `/tmp/${key}/${suffix}.flac`,
+        available: true,
+      });
+    }
+  };
+
+  try {
+    addAlbum({ suffix: 1, title: "Missing Current", releaseDate: "2026-08-20" });
+    addAlbum({ suffix: 2, title: "Owned Current", releaseDate: "2026-08-19", available: true });
+    for (let index = 0; index < 125; index += 1) {
+      addAlbum({ suffix: index + 100, title: `Old Album ${index}`, releaseDate: "2000-01-01" });
+    }
+
+    const projectedArtist = getCanonicalArtistProjection({ reference: canonicalArtist.id })[0];
+    const projectedAlbums = getCanonicalAlbumsByReleaseDate({
+      from: "2026-08-01",
+      to: "2026-08-22",
+      limit: 10,
+    });
+    assert.equal(projectedAlbums[0]?.artistId, projectedArtist?.id);
+
+    const releases = await getRecentMissingReleases(10, {
+      now: "2026-08-22T12:00:00Z",
+    });
+
+    assert.deepEqual(releases.map((album) => album.title), ["Missing Current"]);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(canonicalArtist.id);
+    if (trackIds.length) {
+      db.prepare(
+        `DELETE FROM library_tracks WHERE id IN (${trackIds.map(() => "?").join(",")})`,
+      ).run(...trackIds);
+    }
   }
 });

--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -69,9 +69,38 @@ test("canonical read model maps the existing root to Library-shaped records", ()
   ]);
   assert.equal(result.albums[0].mbid, "release-1");
   assert.equal(result.albums[0].releaseGroupMbid, "album-1");
+  assert.equal(result.artists[0].foreignArtistId, "artist-1");
   assert.equal(result.albums[0].statistics.sizeOnDisk, 123);
   assert.equal(result.artists[0].statistics.sizeOnDisk, 123);
   assert.equal(result.tracks[0].path, "/music/Root Artist/Root Album/01 Root Track.flac");
+});
+
+test("canonical read model preserves non-MBID provider artist identity", () => {
+  const result = buildCanonicalLibraryReadModel({
+    artists: [
+      {
+        id: 4,
+        identityKey: "lidarr-artist:705@deezer",
+        mbid: null,
+        name: "Provider Artist",
+        sortName: "Provider Artist",
+        metadata: {
+          id: 42,
+          foreignArtistId: "705@deezer",
+          librarySource: "lidarr",
+        },
+        albumIds: [],
+        sources: ["lidarr"],
+        available: false,
+      },
+    ],
+    albums: [],
+    tracks: [],
+  });
+
+  assert.equal(result.artists[0].providerId, 42);
+  assert.equal(result.artists[0].mbid, null);
+  assert.equal(result.artists[0].foreignArtistId, "705@deezer");
 });
 
 test("canonical read model keeps flow-like records out when the index excludes them", () => {

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import {
+  beginLibraryScan,
+  finishLibraryScan,
+  upsertLibraryArtist,
+} from "../../backend/services/libraryMediaStore.js";
+import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
+import { lidarrClient } from "../../backend/services/lidarrClient.js";
+import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+
+test("stable artist and discovery reads do not call Lidarr", async (t) => {
+  const identityKey = `stable-read-test:${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey,
+    mbid: "11111111-1111-4111-8111-111111111111",
+    name: "Stable Read Artist",
+    metadata: { id: 9911, monitored: true },
+  });
+  const originalConfigured = lidarrClient.isConfigured;
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("stable reads must not call Lidarr");
+  });
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    throw new Error("stable reads must not call Lidarr");
+  });
+  lidarrClient.isConfigured = () => true;
+
+  try {
+    const artists = await libraryManager.getAllArtists();
+    const releases = await getRecentMissingReleases(10, {
+      now: "2026-08-22T12:00:00Z",
+    });
+
+    assert.equal(artists.some((candidate) => candidate.providerId === "9911"), true);
+    assert.deepEqual(releases, []);
+    assert.equal(request.mock.callCount(), 0);
+  } finally {
+    lidarrClient.isConfigured = originalConfigured;
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("stable artist reads remain local when Lidarr is absent", async (t) => {
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("absent Lidarr must not be called");
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+
+  const artists = await libraryManager.getAllArtists();
+
+  assert.ok(Array.isArray(artists));
+  assert.equal(request.mock.callCount(), 0);
+});
+
+test("explicit artist synchronization retains its Lidarr request", async (t) => {
+  const originalConfigured = lidarrClient.isConfigured;
+  const request = t.mock.method(lidarrClient, "request", async () => []);
+  t.mock.method(libraryManager, "backfillLidarrArtistMappings", async () => {});
+  lidarrClient.isConfigured = () => true;
+
+  try {
+    await libraryManager.syncLidarrArtists({ forceRefresh: true });
+    assert.deepEqual(request.mock.calls.map((call) => call.arguments[0]), ["/artist"]);
+  } finally {
+    lidarrClient.isConfigured = originalConfigured;
+  }
+});
+
+test("a failed provider scan keeps the canonical artist and marks it stale", () => {
+  const identityKey = `stale-read-test:${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey,
+    mbid: "22222222-2222-4222-8222-222222222222",
+    name: "Stale Read Artist",
+  });
+  const scanId = beginLibraryScan({ source: "lidarr" });
+
+  try {
+    finishLibraryScan(scanId, { status: "failed", error: "provider unavailable" });
+    const projection = getCanonicalArtistProjection({ reference: artist.id });
+    assert.equal(projection[0]?.name, "Stale Read Artist");
+    assert.equal(projection[0]?.stale, true);
+  } finally {
+    db.prepare("DELETE FROM library_scan_runs WHERE id = ?").run(scanId);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -23,6 +23,7 @@ import {
 } from "../../backend/services/libraryScanWorker.js";
 import { getLibraryScanQueue } from "../../backend/services/honkerDb.js";
 import { getCanonicalLidarrArtist } from "../../backend/routes/artists/handlers/details.js";
+import { registerArtists } from "../../backend/routes/library/handlers/artists.js";
 
 test("stable artist and discovery reads do not call Lidarr", async (t) => {
   const identityKey = `stable-read-test:${Date.now()}`;
@@ -145,6 +146,60 @@ test("stable artist reads remain local when Lidarr is absent", async (t) => {
 
   assert.ok(Array.isArray(artists));
   assert.equal(request.mock.callCount(), 0);
+});
+
+test("legacy artist list bounds the projection before materialization", async (t) => {
+  const prefix = `zzzzzzzzzz-artist-page-${process.pid}-${Date.now()}`;
+  const artists = Array.from({ length: 101 }, (_, index) => upsertLibraryArtist({
+    identityKey: `${prefix}:${index}`,
+    name: `${prefix}-${String(index).padStart(3, "0")}`,
+    sortName: `${prefix}-${String(index).padStart(3, "0")}`,
+  }));
+  t.mock.method(libraryManager, "getAllArtists", async () => {
+    throw new Error("legacy artist list must not materialize all projection pages");
+  });
+
+  const routes = new Map();
+  registerArtists({
+    get(path, ...handlers) {
+      routes.set(`GET ${path}`, handlers.at(-1));
+    },
+    post(path, ...handlers) {
+      routes.set(`POST ${path}`, handlers.at(-1));
+    },
+    put(path, ...handlers) {
+      routes.set(`PUT ${path}`, handlers.at(-1));
+    },
+    delete(path, ...handlers) {
+      routes.set(`DELETE ${path}`, handlers.at(-1));
+    },
+  });
+
+  let statusCode = 200;
+  let body;
+  try {
+    await routes.get("GET /artists")(
+      { query: { limit: "1", offset: "100" } },
+      {
+        status(code) {
+          statusCode = code;
+          return this;
+        },
+        json(value) {
+          body = value;
+          return this;
+        },
+      },
+    );
+
+    assert.equal(statusCode, 200);
+    assert.deepEqual(body.map((artist) => artist.id), [String(artists[100].id)]);
+    assert.equal(body[0].added, body[0].addedAt);
+  } finally {
+    db.prepare(
+      `DELETE FROM library_artists WHERE id IN (${artists.map(() => "?").join(",")})`,
+    ).run(...artists.map((artist) => artist.id));
+  }
 });
 
 test("artist details do not expose Lidarr state for Aurral-only artists", () => {

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -8,6 +8,7 @@ import {
   linkLibraryAlbumTrack,
   upsertLibraryAlbum,
   upsertLibraryArtist,
+  upsertLibraryMediaFile,
   upsertLibraryTrack,
 } from "../../backend/services/libraryMediaStore.js";
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
@@ -99,15 +100,25 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
   }
 });
 
-test("deleting a Lidarr artist clears canonical provider state", async (t) => {
+test("deleting a Lidarr artist clears canonical provider state for both IDs", async (t) => {
   const mbid = "89898989-8989-4898-8989-898989898989";
+  const foreignArtistId = "8989@deezer";
   const artist = upsertLibraryArtist({
+    identityKey: `lidarr-artist:${foreignArtistId}`,
+    name: "Deleted Provider Artist",
+    metadata: {
+      id: 8989,
+      foreignArtistId,
+      librarySource: "lidarr",
+      monitored: true,
+    },
+  });
+  const resolvedArtist = upsertLibraryArtist({
     identityKey: `mbid:${mbid}`,
     mbid,
     name: "Deleted Provider Artist",
     metadata: {
       id: 8989,
-      foreignArtistId: mbid,
       librarySource: "lidarr",
       monitored: true,
     },
@@ -117,7 +128,7 @@ test("deleting a Lidarr artist clears canonical provider state", async (t) => {
   t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
     id: 8989,
     artistName: "Deleted Provider Artist",
-    foreignArtistId: mbid,
+    foreignArtistId,
   }));
   t.mock.method(lidarrClient, "deleteArtist", async () => true);
 
@@ -127,12 +138,76 @@ test("deleting a Lidarr artist clears canonical provider state", async (t) => {
     assert.equal(projection?.lidarrManaged, false);
     assert.equal(projection?.providerId, null);
     assert.equal(projection?.monitored, false);
+    assert.equal(getCanonicalArtistProjection({ reference: resolvedArtist.id })[0]?.providerId, null);
     assert.equal(getCanonicalLidarrArtist(mbid), null);
+    assert.equal(getCanonicalLidarrArtist(foreignArtistId), null);
   } finally {
     const jobId = getScheduledLibraryScanJobId();
     if (jobId) getLibraryScanQueue().cancel(jobId);
     clearScheduledLibraryScan();
-    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(artist.id, resolvedArtist.id);
+  }
+});
+
+test("canonical artist compatibility reads apply SQL pagination", async () => {
+  const key = `canonical-artist-route:${process.pid}:${Date.now()}`;
+  const artists = [];
+  const tracks = [];
+  const paths = [];
+  for (const name of ["A", "B"]) {
+    const artist = upsertLibraryArtist({
+      identityKey: `${key}:artist:${name}`,
+      name: `${key} ${name}`,
+      sortName: `${key} ${name}`,
+      metadata: { librarySource: "lidarr" },
+    });
+    const album = upsertLibraryAlbum({
+      identityKey: `${key}:album:${name}`,
+      artistId: artist.id,
+      title: `${key} Album ${name}`,
+    });
+    const track = upsertLibraryTrack({
+      identityKey: `${key}:track:${name}`,
+      title: `${key} Track ${name}`,
+    });
+    const filePath = `/tmp/${key}/${name}.flac`;
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+    upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "lidarr",
+      path: filePath,
+      available: true,
+    });
+    artists.push(artist);
+    tracks.push(track);
+    paths.push(filePath);
+  }
+
+  const routes = new Map();
+  registerArtists({
+    get(path, ...handlers) {
+      routes.set(`GET ${path}`, handlers.at(-1));
+    },
+    post() { return this; },
+    put() { return this; },
+    delete() { return this; },
+  });
+
+  let body;
+  try {
+    await routes.get("GET /artists")(
+      { query: { readPath: "canonical", source: "lidarr", limit: "1", offset: "1" } },
+      { json(value) { body = value; return this; } },
+    );
+    assert.deepEqual(body.map((artist) => artist.name), [`${key} B`]);
+    assert.equal(body[0].canonicalId, artists[1].id);
+    assert.equal(body[0].statistics.trackCount, 1);
+    assert.equal(body[0].added, body[0].addedAt);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(...paths);
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(...artists.map((artist) => artist.id));
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(...tracks.map((track) => track.id));
   }
 });
 

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -5,12 +5,18 @@ import { db } from "../../backend/config/db-sqlite.js";
 import {
   beginLibraryScan,
   finishLibraryScan,
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
   upsertLibraryArtist,
+  upsertLibraryTrack,
 } from "../../backend/services/libraryMediaStore.js";
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
-import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+import {
+  getCanonicalArtistProjection,
+  getCanonicalLibraryPage,
+} from "../../backend/services/libraryQueryService.js";
 import {
   clearScheduledLibraryScan,
   getScheduledLibraryScanJobId,
@@ -78,7 +84,7 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
     jobId = getScheduledLibraryScanJobId();
     assert.ok(jobId);
     assert.deepEqual(JSON.parse(getLibraryScanQueue().getJob(jobId).payload), {
-      force: true,
+      force: false,
       includeLidarr: true,
     });
 
@@ -117,6 +123,40 @@ test("artist details do not expose Lidarr state for Aurral-only artists", () => 
     assert.equal(getCanonicalLidarrArtist(mbid), null);
   } finally {
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("canonical artist page totals match hydrated items", () => {
+  const key = `artist-page-shape:${process.pid}:${Date.now()}`;
+  const emptyArtist = upsertLibraryArtist({
+    identityKey: `${key}:empty`,
+    name: `${key} empty`,
+  });
+  const populatedArtist = upsertLibraryArtist({
+    identityKey: `${key}:populated`,
+    name: `${key} populated`,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: populatedArtist.id,
+    title: "Hydrated Album",
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${key}:track`,
+    title: "Hydrated Track",
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+
+  try {
+    const page = getCanonicalLibraryPage({ kind: "artists", query: key });
+    assert.equal(page.total, 1);
+    assert.deepEqual(page.items.map((artist) => artist.id), [populatedArtist.id]);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(
+      emptyArtist.id,
+      populatedArtist.id,
+    );
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
   }
 });
 

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -11,6 +11,12 @@ import { getRecentMissingReleases } from "../../backend/services/discovery/recen
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+import {
+  clearScheduledLibraryScan,
+  getScheduledLibraryScanJobId,
+} from "../../backend/services/libraryScanWorker.js";
+import { getLibraryScanQueue } from "../../backend/services/honkerDb.js";
+import { getCanonicalLidarrArtist } from "../../backend/routes/artists/handlers/details.js";
 
 test("stable artist and discovery reads do not call Lidarr", async (t) => {
   const identityKey = `stable-read-test:${Date.now()}`;
@@ -35,12 +41,54 @@ test("stable artist and discovery reads do not call Lidarr", async (t) => {
       now: "2026-08-22T12:00:00Z",
     });
 
-    assert.equal(artists.some((candidate) => candidate.providerId === "9911"), true);
+    const projectedArtist = artists.find((candidate) => candidate.providerId === "9911");
+    assert.equal(projectedArtist?.id, String(artist.id));
+    assert.equal(projectedArtist?.canonicalId, String(artist.id));
     assert.deepEqual(releases, []);
     assert.equal(request.mock.callCount(), 0);
   } finally {
     lidarrClient.isConfigured = originalConfigured;
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("artist monitoring mutations dedupe canonical reconciliation scans", async (t) => {
+  clearScheduledLibraryScan();
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
+    id: 9922,
+    artistName: "Monitoring Artist",
+    foreignArtistId: "33333333-3333-4333-8333-333333333333",
+    monitored: false,
+  }));
+  t.mock.method(lidarrClient, "updateArtistMonitoring", async () => ({}));
+  t.mock.method(lidarrClient, "getArtist", async () => ({
+    id: 9922,
+    artistName: "Monitoring Artist",
+    foreignArtistId: "33333333-3333-4333-8333-333333333333",
+    monitored: true,
+    monitor: "all",
+  }));
+
+  let jobId;
+  try {
+    await libraryManager.updateArtist("33333333-3333-4333-8333-333333333333", {
+      monitorOption: "all",
+    });
+    jobId = getScheduledLibraryScanJobId();
+    assert.ok(jobId);
+    assert.deepEqual(JSON.parse(getLibraryScanQueue().getJob(jobId).payload), {
+      force: true,
+      includeLidarr: true,
+    });
+
+    await libraryManager.updateArtist("33333333-3333-4333-8333-333333333333", {
+      monitorOption: "all",
+    });
+    assert.equal(getScheduledLibraryScanJobId(), jobId);
+  } finally {
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
   }
 });
 
@@ -56,6 +104,22 @@ test("stable artist reads remain local when Lidarr is absent", async (t) => {
   assert.equal(request.mock.callCount(), 0);
 });
 
+test("artist details do not expose Lidarr state for Aurral-only artists", () => {
+  const mbid = "67676767-6767-4676-8676-676767676767";
+  const artist = upsertLibraryArtist({
+    identityKey: `mbid:${mbid}`,
+    mbid,
+    name: "Aurral Only Artist",
+    metadata: { id: 6767, foreignArtistId: mbid },
+  });
+
+  try {
+    assert.equal(getCanonicalLidarrArtist(mbid), null);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("explicit artist synchronization retains its Lidarr request", async (t) => {
   const originalConfigured = lidarrClient.isConfigured;
   const request = t.mock.method(lidarrClient, "request", async () => []);
@@ -66,6 +130,9 @@ test("explicit artist synchronization retains its Lidarr request", async (t) => 
     await libraryManager.syncLidarrArtists({ forceRefresh: true });
     assert.deepEqual(request.mock.calls.map((call) => call.arguments[0]), ["/artist"]);
   } finally {
+    const jobId = getScheduledLibraryScanJobId();
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
     lidarrClient.isConfigured = originalConfigured;
   }
 });

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -98,6 +98,43 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
   }
 });
 
+test("deleting a Lidarr artist clears canonical provider state", async (t) => {
+  const mbid = "89898989-8989-4898-8989-898989898989";
+  const artist = upsertLibraryArtist({
+    identityKey: `mbid:${mbid}`,
+    mbid,
+    name: "Deleted Provider Artist",
+    metadata: {
+      id: 8989,
+      foreignArtistId: mbid,
+      librarySource: "lidarr",
+      monitored: true,
+    },
+  });
+  clearScheduledLibraryScan();
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
+    id: 8989,
+    artistName: "Deleted Provider Artist",
+    foreignArtistId: mbid,
+  }));
+  t.mock.method(lidarrClient, "deleteArtist", async () => true);
+
+  try {
+    assert.deepEqual(await libraryManager.deleteArtist(mbid), { success: true });
+    const projection = getCanonicalArtistProjection({ reference: artist.id })[0];
+    assert.equal(projection?.lidarrManaged, false);
+    assert.equal(projection?.providerId, null);
+    assert.equal(projection?.monitored, false);
+    assert.equal(getCanonicalLidarrArtist(mbid), null);
+  } finally {
+    const jobId = getScheduledLibraryScanJobId();
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("stable artist reads remain local when Lidarr is absent", async (t) => {
   const request = t.mock.method(lidarrClient, "request", async () => {
     throw new Error("absent Lidarr must not be called");

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { db } from "../../backend/config/db-sqlite.js";
-import { getCanonicalLibraryPage } from "../../backend/services/libraryQueryService.js";
+import {
+  getCanonicalArtistProjection,
+  getCanonicalLibraryPage,
+} from "../../backend/services/libraryQueryService.js";
 import {
   getLibrarySnapshot,
   linkLibraryAlbumTrack,
@@ -355,6 +358,91 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
       "lidarr",
       filePath,
     );
+  }
+});
+
+test("indexLidarrLibrary keeps artists without albums and refreshes monitoring metadata", async () => {
+  const providerArtistId = "1212@deezer";
+  let monitored = false;
+  const client = {
+    isConfigured: () => true,
+    request: async () => [{
+      id: 1212,
+      artistName: "Albumless Artist",
+      foreignArtistId: providerArtistId,
+      monitored,
+      monitor: monitored ? "all" : "none",
+    }],
+    getAllAlbums: async () => [],
+    getRootFolders: async () => [],
+  };
+
+  try {
+    await indexLidarrLibrary({ client });
+    let projection = getCanonicalArtistProjection({ reference: providerArtistId })[0];
+    assert.equal(projection?.name, "Albumless Artist");
+    assert.equal(projection?.foreignArtistId, providerArtistId);
+    assert.equal(projection?.providerId, "1212");
+    assert.equal(projection?.id, projection?.canonicalId);
+    assert.deepEqual(projection?.sources, ["lidarr"]);
+    assert.equal(projection?.monitored, false);
+
+    monitored = true;
+    await indexLidarrLibrary({ client });
+    projection = getCanonicalArtistProjection({ reference: providerArtistId })[0];
+    assert.equal(projection?.monitored, true);
+    assert.equal(projection?.monitorOption, "all");
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(
+      `lidarr-artist:${providerArtistId}`,
+    );
+  }
+});
+
+test("indexLidarrLibrary keeps fully missing albums in canonical reads", async () => {
+  const artistMbid = "13131313-1313-4131-8131-131313131313";
+  const albumMbid = "14141414-1414-4141-8141-141414141414";
+  const trackMbid = "15151515-1515-4151-8151-151515151515";
+  const client = {
+    isConfigured: () => true,
+    request: async () => [{
+      id: 1313,
+      artistName: "Missing Album Artist",
+      foreignArtistId: artistMbid,
+    }],
+    getAllAlbums: async () => [{
+      id: 1414,
+      artistId: 1313,
+      title: "Fully Missing Album",
+      foreignAlbumId: albumMbid,
+      releaseDate: "2026-08-20",
+      statistics: { sizeOnDisk: 0 },
+    }],
+    getTracksByAlbumId: async () => [{
+      id: 1515,
+      albumId: 1414,
+      title: "Missing Track",
+      trackNumber: 1,
+      foreignRecordingId: trackMbid,
+    }],
+    getTrackFilesByAlbumId: async () => [],
+    getRootFolders: async () => [],
+  };
+
+  try {
+    await indexLidarrLibrary({ client });
+    const page = getCanonicalLibraryPage({
+      kind: "albums",
+      page: 1,
+      pageSize: 10,
+      query: "Fully Missing Album",
+    });
+
+    assert.equal(page.items[0]?.title, "Fully Missing Album");
+    assert.equal(page.items[0]?.availableTrackCount, 0);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE mbid = ?").run(artistMbid);
+    db.prepare("DELETE FROM library_tracks WHERE mbid = ?").run(trackMbid);
   }
 });
 

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -385,6 +385,7 @@ test("indexLidarrLibrary keeps artists without albums and refreshes monitoring m
     assert.equal(projection?.providerId, "1212");
     assert.equal(projection?.id, projection?.canonicalId);
     assert.deepEqual(projection?.sources, ["lidarr"]);
+    assert.equal(projection?.lidarrManaged, true);
     assert.equal(projection?.monitored, false);
 
     monitored = true;
@@ -440,6 +441,10 @@ test("indexLidarrLibrary keeps fully missing albums in canonical reads", async (
 
     assert.equal(page.items[0]?.title, "Fully Missing Album");
     assert.equal(page.items[0]?.availableTrackCount, 0);
+    const albumMetadata = db.prepare(
+      "SELECT metadata_json FROM library_albums WHERE mbid = ?",
+    ).get(albumMbid);
+    assert.equal(JSON.parse(albumMetadata.metadata_json).librarySource, "lidarr");
   } finally {
     db.prepare("DELETE FROM library_artists WHERE mbid = ?").run(artistMbid);
     db.prepare("DELETE FROM library_tracks WHERE mbid = ?").run(trackMbid);

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -11,6 +11,10 @@ import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildArtistRequestKey, pendingArtistRequests } from "../utils.js";
 import { getArtistByMbid } from "../../../services/providers/brainzmashProvider.js";
 import { getArtistTagPayload, buildArtistBase } from "../shared/transform.js";
+import {
+  findCanonicalArtist,
+  getCanonicalLibraryReadModelForArtists,
+} from "../../../services/canonicalLibraryReadAdapter.js";
 
 export function registerDetails(router) {
   const parseSelectedReleaseTypes = (value) =>
@@ -146,24 +150,26 @@ export function registerDetails(router) {
 
       logger.info("api", "Fetching artist details", { mbid });
 
-      const { lidarrClient } =
-        await import("../../../services/lidarrClient.js");
       let data = null;
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
 
-      let lidarrArtist = null;
-
-      if (lidarrClient.isConfigured()) {
-        try {
-          lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
-          if (lidarrArtist) {
-            logger.info("api", "Found artist in Lidarr", { artistName: lidarrArtist.artistName });
+      const canonical = getCanonicalLibraryReadModelForArtists({
+        source: "all",
+        availableOnly: false,
+        mbids: [mbid, resolvedMbid],
+      });
+      const canonicalArtist =
+        findCanonicalArtist(canonical.artists, resolvedMbid) ||
+        findCanonicalArtist(canonical.artists, mbid);
+      const lidarrArtist = canonicalArtist
+        ? {
+            id: canonicalArtist.providerId || canonicalArtist.id,
+            artistName: canonicalArtist.artistName,
+            monitored: canonicalArtist.monitored,
+            statistics: canonicalArtist.statistics,
           }
-        } catch (error) {
-          logger.warn("api", "Failed to fetch from Lidarr", { mbid, error: error.message });
-        }
-      }
+        : null;
 
       if (lidarrArtist) {
         const artistMbid = override?.musicbrainzId || mbid;

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -11,10 +11,18 @@ import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildArtistRequestKey, pendingArtistRequests } from "../utils.js";
 import { getArtistByMbid } from "../../../services/providers/brainzmashProvider.js";
 import { getArtistTagPayload, buildArtistBase } from "../shared/transform.js";
-import {
-  findCanonicalArtist,
-  getCanonicalLibraryReadModelForArtists,
-} from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+
+export function getCanonicalLidarrArtist(reference) {
+  const artist = getCanonicalArtistProjection({ reference })[0] || null;
+  if (!artist?.sources.includes("lidarr")) return null;
+  return {
+    id: artist.providerId || artist.id,
+    artistName: artist.artistName,
+    monitored: artist.monitored,
+    statistics: artist.statistics,
+  };
+}
 
 export function registerDetails(router) {
   const parseSelectedReleaseTypes = (value) =>
@@ -154,22 +162,9 @@ export function registerDetails(router) {
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
 
-      const canonical = getCanonicalLibraryReadModelForArtists({
-        source: "all",
-        availableOnly: false,
-        mbids: [mbid, resolvedMbid],
-      });
-      const canonicalArtist =
-        findCanonicalArtist(canonical.artists, resolvedMbid) ||
-        findCanonicalArtist(canonical.artists, mbid);
-      const lidarrArtist = canonicalArtist
-        ? {
-            id: canonicalArtist.providerId || canonicalArtist.id,
-            artistName: canonicalArtist.artistName,
-            monitored: canonicalArtist.monitored,
-            statistics: canonicalArtist.statistics,
-          }
-        : null;
+      const lidarrArtist =
+        getCanonicalLidarrArtist(resolvedMbid) ||
+        (resolvedMbid === mbid ? null : getCanonicalLidarrArtist(mbid));
 
       if (lidarrArtist) {
         const artistMbid = override?.musicbrainzId || mbid;

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -15,7 +15,7 @@ import { getCanonicalArtistProjection } from "../../../services/libraryQueryServ
 
 export function getCanonicalLidarrArtist(reference) {
   const artist = getCanonicalArtistProjection({ reference })[0] || null;
-  if (!artist?.sources.includes("lidarr")) return null;
+  if (!artist?.lidarrManaged) return null;
   return {
     id: artist.providerId || artist.id,
     artistName: artist.artistName,

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -163,73 +163,13 @@ export function registerStream(router) {
             return;
           }
 
-          const { lidarrClient } = await import("../../../services/lidarrClient.js");
-          const { libraryManager } = await import("../../../services/libraryManager.js");
-
-          if (!lidarrClient.isConfigured()) return;
-
-          try {
-            const lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
-            if (!lidarrArtist) {
-              if (isClientConnected()) {
-                sendSSE(res, "library", {
-                  exists: false,
-                  artist: null,
-                  albums: [],
-                });
-              }
-              return;
-            }
-            if (!isClientConnected()) return;
-
-            logger.info("stream", `Found artist in Lidarr: ${lidarrArtist.artistName}`);
-            const metadataArtist = await metadataArtistPromise;
-
-            sendArtist({
-              ...buildArtistBase(lidarrArtist.artistName, resolvedMbid, metadataArtist),
-              _lidarrData: {
-                id: lidarrArtist.id,
-                monitored: lidarrArtist.monitored,
-                statistics: lidarrArtist.statistics,
-              },
-            });
-
-            const libArtist = libraryManager.mapLidarrArtist(lidarrArtist);
+          if (isClientConnected()) {
             sendSSE(res, "library", {
-              exists: true,
-              artist: {
-                ...libArtist,
-                foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
-                added: libArtist.addedAt,
-              },
+              exists: false,
+              canonical: true,
+              artist: null,
               albums: [],
             });
-
-            const lidarrAlbums = await libraryManager.getAlbums(libArtist.id, lidarrArtist);
-
-            if (!isClientConnected()) return;
-
-            sendSSE(res, "library", {
-              exists: true,
-              artist: {
-                ...libArtist,
-                foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
-                added: libArtist.addedAt,
-              },
-              albums: lidarrAlbums.map((a) => ({
-                ...a,
-                foreignAlbumId: a.foreignAlbumId || a.mbid,
-                title: a.albumName,
-                albumType: "Album",
-                statistics: a.statistics || {
-                  trackCount: 0,
-                  sizeOnDisk: 0,
-                  percentOfTracks: 0,
-                },
-              })),
-            });
-          } catch (error) {
-            logger.warn("stream", `Failed to fetch from Lidarr: ${error.message}`);
           }
         })();
         tasks.push(libraryTask);

--- a/backend/routes/discovery/handlers/main.js
+++ b/backend/routes/discovery/handlers/main.js
@@ -4,8 +4,8 @@ import {
   getDiscoveryMode,
   serveCachedRecommendations,
 } from "../../../services/discovery/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import {
   buildArtistKeySet,
   isLibraryArtist,
@@ -63,7 +63,7 @@ export function registerMain(router) {
       let recommendations = discoveryCache.recommendations || [];
       let globalTop = discoveryCache.globalTop || [];
 
-      const libraryArtists = await libraryManager.getAllArtists();
+      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       const existingArtistKeys = buildArtistKeySet(libraryArtists);
 
       recommendations = recommendations.filter(

--- a/backend/routes/discovery/handlers/shows.js
+++ b/backend/routes/discovery/handlers/shows.js
@@ -1,7 +1,7 @@
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { dbOps, userOps } from "../../../db/helpers/index.js";
 import { getTicketmasterApiKey, getLastfmApiKey } from "../../../services/apiClients/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import {
   getDiscoveryCache,
   getDiscoveryFeedback,
@@ -39,7 +39,7 @@ export function registerShows(router) {
       const radiusMiles = Number.isFinite(configuredRadius)
         ? Math.max(5, Math.min(250, Math.floor(configuredRadius)))
         : undefined;
-      const libraryArtists = await libraryManager.getAllArtists();
+      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       const reqUser = userOps.getUserById(req.user.id);
       const userCacheNamespace = getLastfmApiKey()
         ? getListenHistoryCacheNamespace(getListenHistoryProfile(reqUser || {}))

--- a/backend/routes/discovery/handlers/tags.js
+++ b/backend/routes/discovery/handlers/tags.js
@@ -1,5 +1,5 @@
 import { getLastfmApiKey, lastfmRequest } from "../../../services/apiClients/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import { getDiscoveryCache } from "../../../services/discovery/index.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import { extractLastfmImageUrl } from "../../artists/shared/transform.js";
@@ -124,7 +124,7 @@ export function registerTags(router) {
             offset: offsetInt,
             existingArtistKeys: includeLibraryFlag
               ? new Set()
-              : buildArtistKeySet(await libraryManager.getAllArtists()),
+              : buildArtistKeySet([...iterateCanonicalArtistProjection({ pageSize: 100 })]),
           });
           if (fallbackResult) {
             return res.json({

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -7,23 +7,21 @@ import {
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
 import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
+      const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
+      const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
       if (req.query.readPath === "canonical") {
         const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
-        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
-        const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
         return res.json(artists.slice(offset, offset + limit).map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));
       }
-      const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
-      const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
-      const artists = await libraryManager.getAllArtists();
-      const paged = artists.slice(offset, offset + limit);
-      const formatted = paged.map((artist) => ({
+      const artists = getCanonicalArtistProjection({ pageSize: limit, offset });
+      const formatted = artists.map((artist) => ({
         ...artist,
         foreignArtistId: artist.foreignArtistId || artist.mbid,
         added: artist.addedAt,

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -6,16 +6,32 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
-import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
-import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+import { getCanonicalLibraryReadModelForArtistReferences } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection, getCanonicalLibraryPage } from "../../../services/libraryQueryService.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
       const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
       const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
       if (req.query.readPath === "canonical") {
-        const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
-        return res.json(artists.slice(offset, offset + limit).map((artist) => ({
+        const source = req.query.source || "all";
+        const page = getCanonicalLibraryPage({
+          source,
+          availableOnly: true,
+          kind: "artists",
+          pageSize: limit,
+          offset,
+        });
+        const readModel = getCanonicalLibraryReadModelForArtistReferences({
+          source,
+          availableOnly: true,
+          references: page.items.map((artist) => artist.id),
+        });
+        const artistsById = new Map(readModel.artists.map((artist) => [String(artist.id), artist]));
+        const artists = page.items
+          .map((artist) => artistsById.get(String(artist.id)))
+          .filter(Boolean);
+        return res.json(artists.map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -38,7 +38,7 @@ const buildArtist = (artist, albumsByArtistId) => {
     canonicalId: artist.id,
     providerId,
     mbid: artist.mbid,
-    foreignArtistId: artist.mbid || artist.identityKey,
+    foreignArtistId: artist.metadata?.foreignArtistId || artist.mbid || artist.identityKey,
     artistName: artist.name,
     name: artist.name,
     sortName: artist.sortName,

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -1,5 +1,6 @@
 import {
   getCanonicalLibrary,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForAlbumReferences,
   getCanonicalLibraryForArtists,
   getCanonicalTrackPath,
@@ -163,6 +164,16 @@ export function getCanonicalLibraryReadModelForArtists({
 } = {}) {
   return buildCanonicalLibraryReadModel(
     getCanonicalLibraryForArtists({ source, availableOnly, mbids }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForArtistReferences({
+  source = "lidarr",
+  availableOnly = true,
+  references = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({ source, availableOnly, references }),
   );
 }
 

--- a/backend/services/discovery/playlists.js
+++ b/backend/services/discovery/playlists.js
@@ -1,6 +1,6 @@
 import { dbOps } from "../../db/helpers/index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { logger } from "../logger.js";
 import { buildExistingArtistKeySet } from "./recommendationPipeline.js";
 import { websocketService } from "../websocketService.js";
@@ -85,10 +85,7 @@ export const runQueuedDiscoverPlaylistBuild = async (payload = {}) => {
           recordDiscoverPlaylistBuildProgress("Building recommended playlists...");
         }
 
-        const allLibraryArtistsRaw = await libraryManager.getAllArtists();
-        const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-          ? allLibraryArtistsRaw
-          : [];
+        const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
         const existingArtistKeys = buildExistingArtistKeySet(allLibraryArtists);
         const { generateDiscoverPlaylists } =
           await import("./playlistBuilder.js");

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -13,7 +13,7 @@ import {
   getListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import {
   buildExistingArtistKeySet,
   buildDiscoverySeedList,
@@ -440,16 +440,9 @@ export const updateDiscoveryCache = async (options = {}) => {
     .catch((err) => { logger.warn('discovery', err); });
 
   try {
-    const { libraryManager, getCachedArtists } = await import("../libraryManager.js");
     recordDiscoveryUpdateProgress("loading_sources", "Loading library artists", 12);
-    const cachedArtists = getCachedArtists();
-    const [recentLibraryArtists, allLibraryArtistsRaw] = await Promise.all([
-      libraryManager.getRecentArtists(40),
-      cachedArtists.length > 0 ? cachedArtists : libraryManager.getAllArtists(),
-    ]);
-    const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-      ? allLibraryArtistsRaw
-      : [];
+    const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+    const recentLibraryArtists = allLibraryArtists.slice(0, 40);
     const libraryArtists =
       recentLibraryArtists.length > 0
         ? recentLibraryArtists
@@ -901,10 +894,7 @@ export const updateUserDiscoveryCache = async (
   }
 
   try {
-    const allLibraryArtistsRaw = await libraryManager.getAllArtists();
-    const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-      ? allLibraryArtistsRaw
-      : [];
+    const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
     const existingArtistKeys = buildExistingArtistKeySet(allLibraryArtists);
 
     const lastfmHealth = { success: 0, failure: 0 };

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -1,3 +1,4 @@
+import { getCanonicalLibraryPage, iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { libraryManager } from "../libraryManager.js";
 
 const RECENT_RELEASE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
@@ -31,26 +32,48 @@ function resolveDayMs(value) {
 }
 
 export async function getRecentMissingReleases(limit = 24, options = {}) {
-  const { lidarrClient } = await import("../lidarrClient.js");
-  if (!lidarrClient.isConfigured()) {
-    return [];
-  }
-
   const providedArtists =
     Array.isArray(options?.artists) && options.artists.length > 0 ? options.artists : null;
   const providedAlbums = Array.isArray(options?.albums) ? options.albums : null;
   let artists = providedArtists;
   let albums = providedAlbums;
+  let canonicalAlbums = false;
 
   if (!artists && !albums) {
-    [artists, albums] = await Promise.all([
-      lidarrClient.request("/artist"),
-      lidarrClient.getAllAlbums(),
-    ]);
+    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+    albums = [];
+    canonicalAlbums = true;
+    for (let page = 1; ; page += 1) {
+      const result = getCanonicalLibraryPage({
+        source: "all",
+        availableOnly: false,
+        kind: "albums",
+        page,
+        pageSize: 100,
+        sort: "newest",
+        direction: "desc",
+      });
+      albums.push(...result.items);
+      if (!result.hasMore) break;
+    }
   } else if (!artists) {
-    artists = await lidarrClient.request("/artist");
+    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   } else if (!albums) {
-    albums = await lidarrClient.getAllAlbums();
+    albums = [];
+    canonicalAlbums = true;
+    for (let page = 1; ; page += 1) {
+      const result = getCanonicalLibraryPage({
+        source: "all",
+        availableOnly: false,
+        kind: "albums",
+        page,
+        pageSize: 100,
+        sort: "newest",
+        direction: "desc",
+      });
+      albums.push(...result.items);
+      if (!result.hasMore) break;
+    }
   }
 
   if (!Array.isArray(albums) || albums.length === 0) {
@@ -59,10 +82,10 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
 
   const artistsById = new Map();
   if (Array.isArray(artists)) {
-    await libraryManager.backfillLidarrArtistMappings(artists);
+    if (!canonicalAlbums) await libraryManager.backfillLidarrArtistMappings(artists);
     artists.forEach((artist) => {
       if (artist?.id != null) {
-        const mappedArtist = libraryManager.mapLidarrArtist(artist);
+        const mappedArtist = canonicalAlbums ? artist : libraryManager.mapLidarrArtist(artist);
         mappedArtist.artistName = mappedArtist.artistName || artist.name || null;
         artistsById.set(artist.id, mappedArtist);
         artistsById.set(String(artist.id), mappedArtist);
@@ -74,6 +97,32 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
   const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
   const today = resolveDayMs(now);
   const includeFuture = options?.includeFuture !== false;
+
+  if (canonicalAlbums) {
+    return albums
+      .map((album) => {
+        const artist = artistsById.get(album.artistId) || artistsById.get(String(album.artistId));
+        const releaseDate = album.releaseDate || null;
+        const releaseTime = new Date(releaseDate).getTime();
+        if (!artist || !releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
+          return null;
+        }
+        const releaseDay = resolveDayMs(releaseDate);
+        if (!includeFuture && releaseDay != null && today != null && releaseDay > today) return null;
+        if (Number(album.statistics?.trackFileCount || 0) > 0 || Number(album.statistics?.sizeOnDisk || 0) > 0) {
+          return null;
+        }
+        return {
+          ...album,
+          artistName: artist.artistName || artist.name || null,
+          artistMbid: artist.mbid || artist.foreignArtistId || null,
+          foreignArtistId: artist.foreignArtistId || artist.mbid || null,
+        };
+      })
+      .filter(Boolean)
+      .sort((left, right) => String(right.releaseDate || "").localeCompare(String(left.releaseDate || "")))
+      .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+  }
 
   return albums
     .map((album) => {

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -1,4 +1,7 @@
-import { getCanonicalLibraryPage, iterateCanonicalArtistProjection } from "../libraryQueryService.js";
+import {
+  getCanonicalAlbumsByReleaseDate,
+  iterateCanonicalArtistProjection,
+} from "../libraryQueryService.js";
 import { libraryManager } from "../libraryManager.js";
 
 const RECENT_RELEASE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
@@ -32,6 +35,11 @@ function resolveDayMs(value) {
 }
 
 export async function getRecentMissingReleases(limit = 24, options = {}) {
+  const now = resolveTimeMs(options?.now);
+  const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
+  const today = resolveDayMs(now);
+  const includeFuture = options?.includeFuture !== false;
+  const normalizedLimit = Math.max(1, Math.round(Number(limit) || 24));
   const providedArtists =
     Array.isArray(options?.artists) && options.artists.length > 0 ? options.artists : null;
   const providedAlbums = Array.isArray(options?.albums) ? options.albums : null;
@@ -40,40 +48,23 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
   let canonicalAlbums = false;
 
   if (!artists && !albums) {
-    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-    albums = [];
     canonicalAlbums = true;
-    for (let page = 1; ; page += 1) {
-      const result = getCanonicalLibraryPage({
-        source: "all",
-        availableOnly: false,
-        kind: "albums",
-        page,
-        pageSize: 100,
-        sort: "newest",
-        direction: "desc",
-      });
-      albums.push(...result.items);
-      if (!result.hasMore) break;
-    }
+    albums = getCanonicalAlbumsByReleaseDate({
+      from: new Date(recentCutoff).toISOString().slice(0, 10),
+      to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
+      limit: normalizedLimit,
+      missingOnly: true,
+    });
   } else if (!artists) {
     artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   } else if (!albums) {
-    albums = [];
     canonicalAlbums = true;
-    for (let page = 1; ; page += 1) {
-      const result = getCanonicalLibraryPage({
-        source: "all",
-        availableOnly: false,
-        kind: "albums",
-        page,
-        pageSize: 100,
-        sort: "newest",
-        direction: "desc",
-      });
-      albums.push(...result.items);
-      if (!result.hasMore) break;
-    }
+    albums = getCanonicalAlbumsByReleaseDate({
+      from: new Date(recentCutoff).toISOString().slice(0, 10),
+      to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
+      limit: normalizedLimit,
+      missingOnly: true,
+    });
   }
 
   if (!Array.isArray(albums) || albums.length === 0) {
@@ -93,35 +84,27 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
     });
   }
 
-  const now = resolveTimeMs(options?.now);
-  const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
-  const today = resolveDayMs(now);
-  const includeFuture = options?.includeFuture !== false;
-
   if (canonicalAlbums) {
     return albums
       .map((album) => {
-        const artist = artistsById.get(album.artistId) || artistsById.get(String(album.artistId));
         const releaseDate = album.releaseDate || null;
         const releaseTime = new Date(releaseDate).getTime();
-        if (!artist || !releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
+        if (!releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
           return null;
         }
         const releaseDay = resolveDayMs(releaseDate);
         if (!includeFuture && releaseDay != null && today != null && releaseDay > today) return null;
-        if (Number(album.statistics?.trackFileCount || 0) > 0 || Number(album.statistics?.sizeOnDisk || 0) > 0) {
-          return null;
-        }
+        if (Number(album.availableTrackCount || 0) > 0) return null;
         return {
           ...album,
-          artistName: artist.artistName || artist.name || null,
-          artistMbid: artist.mbid || artist.foreignArtistId || null,
-          foreignArtistId: artist.foreignArtistId || artist.mbid || null,
+          artistName: album.artistName || null,
+          artistMbid: album.artistMbid || album.foreignArtistId || null,
+          foreignArtistId: album.foreignArtistId || album.artistMbid || null,
         };
       })
       .filter(Boolean)
       .sort((left, right) => String(right.releaseDate || "").localeCompare(String(left.releaseDate || "")))
-      .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+      .slice(0, normalizedLimit);
   }
 
   return albums
@@ -153,5 +136,5 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
       const dateB = right.releaseDate || "";
       return dateB.localeCompare(dateA);
     })
-    .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+    .slice(0, normalizedLimit);
 }

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -64,6 +64,7 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
       to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
       limit: normalizedLimit,
       missingOnly: true,
+      artistIds: providedArtists.map((artist) => artist?.canonicalId || artist?.id),
     });
   }
 

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -1,6 +1,6 @@
 import { dbOps } from "../../db/helpers/index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import {
   enqueueDiscoveryRefreshJob,
   getHonkerDb,
@@ -143,7 +143,7 @@ export function markDiscoveryRefreshDequeued() {
 export async function isDiscoveryRefreshConfigured() {
   const hasLastfm = !!getLastfmApiKey();
   if (hasLastfm) return true;
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   return libraryArtists.length > 0;
 }
 

--- a/backend/services/discovery/userDiscovery.js
+++ b/backend/services/discovery/userDiscovery.js
@@ -12,7 +12,7 @@ import {
   serveCachedRecommendations,
 } from "./index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { dbOps, userOps } from "../../db/helpers/index.js";
 import {
   DISCOVERY_PROVIDER_LASTFM,
@@ -38,7 +38,7 @@ import { getTopPlayedArtists } from "../playEventService.js";
 
 export async function getUserDiscovery(userId, limit = 50, offset = 0) {
   const hasLastfmKey = !!getLastfmApiKey();
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
 
   const reqUser = userOps.getUserById(userId);
   const externalListenHistoryProfile = getListenHistoryProfile(reqUser || {});

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,7 +1,7 @@
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
 import {
-  getCanonicalLibraryPage,
+  getCanonicalAlbumsByReleaseDate,
   iterateCanonicalArtistProjection,
 } from "./libraryQueryService.js";
 import { getNearbyShows } from "./nearbyShowsService.js";
@@ -51,42 +51,23 @@ const upsertAll = (items) => {
 };
 
 async function buildReleaseItems(userId, now) {
-  const rawArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-  const rawAlbums = [];
-  for (let page = 1; ; page += 1) {
-    const result = getCanonicalLibraryPage({
-      source: "all",
-      availableOnly: false,
-      kind: "albums",
-      page,
-      pageSize: 100,
-      sort: "newest",
-      direction: "desc",
-    });
-    rawAlbums.push(...result.items);
-    if (!result.hasMore) break;
-  }
-
-  const artistsById = new Map(
-    rawArtists.flatMap((artist) => [
-      [String(artist?.id), artist],
-      [artist?.id, artist],
-    ]),
-  );
   const cutoff = now - RELEASE_PAST_DAYS * DAY_MS;
   const horizon = now + RELEASE_FUTURE_DAYS * DAY_MS;
+  const rawAlbums = getCanonicalAlbumsByReleaseDate({
+    from: new Date(cutoff).toISOString().slice(0, 10),
+    to: new Date(horizon).toISOString().slice(0, 10),
+    limit: 1000,
+  });
   const seen = new Set();
 
   return rawAlbums
     .map((album) => {
-      const artist = artistsById.get(String(album?.artistId));
       const releaseMbid = String(album?.foreignAlbumId || "").trim();
       const releaseDate = album?.releaseDate || null;
       const releaseTime = toTime(releaseDate);
-      const artistMbid = String(artist?.foreignArtistId || "").trim();
-      const artistName = String(artist?.artistName || artist?.name || "").trim();
+      const artistMbid = String(album?.foreignArtistId || album?.artistMbid || "").trim();
+      const artistName = String(album?.artistName || "").trim();
       if (
-        !artist ||
         !releaseMbid ||
         !artistMbid ||
         !artistName ||

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,6 +1,9 @@
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
-import { libraryManager } from "./libraryManager.js";
+import {
+  getCanonicalLibraryPage,
+  iterateCanonicalArtistProjection,
+} from "./libraryQueryService.js";
 import { getNearbyShows } from "./nearbyShowsService.js";
 import { getUserDiscovery } from "./discovery/userDiscovery.js";
 import { logger } from "./logger.js";
@@ -48,13 +51,21 @@ const upsertAll = (items) => {
 };
 
 async function buildReleaseItems(userId, now) {
-  const { lidarrClient } = await import("./lidarrClient.js");
-  if (!lidarrClient?.isConfigured()) return [];
-  const [rawArtists, rawAlbums] = await Promise.all([
-    lidarrClient.request("/artist"),
-    lidarrClient.getAllAlbums(),
-  ]);
-  if (!Array.isArray(rawArtists) || !Array.isArray(rawAlbums)) return [];
+  const rawArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+  const rawAlbums = [];
+  for (let page = 1; ; page += 1) {
+    const result = getCanonicalLibraryPage({
+      source: "all",
+      availableOnly: false,
+      kind: "albums",
+      page,
+      pageSize: 100,
+      sort: "newest",
+      direction: "desc",
+    });
+    rawAlbums.push(...result.items);
+    if (!result.hasMore) break;
+  }
 
   const artistsById = new Map(
     rawArtists.flatMap((artist) => [
@@ -263,7 +274,7 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
     const now = Date.now();
     const preferences = getInboxPreferences();
     const libraryArtists = preferences.shows
-      ? await libraryManager.getAllArtists()
+      ? [...iterateCanonicalArtistProjection({ pageSize: 100 })]
       : [];
     const enabledNewsKinds = new Set(
       getEnabledKinds(preferences).filter((kind) =>

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -221,7 +221,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         title: text(album.title) || "Unknown Album",
         albumArtist: artistName,
         releaseDate: album.releaseDate || null,
-        metadata: album,
+        metadata: { ...album, librarySource: "lidarr" },
       });
       for (const track of tracksByAlbumId.get(String(album.id)) || []) {
         const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -5,7 +5,6 @@ import {
   buildIdentityKey,
   linkLibraryAlbumTrack,
   markUnseenFilesUnavailable,
-  removeLibraryAlbumTracksWithoutMedia,
   upsertLibraryAlbum,
   upsertLibraryArtist,
   upsertLibraryMediaFile,
@@ -185,22 +184,27 @@ export async function indexLidarrLibrary({ client } = {}) {
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
 
   return withLibraryScan("lidarr", rootPath, async (scanId) => {
-    for (const album of Array.isArray(albums) ? albums : []) {
-      const artist = artistById.get(String(album?.artistId));
-      if (!artist || !album?.id) continue;
+    const artistRecordsById = new Map();
+    for (const artist of artistById.values()) {
       const artistProviderId = text(artist.foreignArtistId);
       const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
       const artistKey =
         (artistProviderId &&
           buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
         buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
-      const artistRecord = upsertLibraryArtist({
+      artistRecordsById.set(String(artist.id), upsertLibraryArtist({
         identityKey: artistKey,
         mbid: isUuid(artistProviderId) ? artistProviderId : null,
         name: artistName,
         sortName: artist.sortName || null,
-        metadata: artist,
-      });
+        metadata: { ...artist, librarySource: "lidarr" },
+      }));
+    }
+    for (const album of Array.isArray(albums) ? albums : []) {
+      const artist = artistById.get(String(album?.artistId));
+      if (!artist || !album?.id) continue;
+      const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
+      const artistRecord = artistRecordsById.get(String(artist.id));
       const albumProviderId = text(album.foreignAlbumId);
       const albumKey =
         (albumProviderId &&
@@ -219,8 +223,6 @@ export async function indexLidarrLibrary({ client } = {}) {
         releaseDate: album.releaseDate || null,
         metadata: album,
       });
-      let albumFilesIndexed = 0;
-
       for (const track of tracksByAlbumId.get(String(album.id)) || []) {
         const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);
         const trackKey =
@@ -268,13 +270,6 @@ export async function indexLidarrLibrary({ client } = {}) {
           scanId,
         });
         result.filesIndexed += 1;
-        albumFilesIndexed += 1;
-      }
-      if (
-        albumFilesIndexed === 0 &&
-        Number(album.statistics?.sizeOnDisk || 0) === 0
-      ) {
-        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr");
       }
     }
     if (result.filesFailed === 0 && result.filesIndexed > 0) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -53,7 +53,7 @@ const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
 
 function scheduleCanonicalLibraryReconciliation() {
   invalidateCanonicalLibraryCache();
-  return scheduleLibraryScan({ force: true, includeLidarr: true });
+  return scheduleLibraryScan({ includeLidarr: true });
 }
 
 function buildTrackFileIndex(trackFiles) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -9,6 +9,10 @@ import {
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
 import { scheduleLibraryScan } from "./libraryScanWorker.js";
+import {
+  clearCanonicalLidarrAlbum,
+  clearCanonicalLidarrArtist,
+} from "./libraryMediaStore.js";
 const normalizeTypeName = (value) =>
   String(value || "")
     .toLowerCase()
@@ -1111,6 +1115,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
+      clearCanonicalLidarrArtist(mbid);
       scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
@@ -1561,6 +1566,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
+      clearCanonicalLidarrAlbum(id);
       scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1116,6 +1116,7 @@ export class LibraryManager {
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
       clearCanonicalLidarrArtist(mbid);
+      clearCanonicalLidarrArtist(lidarrArtist.foreignArtistId);
       scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -3,6 +3,7 @@ import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
 import {
+  iterateCanonicalArtistProjection,
   getCanonicalLibraryPage,
   getCanonicalTrack,
   invalidateCanonicalLibraryCache,
@@ -318,6 +319,7 @@ export class LibraryManager {
       logger.info('library', `[LibraryManager] Added artist "${artistName}" to Lidarr`);
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);
+      invalidateCanonicalLibraryCache();
       import("./aurralHistoryService.js")
         .then(({ recordArtistAdded }) =>
           recordArtistAdded({
@@ -832,7 +834,11 @@ export class LibraryManager {
       });
   }
 
-  async getAllArtists({ forceRefresh = false } = {}) {
+  async getAllArtists() {
+    return [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+  }
+
+  async syncLidarrArtists({ forceRefresh = false } = {}) {
     if (
       forceRefresh !== true &&
       _cachedArtists.length > 0 &&
@@ -1078,6 +1084,7 @@ export class LibraryManager {
           monitor: normalizedMonitorOption,
         };
         upsertCachedArtist(mapped);
+        invalidateCanonicalLibraryCache();
         return mapped;
       }
       return this.mapLidarrArtist(lidarrArtist);
@@ -1097,6 +1104,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
+      invalidateCanonicalLibraryCache();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
     } catch (error) {
@@ -1173,7 +1181,9 @@ export class LibraryManager {
           .catch(() => existingAlbum);
         const refreshedArtist = await lidarr.getArtist(artistId).catch(() => fallbackArtist);
         if (!refreshedArtist) return null;
-        return this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
+        const mapped = this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
+        invalidateCanonicalLibraryCache();
+        return mapped;
       };
       let lidarrArtist = null;
       const artistResolveAttempts = 8;
@@ -1273,7 +1283,9 @@ export class LibraryManager {
         lidarrAlbum = await lidarr.getAlbum(lidarrAlbum.id).catch(() => lidarrAlbum);
       }
       const updatedArtist = await lidarr.getArtist(artistId);
-      return this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
+      const mapped = this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
+      invalidateCanonicalLibraryCache();
+      return mapped;
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to add album to Lidarr: ${error.message}`);      return { error: error.message };
     }
@@ -1513,7 +1525,9 @@ export class LibraryManager {
         }
         const updated = await lidarr.getAlbum(id);
         const lidarrArtist = await lidarr.getArtist(updated.artistId);
-        return this.mapLidarrAlbum(updated, lidarrArtist);
+        const mapped = this.mapLidarrAlbum(updated, lidarrArtist);
+        invalidateCanonicalLibraryCache();
+        return mapped;
       } catch (error) {
         const msg = error.message || "";
         const isTransient =
@@ -1540,6 +1554,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
+      invalidateCanonicalLibraryCache();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete album from Lidarr: ${error.message}`);      return { success: false, error: error.message };

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -8,6 +8,7 @@ import {
   getCanonicalTrack,
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
+import { scheduleLibraryScan } from "./libraryScanWorker.js";
 const normalizeTypeName = (value) =>
   String(value || "")
     .toLowerCase()
@@ -49,6 +50,11 @@ const _albumAddInflight = new Map();
 const _artistMappingInflight = new Map();
 const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
   "Album already exists in Lidarr under a different artist";
+
+function scheduleCanonicalLibraryReconciliation() {
+  invalidateCanonicalLibraryCache();
+  return scheduleLibraryScan({ force: true, includeLidarr: true });
+}
 
 function buildTrackFileIndex(trackFiles) {
   const index = new Map();
@@ -319,7 +325,7 @@ export class LibraryManager {
       logger.info('library', `[LibraryManager] Added artist "${artistName}" to Lidarr`);
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       import("./aurralHistoryService.js")
         .then(({ recordArtistAdded }) =>
           recordArtistAdded({
@@ -873,6 +879,7 @@ export class LibraryManager {
           await this.backfillLidarrArtistMappings(lidarrArtists);
           _cachedArtists = lidarrArtists.map((a) => this.mapLidarrArtist(a));
           _artistsCachedAt = Date.now();
+          scheduleCanonicalLibraryReconciliation();
           import("../../services/unifiedSearchService.js").then(({ clearSearchContextCache }) => clearSearchContextCache()).catch(() => {});
           return _cachedArtists;
         } catch (error) {
@@ -1084,7 +1091,7 @@ export class LibraryManager {
           monitor: normalizedMonitorOption,
         };
         upsertCachedArtist(mapped);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       }
       return this.mapLidarrArtist(lidarrArtist);
@@ -1104,7 +1111,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
     } catch (error) {
@@ -1182,7 +1189,7 @@ export class LibraryManager {
         const refreshedArtist = await lidarr.getArtist(artistId).catch(() => fallbackArtist);
         if (!refreshedArtist) return null;
         const mapped = this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       };
       let lidarrArtist = null;
@@ -1284,7 +1291,7 @@ export class LibraryManager {
       }
       const updatedArtist = await lidarr.getArtist(artistId);
       const mapped = this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return mapped;
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to add album to Lidarr: ${error.message}`);      return { error: error.message };
@@ -1526,7 +1533,7 @@ export class LibraryManager {
         const updated = await lidarr.getAlbum(id);
         const lidarrArtist = await lidarr.getArtist(updated.artistId);
         const mapped = this.mapLidarrAlbum(updated, lidarrArtist);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       } catch (error) {
         const msg = error.message || "";
@@ -1554,7 +1561,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete album from Lidarr: ${error.message}`);      return { success: false, error: error.message };
@@ -1605,7 +1612,7 @@ export class LibraryManager {
       }
 
       await lidarr.deleteTrackFile(trackFileId);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete track file: ${error.message}`);

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -15,6 +15,19 @@ const normalizeKeyPart = (value) =>
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
 
+const LIDARR_METADATA_KEYS = [
+  "librarySource",
+  "id",
+  "monitored",
+  "monitor",
+  "monitorNewItems",
+  "addOptions",
+  "path",
+  "qualityProfile",
+  "rootFolderPath",
+  "statistics",
+];
+
 let libraryScanDepth = 0;
 let libraryCacheInvalidationPending = false;
 
@@ -87,6 +100,48 @@ export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName =
   ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
   invalidateLibraryCache();
   return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+}
+
+function clearLidarrMetadata(table, where, parameters) {
+  const row = db.prepare(`SELECT id, metadata_json FROM ${table} WHERE ${where} LIMIT 1`)
+    .get(...parameters);
+  if (!row) return false;
+  let metadata = {};
+  try {
+    const parsed = JSON.parse(row.metadata_json || "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadata = parsed;
+  } catch {}
+  for (const key of LIDARR_METADATA_KEYS) delete metadata[key];
+  db.prepare(`UPDATE ${table} SET metadata_json = ?, updated_at = ? WHERE id = ?`)
+    .run(stringify(metadata), now(), row.id);
+  invalidateLibraryCache();
+  return true;
+}
+
+export function clearCanonicalLidarrArtist(reference) {
+  const value = normalizeText(reference);
+  if (!value) return false;
+  return clearLidarrMetadata(
+    "library_artists",
+    `mbid = ? OR identity_key = ? OR (
+      json_valid(metadata_json)
+      AND CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT) = ?
+    )`,
+    [value, value, value],
+  );
+}
+
+export function clearCanonicalLidarrAlbum(reference) {
+  const value = normalizeText(reference);
+  if (!value) return false;
+  return clearLidarrMetadata(
+    "library_albums",
+    `mbid = ? OR release_group_mbid = ? OR identity_key = ? OR (
+      json_valid(metadata_json)
+      AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?
+    )`,
+    [value, value, value, value],
+  );
 }
 
 export function upsertLibraryAlbum({

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -64,13 +64,13 @@ const CANONICAL_SELECT = `SELECT
 const albumMediaCondition = (mediaAlias, albumTrackAlias) =>
   `(${mediaAlias}.album_id = ${albumTrackAlias}.album_id OR ${mediaAlias}.album_id IS NULL)`;
 
-const CANONICAL_FROM = `FROM library_media_files AS media
-  JOIN library_tracks AS track ON track.id = media.track_id
-  JOIN library_album_tracks AS album_track
-    ON album_track.track_id = track.id
-    AND ${albumMediaCondition("media", "album_track")}
-  JOIN library_albums AS album ON album.id = album_track.album_id
-  JOIN library_artists AS artist ON artist.id = album.artist_id`;
+const CANONICAL_FROM = `FROM library_artists AS artist
+  JOIN library_albums AS album ON album.artist_id = artist.id
+  JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+  JOIN library_tracks AS track ON track.id = album_track.track_id
+  LEFT JOIN library_media_files AS media
+    ON media.track_id = track.id
+    AND ${albumMediaCondition("media", "album_track")}`;
 
 function buildLibraryFromRows(rows) {
   const artists = new Map();
@@ -219,6 +219,110 @@ export function getCanonicalArtistMbids({ source = null, availableOnly = false, 
      WHERE ${conditions.join(" AND ")}`,
   ).all(...parameters);
   return new Set(rows.map((row) => row.mbid).filter(Boolean));
+}
+
+const canonicalArtistProjection = (row) => {
+  const metadata = parseJson(row.metadata_json) || {};
+  const providerId = metadata.id == null ? null : String(metadata.id);
+  const monitorOption = metadata.monitor || metadata.addOptions?.monitor || "none";
+  return {
+    id: providerId || String(row.id),
+    canonicalId: String(row.id),
+    providerId,
+    mbid: row.mbid || null,
+    foreignArtistId: row.mbid || row.identity_key,
+    artistName: row.name,
+    name: row.name,
+    sortName: row.sort_name || row.name,
+    path: metadata.path || null,
+    addedAt: metadata.added || (row.created_at ? new Date(row.created_at).toISOString() : null),
+    monitored: metadata.monitored === true,
+    monitorOption,
+    monitorNewItems: metadata.monitorNewItems || "none",
+    addOptions: metadata.addOptions || { monitor: monitorOption },
+    quality: metadata.qualityProfile?.name || "standard",
+    albumFolders: true,
+    statistics: {
+      albumCount: Number(row.album_count || 0),
+      trackCount: Number(row.track_count || 0),
+      sizeOnDisk: Number(row.size_on_disk || 0),
+    },
+    sources: String(row.sources || "")
+      .split(",")
+      .map((source) => source.trim())
+      .filter(Boolean),
+    available: Boolean(row.available),
+    stale: Boolean(row.stale),
+  };
+};
+
+export function getCanonicalArtistProjection({ page = 1, pageSize = 100, reference = null } = {}) {
+  const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
+  const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
+  const references = normalizeLookupValues(reference == null ? [] : [reference]);
+  const parameters = [];
+  const where = [];
+  if (references.length) {
+    where.push(`(
+      artist.id IN (${references.map(() => "?").join(",")}) OR
+      artist.mbid IN (${references.map(() => "?").join(",")}) OR
+      artist.identity_key IN (${references.map(() => "?").join(",")}) OR
+      CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
+      lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
+    )`);
+    parameters.push(...references, ...references, ...references, ...references, ...references);
+  }
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const limit = references.length ? "" : "LIMIT ? OFFSET ?";
+  if (!references.length) {
+    parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
+  }
+  const rows = db.prepare(`
+    SELECT
+      artist.id,
+      artist.identity_key,
+      artist.mbid,
+      artist.name,
+      artist.sort_name,
+      artist.metadata_json,
+      artist.created_at,
+      COUNT(DISTINCT album.id) AS album_count,
+      COUNT(DISTINCT album_track.track_id) AS track_count,
+      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk,
+      GROUP_CONCAT(DISTINCT media.source) AS sources,
+      MAX(CASE WHEN media.available = 1 THEN 1 ELSE 0 END) AS available,
+      CASE WHEN EXISTS (
+        SELECT 1
+        FROM library_scan_runs AS scan
+        WHERE scan.source = 'lidarr'
+          AND scan.status = 'failed'
+          AND scan.id > COALESCE((
+            SELECT complete.id
+            FROM library_scan_runs AS complete
+            WHERE complete.source = 'lidarr' AND complete.status = 'complete'
+            ORDER BY complete.id DESC
+            LIMIT 1
+          ), 0)
+      ) THEN 1 ELSE 0 END AS stale
+    FROM library_artists AS artist
+    LEFT JOIN library_albums AS album ON album.artist_id = artist.id
+    LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+    LEFT JOIN library_media_files AS media ON media.track_id = album_track.track_id
+      AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
+    ${whereSql}
+    GROUP BY artist.id
+    ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+    ${limit}
+  `).all(...parameters);
+  return rows.map(canonicalArtistProjection);
+}
+
+export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
+  for (let page = 1; ; page += 1) {
+    const artists = getCanonicalArtistProjection({ page, pageSize });
+    yield* artists;
+    if (artists.length < Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100))) break;
+  }
 }
 
 export function getCanonicalTrackPath(albumReference, trackReference) {
@@ -426,6 +530,28 @@ export function getCanonicalLibraryForArtists({
     availableOnly,
     conditions: [`artist.mbid IN (${references.map(() => "?").join(",")})`],
     parameters: references,
+  });
+}
+
+export function getCanonicalLibraryForArtistReferences({
+  source = null,
+  availableOnly = false,
+  references: requestedReferences = [],
+} = {}) {
+  const references = normalizeLookupValues(requestedReferences);
+  if (!references.length) return { artists: [], albums: [], tracks: [] };
+  const placeholders = references.map(() => "?").join(",");
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`(
+      artist.id IN (${placeholders}) OR
+      artist.mbid IN (${placeholders}) OR
+      artist.identity_key IN (${placeholders}) OR
+      CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${placeholders}) OR
+      lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
+    )`],
+    parameters: [...references, ...references, ...references, ...references, ...references],
   });
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -5,6 +5,7 @@ const libraryCache = new Map();
 const PAGE_KINDS = new Set(["artists", "albums", "tracks", "genres"]);
 const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 100;
+const MAX_ARTIST_PROJECTION_PAGE_SIZE = 10000;
 
 const parseJson = (value) => {
   if (!value) return null;
@@ -261,9 +262,20 @@ const canonicalArtistProjection = (row) => {
   };
 };
 
-function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, reference = null } = {}) {
+function buildCanonicalArtistProjectionQuery({
+  page = 1,
+  pageSize = 100,
+  offset = null,
+  reference = null,
+} = {}) {
   const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
-  const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
+  const normalizedPageSize = Math.min(
+    MAX_ARTIST_PROJECTION_PAGE_SIZE,
+    Math.max(1, Number.parseInt(pageSize, 10) || 100),
+  );
+  const normalizedOffset = offset == null
+    ? (normalizedPage - 1) * normalizedPageSize
+    : Math.max(0, Number.parseInt(offset, 10) || 0);
   const references = normalizeLookupValues(reference == null ? [] : [reference]);
   const parameters = [];
   const where = [];
@@ -288,7 +300,7 @@ function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, referen
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const limit = references.length ? "" : "LIMIT ? OFFSET ?";
   if (!references.length) {
-    parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
+    parameters.push(normalizedPageSize, normalizedOffset);
   }
   return {
     parameters,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -236,6 +236,7 @@ const canonicalArtistProjection = (row) => {
     id: String(row.id),
     canonicalId: String(row.id),
     providerId,
+    lidarrManaged: metadata.librarySource === "lidarr",
     mbid: row.mbid || null,
     foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
     artistName: row.name,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -871,8 +871,8 @@ const addGenreStats = (stats, metadata, kind) => {
 
 const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
-const pageSize = (value) =>
-  Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
+const pageSize = (value, max = MAX_PAGE_SIZE) =>
+  Math.min(max, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
 
 const genreStatsCache = new Map();
 const GENRE_METADATA_PATHS = ["$.genres", "$.genre", "$.common.genre", "$.tags.genre"];
@@ -1287,6 +1287,7 @@ export function getCanonicalLibraryPage({
   kind = "albums",
   page = 1,
   pageSize: requestedPageSize = DEFAULT_PAGE_SIZE,
+  offset = null,
   query = "",
   genre = "",
   sort = null,
@@ -1306,7 +1307,13 @@ export function getCanonicalLibraryPage({
     text(sort).toLocaleLowerCase() ||
     (normalizedKind === "tracks" && albumId ? "album" : "name");
   const currentPage = pageNumber(page);
-  const currentPageSize = pageSize(requestedPageSize);
+  const currentPageSize = pageSize(
+    requestedPageSize,
+    normalizedKind === "artists" ? MAX_ARTIST_PROJECTION_PAGE_SIZE : MAX_PAGE_SIZE,
+  );
+  const currentOffset = offset == null
+    ? (currentPage - 1) * currentPageSize
+    : Math.max(0, Number.parseInt(offset, 10) || 0);
 
   if (normalizedKind === "genres") {
     let collection = getCanonicalGenreStats({ sourceFilter, availableOnly });
@@ -1371,7 +1378,7 @@ export function getCanonicalLibraryPage({
   ).all(
     ...queryDefinition.parameters,
     currentPageSize,
-    (currentPage - 1) * currentPageSize,
+    currentOffset,
   ).map((row) => row.page_id);
   const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly, albumId);
   const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -225,12 +225,19 @@ const canonicalArtistProjection = (row) => {
   const metadata = parseJson(row.metadata_json) || {};
   const providerId = metadata.id == null ? null : String(metadata.id);
   const monitorOption = metadata.monitor || metadata.addOptions?.monitor || "none";
+  const sources = new Set(
+    String(row.sources || "")
+      .split(",")
+      .map((source) => source.trim())
+      .filter(Boolean),
+  );
+  if (metadata.librarySource === "lidarr") sources.add("lidarr");
   return {
-    id: providerId || String(row.id),
+    id: String(row.id),
     canonicalId: String(row.id),
     providerId,
     mbid: row.mbid || null,
-    foreignArtistId: row.mbid || row.identity_key,
+    foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
     artistName: row.name,
     name: row.name,
     sortName: row.sort_name || row.name,
@@ -247,16 +254,13 @@ const canonicalArtistProjection = (row) => {
       trackCount: Number(row.track_count || 0),
       sizeOnDisk: Number(row.size_on_disk || 0),
     },
-    sources: String(row.sources || "")
-      .split(",")
-      .map((source) => source.trim())
-      .filter(Boolean),
+    sources: [...sources].sort(),
     available: Boolean(row.available),
     stale: Boolean(row.stale),
   };
 };
 
-export function getCanonicalArtistProjection({ page = 1, pageSize = 100, reference = null } = {}) {
+function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, reference = null } = {}) {
   const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
   const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
   const references = normalizeLookupValues(reference == null ? [] : [reference]);
@@ -268,16 +272,40 @@ export function getCanonicalArtistProjection({ page = 1, pageSize = 100, referen
       artist.mbid IN (${references.map(() => "?").join(",")}) OR
       artist.identity_key IN (${references.map(() => "?").join(",")}) OR
       CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
+      CAST(json_extract(artist.metadata_json, '$.foreignArtistId') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
       lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
     )`);
-    parameters.push(...references, ...references, ...references, ...references, ...references);
+    parameters.push(
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+    );
   }
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const limit = references.length ? "" : "LIMIT ? OFFSET ?";
   if (!references.length) {
     parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
   }
-  const rows = db.prepare(`
+  return {
+    parameters,
+    sql: `
+    WITH artist_page AS MATERIALIZED (
+      SELECT
+        artist.id,
+        artist.identity_key,
+        artist.mbid,
+        artist.name,
+        artist.sort_name,
+        artist.metadata_json,
+        artist.created_at
+      FROM library_artists AS artist
+      ${whereSql}
+      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+      ${limit}
+    )
     SELECT
       artist.id,
       artist.identity_key,
@@ -304,17 +332,26 @@ export function getCanonicalArtistProjection({ page = 1, pageSize = 100, referen
             LIMIT 1
           ), 0)
       ) THEN 1 ELSE 0 END AS stale
-    FROM library_artists AS artist
+    FROM artist_page AS artist
     LEFT JOIN library_albums AS album ON album.artist_id = artist.id
     LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
     LEFT JOIN library_media_files AS media ON media.track_id = album_track.track_id
       AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
-    ${whereSql}
     GROUP BY artist.id
     ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
-    ${limit}
-  `).all(...parameters);
+  `,
+  };
+}
+
+export function getCanonicalArtistProjection(options = {}) {
+  const query = buildCanonicalArtistProjectionQuery(options);
+  const rows = db.prepare(query.sql).all(...query.parameters);
   return rows.map(canonicalArtistProjection);
+}
+
+export function getCanonicalArtistProjectionQueryPlan(options = {}) {
+  const query = buildCanonicalArtistProjectionQuery(options);
+  return db.prepare(`EXPLAIN QUERY PLAN ${query.sql}`).all(...query.parameters);
 }
 
 export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
@@ -323,6 +360,104 @@ export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
     yield* artists;
     if (artists.length < Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100))) break;
   }
+}
+
+const canonicalDateAlbumProjection = (row) => {
+  const metadata = parseJson(row.metadata_json) || {};
+  const artistMetadata = parseJson(row.artist_metadata_json) || {};
+  const trackCount = Number(row.track_count || 0);
+  const availableTrackCount = Number(row.available_track_count || 0);
+  return {
+    id: String(row.id),
+    canonicalId: String(row.id),
+    providerId: metadata.id == null ? null : String(metadata.id),
+    artistId: String(row.artist_id),
+    providerArtistId: artistMetadata.id == null ? null : String(artistMetadata.id),
+    artistName: row.artist_name,
+    artistMbid: row.artist_mbid || null,
+    foreignArtistId:
+      artistMetadata.foreignArtistId || row.artist_mbid || row.artist_identity_key,
+    mbid: row.mbid || row.release_group_mbid || null,
+    releaseGroupMbid: row.release_group_mbid || null,
+    foreignAlbumId: row.mbid || row.release_group_mbid || row.identity_key,
+    albumName: row.title,
+    title: row.title,
+    releaseDate: row.release_date,
+    monitored: metadata.monitored === true,
+    albumType: metadata.albumType || metadata.releaseType || null,
+    trackCount,
+    availableTrackCount,
+    statistics: {
+      trackCount,
+      trackFileCount: availableTrackCount,
+      sizeOnDisk: Number(row.size_on_disk || 0),
+      percentOfTracks: trackCount > 0 && availableTrackCount === trackCount ? 100 : 0,
+    },
+  };
+};
+
+export function getCanonicalAlbumsByReleaseDate({
+  from,
+  to = null,
+  limit = 100,
+  missingOnly = false,
+} = {}) {
+  const fromDate = String(from || "").trim();
+  const toDate = String(to || "").trim();
+  if (!fromDate) return [];
+  const conditions = ["album.release_date >= ?"];
+  const parameters = [fromDate];
+  if (toDate) {
+    conditions.push("album.release_date <= ?");
+    parameters.push(toDate);
+  }
+  if (missingOnly === true) {
+    conditions.push(`NOT EXISTS (
+      SELECT 1
+      FROM library_album_tracks AS owned_relation
+      JOIN library_media_files AS owned_media
+        ON owned_media.track_id = owned_relation.track_id
+        AND (owned_media.album_id = owned_relation.album_id OR owned_media.album_id IS NULL)
+      WHERE owned_relation.album_id = album.id
+        AND owned_media.available = 1
+    )`);
+  }
+  parameters.push(Math.min(1000, Math.max(1, Number.parseInt(limit, 10) || 100)));
+  const rows = db.prepare(`
+    WITH date_albums AS MATERIALIZED (
+      SELECT
+        album.id,
+        album.identity_key,
+        album.mbid,
+        album.release_group_mbid,
+        album.artist_id,
+        album.title,
+        album.release_date,
+        album.metadata_json,
+        artist.identity_key AS artist_identity_key,
+        artist.mbid AS artist_mbid,
+        artist.name AS artist_name,
+        artist.metadata_json AS artist_metadata_json
+      FROM library_albums AS album
+      JOIN library_artists AS artist ON artist.id = album.artist_id
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY album.release_date DESC, album.id DESC
+      LIMIT ?
+    )
+    SELECT
+      album.*,
+      COUNT(DISTINCT album_track.track_id) AS track_count,
+      COUNT(DISTINCT CASE WHEN media.available = 1 THEN album_track.track_id END) AS available_track_count,
+      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk
+    FROM date_albums AS album
+    LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+    LEFT JOIN library_media_files AS media
+      ON media.track_id = album_track.track_id
+      AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
+    GROUP BY album.id
+    ORDER BY album.release_date DESC, album.id DESC
+  `).all(...parameters);
+  return rows.map(canonicalDateAlbumProjection);
 }
 
 export function getCanonicalTrackPath(albumReference, trackReference) {
@@ -549,9 +684,17 @@ export function getCanonicalLibraryForArtistReferences({
       artist.mbid IN (${placeholders}) OR
       artist.identity_key IN (${placeholders}) OR
       CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${placeholders}) OR
+      CAST(json_extract(artist.metadata_json, '$.foreignArtistId') AS TEXT) IN (${placeholders}) OR
       lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
     )`],
-    parameters: [...references, ...references, ...references, ...references, ...references],
+    parameters: [
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+    ],
   });
 }
 
@@ -746,6 +889,9 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
 };
 
 const pageMediaExists = (kind, sourceFilter, availableOnly) => {
+  if (!sourceFilter && availableOnly !== true) {
+    return { sql: "1 = 1", parameters: [] };
+  }
   const { conditions, parameters } = mediaSourceClause(sourceFilter);
   if (availableOnly === true) conditions.push("page_media.available = 1");
   const conditionSql = conditions.length ? conditions.join(" AND ") : "1 = 1";

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -391,7 +391,9 @@ const canonicalDateAlbumProjection = (row) => {
       trackCount,
       trackFileCount: availableTrackCount,
       sizeOnDisk: Number(row.size_on_disk || 0),
-      percentOfTracks: trackCount > 0 && availableTrackCount === trackCount ? 100 : 0,
+      percentOfTracks: trackCount > 0
+        ? Math.round((availableTrackCount / trackCount) * 100)
+        : 0,
     },
   };
 };
@@ -401,6 +403,7 @@ export function getCanonicalAlbumsByReleaseDate({
   to = null,
   limit = 100,
   missingOnly = false,
+  artistIds = [],
 } = {}) {
   const fromDate = String(from || "").trim();
   const toDate = String(to || "").trim();
@@ -410,6 +413,18 @@ export function getCanonicalAlbumsByReleaseDate({
   if (toDate) {
     conditions.push("album.release_date <= ?");
     parameters.push(toDate);
+  }
+  const canonicalArtistIds = [...new Set(
+    (Array.isArray(artistIds) ? artistIds : [])
+      .map((value) => Number(value))
+      .filter((value) => Number.isSafeInteger(value) && value > 0),
+  )];
+  if (Array.isArray(artistIds) && artistIds.length > 0) {
+    if (!canonicalArtistIds.length) return [];
+    conditions.push(
+      "album.artist_id IN (SELECT CAST(value AS INTEGER) FROM json_each(?))",
+    );
+    parameters.push(JSON.stringify(canonicalArtistIds));
   }
   if (missingOnly === true) {
     conditions.push(`NOT EXISTS (
@@ -890,6 +905,29 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
 
 const pageMediaExists = (kind, sourceFilter, availableOnly) => {
   if (!sourceFilter && availableOnly !== true) {
+    if (kind === "artists") {
+      return {
+        sql: `EXISTS (
+          SELECT 1
+          FROM library_albums AS page_album
+          JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
+          JOIN library_tracks AS page_track ON page_track.id = page_album_track.track_id
+          WHERE page_album.artist_id = artist.id
+        )`,
+        parameters: [],
+      };
+    }
+    if (kind === "albums") {
+      return {
+        sql: `EXISTS (
+          SELECT 1
+          FROM library_album_tracks AS page_album_track
+          JOIN library_tracks AS page_track ON page_track.id = page_album_track.track_id
+          WHERE page_album_track.album_id = album.id
+        )`,
+        parameters: [],
+      };
+    }
     return { sql: "1 = 1", parameters: [] };
   }
   const { conditions, parameters } = mediaSourceClause(sourceFilter);

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1,6 +1,6 @@
 import { buildImageProxyUrl } from "./imageProxyService.js";
 import { dbOps } from "../db/helpers/index.js";
-import { libraryManager } from "./libraryManager.js";
+import { iterateCanonicalArtistProjection } from "./libraryQueryService.js";
 import { getNewsSettings } from "./apiClients/config.js";
 import { fetchArticleImage, fetchRssFeed } from "./rssNews.js";
 import { mapWithConcurrency } from "./discovery/helpers.js";
@@ -210,7 +210,7 @@ export const disableNewsFeed = (sourceUrl, sourceName) => {
 
 export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "matched" } = {}) {
   const settings = getNewsSettings();
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   const recommendedArtists = userId
     ? ((await getUserDiscovery(userId, 50, 0))?.body?.recommendations || [])
     : [];

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -180,7 +180,7 @@ export async function processSystemTask(payload = {}) {
     }
     case "lidarr-retry": {
       const { libraryManager } = await import("./libraryManager.js");
-      await libraryManager.getAllArtists({ forceRefresh: true });
+      await libraryManager.syncLidarrArtists({ forceRefresh: true });
       return;
     }
     default:

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -5,7 +5,12 @@ import {
   flowPlaylistConfig,
   tracksShareMembership,
 } from "./weeklyFlowPlaylistConfig.js";
-import { libraryManager } from "../libraryManager.js";
+import {
+  buildCanonicalLibraryReadModel,
+  findCanonicalArtist,
+  findCanonicalTracksForAlbum,
+} from "../canonicalLibraryReadAdapter.js";
+import { getCanonicalLibraryForArtistReferences } from "../libraryQueryService.js";
 import { commitImportToPlaylistLibrary, sanitizePathPart } from "../playlistDownloadUtils.js";
 import {
   AURRAL_FLOWS_DIR,
@@ -393,14 +398,15 @@ function findMatchingTrack(tracks, track, strictAlbum = false) {
 
 async function findLidarrSource(track, options = {}) {
   const strictAlbum = options.targetPlaylistType === "library";
-  let artists = [];
-  try {
-    artists = await libraryManager.getAllArtists();
-  } catch (error) {
-    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr artists:", error.message);
-    return null;
-  }
-  const artist = findMatchingArtist(Array.isArray(artists) ? artists : [], track);
+  const { artists, albums, tracks } = buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({
+      source: "lidarr",
+      availableOnly: false,
+      references: [track?.artistMbid, track?.artistName],
+    }),
+  );
+  const artist = findCanonicalArtist(artists, track?.artistMbid) ||
+    findMatchingArtist(artists, track);
   if (!artist) {
     console.log(
       `[WeeklyFlowReuse] Lidarr: no artist match for "${track?.artistName}" (mbid ${track?.artistMbid || "none"}, ${artists.length} Lidarr artists checked)`,
@@ -410,14 +416,8 @@ async function findLidarrSource(track, options = {}) {
   const artistId = artist.id || artist.artistId;
   if (!artistId) return null;
 
-  let albums = [];
-  try {
-    albums = await libraryManager.getAlbums(artistId);
-  } catch (error) {
-    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr albums:", error.message);
-    return null;
-  }
-  if (!albums.length) {
+  const artistAlbums = albums.filter((album) => String(album.artistId) === String(artist.id));
+  if (!artistAlbums.length) {
     console.log(
       `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" (id ${artistId}) matched but has 0 albums`,
     );
@@ -425,7 +425,7 @@ async function findLidarrSource(track, options = {}) {
   }
 
   let foundTitleOnAnyAlbum = false;
-  const rankedAlbums = rankAlbums(Array.isArray(albums) ? albums : [], track);
+  const rankedAlbums = rankAlbums(artistAlbums, track);
   const albumsToCheck = strictAlbum
     ? rankedAlbums.filter((album) => {
         const albumMbid = String(track?.albumMbid || "").trim();
@@ -440,15 +440,9 @@ async function findLidarrSource(track, options = {}) {
       })
     : rankedAlbums;
   for (const album of albumsToCheck) {
-    let tracks = [];
-    try {
-      tracks = await libraryManager.getTracks(album.id);
-    } catch (error) {
-      console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr tracks:", error.message);
-      continue;
-    }
+    const albumTracks = findCanonicalTracksForAlbum(tracks, album.id);
     const matchedTrack = findMatchingTrack(
-      Array.isArray(tracks) ? tracks : [],
+      albumTracks,
       track,
       strictAlbum,
     );
@@ -477,7 +471,7 @@ async function findLidarrSource(track, options = {}) {
   }
   if (!foundTitleOnAnyAlbum) {
     console.log(
-      `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" matched (${albums.length} albums checked) but no album's tracklist contained "${track.trackName}"`,
+      `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" matched (${artistAlbums.length} albums checked) but no album's tracklist contained "${track.trackName}"`,
     );
   }
   return null;

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistSource.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistSource.js
@@ -5,6 +5,14 @@ import { getBlockedArtistKeys } from "../discovery/feedback.js";
 import { mapWithConcurrency } from "../discovery/helpers.js";
 import { getYear } from "../providers/brainzmashRanking.js";
 import { resolveWeeklyFlowTrackContext } from "./weeklyFlowTrackResolver.js";
+import {
+  buildCanonicalLibraryReadModel,
+} from "../canonicalLibraryReadAdapter.js";
+import {
+  getCanonicalLibraryPage,
+  getCanonicalLibraryForArtistReferences,
+  iterateCanonicalArtistProjection,
+} from "../libraryQueryService.js";
 import BoundedMap from "../boundedMap.js";
 const LASTFM_HARVEST_CONCURRENCY = 12;
 const ARTIST_TOP_TRACKS_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
@@ -467,8 +475,7 @@ export class WeeklyFlowPlaylistSource {
     }
 
     const promise = (async () => {
-      const { libraryManager } = await import("../libraryManager.js");
-      const artists = await libraryManager.getAllArtists();
+      const artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       return this._buildArtistKeySet(artists);
     })();
     this.libraryArtistKeysCache = { promise };
@@ -1964,7 +1971,7 @@ export class WeeklyFlowPlaylistSource {
     return tracks.slice(0, limit);
   }
 
-  async _getLibraryOwnership(libraryManager, artistId) {
+  async _getLibraryOwnership(_libraryManager, artistId) {
     const key = String(artistId ?? "");
     if (!key) {
       return { ownedTitles: new Set(), ownedAlbums: new Set() };
@@ -1973,11 +1980,25 @@ export class WeeklyFlowPlaylistSource {
     if (cached?.data && cached.expiresAt > Date.now()) {
       return cached.data;
     }
-    const albums = await libraryManager.getAlbums(artistId);
-    const [ownedTitles, ownedAlbums] = await Promise.all([
-      this.getLibraryTrackTitles(libraryManager, artistId, albums),
-      this.getLibraryAlbumNames(libraryManager, artistId, albums),
-    ]);
+    const { albums, tracks } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
+    );
+    const ownedTitles = new Set(
+      tracks
+        .filter((track) => track.available)
+        .map((track) => String(track.trackName || track.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const ownedAlbums = new Set(
+      albums
+        .filter((album) => album.available)
+        .map((album) => String(album.albumName || album.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
     const data = { ownedTitles, ownedAlbums };
     this.libraryOwnershipCache.set(key, {
       data,
@@ -1986,42 +2007,42 @@ export class WeeklyFlowPlaylistSource {
     return data;
   }
 
-  async getLibraryTrackTitles(libraryManager, artistId, knownAlbums = null) {
-    const albums = Array.isArray(knownAlbums)
-      ? knownAlbums
-      : await libraryManager.getAlbums(artistId);
-    const titles = new Set();
-    const maxAlbums = 30;
-    const trackLists = await Promise.all(
-      albums.slice(0, maxAlbums).map((album) => libraryManager.getTracks(album.id)),
+  async getLibraryTrackTitles(_libraryManager, artistId, _knownAlbums = null) {
+    const { tracks } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
     );
-    for (const tracks of trackLists) {
-      for (const t of tracks) {
-        const name = (t.trackName || t.title || "").trim().toLowerCase();
-        if (name) titles.add(name);
-      }
-    }
-    return titles;
+    return new Set(
+      tracks
+        .filter((track) => track.available)
+        .map((track) => String(track.trackName || track.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
   }
 
-  async getLibraryAlbumNames(libraryManager, artistId, knownAlbums = null) {
-    const albums = Array.isArray(knownAlbums)
-      ? knownAlbums
-      : await libraryManager.getAlbums(artistId);
-    const names = new Set();
-    const maxAlbums = 40;
-    for (const album of albums.slice(0, maxAlbums)) {
-      const name = (album.albumName || album.title || "").trim().toLowerCase();
-      if (name) names.add(name);
-    }
-    return names;
+  async getLibraryAlbumNames(_libraryManager, artistId, _knownAlbums = null) {
+    const { albums } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
+    );
+    return new Set(
+      albums
+        .filter((album) => album.available)
+        .map((album) => String(album.albumName || album.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
   }
 
   async getMixTracks(limit, options = {}) {
-    const { libraryManager } = await import("../libraryManager.js");
     const artists = Array.isArray(options?.libraryArtists)
       ? options.libraryArtists
-      : await libraryManager.getAllArtists();
+      : [...iterateCanonicalArtistProjection({ pageSize: 100 })];
     if (artists.length === 0) {
       throw new Error("No artists in library. Add artists to enable Mix.");
     }
@@ -2050,7 +2071,7 @@ export class WeeklyFlowPlaylistSource {
           if (!artistKey || seenArtists.has(artistKey)) return null;
           try {
             const { ownedTitles, ownedAlbums } = await this._getLibraryOwnership(
-              libraryManager,
+              null,
               artist.id,
             );
             const trackList = await this._getArtistTopTrackList(artistName);
@@ -2104,15 +2125,21 @@ export class WeeklyFlowPlaylistSource {
     }
     const set = new Set();
     try {
-      const { lidarrClient } = await import("../lidarrClient.js");
-      if (lidarrClient.isConfigured()) {
-        const albums = await lidarrClient.getAllAlbums();
-        for (const album of Array.isArray(albums) ? albums : []) {
-          const mbid = String(album?.foreignAlbumId || "")
+      for (let page = 1; ; page += 1) {
+        const result = getCanonicalLibraryPage({
+          source: "all",
+          availableOnly: false,
+          kind: "albums",
+          page,
+          pageSize: 100,
+        });
+        for (const album of result.items) {
+          const mbid = String(album?.foreignAlbumId || album?.mbid || "")
             .trim()
             .toLowerCase();
           if (mbid) set.add(mbid);
         }
+        if (!result.hasMore) break;
       }
     } catch {}
     this.libraryAlbumMbidCache = {

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -506,6 +506,9 @@ async function main() {
         options.repeats,
       );
     }
+    const artistProjectionCold = measure(
+      () => queryService.getCanonicalArtistProjection({ page: 1, pageSize: 100 }),
+    );
     const artistProjectionSamples = [];
     for (let index = 0; index < options.repeats; index += 1) {
       artistProjectionSamples.push(
@@ -514,7 +517,8 @@ async function main() {
     }
     const stripProjection = ({ value: _value, ...sample }) => sample;
     pages["artist-projection"] = {
-      shape: artistProjectionSummary(artistProjectionSamples[0].value),
+      shape: artistProjectionSummary(artistProjectionCold.value),
+      cold: stripProjection(artistProjectionCold),
       warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
     };
     const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -518,7 +518,7 @@ async function main() {
     const stripProjection = ({ value: _value, ...sample }) => sample;
     pages["artist-projection"] = {
       shape: artistProjectionSummary(artistProjectionCold.value),
-      cold: stripProjection(artistProjectionCold),
+      cold: summarizeSamples([stripProjection(artistProjectionCold)]),
       warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
     };
     const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -132,6 +132,10 @@ function pageSummary(page) {
   };
 }
 
+function artistProjectionSummary(artists) {
+  return { itemCount: artists.length };
+}
+
 function seedDatabase(database, { tracks, tracksPerAlbum }) {
   const albumCount = Math.ceil(tracks / tracksPerAlbum);
   const artistCount = Math.ceil(albumCount / 10);
@@ -502,6 +506,22 @@ async function main() {
         options.repeats,
       );
     }
+    const artistProjectionSamples = [];
+    for (let index = 0; index < options.repeats; index += 1) {
+      artistProjectionSamples.push(
+        measure(() => queryService.getCanonicalArtistProjection({ page: 1, pageSize: 100 })),
+      );
+    }
+    const stripProjection = ({ value: _value, ...sample }) => sample;
+    pages["artist-projection"] = {
+      shape: artistProjectionSummary(artistProjectionSamples[0].value),
+      warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
+    };
+    const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({
+      page: 1,
+      pageSize: 100,
+    });
+    const artistProjectionPlanDetails = artistProjectionPlan.map((row) => String(row.detail || ""));
     database.close();
     database = null;
     const fullReads = {};
@@ -548,6 +568,12 @@ async function main() {
       fallbackIndexerStopsAtBulkFailure: indexerProbes.fallback.status === "completed"
         && indexerProbes.fallback.error === "bulk track-file read failed"
         && indexerProbes.fallback.maxActiveAlbums === 0,
+      artistProjectionPageBounded:
+        artistProjectionPlanDetails.some((detail) => detail.includes("MATERIALIZE artist_page"))
+        && artistProjectionPlanDetails.some((detail) =>
+          /SEARCH album USING (?:COVERING )?INDEX .*artist_id/.test(detail),
+        )
+        && !artistProjectionPlanDetails.some((detail) => detail === "SCAN album"),
       pageWarmP95Under750ms: Object.values(pageP95).every((value) => value < 750),
     };
     output = {
@@ -560,6 +586,7 @@ async function main() {
       elapsedMs: Number((performance.now() - started).toFixed(3)),
       seed: { ...seed, elapsedMs: seedElapsedMs },
       pages,
+      artistProjectionPlan,
       fullReads,
       indexer: {
         requestedAlbums: options.indexerAlbums,


### PR DESCRIPTION
Stable library journeys still read Lidarr for artist, album, and track state. Those reads fail when Lidarr is absent or unavailable, and batch consumers can rebuild the full library in memory.

This change moves Discovery, inbox generation, news, shows, Weekly Flow ownership checks, and normal artist detail and stream reads to bounded canonical SQLite projections. Explicit Lidarr synchronization, mutations, searches, downloads, and volatile status polling remain provider-backed. Successful mutations schedule one deduplicated canonical scan.

The follow-up fixes also:

- preselect each artist page before album, track, and media aggregation;
- index Lidarr artists with no albums and retain missing album-track relationships;
- preserve raw provider artist IDs while keeping canonical database IDs consistent across artist and album projections;
- query recent albums by date instead of paging all albums into memory;
- use `availableTrackCount` to exclude owned recent releases; and
- expose `_lidarrData` only when the canonical artist records Lidarr ownership.

## Retained Lidarr calls

- Explicit library synchronization and indexing reads artists, albums, root folders, tracks, and track files.
- Artist, album, and track mutations retain their Lidarr calls. This includes monitoring changes, delete operations, search commands, and download commands.
- Library access tests and request commands retain provider calls.
- Queue, command, history, and download-status polling remain unchanged for TASK-2.1.10.5.

Stable Discovery, inbox generation, news, shows, Weekly Flow ownership, artist lists, artist details, and artist streams make no Lidarr stable-read calls.

## Scope

`backend/services/libraryQueryService.js` is the unavoidable overlap with canonical projection work. It adds the artist-page CTE, raw provider-ID lookup, missing-media page support, and one date-bounded album query. It reuses the current canonical tables and projection iterators. It does not add a cache, repository layer, worker, dependency, or second library graph.

The TASK-2.1.10.2 Subsonic service, compatibility handlers, and `canonicalLibraryReadAdapter.js` are unchanged from `main`. Read-triggered inbox refresh and volatile polling remain out of scope.

## Verification

- Focused canonical regressions: 27 passed, 0 failed.
- Inbox, news, shows, and Weekly Flow tests: 214 passed, 0 failed.
- Full non-integration suite: 785 passed, 0 failed.
- `npm run lint`: passed.
- `npm run build`: passed.
- Integration suite: 53 passed, 1 unrelated failure. The Navidrome settings fixture rejected its disposable `weekly-flow` path. All Lidarr preference, add, and monitoring cases passed.
- Shared Docker Compose configuration: valid. The running Lidarr and supporting test services were healthy or running.
- Large-library benchmark: passed with 3,500 artists, 35,000 albums, and 350,000 tracks. A 100-artist projection page measured 6.105 ms median and 6.615 ms p95 with no RSS increase. SQLite materialized `artist_page` before indexed album, album-track, and media lookups.

Provider call counts: stable configured read 0, stable absent read 0, explicit artist synchronization 1 `/artist` request, bulk index scan 5 calls, and failed bulk scan 5 calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery, playlists, inbox content, news, and weekly flows now use consistent canonical library data.
  * Artist details and streaming library status remain available from the local library when external services are unavailable.
  * Artists, albums, and tracks without media files are now supported, with expanded statistics and provider identity details.
  * Library changes trigger a single reconciliation scan for pending updates.
  * Library artist and album listings now support reliable pagination and accurate totals.

* **Bug Fixes**
  * Failed external scans retain artists and mark them stale.
  * Removing artists or albums clears their external-service state.
  * Recent-release results better exclude owned albums while retaining missing releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->