### PR TITLE
perf(lidarr): consolidate volatile status polling

### DIFF
--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -95,6 +95,54 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
   assert.deepEqual(calls, { queue: 6, history: 6, command: 6 });
 });
 
+test("invalidating a failed refresh allows immediate recovery", async (t) => {
+  let fail = false;
+  let refreshGate = null;
+  const calls = { queue: 0, history: 0, command: 0 };
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "isCircuitOpen", () => false);
+  t.mock.method(lidarrClient, "getQueue", async () => {
+    calls.queue += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+  t.mock.method(lidarrClient, "getHistory", async () => {
+    calls.history += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return { records: [] };
+  });
+  t.mock.method(lidarrClient, "request", async () => {
+    calls.command += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+
+  invalidateAllDownloadStatusesCache();
+  await getLidarrStatusSnapshot({ force: true });
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+
+  fail = true;
+  refreshGate = Promise.withResolvers();
+  const pending = getLidarrStatusSnapshot({ force: true });
+  while (calls.queue < 2 || calls.history < 2 || calls.command < 2) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  invalidateAllDownloadStatusesCache();
+  refreshGate.resolve();
+  const stale = await pending;
+  refreshGate = null;
+  assert.equal(stale.stale, true);
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  fail = false;
+  const recovered = await getLidarrStatusSnapshot();
+  assert.equal(recovered.stale, false);
+  assert.deepEqual(calls, { queue: 3, history: 3, command: 3 });
+});
+
 test("forced Lidarr status reads bypass the client cache", async (t) => {
   let calls = 0;
   const server = http.createServer((_request, response) => {

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import {
+  getLidarrStatusSnapshot,
+  hasActiveLidarrStatusSnapshot,
+  invalidateAllDownloadStatusesCache,
+} from "../../backend/routes/library/handlers/downloads.js";
+import { LidarrClient, lidarrClient } from "../../backend/services/lidarrClient.js";
+import { buildLidarrRequests } from "../../backend/services/lidarrRequestBuilder.js";
+
+test("Lidarr status consumers share refreshes, idle, failure, and recovery state", async (t) => {
+  let active = false;
+  let fail = false;
+  let queueGate = null;
+  const calls = { queue: 0, history: 0, command: 0 };
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "isCircuitOpen", () => false);
+  t.mock.method(lidarrClient, "getQueue", async (options) => {
+    assert.equal(options.forceRefresh, true);
+    calls.queue += 1;
+    if (fail) throw new Error("provider unavailable");
+    if (queueGate) await queueGate.promise;
+    return active ? [{ id: 1, albumId: 10, status: "downloading", size: 10, sizeleft: 5 }] : [];
+  });
+  t.mock.method(lidarrClient, "getHistory", async (...args) => {
+    assert.deepEqual(args, [1, 200, "date", "descending", { forceRefresh: true }]);
+    calls.history += 1;
+    if (fail) throw new Error("provider unavailable");
+    return { records: [] };
+  });
+  t.mock.method(lidarrClient, "request", async (endpoint, method, data, skip, options) => {
+    assert.equal(endpoint, "/command");
+    assert.deepEqual([method, data, skip, options], ["GET", null, false, { forceRefresh: true }]);
+    calls.command += 1;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+
+  invalidateAllDownloadStatusesCache();
+  const [first, concurrent] = await Promise.all([
+    getLidarrStatusSnapshot({ force: true }),
+    getLidarrStatusSnapshot({ force: true }),
+  ]);
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+  assert.equal(first, concurrent);
+  assert.equal(first.active, false);
+  assert.equal((await getLidarrStatusSnapshot()).updatedAt, first.updatedAt);
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+
+  active = true;
+  invalidateAllDownloadStatusesCache();
+  const activeSnapshot = await getLidarrStatusSnapshot();
+  assert.equal(activeSnapshot.active, true);
+  assert.equal(hasActiveLidarrStatusSnapshot(), true);
+  assert.equal(activeSnapshot.statuses[10].status, "downloading");
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  const requests = await buildLidarrRequests(lidarrClient, activeSnapshot.provider);
+  assert.equal(requests[0].albumId, "10");
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  fail = true;
+  invalidateAllDownloadStatusesCache();
+  const stale = await getLidarrStatusSnapshot();
+  assert.equal(stale.stale, true);
+  assert.equal(stale.statuses[10].status, "downloading");
+  assert.match(stale.error, /provider unavailable/);
+  assert.equal((await getLidarrStatusSnapshot()).stale, true);
+  assert.deepEqual(calls, { queue: 3, history: 3, command: 3 });
+
+  fail = false;
+  active = false;
+  const recovered = await getLidarrStatusSnapshot({ force: true });
+  assert.equal(recovered.stale, false);
+  assert.equal(recovered.active, false);
+  assert.deepEqual(calls, { queue: 4, history: 4, command: 4 });
+
+  queueGate = Promise.withResolvers();
+  const pending = getLidarrStatusSnapshot({ force: true });
+  while (calls.queue < 5) await new Promise((resolve) => setImmediate(resolve));
+  invalidateAllDownloadStatusesCache();
+  queueGate.resolve();
+  await pending;
+  queueGate = null;
+  await getLidarrStatusSnapshot();
+  assert.deepEqual(calls, { queue: 6, history: 6, command: 6 });
+});
+
+test("forced Lidarr status reads bypass the client cache", async (t) => {
+  let calls = 0;
+  const server = http.createServer((_request, response) => {
+    calls += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify([{ id: calls }]));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${server.address().port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+  t.after(() => {
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  assert.equal((await client.getQueue())[0].id, 1);
+  assert.equal((await client.getQueue())[0].id, 1);
+  assert.equal((await client.getQueue({ forceRefresh: true }))[0].id, 2);
+  assert.equal(calls, 2);
+});

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -3,6 +3,7 @@ import http from "node:http";
 import test from "node:test";
 
 import {
+  getDownloadStatusesForAlbumIds,
   getLidarrStatusSnapshot,
   hasActiveLidarrStatusSnapshot,
   invalidateAllDownloadStatusesCache,
@@ -14,6 +15,7 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
   let active = false;
   let fail = false;
   let queueGate = null;
+  let albumCalls = 0;
   const calls = { queue: 0, history: 0, command: 0 };
   t.mock.method(lidarrClient, "isConfigured", () => true);
   t.mock.method(lidarrClient, "isCircuitOpen", () => false);
@@ -37,6 +39,10 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
     if (fail) throw new Error("provider unavailable");
     return [];
   });
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    albumCalls += 1;
+    return [];
+  });
 
   invalidateAllDownloadStatusesCache();
   const [first, concurrent] = await Promise.all([
@@ -44,6 +50,7 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
     getLidarrStatusSnapshot({ force: true }),
   ]);
   assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+  assert.equal(albumCalls, 0);
   assert.equal(first, concurrent);
   assert.equal(first.active, false);
   assert.equal((await getLidarrStatusSnapshot()).updatedAt, first.updatedAt);
@@ -119,4 +126,70 @@ test("forced Lidarr status reads bypass the client cache", async (t) => {
   assert.equal((await client.getQueue())[0].id, 1);
   assert.equal((await client.getQueue({ forceRefresh: true }))[0].id, 2);
   assert.equal(calls, 2);
+});
+
+test("failed or stale history verifies albums with one bulk read", async (t) => {
+  const now = Date.now();
+  const calls = { bulk: 0, detail: 0 };
+  let bulkFailure = false;
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    calls.bulk += 1;
+    if (bulkFailure) throw new Error("provider unavailable");
+    return [
+      { id: 101, statistics: { trackFileCount: 2 } },
+      { id: 102, statistics: { trackFileCount: 0 } },
+    ];
+  });
+  t.mock.method(lidarrClient, "getAlbum", async () => {
+    calls.detail += 1;
+    return null;
+  });
+
+  const normal = await getDownloadStatusesForAlbumIds(["100"], {
+    queue: [],
+    history: {
+      records: [{ albumId: 100, eventType: "AlbumGrabbed", date: new Date(now).toISOString() }],
+    },
+    commands: [],
+  });
+  assert.equal(normal[100].status, "processing");
+  assert.deepEqual(calls, { bulk: 0, detail: 0 });
+
+  const verified = await getDownloadStatusesForAlbumIds(["101", "102"], {
+    queue: [],
+    history: {
+      records: [
+        {
+          albumId: 101,
+          eventType: "AlbumImportIncomplete",
+          date: new Date(now).toISOString(),
+        },
+        {
+          albumId: 102,
+          eventType: "AlbumGrabbed",
+          date: new Date(now - 16 * 60 * 1000).toISOString(),
+        },
+      ],
+    },
+    commands: [],
+  });
+  assert.equal(verified[101].status, "added");
+  assert.equal(verified[102].status, "failed");
+  assert.deepEqual(calls, { bulk: 1, detail: 0 });
+
+  bulkFailure = true;
+  const failedVerification = await getDownloadStatusesForAlbumIds(["101", "102"], {
+    queue: [],
+    history: {
+      records: [
+        { albumId: 101, eventType: "DownloadFailed", date: new Date(now).toISOString() },
+        { albumId: 102, eventType: "AlbumImportIncomplete", date: new Date(now).toISOString() },
+      ],
+    },
+    commands: [],
+  });
+  assert.equal(failedVerification[101].status, "failed");
+  assert.equal(failedVerification[102].status, "failed");
+  assert.deepEqual(calls, { bulk: 2, detail: 0 });
 });

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -72,6 +72,13 @@ export const getDownloadStatusesForAlbumIds = async (
         queueByAlbumId.set(qAlbumId, q);
       }
 
+      let verifiedAlbumsPromise;
+      const getVerifiedAlbums = () =>
+        (verifiedAlbumsPromise ??= lidarrClient
+          .getAllAlbums()
+          .then((albums) => new Map(albums.map((album) => [String(album.id), album])))
+          .catch(() => new Map()));
+
       for (const albumId of albumIdArray) {
         if (!albumId || albumId === "undefined" || albumId === "null") continue;
         const lidarrAlbumId = parseInt(albumId, 10);
@@ -189,7 +196,7 @@ export const getDownloadStatusesForAlbumIds = async (
               updatedAt: new Date().toISOString(),
             };
           } else if (isFailedImport || isFailedDownload || isStaleGrabbed) {
-            const album = await lidarrClient.getAlbum(lidarrAlbumId).catch(() => null);
+            const album = (await getVerifiedAlbums()).get(String(lidarrAlbumId));
             statuses[albumId] = {
               status: albumHasTrackFiles(album) ? "added" : "failed",
               updatedAt: new Date().toISOString(),

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -11,12 +11,21 @@ import { logger } from "../../../services/logger.js";
 import { getCanonicalTrackOwnership } from "../../../services/libraryQueryService.js";
 
 const STALE_GRABBED_MS = 15 * 60 * 1000;
-const DOWNLOAD_STATUS_CACHE_MS = 5000;
+const ACTIVE_STATUS_CACHE_MS = 10 * 1000;
+const IDLE_STATUS_CACHE_MS = 60 * 1000;
+const MAX_STATUS_RETRY_MS = 2 * 60 * 1000;
 let allDownloadStatusesCache = {
-  at: 0,
-  statuses: null,
+  snapshot: null,
   pending: null,
+  failures: 0,
+  nextRefreshAt: 0,
+  revision: 0,
 };
+
+const activeDownloadStatuses = new Set(["searching", "downloading", "processing"]);
+
+const snapshotHasActiveWork = (statuses) =>
+  Object.values(statuses || {}).some((status) => activeDownloadStatuses.has(status?.status));
 
 const invalidateActivityRequestsCache = () =>
   import("../../requests.js")
@@ -33,13 +42,7 @@ export const getDownloadStatusesForAlbumIds = async (
 
   if (lidarrClient.isConfigured()) {
     try {
-      const { queue, history, commands } =
-        snapshot ||
-        (await Promise.all([
-          lidarrClient.getQueue(),
-          lidarrClient.getHistory(1, 200),
-          lidarrClient.request("/command").catch(() => []),
-        ]).then(([queue, history, commands]) => ({ queue, history, commands })));
+      const { queue, history, commands } = snapshot || (await getLidarrStatusSnapshot()).provider;
       const queueItems = Array.isArray(queue) ? queue : queue.records || [];
       const historyItems = Array.isArray(history) ? history : history.records || [];
       const searchContext = parseLidarrSearchContext({
@@ -221,85 +224,106 @@ export const getDownloadStatusesForAlbumIds = async (
   return statuses;
 };
 
-const computeAllDownloadStatuses = async () => {
+const computeLidarrStatusSnapshot = async () => {
   const { lidarrClient } = await import("../../../services/lidarrClient.js");
 
   if (!lidarrClient.isConfigured()) {
-    return {};
-  }
-  if (lidarrClient.isCircuitOpen()) {
-    return allDownloadStatusesCache.statuses || {};
+    return { provider: { queue: [], history: { records: [] }, commands: [] }, statuses: {} };
   }
 
-  try {
-    const [queue, history, commands] = await Promise.all([
-      lidarrClient.getQueue(),
-      lidarrClient.getHistory(1, 200),
-      lidarrClient.request("/command").catch(() => []),
-    ]);
-    const queueItems = Array.isArray(queue) ? queue : queue.records || [];
-    const historyItems = Array.isArray(history) ? history : history.records || [];
-    const oneHourAgo = Date.now() - 60 * 60 * 1000;
-    const albumIds = new Set();
-    const searchContext = parseLidarrSearchContext({
-      queue,
-      history,
-      commands,
-    });
+  const [queue, history, commands] = await Promise.all([
+    lidarrClient.getQueue({ forceRefresh: true }),
+    lidarrClient.getHistory(1, 200, "date", "descending", { forceRefresh: true }),
+    lidarrClient.request("/command", "GET", null, false, { forceRefresh: true }),
+  ]);
+  const provider = { queue, history, commands };
+  const queueItems = Array.isArray(queue) ? queue : queue.records || [];
+  const historyItems = Array.isArray(history) ? history : history.records || [];
+  const oneHourAgo = Date.now() - 60 * 60 * 1000;
+  const albumIds = new Set();
+  const searchContext = parseLidarrSearchContext({ queue, history, commands });
 
-    for (const item of queueItems) {
-      const albumId = item?.albumId ?? item?.album?.id;
-      if (albumId != null) albumIds.add(String(albumId));
-    }
-    for (const item of historyItems) {
-      if (item?.albumId == null) continue;
-      const historyTime = new Date(item?.date || item?.eventDate || 0).getTime();
-      if (historyTime > oneHourAgo) albumIds.add(String(item.albumId));
-    }
-    for (const albumId of searchContext.searchingAlbumIds) {
-      albumIds.add(String(albumId));
-    }
-
-    return getDownloadStatusesForAlbumIds([...albumIds], {
-      queue,
-      history,
-      commands,
-    });
-  } catch (error) {
-    logger.warn("downloads", "Failed to fetch Lidarr status:", { message: error.message });
-    return allDownloadStatusesCache.statuses || {};
+  for (const item of queueItems) {
+    const albumId = item?.albumId ?? item?.album?.id;
+    if (albumId != null) albumIds.add(String(albumId));
   }
+  for (const item of historyItems) {
+    if (item?.albumId == null) continue;
+    const historyTime = new Date(item?.date || item?.eventDate || 0).getTime();
+    if (historyTime > oneHourAgo) albumIds.add(String(item.albumId));
+  }
+  for (const albumId of searchContext.searchingAlbumIds) {
+    albumIds.add(String(albumId));
+  }
+
+  const statuses = await getDownloadStatusesForAlbumIds([...albumIds], provider);
+  return { provider, statuses };
 };
 
 export const invalidateAllDownloadStatusesCache = () => {
-  allDownloadStatusesCache.at = 0;
-  allDownloadStatusesCache.statuses = null;
-  allDownloadStatusesCache.pending = null;
+  allDownloadStatusesCache.revision += 1;
+  allDownloadStatusesCache.nextRefreshAt = 0;
 };
 
-export const getAllDownloadStatuses = async () => {
+export const hasActiveLidarrStatusSnapshot = () =>
+  allDownloadStatusesCache.snapshot?.active === true;
+
+const staleSnapshot = (error) => ({
+  ...(allDownloadStatusesCache.snapshot || {
+    provider: { queue: [], history: { records: [] }, commands: [] },
+    statuses: {},
+    updatedAt: null,
+    active: false,
+  }),
+  stale: true,
+  error: error?.message || String(error),
+});
+
+export const getLidarrStatusSnapshot = async ({ force = false } = {}) => {
   const { lidarrClient } = await import("../../../services/lidarrClient.js");
-  if (lidarrClient.isCircuitOpen() && allDownloadStatusesCache.statuses) {
-    return allDownloadStatusesCache.statuses;
+  if (lidarrClient.isCircuitOpen()) {
+    return staleSnapshot("Lidarr circuit is open");
   }
 
   const now = Date.now();
-  if (
-    allDownloadStatusesCache.statuses &&
-    now - allDownloadStatusesCache.at < DOWNLOAD_STATUS_CACHE_MS
-  ) {
-    return allDownloadStatusesCache.statuses;
+  if (!force && allDownloadStatusesCache.snapshot && now < allDownloadStatusesCache.nextRefreshAt) {
+    return allDownloadStatusesCache.snapshot;
   }
-
   if (allDownloadStatusesCache.pending) {
     return allDownloadStatusesCache.pending;
   }
 
-  allDownloadStatusesCache.pending = computeAllDownloadStatuses()
-    .then((statuses) => {
-      allDownloadStatusesCache.statuses = statuses;
-      allDownloadStatusesCache.at = Date.now();
-      return statuses;
+  const refreshRevision = allDownloadStatusesCache.revision;
+  allDownloadStatusesCache.pending = computeLidarrStatusSnapshot()
+    .then(({ provider, statuses }) => {
+      const active = snapshotHasActiveWork(statuses);
+      const refreshedAt = Date.now();
+      const snapshot = {
+        provider,
+        statuses,
+        updatedAt: new Date(refreshedAt).toISOString(),
+        active,
+        stale: false,
+        error: null,
+      };
+      allDownloadStatusesCache.snapshot = snapshot;
+      allDownloadStatusesCache.failures = 0;
+      allDownloadStatusesCache.nextRefreshAt =
+        refreshRevision === allDownloadStatusesCache.revision
+          ? refreshedAt + (active ? ACTIVE_STATUS_CACHE_MS : IDLE_STATUS_CACHE_MS)
+          : 0;
+      return snapshot;
+    })
+    .catch((error) => {
+      allDownloadStatusesCache.failures += 1;
+      allDownloadStatusesCache.nextRefreshAt = Date.now() + Math.min(
+        MAX_STATUS_RETRY_MS,
+        ACTIVE_STATUS_CACHE_MS * 2 ** (allDownloadStatusesCache.failures - 1),
+      );
+      logger.warn("downloads", "Failed to refresh Lidarr status:", { message: error.message });
+      const snapshot = staleSnapshot(error);
+      allDownloadStatusesCache.snapshot = snapshot;
+      return snapshot;
     })
     .finally(() => {
       allDownloadStatusesCache.pending = null;
@@ -307,6 +331,9 @@ export const getAllDownloadStatuses = async () => {
 
   return allDownloadStatusesCache.pending;
 };
+
+export const getAllDownloadStatuses = async () =>
+  (await getLidarrStatusSnapshot()).statuses;
 
 export function registerDownloads(router) {
   router.post("/downloads/track", requireAuth, requirePermission("addAlbum"), async (req, res) => {
@@ -549,7 +576,7 @@ export function registerDownloads(router) {
       if (!lidarrClient.isConfigured()) {
         return res.json([]);
       }
-      const queue = await lidarrClient.getQueue();
+      const queue = (await getLidarrStatusSnapshot()).provider.queue;
       const queueItems = Array.isArray(queue) ? queue : queue.records || [];
       res.json(
         queueItems.map((item) => ({

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -323,10 +323,12 @@ export const getLidarrStatusSnapshot = async ({ force = false } = {}) => {
     })
     .catch((error) => {
       allDownloadStatusesCache.failures += 1;
-      allDownloadStatusesCache.nextRefreshAt = Date.now() + Math.min(
+      const retryAt = Date.now() + Math.min(
         MAX_STATUS_RETRY_MS,
         ACTIVE_STATUS_CACHE_MS * 2 ** (allDownloadStatusesCache.failures - 1),
       );
+      allDownloadStatusesCache.nextRefreshAt =
+        refreshRevision === allDownloadStatusesCache.revision ? retryAt : 0;
       logger.warn("downloads", "Failed to refresh Lidarr status:", { message: error.message });
       const snapshot = staleSnapshot(error);
       allDownloadStatusesCache.snapshot = snapshot;

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -2,7 +2,10 @@ import express from "express";
 import { UUID_REGEX } from "../../lib/uuid.js";
 import { noCache } from "../middleware/cache.js";
 import { requireAuth, requirePermission } from "../middleware/requirePermission.js";
-import { invalidateAllDownloadStatusesCache } from "./library/handlers/downloads.js";
+import {
+  getLidarrStatusSnapshot,
+  invalidateAllDownloadStatusesCache,
+} from "./library/handlers/downloads.js";
 import { buildLidarrRequests } from "../services/lidarrRequestBuilder.js";
 import { getAurralHistoryRequests } from "../services/aurralHistoryService.js";
 
@@ -71,8 +74,11 @@ const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
 };
 
 const buildRequestsResponse = async (lidarrClient) => {
+  const snapshot = lidarrClient?.isConfigured()
+    ? await getLidarrStatusSnapshot()
+    : null;
   const [lidarrRequests, aurralRequests] = await Promise.all([
-    lidarrClient?.isConfigured() ? buildLidarrRequests(lidarrClient) : Promise.resolve([]),
+    snapshot ? buildLidarrRequests(lidarrClient, snapshot.provider) : Promise.resolve([]),
     getAurralHistoryRequests(lidarrClient),
   ]);
   const filteredAurral = filterRedundantAurralRequests(aurralRequests, lidarrRequests);

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -73,9 +73,9 @@ const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
   });
 };
 
-const buildRequestsResponse = async (lidarrClient) => {
+const buildRequestsResponse = async (lidarrClient, { force = false } = {}) => {
   const snapshot = lidarrClient?.isConfigured()
-    ? await getLidarrStatusSnapshot()
+    ? await getLidarrStatusSnapshot({ force })
     : null;
   const [lidarrRequests, aurralRequests] = await Promise.all([
     snapshot ? buildLidarrRequests(lidarrClient, snapshot.provider) : Promise.resolve([]),
@@ -87,9 +87,9 @@ const buildRequestsResponse = async (lidarrClient) => {
   );
 };
 
-const refreshRequestsCache = async (lidarrClient) => {
+const refreshRequestsCache = async (lidarrClient, options) => {
   if (pendingRequestsRefresh) return pendingRequestsRefresh;
-  pendingRequestsRefresh = buildRequestsResponse(lidarrClient)
+  pendingRequestsRefresh = buildRequestsResponse(lidarrClient, options)
     .then(updateRequestsCache)
     .finally(() => {
       pendingRequestsRefresh = null;
@@ -124,7 +124,7 @@ router.get("/", requireAuth, noCache, async (req, res) => {
       return res.json(filterDismissedRequests(lastRequestsResponse));
     }
 
-    const requests = await refreshRequestsCache(lidarrClient);
+    const requests = await refreshRequestsCache(lidarrClient, { force: forceRefresh });
     res.json(requests);
   } catch (error) {
     if (lastRequestsResponse) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,10 @@ import { authMiddleware, isProxyAuthEnabled } from "./middleware/auth.js";
 import { handleOidcCallback, isOidcEnabled } from "./services/oidcAuth.js";
 import { logger } from "./services/logger.js";
 import { websocketService } from "./services/websocketService.js";
-import { getAllDownloadStatuses } from "./routes/library/handlers/downloads.js";
+import {
+  getLidarrStatusSnapshot,
+  hasActiveLidarrStatusSnapshot,
+} from "./routes/library/handlers/downloads.js";
 import { getWeeklyFlowStatusSnapshot } from "./services/weeklyFlow/weeklyFlowStatusSnapshot.js";
 
 import settingsRouter from "./routes/settings/index.js";
@@ -302,17 +305,19 @@ const broadcastDownloadStatuses = async () => {
   if (downloadStatusBroadcastInFlight) return;
   downloadStatusBroadcastInFlight = true;
   try {
-    if (!hasWsSubscribers("downloads")) return;
-    const { lidarrClient } = await import("./services/lidarrClient.js");
-    if (lidarrClient.isCircuitOpen()) return;
-    const statuses = await getAllDownloadStatuses();
-    const payload = JSON.stringify(statuses);
+    if (!hasWsSubscribers("downloads") && !hasActiveLidarrStatusSnapshot()) return;
+    const snapshot = await getLidarrStatusSnapshot();
+    const message = {
+      type: "download_statuses",
+      statuses: snapshot.statuses,
+      stale: snapshot.stale,
+      error: snapshot.error,
+      updatedAt: snapshot.updatedAt,
+    };
+    const payload = JSON.stringify(message);
     if (payload !== lastDownloadStatusesPayload) {
       lastDownloadStatusesPayload = payload;
-      websocketService.broadcast("downloads", {
-        type: "download_statuses",
-        statuses,
-      });
+      websocketService.broadcast("downloads", message);
     }
   } catch (error) {
     logger.warn("system", "Failed to broadcast download statuses:", { message: error.message });

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -443,7 +443,7 @@ export class LidarrClient {
     const isStatusRequest =
       method === "GET" &&
       (endpoint === "/queue" || endpoint === "/command" || endpoint.startsWith("/history"));
-    if (isStatusRequest) {
+    if (isStatusRequest && !options.forceRefresh) {
       const cached = this._statusCache.get(endpoint);
       if (cached && now - cached.at < LIDARR_STATUS_CACHE_MS) {
         return cached.data;
@@ -1484,8 +1484,8 @@ export class LidarrClient {
     });
   }
 
-  async getQueue() {
-    const response = await this.request("/queue");
+  async getQueue(options = {}) {
+    const response = await this.request("/queue", "GET", null, false, options);
     if (response && Array.isArray(response)) {
       return response;
     }
@@ -1496,14 +1496,20 @@ export class LidarrClient {
     return this.request(`/queue/${queueId}`);
   }
 
-  async getHistory(page = 1, pageSize = 20, sortKey = "date", sortDirection = "descending") {
+  async getHistory(
+    page = 1,
+    pageSize = 20,
+    sortKey = "date",
+    sortDirection = "descending",
+    options = {},
+  ) {
     const params = new URLSearchParams({
       page: page.toString(),
       pageSize: pageSize.toString(),
       sortKey,
       sortDirection,
     });
-    return this.request(`/history?${params.toString()}`);
+    return this.request(`/history?${params.toString()}`, "GET", null, false, options);
   }
 
   async getHistoryForAlbum(albumId) {

--- a/backend/services/lidarrRequestBuilder.js
+++ b/backend/services/lidarrRequestBuilder.js
@@ -8,11 +8,13 @@ const toIso = (value) => {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 };
 
-export const buildLidarrRequests = async (lidarrClient) => {
-  const [queue, history] = await Promise.all([
-    lidarrClient.getQueue().catch(() => []),
-    lidarrClient.getHistory(1, 200).catch(() => ({ records: [] })),
-  ]);
+export const buildLidarrRequests = async (lidarrClient, snapshot = null) => {
+  const [queue, history] = snapshot
+    ? [snapshot.queue, snapshot.history]
+    : await Promise.all([
+        lidarrClient.getQueue().catch(() => []),
+        lidarrClient.getHistory(1, 200).catch(() => ({ records: [] })),
+      ]);
 
   const requestsByAlbumId = new Map();
   const queueItems = Array.isArray(queue) ? queue : queue?.records || [];


### PR DESCRIPTION
## Summary

- share one queue, history, and command snapshot across download status, activity requests, and WebSocket updates
- stop provider polling when there are no subscribers and no active work; refresh active state every 10 seconds and idle state every 60 seconds
- preserve the last good snapshot with bounded retry backoff when Lidarr is unavailable
- invalidate the shared snapshot after mutations and bypass the lower-level status cache on the next refresh

## Verification

- `npm test` — 777 passed
- focused Lidarr status and circuit tests — 22 passed
- `npm run lint`
- `npm run build`
- `git diff --check`

Backlog: TASK-2.1.10.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved download and request status loading through shared, deduplicated status updates.
  * Reduced unnecessary service requests while keeping active information current.

* **Reliability**
  * Added stale-data recovery and retry handling when status services are unavailable.
  * Forced refreshes now bypass cached status data when needed.

* **Bug Fixes**
  * Improved album verification and fallback behavior when bulk status checks fail.
  * Status updates now include clearer freshness and error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->