### PR TITLE
perf(subsonic): bound hosted library reads

### DIFF
--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { db } from "../../backend/config/db-sqlite.js";
+import { registerAlbums } from "../../backend/routes/library/handlers/albums.js";
 import { registerTracks } from "../../backend/routes/library/handlers/tracks.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
 
@@ -126,6 +127,53 @@ test("canonical track reads remove nested filesystem paths", async () => {
     assert.deepEqual(body[0].quality, { audioFormat: "FLAC", nested: {} });
     assert.match(body[0].streamPath, /\/library\/canonical-stream\/\d+\/\d+$/);
     assert.equal(body[0].streamFormat, "flac");
+
+    await routes.get("/tracks")(
+      {
+        query: {
+          readPath: "canonical",
+          albumId: "999999999",
+          releaseGroupMbid: "72222222-2222-4222-8222-222222222222",
+        },
+      },
+      {
+        json(value) {
+          body = value;
+          return this;
+        },
+        status() {
+          return this;
+        },
+      },
+    );
+    assert.deepEqual(body.map((track) => track.title), ["Route Track"]);
+
+    registerAlbums({
+      get(routePath, ...handlers) {
+        routes.set(routePath, handlers.at(-1));
+      },
+      post() {},
+      delete() {},
+      put() {},
+    });
+    const artist = db.prepare(
+      "SELECT id, identity_key AS identityKey, mbid FROM library_artists WHERE mbid = ?",
+    ).get("71111111-1111-4111-8111-111111111111");
+    for (const artistId of [artist.id, artist.identityKey, artist.mbid]) {
+      await routes.get("/albums")(
+        { query: { readPath: "canonical", artistId } },
+        {
+          json(value) {
+            body = value;
+            return this;
+          },
+          status() {
+            return this;
+          },
+        },
+      );
+      assert.deepEqual(body.map((album) => album.title), ["Route Album"]);
+    }
   } finally {
     const track = db.prepare(
       "SELECT track_id AS trackId FROM library_media_files WHERE source = ? AND path = ?",

--- a/.tests/library/malformed-metadata-index.test.js
+++ b/.tests/library/malformed-metadata-index.test.js
@@ -51,7 +51,10 @@ test("malformed artist metadata does not break startup or indexed reference look
             identityKey: "valid:artist",
             mbid: "valid-artist-mbid",
             name: "Valid Artist",
-            metadata: { id: "valid-provider-id" },
+            metadata: {
+              id: "valid-provider-id",
+              foreignArtistId: "valid-foreign-artist-id",
+            },
           });
           const album = upsertLibraryAlbum({
             identityKey: "valid:album",
@@ -69,19 +72,28 @@ test("malformed artist metadata does not break startup or indexed reference look
             source: "aurral",
             path: "/tmp/valid-track.flac",
           });
-          const result = getCanonicalLibraryForArtistReferences({
+          const providerResult = getCanonicalLibraryForArtistReferences({
             references: ["valid-provider-id"],
           });
+          const foreignResult = getCanonicalLibraryForArtistReferences({
+            references: ["valid-foreign-artist-id"],
+          });
           const expression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)";
-          const plan = db.prepare(
+          const foreignExpression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT)";
+          const providerPlan = db.prepare(
             "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + expression + " IN (?)",
           ).all("valid-provider-id");
+          const foreignPlan = db.prepare(
+            "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + foreignExpression + " IN (?)",
+          ).all("valid-foreign-artist-id");
           process.stdout.write(JSON.stringify({
-            artistNames: result.artists.map(({ name }) => name),
-            indexSql: db.prepare(
-              "SELECT sql FROM sqlite_master WHERE name = 'idx_library_artists_provider_id'",
-            ).get().sql,
-            plan,
+            artistNames: providerResult.artists.map(({ name }) => name),
+            foreignArtistNames: foreignResult.artists.map(({ name }) => name),
+            indexes: db.prepare(
+              "SELECT name, sql FROM sqlite_master WHERE name IN ('idx_library_artists_provider_id', 'idx_library_artists_foreign_artist_id') ORDER BY name",
+            ).all(),
+            providerPlan,
+            foreignPlan,
           }));
         `,
       ],
@@ -93,9 +105,21 @@ test("malformed artist metadata does not break startup or indexed reference look
     );
     const evidence = JSON.parse(output);
     assert.deepEqual(evidence.artistNames, ["Valid Artist"]);
-    assert.match(evidence.indexSql, /json_valid\(metadata_json\)/);
+    assert.deepEqual(evidence.foreignArtistNames, ["Valid Artist"]);
+    const indexes = new Map(evidence.indexes.map(({ name, sql }) => [name, sql]));
+    assert.match(indexes.get("idx_library_artists_provider_id"), /json_valid\(metadata_json\)/);
+    assert.match(indexes.get("idx_library_artists_provider_id"), /json_extract\(metadata_json, '\$\.id'\)/);
+    assert.match(indexes.get("idx_library_artists_foreign_artist_id"), /json_valid\(metadata_json\)/);
+    assert.match(
+      indexes.get("idx_library_artists_foreign_artist_id"),
+      /json_extract\(metadata_json, '\$\.foreignArtistId'\)/,
+    );
     assert.equal(
-      evidence.plan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      evidence.providerPlan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      true,
+    );
+    assert.equal(
+      evidence.foreignPlan.some(({ detail }) => detail.includes("idx_library_artists_foreign_artist_id")),
       true,
     );
   } finally {

--- a/.tests/library/malformed-metadata-index.test.js
+++ b/.tests/library/malformed-metadata-index.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("malformed artist metadata does not break startup or indexed reference lookup", () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "aurral-malformed-metadata-"));
+  const dbPath = path.join(dataDir, "aurral.db");
+  const seedDb = new Database(dbPath);
+  seedDb.exec(`
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE library_artists (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      identity_key TEXT NOT NULL UNIQUE,
+      mbid TEXT,
+      name TEXT NOT NULL,
+      sort_name TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    INSERT INTO library_artists
+      (identity_key, name, metadata_json, created_at, updated_at)
+    VALUES ('malformed:artist', 'Malformed Artist', '{', 1, 1);
+  `);
+  seedDb.close();
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          const { db } = await import("./backend/config/db-sqlite.js");
+          const {
+            linkLibraryAlbumTrack,
+            upsertLibraryAlbum,
+            upsertLibraryArtist,
+            upsertLibraryMediaFile,
+            upsertLibraryTrack,
+          } = await import("./backend/services/libraryMediaStore.js");
+          const { getCanonicalLibraryForArtistReferences } = await import("./backend/services/libraryQueryService.js");
+          const artist = upsertLibraryArtist({
+            identityKey: "valid:artist",
+            mbid: "valid-artist-mbid",
+            name: "Valid Artist",
+            metadata: { id: "valid-provider-id" },
+          });
+          const album = upsertLibraryAlbum({
+            identityKey: "valid:album",
+            artistId: artist.id,
+            title: "Valid Album",
+          });
+          const track = upsertLibraryTrack({
+            identityKey: "valid:track",
+            title: "Valid Track",
+          });
+          linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+          upsertLibraryMediaFile({
+            trackId: track.id,
+            albumId: album.id,
+            source: "aurral",
+            path: "/tmp/valid-track.flac",
+          });
+          const result = getCanonicalLibraryForArtistReferences({
+            references: ["valid-provider-id"],
+          });
+          const expression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)";
+          const plan = db.prepare(
+            "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + expression + " IN (?)",
+          ).all("valid-provider-id");
+          process.stdout.write(JSON.stringify({
+            artistNames: result.artists.map(({ name }) => name),
+            indexSql: db.prepare(
+              "SELECT sql FROM sqlite_master WHERE name = 'idx_library_artists_provider_id'",
+            ).get().sql,
+            plan,
+          }));
+        `,
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, AURRAL_DATA_DIR: dataDir, AURRAL_DB_PATH: dbPath },
+        encoding: "utf8",
+      },
+    );
+    const evidence = JSON.parse(output);
+    assert.deepEqual(evidence.artistNames, ["Valid Artist"]);
+    assert.match(evidence.indexSql, /json_valid\(metadata_json\)/);
+    assert.equal(
+      evidence.plan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      true,
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -466,7 +466,10 @@ test("artist and album reference reads resolve through indexed entity lookups", 
       assert.equal(plan.some(({ detail }) => /SCAN library_(artists|albums)/.test(detail)), false);
       assert.equal(plan.some(({ detail }) => /INDEX/.test(detail)), true);
     }
-    const hydration = prepared.filter((sql) => sql.includes("FROM library_tracks AS track"));
+    const hydration = prepared.filter((sql) =>
+      sql.includes("track.id AS track_id") && sql.includes("FROM library_tracks AS track"),
+    );
+    assert.ok(hydration.length > 0);
     assert.equal(hydration.every((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
     for (const sql of hydration) {
       const parameterCount = (sql.match(/\?/g) || []).length;
@@ -544,10 +547,20 @@ test("album-reference reads preserve identity keys and album-specific ownership"
     assert.equal(missing?.identityKey, missingAlbum.identity_key);
     assert.equal(owned?.statistics.trackFileCount, 1);
     assert.equal(missing?.statistics.trackFileCount, 1);
-    assert.equal(
-      readModel.tracks.find((entry) => entry.albumId === missingAlbum.id)?.hasFile,
-      false,
+    assert.deepEqual(
+      readModel.tracks
+        .filter((entry) => entry.albumId === missingAlbum.id)
+        .map((entry) => entry.title),
+      ["Owned Only By Missing Album"],
     );
+    db.prepare("UPDATE library_media_files SET available = 0 WHERE path = ?").run(missingAlbumPath);
+    const available = getCanonicalLibraryReadModelForAlbumReferences({
+      source: "aurral",
+      availableOnly: true,
+      references: [missingAlbum.identity_key],
+    });
+    assert.deepEqual(available.albums, []);
+    assert.deepEqual(available.tracks, []);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(
       ownedPath,

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -11,6 +11,7 @@ import {
   getCanonicalArtistMbids,
   getCanonicalLibrary,
   getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForArtists,
   getCanonicalLibraryPage,
   getCanonicalTrack,
@@ -410,6 +411,77 @@ test("scoped canonical reads keep ownership lookups off unrelated library record
       unrelatedArtist.id,
     );
     invalidateCanonicalLibraryCache();
+  }
+});
+
+test("artist and album reference reads resolve through indexed entity lookups", (t) => {
+  const key = `query-plan-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}:artist-mbid`,
+    name: "Query Plan Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}:album-mbid`,
+    releaseGroupMbid: `${key}:release-group`,
+    artistId: artist.id,
+    title: "Query Plan Album",
+  });
+  const track = upsertLibraryTrack({ identityKey: `${key}:track`, title: "Plan Track" });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: `/tmp/${key}.flac`,
+  });
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  try {
+    assert.deepEqual(
+      getCanonicalLibraryForArtistReferences({ references: [artist.mbid] }).artists.map(({ id }) => id),
+      [artist.id],
+    );
+    assert.deepEqual(
+      getCanonicalLibraryForAlbumReferences({ references: [album.release_group_mbid] }).albums.map(({ id }) => id),
+      [album.id],
+    );
+    spy.mock.restore();
+
+    const lookups = prepared.filter((sql) =>
+      /^SELECT id FROM library_(artists|albums)/.test(sql.trim()),
+    );
+    assert.equal(lookups.length, 2);
+    for (const sql of lookups) {
+      const parameterCount = (sql.match(/\?/g) || []).length;
+      const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(
+        ...Array.from({ length: parameterCount }, () => `${key}:missing`),
+      );
+      assert.equal(plan.some(({ detail }) => /SCAN library_(artists|albums)/.test(detail)), false);
+      assert.equal(plan.some(({ detail }) => /INDEX/.test(detail)), true);
+    }
+    const hydration = prepared.filter((sql) => sql.includes("FROM library_tracks AS track"));
+    assert.equal(hydration.every((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+    for (const sql of hydration) {
+      const parameterCount = (sql.match(/\?/g) || []).length;
+      const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(
+        ...Array.from({ length: parameterCount }, () => artist.id),
+      );
+      assert.equal(plan.some(({ detail }) => /SCAN (album|album_track)/.test(detail)), false);
+    }
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE track_id = ?").run(track.id);
+    db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(track.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
   }
 });
 

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -420,6 +420,10 @@ test("artist and album reference reads resolve through indexed entity lookups", 
     identityKey: `${key}:artist`,
     mbid: `${key}:artist-mbid`,
     name: "Query Plan Artist",
+    metadata: {
+      id: `${key}:provider-id`,
+      foreignArtistId: `${key}:foreign-artist-id`,
+    },
   });
   const album = upsertLibraryAlbum({
     identityKey: `${key}:album`,
@@ -445,7 +449,14 @@ test("artist and album reference reads resolve through indexed entity lookups", 
 
   try {
     assert.deepEqual(
-      getCanonicalLibraryForArtistReferences({ references: [artist.mbid] }).artists.map(({ id }) => id),
+      getCanonicalLibraryForArtistReferences({
+        references: [
+          artist.mbid,
+          `${key}:provider-id`,
+          `${key}:foreign-artist-id`,
+          "QUERY PLAN ARTIST",
+        ],
+      }).artists.map(({ id }) => id),
       [artist.id],
     );
     assert.deepEqual(

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -1,26 +1,76 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFile } from "node:fs/promises";
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
 
-const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const [isolatedState, { db }, subsonic, libraryStore] = await setupIsolatedBackend(
+  "subsonic-bounded-reads",
+  "backend/config/db-sqlite.js",
+  "backend/services/subsonicLibraryService.js",
+  "backend/services/libraryMediaStore.js",
+);
 
-test("hosted Subsonic single and paged reads do not use the complete-library helper", async () => {
-  const source = await read("../../backend/services/subsonicLibraryService.js");
-
-  assert.doesNotMatch(source, /\bfunction readLibrary\b/);
-  assert.doesNotMatch(source, /\bconst indexLibrary\b/);
-  assert.doesNotMatch(source, /getCanonicalLibrary\(\{\s*availableOnly:\s*false/);
+test.before(() => {
+  resetDatabase(db);
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: "bounded:artist",
+    mbid: "bounded-artist-mbid",
+    name: "Bounded Artist",
+    metadata: { genres: ["Rock"] },
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: "bounded:album",
+    mbid: "bounded-album-mbid",
+    releaseGroupMbid: "bounded-release-group",
+    artistId: artist.id,
+    title: "Bounded Album",
+    metadata: { genres: ["Rock"] },
+  });
+  const track = libraryStore.upsertLibraryTrack({
+    identityKey: "bounded:track",
+    title: "Bounded Track",
+    artistName: artist.name,
+    metadata: { genres: ["Rock"] },
+  });
+  libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  libraryStore.upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: "/tmp/bounded-track.flac",
+  });
 });
 
-test("legacy canonical compatibility reads select focused adapters", async () => {
-  const sources = await Promise.all([
-    read("../../backend/routes/library/handlers/artists.js"),
-    read("../../backend/routes/library/handlers/albums.js"),
-    read("../../backend/routes/library/handlers/tracks.js"),
-  ]);
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
 
-  for (const source of sources) {
-    assert.doesNotMatch(source, /getCanonicalLibraryReadModel\(/);
-    assert.doesNotMatch(source, /\bgetCanonicalLibrary\(/);
-  }
+test("focused Subsonic requests never execute an unfiltered complete-library query", (t) => {
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  db.prepare("UPDATE library_tracks SET metadata_json = '{' WHERE identity_key = ?")
+    .run("bounded:track");
+
+  assert.ok(subsonic.listArtists().length);
+  assert.ok(subsonic.getArtist(`artist:${encodeURIComponent("bounded:artist")}`));
+  assert.ok(subsonic.getAlbum(`album:${encodeURIComponent("bounded:album")}`));
+  assert.ok(subsonic.searchLibrary("Bounded", { songCount: 1 }).song.length);
+  assert.ok(subsonic.getAlbumList({ size: 1 }).length);
+  assert.ok(subsonic.getSongsByGenre("Rock", { count: 1 }).length);
+  assert.deepEqual(subsonic.getGenres(), [{ albumCount: 1, songCount: 1, value: "Rock" }]);
+
+  const completeQueries = prepared.filter((sql) =>
+    sql.includes("FROM library_tracks AS track")
+      && sql.includes("LEFT JOIN library_media_files AS media")
+      && !/\bWHERE\b/.test(sql),
+  );
+  assert.deepEqual(completeQueries, []);
+  assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
 });

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("hosted Subsonic single and paged reads do not use the complete-library helper", async () => {
+  const source = await read("../../backend/services/subsonicLibraryService.js");
+
+  assert.doesNotMatch(source, /\bfunction readLibrary\b/);
+  assert.doesNotMatch(source, /\bconst indexLibrary\b/);
+  assert.doesNotMatch(source, /getCanonicalLibrary\(\{\s*availableOnly:\s*false/);
+});
+
+test("legacy canonical compatibility reads select focused adapters", async () => {
+  const sources = await Promise.all([
+    read("../../backend/routes/library/handlers/artists.js"),
+    read("../../backend/routes/library/handlers/albums.js"),
+    read("../../backend/routes/library/handlers/tracks.js"),
+  ]);
+
+  for (const source of sources) {
+    assert.doesNotMatch(source, /getCanonicalLibraryReadModel\(/);
+    assert.doesNotMatch(source, /\bgetCanonicalLibrary\(/);
+  }
+});

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -72,7 +72,11 @@ test("focused Subsonic requests never execute an unfiltered complete-library que
       && !/\bWHERE\b/.test(sql),
   );
   assert.deepEqual(completeQueries, []);
-  assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+  const hydration = prepared.filter((sql) =>
+    sql.includes("track.id AS track_id") && sql.includes("FROM library_tracks AS track"),
+  );
+  assert.ok(hydration.length > 0);
+  assert.equal(hydration.every((sql) => /WHERE (artist|album|track)\.id IN/.test(sql)), true);
   const artistIndexQuery = prepared.find((sql) =>
     sql.includes("COUNT(DISTINCT album.id) AS album_count")
       && sql.includes("FROM library_artists AS artist"),

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -73,4 +73,10 @@ test("focused Subsonic requests never execute an unfiltered complete-library que
   );
   assert.deepEqual(completeQueries, []);
   assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+  const artistIndexQuery = prepared.find((sql) =>
+    sql.includes("COUNT(DISTINCT album.id) AS album_count")
+      && sql.includes("FROM library_artists AS artist"),
+  );
+  assert.ok(artistIndexQuery);
+  assert.doesNotMatch(artistIndexQuery, /library_(album_tracks|media_files)/);
 });

--- a/.tests/subsonic/subsonic-library.test.js
+++ b/.tests/subsonic/subsonic-library.test.js
@@ -7,13 +7,15 @@ import {
   setupIsolatedBackend,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { getAlbumList, getTopSongs }, libraryStore] =
+const [isolatedState, { db }, subsonic, libraryStore] =
   await setupIsolatedBackend(
     "subsonic-library",
     "backend/config/db-sqlite.js",
     "backend/services/subsonicLibraryService.js",
     "backend/services/libraryMediaStore.js",
   );
+
+const { getAlbumList, getTopSongs, starMany } = subsonic;
 
 const {
   linkLibraryAlbumTrack,
@@ -46,6 +48,18 @@ function addAlbum({ artist, title, releaseDate, trackTitle }) {
   });
 }
 
+test("starMany validates duplicate and equivalent encoded canonical targets", () => {
+  const user = db.prepare(
+    "INSERT INTO users (username, password_hash, role, permissions) VALUES (?, '', 'user', '{}') RETURNING id",
+  ).get("subsonic-star-many");
+  const key = "test-track:Old Song";
+  const encoded = `song:${encodeURIComponent(key)}`;
+  const alternate = encoded.replaceAll("%3A", "%3a");
+  assert.equal(starMany(user, [encoded, encoded]), true);
+  assert.equal(starMany(user, [encoded, alternate]), true);
+  assert.equal(starMany(user, [encoded, "song:missing"]), false);
+});
+
 test.before(() => {
   resetDatabase(db);
   const artistA = upsertLibraryArtist({
@@ -74,20 +88,28 @@ test.before(() => {
     releaseDate: "2022-01-01",
     trackTitle: "Other Artist Song",
   });
+  db.prepare(
+    `UPDATE library_media_files
+     SET created_at = CASE
+       WHEN path LIKE '%Old Album%' THEN 300
+       WHEN path LIKE '%New Album%' THEN 200
+       ELSE 100
+     END`,
+  ).run();
 });
 
 test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("orders newest albums before applying pagination", () => {
+test("orders newest albums by media arrival before applying pagination", () => {
   assert.deepEqual(
     getAlbumList({ type: "newest", size: 1 }).map((album) => album.title),
-    ["New Album"],
+    ["Old Album"],
   );
   assert.deepEqual(
     getAlbumList({ type: "newest", size: 1, offset: 1 }).map((album) => album.title),
-    ["Artist A Collection"],
+    ["New Album"],
   );
   assert.deepEqual(
     getAlbumList({ type: "byYear", fromYear: 2024, toYear: 2010 }).map((album) => album.title),
@@ -99,4 +121,8 @@ test("returns top songs only for the requested artist", () => {
   const songs = getTopSongs("Artist A", { count: 10 });
   assert.deepEqual(songs.map((song) => song.title), ["New Song", "Old Song"]);
   assert.equal(songs.every((song) => song.artist === "Artist A"), true);
+  assert.deepEqual(
+    getTopSongs("  test-artist:artist-a  ", { count: 10 }).map((song) => song.title),
+    ["New Song", "Old Song"],
+  );
 });

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -284,6 +284,12 @@ db.exec(`
     ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
     ON library_artists (mbid);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
   CREATE INDEX IF NOT EXISTS idx_library_tracks_title
@@ -452,6 +458,12 @@ if (hasUniqueIndex(["path"])) {
 }
 
 db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available
     ON library_media_files (album_id, source, available);
 `);

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -272,12 +272,18 @@ db.exec(`
     ON lidarr_artist_id_map (lidarr_foreign_artist_id);
   CREATE INDEX IF NOT EXISTS idx_library_albums_artist_id
     ON library_albums (artist_id);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_mbid
+    ON library_albums (mbid);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_release_group_mbid
+    ON library_albums (release_group_mbid);
   CREATE INDEX IF NOT EXISTS idx_library_albums_title
     ON library_albums (title COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_albums_release_date
     ON library_albums (release_date DESC);
   CREATE INDEX IF NOT EXISTS idx_library_artists_sort_name_name
     ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
+    ON library_artists (mbid);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
   CREATE INDEX IF NOT EXISTS idx_library_tracks_title

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -285,9 +285,9 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
     ON library_artists (mbid);
   CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_name
     ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
@@ -459,9 +459,9 @@ if (hasUniqueIndex(["path"])) {
 
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_name
     ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -9,7 +9,6 @@ import {
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
 import {
-  findCanonicalAlbumsForArtist,
   getCanonicalLibraryReadModelForArtistReferences,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 
@@ -27,7 +26,7 @@ export function registerAlbums(router) {
           availableOnly: true,
           references: [artistId],
         });
-        return res.json(findCanonicalAlbumsForArtist(albums, artistId));
+        return res.json(albums);
       }
 
       const albums = await libraryManager.getAlbums(artistId);

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -10,7 +10,7 @@ import {
 import { logger } from "../../../services/logger.js";
 import {
   findCanonicalAlbumsForArtist,
-  getCanonicalLibraryReadModel,
+  getCanonicalLibraryReadModelForArtistReferences,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 
 export function registerAlbums(router) {
@@ -22,7 +22,11 @@ export function registerAlbums(router) {
       }
 
       if (req.query.readPath === "canonical") {
-        const { albums } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
+        const { albums } = getCanonicalLibraryReadModelForArtistReferences({
+          source: req.query.source || "all",
+          availableOnly: true,
+          references: [artistId],
+        });
         return res.json(findCanonicalAlbumsForArtist(albums, artistId));
       }
 

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -6,15 +6,19 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
-import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalLibraryReadModelForArtistPage } from "../../../services/canonicalLibraryReadAdapter.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
       if (req.query.readPath === "canonical") {
-        const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
         const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
         const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
-        return res.json(artists.slice(offset, offset + limit).map((artist) => ({
+        const { artists } = getCanonicalLibraryReadModelForArtistPage({
+          source: req.query.source || "all",
+          limit,
+          offset,
+        });
+        return res.json(artists.map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -95,7 +95,7 @@ export function registerTracks(router) {
       const { albumId, releaseGroupMbid } = req.query;
 
       if (req.query.readPath === "canonical") {
-        const canonical = albumId
+        let canonical = albumId
           ? getCanonicalLibraryReadModelForAlbumIds({
               source: req.query.source || "all",
               availableOnly: true,
@@ -106,6 +106,13 @@ export function registerTracks(router) {
               availableOnly: true,
               references: releaseGroupMbid ? [releaseGroupMbid] : [],
             });
+        if (albumId && canonical.albums.length === 0 && releaseGroupMbid) {
+          canonical = getCanonicalLibraryReadModelForAlbumReferences({
+            source: req.query.source || "all",
+            availableOnly: true,
+            references: [releaseGroupMbid],
+          });
+        }
         const { albums, tracks } = canonical;
         const album = [albumId, releaseGroupMbid]
           .filter(Boolean)

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -9,11 +9,11 @@ import fsp from "fs/promises";
 import path from "path";
 import { logger } from "../../../services/logger.js";
 import {
-  buildCanonicalLibraryReadModel,
   findCanonicalTracksForAlbum,
+  getCanonicalLibraryReadModelForAlbumIds,
+  getCanonicalLibraryReadModelForAlbumReferences,
   resolveCanonicalTrackPath,
 } from "../../../services/canonicalLibraryReadAdapter.js";
-import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 import { stripFilesystemPaths } from "./canonical.js";
 import { streamAudioFile } from "../../../services/audioFileStream.js";
 
@@ -95,11 +95,18 @@ export function registerTracks(router) {
       const { albumId, releaseGroupMbid } = req.query;
 
       if (req.query.readPath === "canonical") {
-        const canonicalLibrary = getCanonicalLibrary({
-          source: req.query.source || "all",
-          availableOnly: true,
-        });
-        const { albums, tracks } = buildCanonicalLibraryReadModel(canonicalLibrary);
+        const canonical = albumId
+          ? getCanonicalLibraryReadModelForAlbumIds({
+              source: req.query.source || "all",
+              availableOnly: true,
+              ids: [albumId],
+            })
+          : getCanonicalLibraryReadModelForAlbumReferences({
+              source: req.query.source || "all",
+              availableOnly: true,
+              references: releaseGroupMbid ? [releaseGroupMbid] : [],
+            });
+        const { albums, tracks } = canonical;
         const album = [albumId, releaseGroupMbid]
           .filter(Boolean)
           .map((reference) =>

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -1,11 +1,11 @@
 import {
-  getCanonicalLibrary,
+  getCanonicalArtistPage,
+  getCanonicalLibraryForAlbumIds,
   getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForArtists,
   getCanonicalTrackPath,
 } from "./libraryQueryService.js";
-
-const readModelCache = new WeakMap();
 
 const albumFiles = (track, albumId) =>
   (track.files || []).filter((file) => file.albumId == null || file.albumId === albumId);
@@ -30,8 +30,13 @@ const recordMatches = (record, reference) => {
 
 const buildArtist = (artist, albumsByArtistId) => {
   const artistAlbums = albumsByArtistId.get(artist.id) || [];
-  const trackCount = artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
-  const sizeOnDisk = artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
+  const hasSummary = artist.albumCount !== undefined;
+  const trackCount = hasSummary
+    ? Number(artist.trackCount || 0)
+    : artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
+  const sizeOnDisk = hasSummary
+    ? Number(artist.sizeOnDisk || 0)
+    : artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
   const providerId = artist.metadata?.id ?? null;
   return {
     id: artist.id,
@@ -51,7 +56,7 @@ const buildArtist = (artist, albumsByArtistId) => {
       "none",
     addOptions: artist.metadata?.addOptions || null,
     statistics: {
-      albumCount: artistAlbums.length,
+      albumCount: hasSummary ? Number(artist.albumCount || 0) : artistAlbums.length,
       trackCount,
       sizeOnDisk,
     },
@@ -147,13 +152,18 @@ export function buildCanonicalLibraryReadModel(library) {
   return { artists: readArtists, albums: readAlbums, tracks: readTracks };
 }
 
-export function getCanonicalLibraryReadModel({ source = "lidarr", availableOnly = true } = {}) {
-  const library = getCanonicalLibrary({ source, availableOnly });
-  const cached = readModelCache.get(library);
-  if (cached) return cached;
-  const readModel = buildCanonicalLibraryReadModel(library);
-  readModelCache.set(library, readModel);
-  return readModel;
+export function getCanonicalLibraryReadModelForArtistPage({
+  source = "lidarr",
+  availableOnly = true,
+  limit = 10000,
+  offset = 0,
+} = {}) {
+  const library = getCanonicalArtistPage({ source, availableOnly, limit, offset, includeStats: true });
+  return {
+    artists: library.artists.map((artist) => buildArtist(artist, new Map())),
+    albums: [],
+    tracks: [],
+  };
 }
 
 export function getCanonicalLibraryReadModelForArtists({
@@ -163,6 +173,26 @@ export function getCanonicalLibraryReadModelForArtists({
 } = {}) {
   return buildCanonicalLibraryReadModel(
     getCanonicalLibraryForArtists({ source, availableOnly, mbids }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForArtistReferences({
+  source = "all",
+  availableOnly = false,
+  references = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({ source, availableOnly, references }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForAlbumIds({
+  source = "lidarr",
+  availableOnly = true,
+  ids = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForAlbumIds({ source, availableOnly, ids }),
   );
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -770,6 +770,20 @@ export function getCanonicalArtistPage({
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
 
   if (!includeStats) {
+    const filterAlbums = Boolean(sourceFilter) || availableOnly === true;
+    const albumJoin = filterAlbums ? "JOIN" : "LEFT JOIN";
+    const albumFilter = filterAlbums
+      ? `AND EXISTS (
+          SELECT 1
+          FROM library_album_tracks AS album_track
+          JOIN library_media_files AS media
+            ON media.track_id = album_track.track_id
+            AND ${albumMediaCondition("media", "album_track")}
+          WHERE album_track.album_id = album.id
+            ${sourceFilter ? "AND media.source = ?" : ""}
+            ${availableOnly === true ? "AND media.available = 1" : ""}
+        )`
+      : "";
     const rows = db.prepare(
       `SELECT
          artist.id AS artist_id,
@@ -780,18 +794,9 @@ export function getCanonicalArtistPage({
          artist.metadata_json AS artist_metadata_json,
          COUNT(DISTINCT album.id) AS album_count
        FROM library_artists AS artist
-       JOIN library_albums AS album ON album.artist_id = artist.id
+       ${albumJoin} library_albums AS album ON album.artist_id = artist.id
        WHERE artist.id IN (${ids.map(() => "?").join(",")})
-         AND EXISTS (
-           SELECT 1
-           FROM library_album_tracks AS album_track
-           JOIN library_media_files AS media
-             ON media.track_id = album_track.track_id
-             AND ${albumMediaCondition("media", "album_track")}
-           WHERE album_track.album_id = album.id
-             ${sourceFilter ? "AND media.source = ?" : ""}
-             ${availableOnly === true ? "AND media.available = 1" : ""}
-         )
+         ${albumFilter}
        GROUP BY artist.id`,
     ).all(...ids, ...(sourceFilter ? [sourceFilter] : []));
     const byId = new Map(rows.map((row) => [row.artist_id, {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -443,6 +443,25 @@ function getCanonicalLibraryForIds(kind, ids, source, availableOnly) {
   });
 }
 
+function resolveCanonicalReferenceIds(table, references, columns) {
+  const numericIds = references
+    .filter((reference) => /^\d+$/.test(reference))
+    .map(Number);
+  const queries = [];
+  const parameters = [];
+  if (numericIds.length) {
+    queries.push(`SELECT id FROM ${table} WHERE id IN (${numericIds.map(() => "?").join(",")})`);
+    parameters.push(...numericIds);
+  }
+  for (const column of columns) {
+    queries.push(
+      `SELECT id FROM ${table} WHERE ${column} IN (${references.map(() => "?").join(",")})`,
+    );
+    parameters.push(...references);
+  }
+  return db.prepare(queries.join(" UNION ")).all(...parameters).map((row) => row.id);
+}
+
 export function getCanonicalLibraryForArtistReferences({
   source = null,
   availableOnly = false,
@@ -450,23 +469,12 @@ export function getCanonicalLibraryForArtistReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-  const conditions = [];
-  const parameters = [];
-  for (const reference of references) {
-    if (/^\d+$/.test(reference)) {
-      conditions.push("artist.id = ?");
-      parameters.push(Number(reference));
-    } else {
-      conditions.push("(artist.identity_key = ? OR artist.mbid = ?)");
-      parameters.push(reference, reference);
-    }
-  }
-  return getScopedCanonicalLibrary({
-    source,
-    availableOnly,
-    conditions: [`(${conditions.join(" OR ")})`],
-    parameters,
-  });
+  const ids = resolveCanonicalReferenceIds(
+    "library_artists",
+    references,
+    ["identity_key", "mbid"],
+  );
+  return getCanonicalLibraryForIds("artists", ids, source, availableOnly);
 }
 
 export function getCanonicalLibraryForAlbumIds({
@@ -503,56 +511,34 @@ export function getCanonicalLibraryForAlbumReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-
+  const ids = resolveCanonicalReferenceIds(
+    "library_albums",
+    references,
+    ["identity_key", "mbid", "release_group_mbid"],
+  );
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
   const sourceFilter = normalizeSource(source);
-  const referenceCondition = `(
-    album.mbid IN (${references.map(() => "?").join(",")}) OR
-    album.release_group_mbid IN (${references.map(() => "?").join(",")}) OR
-    album.identity_key IN (${references.map(() => "?").join(",")})
-  )`;
-  const albumParameters = [];
   const mediaConditions = [
     "media.track_id = album_track.track_id",
     albumMediaCondition("media", "album_track"),
   ];
+  const parameters = [];
   if (sourceFilter) {
     mediaConditions.push("media.source = ?");
-    albumParameters.push(sourceFilter);
+    parameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
-  albumParameters.push(...references, ...references, ...references);
-
-  const albumIds = db.prepare(
-    `SELECT DISTINCT album.id AS id
-     FROM library_albums AS album
-     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
-     WHERE ${referenceCondition}`,
-  ).all(...albumParameters).map((row) => row.id);
-  if (!albumIds.length) return { artists: [], albums: [], tracks: [] };
-
-  const trackMediaConditions = [
-    "media.track_id = album_track.track_id",
-    albumMediaCondition("media", "album_track"),
-  ];
-  const trackParameters = [];
-  if (sourceFilter) {
-    trackMediaConditions.push("media.source = ?");
-    trackParameters.push(sourceFilter);
-  }
-  if (availableOnly === true) trackMediaConditions.push("media.available = 1");
-  trackParameters.push(...albumIds);
-
+  parameters.push(...ids);
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
-     LEFT JOIN library_media_files AS media ON ${trackMediaConditions.join(" AND ")}
-     WHERE album.id IN (${albumIds.map(() => "?").join(",")})
+     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE album.id IN (${ids.map(() => "?").join(",")})
      ${canonicalOrder}`,
-  ).iterate(...trackParameters);
+  ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 
@@ -734,10 +720,10 @@ const genrePredicate = (aliases, genre) => {
   aliases.forEach((alias) => {
     GENRE_METADATA_PATHS.forEach((path) => {
       clauses.push(
-        `EXISTS (
-          SELECT 1 FROM json_each(COALESCE(${alias}.metadata_json, '{}'), '${path}') AS genre_value
+        `(json_valid(${alias}.metadata_json) AND EXISTS (
+          SELECT 1 FROM json_each(${alias}.metadata_json, '${path}') AS genre_value
           WHERE lower(CAST(genre_value.value AS TEXT)) = lower(?)
-        )`,
+        ))`,
       );
       parameters.push(genre);
     });
@@ -942,7 +928,7 @@ export function getCanonicalAlbumPage({
   if (type === "random") {
     orderBy = "random()";
   } else if (type === "newest" || type === "recent") {
-    orderBy = "CASE WHEN album.release_date GLOB '[0-9][0-9][0-9][0-9]*' THEN album.release_date END DESC, album.title COLLATE NOCASE";
+    orderBy = recentMediaOrder("albums", sourceFilter, availableOnly, "asc");
   } else if (type === "alphabeticalByArtist") {
     orderBy = "coalesce(album.album_artist, artist.name) COLLATE NOCASE, album.title COLLATE NOCASE";
   } else if (type === "byYear") {
@@ -1000,10 +986,11 @@ export function getCanonicalTrackPage({
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
     parameters.push(...fields.map(() => pattern));
   }
-  const normalizedArtist = text(artist).toLocaleLowerCase();
+  const artistReference = text(artist);
+  const normalizedArtist = artistReference.toLocaleLowerCase();
   if (normalizedArtist) {
     conditions.push("(lower(artist.name) = ? OR lower(coalesce(track.artist_name, '')) = ? OR artist.identity_key = ?)");
-    parameters.push(normalizedArtist, normalizedArtist, artist);
+    parameters.push(normalizedArtist, normalizedArtist, artistReference);
   }
   if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
     conditions.push("artist.id = ?");
@@ -1094,51 +1081,72 @@ export function getCanonicalGenres({ source = null, availableOnly = false } = {}
     parameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
-  const albums = new Map();
-  for (const row of db.prepare(
-    `SELECT
-       album.id AS album_id,
-       track.id AS track_id,
-       artist.metadata_json AS artist_metadata_json,
-       album.metadata_json AS album_metadata_json,
-       track.metadata_json AS track_metadata_json
-     FROM library_albums AS album
-     JOIN library_artists AS artist ON artist.id = album.artist_id
-     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_tracks AS track ON track.id = album_track.track_id
-     WHERE EXISTS (
-       SELECT 1
-       FROM library_media_files AS media
-       WHERE ${mediaConditions.join(" AND ")}
+  const genreRows = (column) => GENRE_METADATA_PATHS.map((path) => `
+    SELECT album_id, track_id, TRIM(CAST(genre_value.value AS TEXT)) AS genre
+    FROM eligible_tracks
+    JOIN json_each(
+      CASE WHEN json_valid(${column}) THEN ${column} ELSE '{}' END,
+      '${path}'
+    ) AS genre_value
+    WHERE json_valid(${column})
+      AND TRIM(CAST(genre_value.value AS TEXT)) <> ''`).join(" UNION ");
+  return db.prepare(
+    `WITH eligible_tracks AS MATERIALIZED (
+       SELECT DISTINCT
+         album.id AS album_id,
+         track.id AS track_id,
+         artist.metadata_json AS artist_metadata_json,
+         album.metadata_json AS album_metadata_json,
+         track.metadata_json AS track_metadata_json
+       FROM library_albums AS album
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+       JOIN library_tracks AS track ON track.id = album_track.track_id
+       WHERE EXISTS (
+         SELECT 1
+         FROM library_media_files AS media
+         WHERE ${mediaConditions.join(" AND ")}
+       )
+     ),
+     direct_genres AS (
+       SELECT DISTINCT album_id, genre FROM (
+         ${genreRows("artist_metadata_json")}
+         UNION
+         ${genreRows("album_metadata_json")}
+       )
+     ),
+     track_genres AS (
+       SELECT DISTINCT album_id, track_id, genre FROM (
+         ${genreRows("track_metadata_json")}
+       )
+     ),
+     track_counts AS (
+       SELECT album_id, COUNT(*) AS song_count
+       FROM eligible_tracks
+       GROUP BY album_id
+     ),
+     album_genres AS (
+       SELECT direct.album_id, direct.genre, tracks.song_count
+       FROM direct_genres AS direct
+       JOIN track_counts AS tracks ON tracks.album_id = direct.album_id
+       UNION ALL
+       SELECT track.album_id, track.genre, COUNT(*) AS song_count
+       FROM track_genres AS track
+       WHERE NOT EXISTS (
+         SELECT 1 FROM direct_genres AS direct
+         WHERE direct.album_id = track.album_id AND direct.genre = track.genre
+       )
+       GROUP BY track.album_id, track.genre
      )
-     GROUP BY album.id, track.id`,
-  ).iterate(...parameters)) {
-    const album = albums.get(row.album_id) || {
-      artistGenres: metadataGenres({ metadata: parseJson(row.artist_metadata_json) }),
-      albumGenres: metadataGenres({ metadata: parseJson(row.album_metadata_json) }),
-      tracks: new Map(),
-    };
-    album.tracks.set(row.track_id, metadataGenres({ metadata: parseJson(row.track_metadata_json) }));
-    albums.set(row.album_id, album);
-  }
-  const genres = new Map();
-  for (const album of albums.values()) {
-    const trackCount = album.tracks.size;
-    const albumGenres = new Set([
-      ...album.artistGenres,
-      ...album.albumGenres,
-      ...[...album.tracks.values()].flat(),
-    ]);
-    for (const name of albumGenres) {
-      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
-      value.albumCount += 1;
-      value.songCount += album.artistGenres.includes(name) || album.albumGenres.includes(name)
-        ? trackCount
-        : [...album.tracks.values()].filter((trackGenres) => trackGenres.includes(name)).length;
-      genres.set(name, value);
-    }
-  }
-  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+     SELECT genre AS value, COUNT(*) AS albumCount, SUM(song_count) AS songCount
+     FROM album_genres
+     GROUP BY genre
+     ORDER BY genre COLLATE NOCASE`,
+  ).all(...parameters).map((row) => ({
+    albumCount: Number(row.albumCount || 0),
+    songCount: Number(row.songCount || 0),
+    value: row.value,
+  }));
 }
 
 function buildPageQuery({

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -429,6 +429,73 @@ export function getCanonicalLibraryForArtists({
   });
 }
 
+function getCanonicalLibraryForIds(kind, ids, source, availableOnly) {
+  const values = [...new Set((Array.isArray(ids) ? ids : [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0))];
+  if (!values.length) return { artists: [], albums: [], tracks: [] };
+  const alias = kind === "artists" ? "artist" : kind === "albums" ? "album" : "track";
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`${alias}.id IN (${values.map(() => "?").join(",")})`],
+    parameters: values,
+  });
+}
+
+export function getCanonicalLibraryForArtistReferences({
+  source = null,
+  availableOnly = false,
+  references: requestedReferences = [],
+} = {}) {
+  const references = normalizeLookupValues(requestedReferences);
+  if (!references.length) return { artists: [], albums: [], tracks: [] };
+  const conditions = [];
+  const parameters = [];
+  for (const reference of references) {
+    if (/^\d+$/.test(reference)) {
+      conditions.push("artist.id = ?");
+      parameters.push(Number(reference));
+    } else {
+      conditions.push("(artist.identity_key = ? OR artist.mbid = ?)");
+      parameters.push(reference, reference);
+    }
+  }
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`(${conditions.join(" OR ")})`],
+    parameters,
+  });
+}
+
+export function getCanonicalLibraryForAlbumIds({
+  source = null,
+  availableOnly = false,
+  ids = [],
+} = {}) {
+  return getCanonicalLibraryForIds("albums", ids, source, availableOnly);
+}
+
+export function getCanonicalLibraryForTrackIds({
+  source = null,
+  availableOnly = false,
+  ids = [],
+  albumId = null,
+} = {}) {
+  const values = [...new Set((Array.isArray(ids) ? ids : [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0))];
+  if (!values.length) return { artists: [], albums: [], tracks: [] };
+  const conditions = [`track.id IN (${values.map(() => "?").join(",")})`];
+  const parameters = [...values];
+  if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
+    conditions.push("album.id = ?");
+    parameters.push(Number(albumId));
+  }
+  return getScopedCanonicalLibrary({ source, availableOnly, conditions, parameters });
+}
+
 export function getCanonicalLibraryForAlbumReferences({
   source = null,
   availableOnly = false,
@@ -677,6 +744,402 @@ const genrePredicate = (aliases, genre) => {
   });
   return { sql: `(${clauses.join(" OR ")})`, parameters };
 };
+
+const pageLimit = (value, fallback = 10000) => {
+  if (value === null || value === undefined || value === "") return fallback;
+  return Math.min(10000, Math.max(0, Number.parseInt(value, 10) || 0));
+};
+
+const pageOffset = (value) => Math.max(0, Number.parseInt(value, 10) || 0);
+
+export function getCanonicalArtistPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  offset = 0,
+  limit = null,
+  includeStats = false,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("artists", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    conditions.push("lower(artist.name) LIKE ? ESCAPE '\\'");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`);
+  }
+  const boundedLimit = limit === null || limit === undefined || limit === ""
+    ? null
+    : pageLimit(limit);
+  const pageSql = boundedLimit === null ? "" : "LIMIT ? OFFSET ?";
+  const ids = db.prepare(
+    `SELECT artist.id
+     FROM library_artists AS artist
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
+       artist.name COLLATE NOCASE
+     ${pageSql}`,
+  ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
+
+  if (!includeStats) {
+    const rows = db.prepare(
+      `SELECT
+         artist.id AS artist_id,
+         artist.identity_key AS artist_identity_key,
+         artist.mbid AS artist_mbid,
+         artist.name AS artist_name,
+         artist.sort_name AS artist_sort_name,
+         artist.metadata_json AS artist_metadata_json,
+         COUNT(DISTINCT album.id) AS album_count
+       FROM library_artists AS artist
+       JOIN library_albums AS album ON album.artist_id = artist.id
+       WHERE artist.id IN (${ids.map(() => "?").join(",")})
+         AND EXISTS (
+           SELECT 1
+           FROM library_album_tracks AS album_track
+           JOIN library_media_files AS media
+             ON media.track_id = album_track.track_id
+             AND ${albumMediaCondition("media", "album_track")}
+           WHERE album_track.album_id = album.id
+             ${sourceFilter ? "AND media.source = ?" : ""}
+             ${availableOnly === true ? "AND media.available = 1" : ""}
+         )
+       GROUP BY artist.id`,
+    ).all(...ids, ...(sourceFilter ? [sourceFilter] : []));
+    const byId = new Map(rows.map((row) => [row.artist_id, {
+      id: row.artist_id,
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata: parseJson(row.artist_metadata_json),
+      albumIds: [],
+      albumCount: Number(row.album_count || 0),
+      sources: [],
+      available: availableOnly === true,
+    }]));
+    return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
+  }
+
+  const aggregateParameters = [];
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    aggregateParameters.push(sourceFilter);
+  }
+  if (availableOnly === true) mediaConditions.push("media.available = 1");
+  aggregateParameters.push(...ids);
+  const rows = db.prepare(
+    `SELECT
+       artist.id AS artist_id,
+       artist.identity_key AS artist_identity_key,
+       artist.mbid AS artist_mbid,
+       artist.name AS artist_name,
+       artist.sort_name AS artist_sort_name,
+       artist.metadata_json AS artist_metadata_json,
+       COUNT(DISTINCT album.id) AS album_count,
+       COUNT(DISTINCT album_track.track_id) AS track_count,
+       COALESCE(SUM(media.size), 0) AS size_on_disk,
+       MAX(media.available) AS available
+     FROM library_artists AS artist
+     JOIN library_albums AS album ON album.artist_id = artist.id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE artist.id IN (${ids.map(() => "?").join(",")})
+     GROUP BY artist.id
+     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
+       artist.name COLLATE NOCASE`,
+  ).all(...aggregateParameters);
+  const byId = new Map(rows.map((row) => [row.artist_id, {
+    id: row.artist_id,
+    identityKey: row.artist_identity_key,
+    mbid: row.artist_mbid,
+    name: row.artist_name,
+    sortName: row.artist_sort_name,
+    metadata: parseJson(row.artist_metadata_json),
+    albumIds: [],
+    albumCount: Number(row.album_count || 0),
+    trackCount: Number(row.track_count || 0),
+    sizeOnDisk: Number(row.size_on_disk || 0),
+    sources: [],
+    available: Boolean(row.available),
+  }]));
+  return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
+}
+
+function albumGenrePredicate(genre) {
+  const direct = genrePredicate(["artist", "album"], genre);
+  const tracks = genrePredicate(["track"], genre);
+  return {
+    sql: `(${direct.sql} OR EXISTS (
+      SELECT 1
+      FROM library_album_tracks AS genre_album_track
+      JOIN library_tracks AS track ON track.id = genre_album_track.track_id
+      WHERE genre_album_track.album_id = album.id
+        AND ${tracks.sql}
+    ))`,
+    parameters: [...direct.parameters, ...tracks.parameters],
+  };
+}
+
+export function getCanonicalAlbumPage({
+  source = null,
+  availableOnly = false,
+  type = "alphabeticalByName",
+  genre = "",
+  fromYear = null,
+  toYear = null,
+  query = "",
+  artistId = null,
+  offset = 0,
+  limit = 20,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("albums", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    const fields = ["album.title", "album.album_artist", "artist.name"];
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    conditions.push(`(${fields.map((field) =>
+      `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...fields.map(() => pattern));
+  }
+  if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
+    conditions.push("album.artist_id = ?");
+    parameters.push(Number(artistId));
+  }
+  const normalizedGenre = text(genre);
+  if (normalizedGenre) {
+    const predicate = albumGenrePredicate(normalizedGenre);
+    conditions.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+  const parsedFromYear = Number.parseInt(fromYear, 10);
+  const parsedToYear = Number.parseInt(toYear, 10);
+  const lowerYear = Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear)
+    ? Math.min(parsedFromYear, parsedToYear)
+    : parsedFromYear;
+  const upperYear = Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear)
+    ? Math.max(parsedFromYear, parsedToYear)
+    : parsedToYear;
+  if (Number.isFinite(lowerYear)) {
+    conditions.push("CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) >= ?");
+    parameters.push(lowerYear);
+  }
+  if (Number.isFinite(upperYear)) {
+    conditions.push("CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) <= ?");
+    parameters.push(upperYear);
+  }
+
+  let orderBy;
+  if (type === "random") {
+    orderBy = "random()";
+  } else if (type === "newest" || type === "recent") {
+    orderBy = "CASE WHEN album.release_date GLOB '[0-9][0-9][0-9][0-9]*' THEN album.release_date END DESC, album.title COLLATE NOCASE";
+  } else if (type === "alphabeticalByArtist") {
+    orderBy = "coalesce(album.album_artist, artist.name) COLLATE NOCASE, album.title COLLATE NOCASE";
+  } else if (type === "byYear") {
+    orderBy = `CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) ${Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear) && parsedFromYear > parsedToYear ? "DESC" : "ASC"}, album.title COLLATE NOCASE`;
+  } else if (type === "byGenre") {
+    orderBy = "coalesce(artist.name, album.album_artist) COLLATE NOCASE, album.title COLLATE NOCASE";
+  } else {
+    orderBy = "album.title COLLATE NOCASE, coalesce(album.album_artist, artist.name) COLLATE NOCASE";
+  }
+
+  const boundedLimit = pageLimit(limit, 20);
+  if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const ids = db.prepare(
+    `SELECT album.id
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE ${conditions.join(" AND ")}
+     GROUP BY album.id
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+  ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
+  const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
+  const albumsById = new Map(library.albums.map((album) => [album.id, album]));
+  library.albums = ids.map((id) => albumsById.get(id)).filter(Boolean);
+  return library;
+}
+
+export function getCanonicalTrackPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  genre = "",
+  artist = "",
+  artistId = null,
+  albumId = null,
+  offset = 0,
+  limit = 20,
+  random = false,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("tracks", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const fields = [
+    "track.title",
+    "track.artist_name",
+    "album.title",
+    "album.album_artist",
+    "artist.name",
+  ];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    conditions.push(`(${fields.map((field) =>
+      `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...fields.map(() => pattern));
+  }
+  const normalizedArtist = text(artist).toLocaleLowerCase();
+  if (normalizedArtist) {
+    conditions.push("(lower(artist.name) = ? OR lower(coalesce(track.artist_name, '')) = ? OR artist.identity_key = ?)");
+    parameters.push(normalizedArtist, normalizedArtist, artist);
+  }
+  if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
+    conditions.push("artist.id = ?");
+    parameters.push(Number(artistId));
+  }
+  if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
+    conditions.push("album.id = ?");
+    parameters.push(Number(albumId));
+  }
+  const normalizedGenre = text(genre);
+  if (normalizedGenre) {
+    const predicate = genrePredicate(["artist", "album", "track"], normalizedGenre);
+    conditions.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+  const boundedLimit = pageLimit(limit, 20);
+  if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const orderBy = random
+    ? "random()"
+    : "artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number, track.title COLLATE NOCASE";
+  const ids = db.prepare(
+    `SELECT track.id
+     FROM library_tracks AS track
+     JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+     JOIN library_albums AS album ON album.id = album_track.album_id
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE ${conditions.join(" AND ")}
+     GROUP BY track.id
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+  ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
+  const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+  const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+  library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+  return library;
+}
+
+export function getCanonicalSearchPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  artistLimit = 20,
+  artistOffset = 0,
+  albumLimit = 20,
+  albumOffset = 0,
+  songLimit = 20,
+  songOffset = 0,
+} = {}) {
+  const albumLibrary = getCanonicalAlbumPage({
+    source,
+    availableOnly,
+    query,
+    limit: albumLimit,
+    offset: albumOffset,
+  });
+  const trackLibrary = getCanonicalTrackPage({
+    source,
+    availableOnly,
+    query,
+    limit: songLimit,
+    offset: songOffset,
+  });
+  return {
+    artists: getCanonicalArtistPage({ source, availableOnly, query, limit: artistLimit, offset: artistOffset }).artists,
+    albums: albumLibrary,
+    tracks: trackLibrary,
+  };
+}
+
+export function getCanonicalTopTracks({
+  source = null,
+  availableOnly = false,
+  artist,
+  limit = 20,
+} = {}) {
+  return getCanonicalTrackPage({ source, availableOnly, artist, limit });
+}
+
+export function getCanonicalGenres({ source = null, availableOnly = false } = {}) {
+  const sourceFilter = normalizeSource(source);
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) mediaConditions.push("media.available = 1");
+  const albums = new Map();
+  for (const row of db.prepare(
+    `SELECT
+       album.id AS album_id,
+       track.id AS track_id,
+       artist.metadata_json AS artist_metadata_json,
+       album.metadata_json AS album_metadata_json,
+       track.metadata_json AS track_metadata_json
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     JOIN library_tracks AS track ON track.id = album_track.track_id
+     WHERE EXISTS (
+       SELECT 1
+       FROM library_media_files AS media
+       WHERE ${mediaConditions.join(" AND ")}
+     )
+     GROUP BY album.id, track.id`,
+  ).iterate(...parameters)) {
+    const album = albums.get(row.album_id) || {
+      artistGenres: metadataGenres({ metadata: parseJson(row.artist_metadata_json) }),
+      albumGenres: metadataGenres({ metadata: parseJson(row.album_metadata_json) }),
+      tracks: new Map(),
+    };
+    album.tracks.set(row.track_id, metadataGenres({ metadata: parseJson(row.track_metadata_json) }));
+    albums.set(row.album_id, album);
+  }
+  const genres = new Map();
+  for (const album of albums.values()) {
+    const trackCount = album.tracks.size;
+    const albumGenres = new Set([
+      ...album.artistGenres,
+      ...album.albumGenres,
+      ...[...album.tracks.values()].flat(),
+    ]);
+    for (const name of albumGenres) {
+      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
+      value.albumCount += 1;
+      value.songCount += album.artistGenres.includes(name) || album.albumGenres.includes(name)
+        ? trackCount
+        : [...album.tracks.values()].filter((trackGenres) => trackGenres.includes(name)).length;
+      genres.set(name, value);
+    }
+  }
+  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+}
 
 function buildPageQuery({
   kind,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -529,13 +529,14 @@ export function getCanonicalLibraryForAlbumReferences({
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
   parameters.push(...ids);
+  const mediaJoin = sourceFilter || availableOnly === true ? "JOIN" : "LEFT JOIN";
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
-     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     ${mediaJoin} library_media_files AS media ON ${mediaConditions.join(" AND ")}
      WHERE album.id IN (${ids.map(() => "?").join(",")})
      ${canonicalOrder}`,
   ).iterate(...parameters);

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -475,8 +475,8 @@ export function getCanonicalLibraryForArtistReferences({
     [
       "identity_key",
       "mbid",
-      "CAST(json_extract(metadata_json, '$.id') AS TEXT)",
-      "CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT)",
+      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT)",
       "name COLLATE NOCASE",
     ],
   );

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -472,7 +472,13 @@ export function getCanonicalLibraryForArtistReferences({
   const ids = resolveCanonicalReferenceIds(
     "library_artists",
     references,
-    ["identity_key", "mbid"],
+    [
+      "identity_key",
+      "mbid",
+      "CAST(json_extract(metadata_json, '$.id') AS TEXT)",
+      "CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT)",
+      "name COLLATE NOCASE",
+    ],
   );
   return getCanonicalLibraryForIds("artists", ids, source, availableOnly);
 }

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -1,7 +1,19 @@
 import { randomUUID } from "node:crypto";
 import { dbOps } from "../db/helpers/index.js";
 import { db } from "../config/db-sqlite.js";
-import { getCanonicalLibrary } from "./libraryQueryService.js";
+import {
+  getCanonicalAlbumPage,
+  getCanonicalArtistPage,
+  getCanonicalFavoriteTargetKeys,
+  getCanonicalGenres,
+  getCanonicalLibrary,
+  getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
+  getCanonicalSearchPage,
+  getCanonicalTopTracks,
+  getCanonicalTrack,
+  getCanonicalTrackPage,
+} from "./libraryQueryService.js";
 import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
 import { getArtistImage } from "./imageService.js";
 import { buildImageProxyUrl, warmPublicImageUrl } from "./imageProxyService.js";
@@ -212,14 +224,14 @@ const toArtistSummary = (artist) => {
     id: idFor("artist", artist.identityKey),
     name: artist.name,
     coverArt: idFor("artist", artist.identityKey),
-    albumCount: artist.albumIds.length,
+    albumCount: artist.albumCount ?? artist.albumIds.length,
     ...(genres.length
       ? { genre: genres[0], genres: genres.map((name) => ({ name })) }
       : {}),
   };
 };
 
-const indexLibrary = (library) => ({
+const indexFocusedLibrary = (library) => ({
   ...library,
   artistsById: new Map(library.artists.map((artist) => [artist.id, artist])),
   albumsById: new Map(library.albums.map((album) => [album.id, album])),
@@ -228,10 +240,6 @@ const indexLibrary = (library) => ({
   albumsByIdentity: new Map(library.albums.map((album) => [album.identityKey, album])),
   tracksByIdentity: new Map(library.tracks.map((track) => [track.identityKey, track])),
 });
-
-function readLibrary() {
-  return indexLibrary(getCanonicalLibrary({ availableOnly: false }));
-}
 
 function findCanonical(library, parsed) {
   if (!parsed) return null;
@@ -325,24 +333,30 @@ const flowJobs = (flow, { includePending = false } = {}) =>
 const playlistCoverArt = (kind, playlistId) => idFor(kind, playlistId);
 
 export function listArtists() {
-  const library = readLibrary();
-  const artists = [...library.artists].sort((left, right) =>
-    String(left.sortName || left.name).localeCompare(String(right.sortName || right.name)),
-  );
-  return artists.map(toArtistSummary);
+  return getCanonicalArtistPage({ source: "all", availableOnly: false }).artists.map(toArtistSummary);
 }
 
 export function getArtist(value) {
-  const library = readLibrary();
   const parsed = parseId(value);
-  const artist = parsed?.kind === "artist" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "artist") return null;
+  const library = indexFocusedLibrary(getCanonicalLibraryForArtistReferences({
+    source: "all",
+    availableOnly: false,
+    references: [parsed.key],
+  }));
+  const artist = findCanonical(library, parsed);
   return artist?.identityKey ? toArtist(library, artist) : null;
 }
 
 export function getAlbum(value) {
-  const library = readLibrary();
   const parsed = parseId(value);
-  const album = parsed?.kind === "album" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "album") return null;
+  const library = indexFocusedLibrary(getCanonicalLibraryForAlbumReferences({
+    source: "all",
+    availableOnly: false,
+    references: [parsed.key],
+  }));
+  const album = findCanonical(library, parsed);
   return album?.identityKey ? toAlbum(library, album) : null;
 }
 
@@ -350,9 +364,14 @@ export function getSong(value, user) {
   const playlistEntry = playlistJobFromId(user, value);
   if (playlistEntry) return toPlaylistSong(playlistEntry.playlist, playlistEntry.kind, playlistEntry.job);
 
-  const library = readLibrary();
   const parsed = parseId(value);
-  const track = parsed?.kind === "song" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "song") return null;
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
+  const track = findCanonical(library, parsed);
   return track?.identityKey ? toSong(library, track) : null;
 }
 
@@ -385,165 +404,58 @@ export function getMusicDirectory(value) {
 
 export function searchLibrary(query, options = {}) {
   const needle = String(query || "").trim().toLocaleLowerCase();
-  const library = readLibrary();
-  const artists = library.artists.filter((artist) =>
-    artist.name.toLocaleLowerCase().includes(needle),
-  );
-  const albums = library.albums
-    .filter((album) => {
-      const artist = findArtistForAlbum(library, album);
-      return [album.title, album.albumArtist, artist?.name].some((value) =>
-        String(value || "").toLocaleLowerCase().includes(needle),
-      );
-    });
-  const songs = library.tracks
-    .filter((track) => {
-      const album = findAlbumForTrack(library, track);
-      const artist = findArtistForAlbum(library, album);
-      return [track.title, track.artistName, album?.title, artist?.name].some((value) =>
-        String(value || "").toLocaleLowerCase().includes(needle),
-      );
-    });
-  const page = (items, count, offset) => items.slice(offset, offset + count);
+  const result = getCanonicalSearchPage({
+    source: "all",
+    availableOnly: false,
+    query: needle,
+    artistLimit: normalizeLimit(options.artistCount),
+    artistOffset: normalizeOffset(options.artistOffset),
+    albumLimit: normalizeLimit(options.albumCount),
+    albumOffset: normalizeOffset(options.albumOffset),
+    songLimit: normalizeLimit(options.songCount),
+    songOffset: normalizeOffset(options.songOffset),
+  });
+  const artistLibrary = indexFocusedLibrary({ artists: result.artists, albums: [], tracks: [] });
+  const albumLibrary = indexFocusedLibrary(result.albums);
+  const trackLibrary = indexFocusedLibrary(result.tracks);
   return {
-    artist: page(artists, normalizeLimit(options.artistCount), normalizeOffset(options.artistOffset)).map(
-      toArtistSummary,
-    ),
-    album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)).map(
-      (album) => toAlbum(library, album),
-    ),
-    song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)).map(
-      (track) => toSong(library, track),
-    ),
+    artist: artistLibrary.artists.map(toArtistSummary),
+    album: albumLibrary.albums.map((album) => toAlbum(albumLibrary, album)),
+    song: trackLibrary.tracks.map((track) => toSong(trackLibrary, track)),
   };
 }
 
 export function getAlbumList(options = {}) {
-  const library = readLibrary();
   const type = String(options.type || "alphabeticalByName");
-  let albums = [...library.albums];
-
   if (type === "starred") return [];
-  if (options.genre) {
-    const genre = String(options.genre).toLocaleLowerCase();
-    albums = albums.filter((album) =>
-      albumData(library, album).value.genres?.some((entry) =>
-        entry.name.toLocaleLowerCase() === genre,
-      ),
-    );
-  }
-  if (type === "byYear" || options.fromYear || options.toYear) {
-    const fromYear = Number.parseInt(options.fromYear, 10);
-    const toYear = Number.parseInt(options.toYear, 10);
-    const lowerYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
-      ? Math.min(fromYear, toYear)
-      : fromYear;
-    const upperYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
-      ? Math.max(fromYear, toYear)
-      : toYear;
-    albums = albums.filter((album) => {
-      const releaseYear = year(album.releaseDate) || 0;
-      return (!Number.isFinite(lowerYear) || releaseYear >= lowerYear) &&
-        (!Number.isFinite(upperYear) || releaseYear <= upperYear);
-    });
-  }
-
-  const values = new Map(albums.map((album) => [album.id, albumData(library, album).value]));
-  const compareName = (left, right) =>
-    `${left.title}\u0000${left.albumArtist}`.localeCompare(
-      `${right.title}\u0000${right.albumArtist}`,
-    );
-  const compareArtist = (left, right) =>
-    `${left.albumArtist}\u0000${left.title}`.localeCompare(
-      `${right.albumArtist}\u0000${right.title}`,
-    );
-  const compareReleaseDate = (left, right) => {
-    const leftDate = Date.parse(String(left.releaseDate || ""));
-    const rightDate = Date.parse(String(right.releaseDate || ""));
-    if (!Number.isFinite(leftDate) && !Number.isFinite(rightDate)) return compareName(left, right);
-    if (!Number.isFinite(leftDate)) return 1;
-    if (!Number.isFinite(rightDate)) return -1;
-    return rightDate - leftDate || compareName(left, right);
-  };
-  const compareYear = (left, right) => {
-    const leftYear = year(left.releaseDate) || 0;
-    const rightYear = year(right.releaseDate) || 0;
-    return leftYear - rightYear || compareName(left, right);
-  };
-  const compareGenre = (left, right) =>
-    `${values.get(left.id)?.genre || ""}\u0000${left.title}`.localeCompare(
-      `${values.get(right.id)?.genre || ""}\u0000${right.title}`,
-    );
-
-  if (type === "random") {
-    for (let index = albums.length - 1; index > 0; index -= 1) {
-      const swapIndex = Math.floor(Math.random() * (index + 1));
-      [albums[index], albums[swapIndex]] = [albums[swapIndex], albums[index]];
-    }
-  } else if (type === "newest" || type === "recent") {
-    albums.sort(compareReleaseDate);
-  } else if (type === "alphabeticalByArtist") {
-    albums.sort(compareArtist);
-  } else if (type === "byYear") {
-    const fromYear = Number.parseInt(options.fromYear, 10);
-    const toYear = Number.parseInt(options.toYear, 10);
-    albums.sort((left, right) => {
-      const comparison = compareYear(left, right);
-      return Number.isFinite(fromYear) && Number.isFinite(toYear) && fromYear > toYear
-        ? -comparison
-        : comparison;
-    });
-  } else if (type === "byGenre") {
-    albums.sort(compareGenre);
-  } else {
-    albums.sort(compareName);
-  }
-  const offset = normalizeOffset(options.offset);
-  const size = normalizeLimit(options.size);
-  return albums.slice(offset, offset + size).map((album) => toAlbumSummary(library, album));
+  const library = indexFocusedLibrary(getCanonicalAlbumPage({
+    source: "all",
+    availableOnly: false,
+    type,
+    genre: options.genre,
+    fromYear: options.fromYear,
+    toYear: options.toYear,
+    offset: normalizeOffset(options.offset),
+    limit: normalizeLimit(options.size),
+  }));
+  return library.albums.map((album) => toAlbumSummary(library, album));
 }
 
 export function getSongsByGenre(genre, options = {}) {
   const target = String(genre || "").trim().toLocaleLowerCase();
   if (!target) return [];
-  const library = readLibrary();
-  const tracks = library.tracks.filter((track) => {
-    const album = findAlbumForTrack(library, track);
-    const artist = findArtistForAlbum(library, album);
-    return [
-      ...entityGenres(artist),
-      ...entityGenres(album),
-      ...entityGenres(track),
-    ].some((value) => value.toLocaleLowerCase() === target);
-  });
-  const offset = normalizeOffset(options.offset);
-  const size = normalizeLimit(options.count);
-  return tracks.slice(offset, offset + size).map((track) => toSong(library, track));
+  const library = indexFocusedLibrary(getCanonicalTrackPage({
+    source: "all",
+    availableOnly: false,
+    genre: target,
+    offset: normalizeOffset(options.offset),
+    limit: normalizeLimit(options.count),
+  }));
+  return library.tracks.map((track) => toSong(library, track));
 }
 
 export function getGenres() {
-  const library = readLibrary();
-  const genres = new Map();
-  for (const album of library.albums) {
-    const tracks = albumTracks(library, album);
-    const artistGenres = entityGenres(findArtistForAlbum(library, album));
-    const albumMetadataGenres = entityGenres(album);
-    const albumGenres = [
-      ...artistGenres,
-      ...entityGenres(album),
-      ...tracks.flatMap((track) => entityGenres(track)),
-    ];
-    for (const name of new Set(albumGenres)) {
-      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
-      value.albumCount += 1;
-      value.songCount +=
-        artistGenres.includes(name) || albumMetadataGenres.includes(name)
-          ? tracks.length
-          : tracks.filter((track) => entityGenres(track).includes(name)).length;
-      genres.set(name, value);
-    }
-  }
-  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+  return getCanonicalGenres({ source: "all", availableOnly: false });
 }
 
 const getStarsStmt = db.prepare(
@@ -607,7 +519,11 @@ const resolveSubsonicTrack = (user, value) => {
   if (playlistSong) return playlistSong;
   const parsed = parseId(value);
   if (parsed?.kind !== "song") return null;
-  const library = readLibrary();
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
   const track = findCanonical(library, parsed);
   const normalized = trackFromCanonical(library, track);
   return normalized ? { kind: "song", track: normalized, canonical: track } : null;
@@ -628,7 +544,19 @@ const findLibraryJob = (track) => {
 };
 
 const findAvailableCanonicalFile = (track) => {
-  const library = readLibrary();
+  const library = indexFocusedLibrary(track?.trackMbid
+    ? getCanonicalTrack({
+        trackId: track.trackMbid,
+        source: "all",
+        availableOnly: true,
+      })
+    : getCanonicalTrackPage({
+        source: "all",
+        availableOnly: true,
+        query: track?.trackName,
+        artist: track?.artistName,
+        limit: 1,
+      }));
   const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   const file = firstFile(candidate);
   return file?.available && file.path ? { file, albumName: findAlbumForTrack(library, candidate)?.title } : null;
@@ -795,16 +723,20 @@ export function star(user, value) {
 export function starMany(user, values, { skipCanonicalValidation = false } = {}) {
   const parsed = values.map(starTarget);
   if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
-  const library = skipCanonicalValidation ? null : readLibrary();
+  const canonicalTargets = parsed
+    .filter((target) => ["artist", "album", "song"].includes(target.kind))
+    .map((target) => idFor(target.kind, target.key));
   const playlistSongs = parsed.map((target) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? resolvePlaylistSong(user, idFor(target.kind, target.key))
       : null,
   );
+  if (!skipCanonicalValidation &&
+    getCanonicalFavoriteTargetKeys(canonicalTargets).size !== canonicalTargets.length) return false;
   if (parsed.some((target, index) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? !playlistSongs[index]
-      : !skipCanonicalValidation && !findCanonical(library, target),
+      : false,
   )) return false;
   if (favoriteAutoKeepEnabled()) {
     const createdJobIds = [];
@@ -873,7 +805,7 @@ export function getStarredWithLibrary(user) {
   const library = getCanonicalLibrary({
     favoriteKeys: canonicalRows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),
   });
-  return { starred: buildStarred(indexLibrary(library), rows, user), library };
+  return { starred: buildStarred(indexFocusedLibrary(library), rows, user), library };
 }
 
 export function getStarred(user) {
@@ -887,22 +819,13 @@ export function getArtistInfo(value) {
 export function getTopSongs(artist, options = {}) {
   const target = String(artist || "").trim();
   if (!target) return [];
-  const library = readLibrary();
-  const normalizedTarget = target.toLocaleLowerCase();
-  const artistRecord = library.artists.find(
-    (entry) =>
-      entry.identityKey === target || entry.name.toLocaleLowerCase() === normalizedTarget,
-  );
-  if (!artistRecord) return [];
-  const tracks = library.tracks.filter((track) => {
-    const album = findAlbumForTrack(library, track);
-    const trackArtist = findArtistForAlbum(library, album);
-    return (
-      trackArtist?.id === artistRecord.id ||
-      String(track.artistName || "").trim().toLocaleLowerCase() === normalizedTarget
-    );
-  });
-  return tracks.slice(0, normalizeLimit(options.count)).map((track) => toSong(library, track));
+  const library = indexFocusedLibrary(getCanonicalTopTracks({
+    source: "all",
+    availableOnly: false,
+    artist: target,
+    limit: normalizeLimit(options.count),
+  }));
+  return library.tracks.map((track) => toSong(library, track));
 }
 
 export function getFlowPlaylists(user) {
@@ -967,8 +890,14 @@ export function resolveStreamPath(value, user) {
       : null;
   }
 
-  const library = readLibrary();
-  const track = findCanonical(library, parseId(value));
+  const parsed = parseId(value);
+  if (parsed?.kind !== "song") return null;
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
+  const track = findCanonical(library, parsed);
   const file = firstFile(track);
   return file?.available && file.path ? file.path : null;
 }
@@ -997,7 +926,23 @@ export async function resolveArtworkUrl(value) {
     return artwork;
   }
 
-  const library = readLibrary();
+  const library = indexFocusedLibrary(parsed.kind === "artist"
+    ? getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [parsed.key],
+      })
+    : parsed.kind === "album"
+      ? getCanonicalLibraryForAlbumReferences({
+          source: "all",
+          availableOnly: false,
+          references: [parsed.key],
+        })
+      : getCanonicalTrack({
+          trackId: parsed.key,
+          source: "all",
+          availableOnly: false,
+        }));
   const entity = findCanonical(library, parsed);
   if (!entity) return null;
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -731,8 +731,12 @@ export function starMany(user, values, { skipCanonicalValidation = false } = {})
       ? resolvePlaylistSong(user, idFor(target.kind, target.key))
       : null,
   );
-  if (!skipCanonicalValidation &&
-    getCanonicalFavoriteTargetKeys(canonicalTargets).size !== canonicalTargets.length) return false;
+  const canonicalTargetKeys = skipCanonicalValidation
+    ? null
+    : getCanonicalFavoriteTargetKeys(canonicalTargets);
+  if (canonicalTargetKeys && canonicalTargets.some((target) => !canonicalTargetKeys.has(target))) {
+    return false;
+  }
   if (parsed.some((target, index) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? !playlistSongs[index]

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -555,7 +555,7 @@ const findAvailableCanonicalFile = (track) => {
         availableOnly: true,
         query: track?.trackName,
         artist: track?.artistName,
-        limit: 1,
+        limit: 25,
       }));
   const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   const file = firstFile(candidate);

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -114,9 +114,11 @@ function measure(operation) {
   const after = memoryStats();
   return {
     elapsedMs: Number(elapsedMs.toFixed(3)),
+    jsonBytes: Buffer.byteLength(JSON.stringify(value)),
     memoryBefore: before,
     memoryAfter: after,
     rssDeltaBytes: after.rssBytes - before.rssBytes,
+    heapDeltaBytes: after.heapUsedBytes - before.heapUsedBytes,
     value,
   };
 }
@@ -244,6 +246,19 @@ function seedDatabase(database, { tracks, tracksPerAlbum }) {
   };
 }
 
+function seedSubsonicFavorite(database) {
+  const now = Date.now();
+  const userId = Number(database.prepare(
+    `INSERT INTO users (username, password_hash, role, permissions)
+     VALUES ('benchmark', 'benchmark', 'user', '{}')`,
+  ).run().lastInsertRowid);
+  database.prepare(
+    `INSERT INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
+     VALUES (?, 'song', 'benchmark:track:0', ?)`,
+  ).run(userId, now);
+  return { id: userId, username: "benchmark", permissions: {} };
+}
+
 function collectPageSamples(getPage, invalidate, repeats) {
   const coldSamples = [];
   const warmSamples = [];
@@ -338,53 +353,76 @@ function runChild({ dataDir, dbPath, code, timeoutMs, heapMb, env = {} }) {
   });
 }
 
-const fullReadCode = `
-import { performance } from "node:perf_hooks";
-import { getCanonicalLibrary } from "./backend/services/libraryQueryService.js";
-import { getCanonicalLibraryReadModel } from "./backend/services/canonicalLibraryReadAdapter.js";
+const boundedReadCode = `
+import { groupArtists } from "./backend/routes/subsonic.js";
 import {
-  buildPublicLibrary,
-  publicLibraryJsonReplacer,
-} from "./backend/routes/library/handlers/canonical.js";
+  getAlbum,
+  getFlowPlaylists,
+  getStarred,
+  getArtist,
+  listArtists,
+  searchLibrary,
+} from "./backend/services/subsonicLibraryService.js";
+import { getCanonicalTrackPage } from "./backend/services/libraryQueryService.js";
 
-const mode = process.env.AURRAL_BENCHMARK_MODE;
-let value;
-let rawReadMs = 0;
-let transformMs = 0;
-if (mode === "legacy-adapter") {
-  const started = performance.now();
-  value = getCanonicalLibraryReadModel({ source: "lidarr", availableOnly: true });
-  rawReadMs = performance.now() - started;
-} else {
-  const rawStarted = performance.now();
-  const raw = getCanonicalLibrary({ source: "lidarr", availableOnly: true });
-  rawReadMs = performance.now() - rawStarted;
-  const transformStarted = performance.now();
-  value = buildPublicLibrary(raw);
-  transformMs = performance.now() - transformStarted;
-}
-const readMs = rawReadMs + transformMs;
-const serializeStarted = performance.now();
-const jsonReplacer = mode === "full-endpoint" ? publicLibraryJsonReplacer : undefined;
-const jsonBytes = Buffer.byteLength(JSON.stringify(value, jsonReplacer));
-const serializeMs = performance.now() - serializeStarted;
-const memory = process.memoryUsage();
-const counts = {
-  artists: Array.isArray(value.artists) ? value.artists.length : 0,
-  albums: Array.isArray(value.albums) ? value.albums.length : 0,
-  tracks: Array.isArray(value.tracks) ? value.tracks.length : 0,
+const user = { id: 1, username: "benchmark", permissions: {} };
+const encodedId = (kind, key) => kind + ":" + encodeURIComponent(key);
+const operation = process.env.AURRAL_BENCHMARK_OPERATION;
+const read = {
+  getIndexes: () => ({ index: groupArtists(listArtists()) }),
+  getArtist: () => getArtist(encodedId("artist", "benchmark:artist:0")),
+  getAlbum: () => getAlbum(encodedId("album", "benchmark:album:0")),
+  search3: () => searchLibrary("Benchmark Track", {
+    artistCount: "20",
+    albumCount: "20",
+    songCount: "20",
+  }),
+  randomSongs: () => getCanonicalTrackPage({
+    source: "lidarr",
+    availableOnly: true,
+    random: true,
+    limit: 20,
+  }).tracks,
+  starred: () => getStarred(user),
+  playlists: () => getFlowPlaylists(user),
 };
+const before = process.memoryUsage();
+const started = performance.now();
+const value = read[operation]();
+const elapsedMs = performance.now() - started;
+const after = process.memoryUsage();
+const counts = Array.isArray(value)
+  ? { items: value.length }
+  : {
+      artists: Array.isArray(value?.artist) ? value.artist.length : undefined,
+      albums: Array.isArray(value?.album) ? value.album.length : undefined,
+      songs: Array.isArray(value?.song) ? value.song.length : undefined,
+    };
 console.log(JSON.stringify({
-  rawReadMs: Number(rawReadMs.toFixed(3)),
-  transformMs: Number(transformMs.toFixed(3)),
-  readMs: Number(readMs.toFixed(3)),
-  serializeMs: Number(serializeMs.toFixed(3)),
-  jsonBytes,
+  elapsedMs: Number(elapsedMs.toFixed(3)),
+  jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+  rssDeltaBytes: after.rss - before.rss,
+  heapDeltaBytes: after.heapUsed - before.heapUsed,
+  rssBytes: after.rss,
+  heapUsedBytes: after.heapUsed,
   counts,
-  rssBytes: memory.rss,
-  heapUsedBytes: memory.heapUsed,
 }));
 `;
+
+function summarizeReadSamples(samples) {
+  const values = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
+  const completed = samples.filter((sample) => sample.status === "completed");
+  const strip = ({ status: _status, ...sample }) => sample;
+  return {
+    samples: samples.map(strip),
+    responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
+    medianMs: completed.length ? percentile(0.5) : null,
+    p95Ms: completed.length ? percentile(0.95) : null,
+    maxRssDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.rssDeltaBytes)) : null,
+    maxHeapDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.heapDeltaBytes)) : null,
+  };
+}
 
 const indexerProbeCode = `
 import { performance } from "node:perf_hooks";
@@ -486,6 +524,7 @@ async function main() {
     const queryService = await import("../backend/services/libraryQueryService.js");
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
+    const benchmarkUser = seedSubsonicFavorite(database);
     const seedElapsedMs = Number((performance.now() - seedStarted).toFixed(3));
     const pageCases = [
       ["artists", { kind: "artists", page: 1, pageSize: 100 }],
@@ -504,16 +543,31 @@ async function main() {
     }
     database.close();
     database = null;
-    const fullReads = {};
-    for (const mode of ["full-endpoint", "legacy-adapter"]) {
-      fullReads[mode] = await runChild({
-        dataDir,
-        dbPath,
-        timeoutMs: options.fullReadTimeoutMs,
-        heapMb: options.childHeapMb,
-        code: fullReadCode,
-        env: { AURRAL_BENCHMARK_MODE: mode },
-      });
+    const subsonicReads = {};
+    for (const operation of [
+      "getIndexes",
+      "getArtist",
+      "getAlbum",
+      "search3",
+      "randomSongs",
+      "starred",
+      "playlists",
+    ]) {
+      const samples = [];
+      for (let index = 0; index < options.repeats; index += 1) {
+        samples.push(await runChild({
+          dataDir,
+          dbPath,
+          timeoutMs: options.fullReadTimeoutMs,
+          heapMb: options.childHeapMb,
+          code: boundedReadCode,
+          env: {
+            AURRAL_BENCHMARK_OPERATION: operation,
+            AURRAL_BENCHMARK_USER_ID: String(benchmarkUser.id),
+          },
+        }));
+      }
+      subsonicReads[operation] = summarizeReadSamples(samples);
     }
     const indexerProbes = {};
     for (const [mode, probeDir] of [
@@ -534,13 +588,13 @@ async function main() {
     }
     const expectedBulkIndexerCalls = 5;
     const expectedFallbackIndexerCalls = 5;
-    const adapter = fullReads["legacy-adapter"];
     const pageP95 = Object.fromEntries(
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
     );
+    const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
+      read.samples.every((sample) => sample.error === undefined));
     const checks = {
-      fullEndpointReadCompleted: fullReads["full-endpoint"].status === "completed",
-      legacyReadCompleted: adapter.status === "completed",
+      boundedReadCompleted,
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
         && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
       fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
@@ -559,8 +613,8 @@ async function main() {
       options,
       elapsedMs: Number((performance.now() - started).toFixed(3)),
       seed: { ...seed, elapsedMs: seedElapsedMs },
+      subsonicReads,
       pages,
-      fullReads,
       indexer: {
         requestedAlbums: options.indexerAlbums,
         expectedBulkCalls: expectedBulkIndexerCalls,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -250,13 +250,13 @@ function seedSubsonicFavorite(database) {
   const now = Date.now();
   const userId = Number(database.prepare(
     `INSERT INTO users (username, password_hash, role, permissions)
-     VALUES ('benchmark', 'benchmark', 'user', '{}')`,
+     VALUES ('benchmark', 'benchmark', 'user', '{"accessFlow":true}')`,
   ).run().lastInsertRowid);
   database.prepare(
     `INSERT INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
      VALUES (?, 'song', 'benchmark:track:0', ?)`,
   ).run(userId, now);
-  return { id: userId, username: "benchmark", permissions: {} };
+  return { id: userId, username: "benchmark", permissions: { accessFlow: true } };
 }
 
 function collectPageSamples(getPage, invalidate, repeats) {
@@ -365,7 +365,11 @@ import {
 } from "./backend/services/subsonicLibraryService.js";
 import { getCanonicalTrackPage } from "./backend/services/libraryQueryService.js";
 
-const user = { id: 1, username: "benchmark", permissions: {} };
+const user = {
+  id: Number(process.env.AURRAL_BENCHMARK_USER_ID),
+  username: "benchmark",
+  permissions: { accessFlow: true },
+};
 const encodedId = (kind, key) => kind + ":" + encodeURIComponent(key);
 const operation = process.env.AURRAL_BENCHMARK_OPERATION;
 const read = {
@@ -410,12 +414,11 @@ console.log(JSON.stringify({
 `;
 
 function summarizeReadSamples(samples) {
-  const values = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
-  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   const completed = samples.filter((sample) => sample.status === "completed");
-  const strip = ({ status: _status, ...sample }) => sample;
+  const values = completed.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   return {
-    samples: samples.map(strip),
+    samples,
     responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
     medianMs: completed.length ? percentile(0.5) : null,
     p95Ms: completed.length ? percentile(0.95) : null,
@@ -522,9 +525,17 @@ async function main() {
     const imported = await import("../backend/config/db-sqlite.js");
     database = imported.db;
     const queryService = await import("../backend/services/libraryQueryService.js");
+    const { flowPlaylistConfig } = await import(
+      "../backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js"
+    );
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
     const benchmarkUser = seedSubsonicFavorite(database);
+    flowPlaylistConfig.createSharedPlaylist({
+      name: "Benchmark Playlist",
+      ownerUserId: benchmarkUser.id,
+      tracks: [],
+    });
     const seedElapsedMs = Number((performance.now() - seedStarted).toFixed(3));
     const pageCases = [
       ["artists", { kind: "artists", page: 1, pageSize: 100 }],
@@ -592,7 +603,7 @@ async function main() {
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
     );
     const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
-      read.samples.every((sample) => sample.error === undefined));
+      read.samples.every((sample) => sample.status === "completed"));
     const checks = {
       boundedReadCompleted,
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -45,7 +45,7 @@ Options:
   --tracks-per-album N        Synthetic tracks per album, default 10
   --repeats N                 Page samples per cold/warm group, default 3
   --indexer-albums N          Albums in the Lidarr call probe, default 1000
-  --full-read-timeout-ms N    Timeout for full-read child probes, default 30000
+  --child-probe-timeout-ms N  Timeout for child probes, default 30000
   --child-heap-mb N           Child heap cap in megabytes, default 2048
   --output PATH               JSON result path, default perf-results/library-<timestamp>.json
   --check                     Exit nonzero when the regression gate fails
@@ -62,9 +62,9 @@ Options:
     readOption(args, "indexer-albums", 1000),
     "indexer-albums",
   );
-  const fullReadTimeoutMs = positiveInteger(
-    readOption(args, "full-read-timeout-ms", 30000),
-    "full-read-timeout-ms",
+  const childProbeTimeoutMs = positiveInteger(
+    readOption(args, "child-probe-timeout-ms", 30000),
+    "child-probe-timeout-ms",
   );
   const childHeapMb = positiveInteger(readOption(args, "child-heap-mb", 2048), "child-heap-mb");
   const output = readOption(
@@ -77,7 +77,7 @@ Options:
     tracksPerAlbum,
     repeats,
     indexerAlbums,
-    fullReadTimeoutMs,
+    childProbeTimeoutMs,
     childHeapMb,
     output: path.isAbsolute(output) ? output : path.join(repoRoot, output),
     check: args.includes("--check"),
@@ -569,7 +569,7 @@ async function main() {
         samples.push(await runChild({
           dataDir,
           dbPath,
-          timeoutMs: options.fullReadTimeoutMs,
+          timeoutMs: options.childProbeTimeoutMs,
           heapMb: options.childHeapMb,
           code: boundedReadCode,
           env: {
@@ -588,7 +588,7 @@ async function main() {
       indexerProbes[mode] = await runChild({
         dataDir: probeDir,
         dbPath: path.join(probeDir, "aurral.db"),
-        timeoutMs: options.fullReadTimeoutMs,
+        timeoutMs: options.childProbeTimeoutMs,
         heapMb: options.childHeapMb,
         code: indexerProbeCode,
         env: {


### PR DESCRIPTION
## Problem

Hosted Subsonic and legacy compatibility reads could load the complete canonical library before returning one entity or a small page. The first bounded implementation also changed some legacy identifier and album ordering behavior, and its benchmark did not exercise non-empty favorites or playlists.

## Solution

This PR resolves artist and album references through indexed entity-table lookups, then hydrates only the matching local IDs. Paged reads apply their filters, offsets, counts, and limits in SQLite before mapping.

The review update also:

- preserves numeric, identity-key, MBID, release-group MBID, and compatibility fallback behavior;
- restores Subsonic `newest` ordering by media arrival time;
- aggregates Subsonic genre counts in SQLite and tolerates malformed metadata JSON;
- validates every `starMany` target, including duplicate and alternate percent-encoded IDs;
- replaces source-text guards with runtime query spies and query-plan checks; and
- records benchmark sample status and measures non-empty starred and playlist responses for the requested user.

`libraryQueryService.js` adds the smallest overlap needed for this task: indexed reference-to-local-ID resolution, ID-scoped hydration, SQL genre aggregation, and bounded protocol page queries. It does not add a repository layer, cache system, dependency, worker, FTS index, or random sampler.

TASK-2.1.10.3 and later provider work remain out of scope. Leading-wildcard search and `ORDER BY random()` tuning remain in TASK-2.1.10.6.

## Verification

- Focused library, compatibility, and Subsonic tests: 20 passed.
- Full backend test suite: 779 passed.
- `npm run lint`: passed.
- `npm run build`: passed.
- Benchmark smoke with completed-sample checks: passed. Starred returned one song and playlists returned one owner-visible playlist.
- `npm run test:integration`: 53 passed, 1 failed. The existing Navidrome settings fixture did not create its expected temporary `weekly-flow` path. The hosted Subsonic integration suite passed, including IDs, search, playlists, favorites, streams, artwork, missing entities, user isolation, and restart behavior.
- Candidate image build, health check, restart check, authenticated Subsonic `ping`, `getIndexes`, `search3`, and missing-artist behavior: passed.
- Documentation build: not applicable because this PR does not change documentation.

The reference lookup and hydration tests run `EXPLAIN QUERY PLAN`. They reject full album or album-track scans and require indexed entity lookups followed by local-ID predicates. Runtime query spies also fail if focused Subsonic reads execute an unfiltered complete-library query.

## Scale measurements

The benchmark used synthetic SQLite libraries with 10 tracks per album, 10 albums per artist, and three fresh child-process samples per operation. Bytes are serialized response size. Latency is p95. RSS and heap are the largest per-sample deltas.

| Operation | 100k tracks: bytes / p95 ms / RSS bytes / heap bytes | 350k tracks: bytes / p95 ms / RSS bytes / heap bytes |
| --- | ---: | ---: |
| getIndexes | 175,815 / 20.114 / 65,536,000 / 3,138,728 | 620,815 / 68.528 / 237,858,816 / 11,181,992 |
| getArtist | 5,571 / 2.439 / 1,048,576 / 757,352 | 5,571 / 2.570 / 917,504 / 757,408 |
| getAlbum | 7,918 / 1.671 / 917,504 / 254,504 | 7,918 / 1.770 / 917,504 / 256,744 |
| search3 | 14,815 / 86.640 / 68,063,232 / 402,208 | 14,815 / 302.421 / 241,389,568 / 402,440 |
| random songs | 11,583-11,604 / 44.372 / 68,001,792 / 199,024 | 11,656-11,686 / 158.910 / 241,426,432 / 198,952 |
| starred | 771 / 1.088 / 1,048,576 / 102,304 | 771 / 1.066 / 917,504 / 102,272 |
| playlists | 275 / 0.346 / 282,624 / 18,152 | 275 / 0.337 / 278,528 / 18,152 |

All 42 bounded-read samples completed. The benchmark gate passed at both sizes. Search and random-song RSS still scales with library size because SQLite scans leading-wildcard search and random ordering. This PR reports those costs without adding the SQL tuning owned by TASK-2.1.10.6.

## Status by area

- Backend and API: passed.
- Persistence: passed. This PR adds MBID and release-group lookup indexes, with no data migration.
- Frontend: passed lint and build. No UI behavior changed.
- Hosted Subsonic: passed automated and local candidate journeys.
- Legacy compatibility reads: passed behavior tests for identifier forms and fallback.
- Provider integrations: not applicable to this task.
- Documentation: not applicable.
- Docker and restart behavior: passed.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved library and Subsonic browsing with faster, focused reads.
  - Added database indexes to speed up album and artist lookups.
  - Reduced data loaded during searches, artwork requests, favorites, genres, and top-song retrieval.

- **Bug Fixes**
  - Improved album and track resolution using numeric IDs, identity keys, and release-group identifiers.
  - Corrected recent-album ordering and top-song artist matching.
  - Improved genre filtering and favorite validation.

- **Enhancements**
  - Artist listings now support efficient pagination.
  - Improved handling of unavailable media and missing album references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->