### PR TITLE
perf(background): make reads side-effect free

### DIFF
--- a/.tests/discovery/discovery-refresh-scheduler.test.js
+++ b/.tests/discovery/discovery-refresh-scheduler.test.js
@@ -16,12 +16,14 @@ const [isolatedState, honkerDbModule, refreshScheduler, discoveryIndex] =
 
 const {
   discoveryNeedsRefresh,
+  bootstrapDiscoveryRefresh,
   enqueueDiscoveryRefresh,
   markDiscoveryRefreshDequeued,
   recoverDeadDiscoveryRefresh,
   scheduleNextDiscoveryRefresh,
 } = refreshScheduler;
 const { getDiscoveryCache } = discoveryIndex;
+const originalLastfmApiKey = process.env.LASTFM_API_KEY;
 
 let heldGlobalRefreshLock = null;
 
@@ -69,13 +71,36 @@ function countDiscoveryRefreshJobs() {
   );
 }
 
+function discoveryRefreshPayloads() {
+  return honkerDbModule
+    .getHonkerDb()
+    .query("SELECT payload FROM _honker_live WHERE queue = ? ORDER BY id", [
+      "discovery-refresh",
+    ])
+    .map((row) => JSON.parse(row.payload));
+}
+
+function setDiscoveryCache(overrides = {}) {
+  Object.assign(getDiscoveryCache(), {
+    recommendations: [],
+    globalTop: [],
+    topGenres: [],
+    lastUpdated: null,
+    isUpdating: false,
+    ...overrides,
+  });
+}
+
 test.beforeEach(() => {
+  clearDiscoveryRefreshJobs();
   markDiscoveryRefreshDequeued();
-  getDiscoveryCache().isUpdating = false;
+  setDiscoveryCache();
   releaseHeldGlobalRefreshLock();
 });
 
 test.after(async () => {
+  if (originalLastfmApiKey === undefined) delete process.env.LASTFM_API_KEY;
+  else process.env.LASTFM_API_KEY = originalLastfmApiKey;
   releaseHeldGlobalRefreshLock();
   markDiscoveryRefreshDequeued();
   await cleanupIsolatedState(isolatedState);
@@ -101,6 +126,59 @@ test("discoveryNeedsRefresh returns false for fresh populated cache", () => {
     }),
     false,
   );
+});
+
+test("first discovery startup queues one refresh", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+
+  await bootstrapDiscoveryRefresh();
+
+  const payloads = discoveryRefreshPayloads();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].reason, "startup");
+  assert.equal(payloads[0].scheduleOnly, false);
+});
+
+test("completed empty discovery cache stays fresh across two restarts", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({ lastUpdated: new Date().toISOString() });
+
+  await bootstrapDiscoveryRefresh();
+  await bootstrapDiscoveryRefresh();
+
+  const payloads = discoveryRefreshPayloads();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].reason, "scheduled");
+  assert.equal(payloads[0].scheduleOnly, true);
+});
+
+test("stale and incomplete discovery caches retry", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({
+    recommendations: [{ id: "old" }],
+    topGenres: ["rock"],
+    lastUpdated: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+  });
+
+  await bootstrapDiscoveryRefresh();
+  assert.equal(discoveryRefreshPayloads()[0].reason, "startup");
+
+  clearDiscoveryRefreshJobs();
+  markDiscoveryRefreshDequeued();
+  setDiscoveryCache({ recommendations: [{ id: "partial" }] });
+
+  await bootstrapDiscoveryRefresh();
+  assert.equal(discoveryRefreshPayloads()[0].reason, "startup");
+});
+
+test("repeated startup checks do not create duplicate active refresh jobs", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({ lastUpdated: null });
+
+  await bootstrapDiscoveryRefresh();
+  await bootstrapDiscoveryRefresh();
+
+  assert.equal(countDiscoveryRefreshJobs(), 1);
 });
 
 test("enqueueDiscoveryRefresh deduplicates active refresh requests", () => {

--- a/.tests/honker/honker-db-config.test.js
+++ b/.tests/honker/honker-db-config.test.js
@@ -79,6 +79,7 @@ test("startup only queues due bootstrap work and a pending migration", () => {
 
   clearQueue();
   honkerDb.enqueueHonkerStartupTasks();
+  honkerDb.enqueueHonkerStartupTasks();
   assert.deepEqual(queuedKinds(), [
     "playlist-startup-migration",
     "weekly-flow-startup-check",

--- a/.tests/inbox-refresh-queue.test.js
+++ b/.tests/inbox-refresh-queue.test.js
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  setupIsolatedBackend,
+} from "./helpers/backendTestHarness.js";
+
+const [
+  isolatedState,
+  { db },
+  { dbOps, userOps },
+  inboxService,
+  honkerDb,
+  systemTaskWorker,
+  { upsertLibraryArtist },
+  axios,
+] = await setupIsolatedBackend(
+  "inbox-refresh-queue",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+  "backend/services/inboxService.js",
+  "backend/services/honkerDb.js",
+  "backend/services/systemTaskWorker.js",
+  "backend/services/libraryMediaStore.js",
+  "lib/axiosFetch.js",
+);
+
+const {
+  enqueueInboxRefreshForUser,
+  getInboxForUser,
+  getInboxRefreshStatus,
+  refreshInboxForUser,
+} = inboxService;
+const { enqueueHonkerStartupTasks, getHonkerDb, getSystemTaskQueue } = honkerDb;
+const { processSystemTask } = systemTaskWorker;
+
+let userId;
+
+function clearRefreshState() {
+  const transaction = getHonkerDb().transaction();
+  transaction.execute("DELETE FROM _honker_live");
+  transaction.commit();
+  db.prepare("DELETE FROM inbox_items").run();
+  db.prepare("DELETE FROM settings WHERE key LIKE 'inboxRefresh:%'").run();
+}
+
+test.before(() => {
+  getSystemTaskQueue();
+  userId = userOps.createUser("inbox-refresh-user", "password-hash").id;
+  upsertLibraryArtist({
+    identityKey: "artist:inbox-refresh",
+    mbid: "artist-mbid",
+    name: "Inbox Refresh Artist",
+  });
+});
+
+test.beforeEach(() => {
+  clearRefreshState();
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("GET inbox reads cached rows without creating refresh work", () => {
+  const result = getInboxForUser(userId);
+  const jobs = getHonkerDb().query(
+    "SELECT id FROM _honker_live WHERE queue = 'system-task'",
+  );
+
+  assert.equal(result.refreshStatus.status, "idle");
+  assert.equal(result.refreshing, false);
+  assert.equal(jobs.length, 0);
+});
+
+test("manual refreshes deduplicate per user and survive a Honker reopen", async () => {
+  const queue = getSystemTaskQueue();
+  const originalEnqueue = queue.enqueue;
+  queue.enqueue = function enqueueWithFutureRunAt(payload, options = {}) {
+    return originalEnqueue.call(this, payload, {
+      ...options,
+      runAt: Math.floor(Date.now() / 1000) + 120,
+    });
+  };
+
+  let first;
+  let second;
+  try {
+    first = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+    second = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+  } finally {
+    queue.enqueue = originalEnqueue;
+  }
+
+  assert.equal(first.queued, true);
+  assert.equal(second.queued, false);
+  assert.equal(second.jobId, first.jobId);
+  assert.equal(
+    getHonkerDb().query(
+      "SELECT id FROM _honker_live WHERE queue = 'system-task' AND state = 'pending'",
+    ).length,
+    1,
+  );
+
+  honkerDb.closeHonkerDb();
+  const statusAfterReopen = getInboxRefreshStatus(userId);
+  assert.equal(statusAfterReopen.status, "queued");
+  assert.equal(statusAfterReopen.jobId, first.jobId);
+});
+
+test("a removed queued refresh is reported stale", async () => {
+  const queue = getSystemTaskQueue();
+  const originalEnqueue = queue.enqueue;
+  queue.enqueue = function enqueueWithFutureRunAt(payload, options = {}) {
+    return originalEnqueue.call(this, payload, {
+      ...options,
+      runAt: Math.floor(Date.now() / 1000) + 120,
+    });
+  };
+  let refresh;
+  try {
+    refresh = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+  } finally {
+    queue.enqueue = originalEnqueue;
+  }
+  const transaction = getHonkerDb().transaction();
+  transaction.execute("DELETE FROM _honker_live WHERE id = ?", [refresh.jobId]);
+  transaction.commit();
+
+  const status = getInboxRefreshStatus(userId);
+  assert.equal(status.status, "stale");
+  assert.equal(status.stale, true);
+  assert.match(status.error, /no longer active/i);
+});
+
+test("expired inbox leases are reported stale and recovered without overlap", async () => {
+  const queue = getSystemTaskQueue();
+  const jobId = queue.enqueue({ kind: "inbox-refresh", userId });
+  const expiredAt = Math.floor(Date.now() / 1000) - 10;
+  const transaction = getHonkerDb().transaction();
+  transaction.execute(
+    `UPDATE _honker_live
+     SET state = 'processing', worker_id = ?, claim_expires_at = ?
+     WHERE id = ?`,
+    ["stale-worker", expiredAt, jobId],
+  );
+  transaction.commit();
+
+  const staleStatus = getInboxRefreshStatus(userId);
+  assert.equal(staleStatus.status, "stale");
+  assert.equal(staleStatus.stale, true);
+  assert.match(staleStatus.error, /lease expired/i);
+
+  const recovered = await enqueueInboxRefreshForUser(userId, { reason: "retry" });
+  assert.equal(recovered.queued, true);
+  assert.notEqual(recovered.jobId, jobId);
+  assert.equal(
+    getHonkerDb().query(
+      `SELECT id FROM _honker_live
+       WHERE queue = 'system-task'
+         AND (state = 'pending' OR (state = 'processing' AND claim_expires_at > ?))`,
+      [Math.floor(Date.now() / 1000)],
+    ).length,
+    1,
+  );
+});
+
+test("provider failure preserves rows and marks the inbox stale", async () => {
+  const previous = dbOps.upsertInboxItem({
+    userId,
+    kind: "release",
+    sourceKey: "prior:release",
+    title: "Previously cached release",
+  });
+  const originalAxiosGet = axios.default.get;
+  const originalTicketmasterKey = process.env.TICKETMASTER_API_KEY;
+  process.env.TICKETMASTER_API_KEY = "test-ticketmaster-key";
+  axios.default.get = (url, options) => {
+    if (String(url).includes("zippopotam.us")) {
+      return Promise.resolve({
+        data: {
+          places: [{
+            "place name": "New York",
+            state: "New York",
+            "state abbreviation": "NY",
+            latitude: "40.71",
+            longitude: "-74.00",
+          }],
+        },
+      });
+    }
+    if (String(url).includes("ticketmaster.com")) {
+      return Promise.reject(new Error("Ticketmaster unavailable"));
+    }
+    return originalAxiosGet(url, options);
+  };
+
+  try {
+    const refreshed = await refreshInboxForUser(userId, {
+      force: true,
+      ipAddress: "127.0.0.1",
+      zipCode: "10001",
+    });
+    assert.equal(refreshed, false);
+    const status = getInboxRefreshStatus(userId);
+    assert.equal(status.status, "stale");
+    assert.equal(status.stale, true);
+    assert.match(status.error, /shows: Ticketmaster unavailable/);
+    assert.equal(dbOps.getInboxItem(userId, previous.id)?.title, "Previously cached release");
+  } finally {
+    axios.default.get = originalAxiosGet;
+    if (originalTicketmasterKey === undefined) delete process.env.TICKETMASTER_API_KEY;
+    else process.env.TICKETMASTER_API_KEY = originalTicketmasterKey;
+  }
+});
+
+test("failed refreshes are explicit and a worker retry can complete", async () => {
+  const previous = dbOps.upsertInboxItem({
+    userId,
+    kind: "release",
+    sourceKey: "failed:release",
+    title: "Retained while refresh fails",
+  });
+  const originalGetSettings = dbOps.getSettings;
+  dbOps.getSettings = () => {
+    throw new Error("Inbox provider unavailable");
+  };
+
+  try {
+    await assert.rejects(
+      processSystemTask({ kind: "inbox-refresh", userId }, { id: 9001 }),
+      /Inbox provider unavailable/,
+    );
+    const failed = getInboxRefreshStatus(userId);
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.stale, true);
+    assert.match(failed.error, /Inbox provider unavailable/);
+    assert.equal(dbOps.getInboxItem(userId, previous.id)?.title, "Retained while refresh fails");
+  } finally {
+    dbOps.getSettings = originalGetSettings;
+  }
+
+  await processSystemTask({ kind: "inbox-refresh", userId }, { id: 9002 });
+  const recovered = getInboxRefreshStatus(userId);
+  assert.equal(recovered.status, "complete");
+  assert.equal(recovered.stale, false);
+  assert.equal(recovered.lastSuccessAt > 0, true);
+});
+
+test("startup markers prevent duplicate bootstrap jobs on restart", () => {
+  enqueueHonkerStartupTasks();
+  enqueueHonkerStartupTasks();
+  const kinds = getHonkerDb()
+    .query("SELECT payload FROM _honker_live WHERE queue = 'system-task'")
+    .map((row) => JSON.parse(row.payload).kind);
+
+  assert.equal(kinds.filter((kind) => kind === "weekly-flow-startup-check").length, 1);
+  assert.equal(kinds.filter((kind) => kind === "discovery-bootstrap").length, 1);
+  assert.equal(kinds.filter((kind) => kind === "library-index-bootstrap").length, 1);
+});

--- a/backend/routes/inbox.js
+++ b/backend/routes/inbox.js
@@ -4,8 +4,10 @@ import { hasPermission } from "../middleware/auth.js";
 import { requireAuth } from "../middleware/requirePermission.js";
 import { libraryManager } from "../services/libraryManager.js";
 import {
+  enqueueInboxRefreshForUser,
   getInboxForUser,
   getInboxRefreshCooldownMs,
+  getInboxRefreshStatus,
   markAllInboxItemsRead,
   updateInboxItem,
 } from "../services/inboxService.js";
@@ -56,9 +58,6 @@ router.get("/", requireAuth, async (req, res) => {
     const limit = Math.max(1, Math.min(50, Number.parseInt(req.query.limit, 10) || 50));
     const result = await getInboxForUser(getUserId(req), {
       limit,
-      zipCode: String(req.query.zip || "").trim(),
-      req,
-      awaitRefresh: false,
     });
     res.set("Cache-Control", "private, no-cache, no-store, must-revalidate");
     return res.json(result);
@@ -72,21 +71,37 @@ router.post("/refresh", requireAuth, async (req, res) => {
   const now = Date.now();
   const last = lastManualRefresh.get(userId) || 0;
   const cooldown = getInboxRefreshCooldownMs() * 3;
+  const current = getInboxRefreshStatus(userId);
+  if (current.status === "queued" || current.status === "running") {
+    return res.status(202).json({
+      accepted: false,
+      queued: false,
+      jobId: current.jobId,
+      status: current.status,
+      refreshStatus: current,
+    });
+  }
   if (now - last < cooldown) {
     return res.status(429).json({
       error: "Inbox refresh is rate limited",
       retryAfterSeconds: Math.ceil((cooldown - (now - last)) / 1000),
     });
   }
-  lastManualRefresh.set(userId, now);
   try {
-    const result = await getInboxForUser(userId, {
-      limit: 50,
+    const refresh = await enqueueInboxRefreshForUser(userId, {
+      reason: "manual",
       zipCode: String(req.body?.zip || req.query.zip || "").trim(),
-      req,
-      force: true,
+      ipAddress: req.ip || req.headers["x-forwarded-for"] || "",
     });
-    return res.json(result);
+    lastManualRefresh.set(userId, now);
+    const result = getInboxForUser(userId, { limit: 50 });
+    return res.status(202).json({
+      ...result,
+      accepted: refresh.queued,
+      queued: refresh.queued,
+      jobId: refresh.jobId,
+      status: refresh.status,
+    });
   } catch (error) {
     return res.status(500).json({ error: "Failed to refresh inbox", message: error.message });
   }

--- a/backend/routes/settings/handlers/storageHealth.js
+++ b/backend/routes/settings/handlers/storageHealth.js
@@ -2,12 +2,35 @@ import { noCache } from "../../../middleware/cache.js";
 import { logger } from "../../../services/logger.js";
 
 export function registerStorageHealth(router) {
-  router.get("/storage-health", noCache, async (req, res) => {
+  router.get("/storage-health", noCache, async (_req, res) => {
+    try {
+      const { getStorageHealthSnapshot } =
+        await import("../../../services/storageHealthService.js");
+      const result = getStorageHealthSnapshot() || {
+        ok: null,
+        partial: false,
+        checkedAt: null,
+        sections: [],
+        unavailable: true,
+      };
+      res.json({
+        success: result.ok === true,
+        ...result,
+      });
+    } catch (error) {
+      logger.error("settings", "Storage health check error:", error);
+      res.status(500).json({
+        error: "Storage health check failed",
+        message: error.message,
+      });
+    }
+  });
+
+  router.post("/storage-health/check", noCache, async (_req, res) => {
     try {
       const { runStorageHealthCheck } =
         await import("../../../services/storageHealthService.js");
-      const force = req.query.force === "1" || req.query.force === "true";
-      const result = await runStorageHealthCheck({ force });
+      const result = await runStorageHealthCheck({ force: true });
       res.json({
         success: result.ok,
         ...result,

--- a/backend/routes/weeklyFlow/handlers/stream.js
+++ b/backend/routes/weeklyFlow/handlers/stream.js
@@ -51,9 +51,6 @@ export function registerStream(router) {
     if (!resolved) {
       return res.status(404).json({ error: "Track file missing" });
     }
-    if (resolved.migratedFrom) {
-      downloadTracker.setDone(job.id, resolved.path, job.albumName || null);
-    }
     const safePath = resolved.path;
     try {
       await fsp.access(safePath);

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -149,17 +149,10 @@ export async function isDiscoveryRefreshConfigured() {
 
 export function discoveryNeedsRefresh(cache = getDiscoveryCache()) {
   const lastUpdated = cache?.lastUpdated;
-  const hasRecommendations =
-    Array.isArray(cache?.recommendations) && cache.recommendations.length > 0;
-  const hasGenres = Array.isArray(cache?.topGenres) && cache.topGenres.length > 0;
   const refreshHours = getDiscoveryAutoRefreshHours();
   const staleCutoff = Date.now() - refreshHours * 60 * 60 * 1000;
-  return (
-    !lastUpdated ||
-    new Date(lastUpdated).getTime() < staleCutoff ||
-    !hasRecommendations ||
-    !hasGenres
-  );
+  const lastUpdatedAt = new Date(lastUpdated || "").getTime();
+  return !Number.isFinite(lastUpdatedAt) || lastUpdatedAt < staleCutoff;
 }
 
 function emitDiscoveryQueued(reason) {
@@ -286,16 +279,6 @@ export async function bootstrapDiscoveryRefresh() {
   const result = await enqueueDiscoveryRefreshIfNeeded({ reason: "startup" });
   if (result.reason === "fresh") {
     const latest = getDiscoveryCache();
-    if (
-      (!latest.recommendations?.length && !latest.globalTop?.length) ||
-      !latest.topGenres?.length
-    ) {
-      const retry = enqueueDiscoveryRefresh({ reason: "startup_incomplete" });
-      if (retry.enqueued) {
-        console.log("Discovery cache timestamp exists but data is incomplete. Re-queued refresh.");
-      }
-      return;
-    }
     console.log(
       `Discovery cache is fresh (last updated ${latest.lastUpdated}). Scheduling next refresh.`,
     );

--- a/backend/services/discovery/userDiscovery.js
+++ b/backend/services/discovery/userDiscovery.js
@@ -1,11 +1,7 @@
-import { logger } from "../logger.js";
 import {
   getDiscoveryCache,
   getDiscoveryUpdateStatus,
   getDiscoveryPlaylistBuildStatus,
-  requestUserDiscoveryRefresh,
-  getUserDiscoveryCacheStaleness,
-  isGlobalDiscoveryRefreshInProgress,
   getDiscoveryMode,
   getDiscoveryFeedback,
   filterBlockedArtistsForUser,
@@ -13,11 +9,10 @@ import {
 } from "./index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
 import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
-import { dbOps, userOps } from "../../db/helpers/index.js";
+import { userOps } from "../../db/helpers/index.js";
 import {
   DISCOVERY_PROVIDER_LASTFM,
   DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK,
-  buildListenbrainzFallbackDiscovery,
   getDiscoveryCapabilities,
 } from "../listenbrainzDiscoveryFallback.js";
 import {
@@ -25,13 +20,9 @@ import {
   getListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
-import { enqueueDiscoveryRefresh } from "./refreshScheduler.js";
 import {
   buildArtistKeySet,
   isLibraryArtist,
-  getDiscoveryRevalidateAt,
-  setDiscoveryRevalidateAt,
-  DISCOVERY_REVALIDATE_COOLDOWN_MS,
   getDiscoveryStaleMs,
 } from "../../routes/discovery/handlers/utils.js";
 import { getTopPlayedArtists } from "../playEventService.js";
@@ -52,63 +43,12 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     : hasLocalListenHistory
       ? { listenHistoryProvider: "lastfm", listenHistoryUsername: `__aurral_local_${userId}` }
       : externalListenHistoryProfile;
-  const localOnly = !hasExternalListenHistory && hasLocalListenHistory;
   const userCacheNamespace =
     getListenHistoryCacheNamespace(listenHistoryProfile);
   const effectiveCacheNamespace = hasLastfmKey ? userCacheNamespace : null;
 
-  if (
-    hasListenHistoryProfile(listenHistoryProfile) &&
-    hasLastfmKey &&
-    !isGlobalDiscoveryRefreshInProgress()
-  ) {
-    const staleness = getUserDiscoveryCacheStaleness(userCacheNamespace);
-    const staleMs = await getDiscoveryStaleMs();
-    if (staleness > staleMs) {
-      requestUserDiscoveryRefresh(listenHistoryProfile, {
-        feedbackUserId: userId || null,
-        localOnly,
-      }).catch((err) => {
-        logger.error("discovery", `On-demand refresh for ${listenHistoryProfile.listenHistoryProvider}:${listenHistoryProfile.listenHistoryUsername} failed`, { error: err.message });
-      });
-    }
-  }
-
-  let discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
-
-  const hasData =
-    discoveryCache.recommendations?.length > 0 ||
-    discoveryCache.globalTop?.length > 0 ||
-    discoveryCache.topGenres?.length > 0 ||
-    discoveryCache.fallbackGenres?.length > 0;
-  const hasCompletedRefresh =
-    !!discoveryCache.lastUpdated &&
-    (discoveryCache.recommendations?.length > 0 ||
-      discoveryCache.globalTop?.length > 0 ||
-      discoveryCache.topGenres?.length > 0 ||
-      discoveryCache.fallbackGenres?.length > 0);
-
-  let isUpdating = discoveryCache.isUpdating || false;
-
-  if (
-    !hasLastfmKey &&
-    (!hasData ||
-      discoveryCache.provider !== DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK)
-  ) {
-    const fallbackData = await buildListenbrainzFallbackDiscovery({
-      existingArtistKeys: buildArtistKeySet(libraryArtists),
-    });
-    dbOps.updateDiscoveryCache(fallbackData);
-    Object.assign(getDiscoveryCache(), fallbackData, { isUpdating: false });
-    discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
-    isUpdating = false;
-  } else if (!hasData && !hasCompletedRefresh && !isUpdating) {
-    setDiscoveryRevalidateAt(Date.now());
-    const lazyRefresh = enqueueDiscoveryRefresh({ reason: "lazy" });
-    if (lazyRefresh.enqueued) {
-      isUpdating = true;
-    }
-  }
+  const discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
+  const isUpdating = discoveryCache.isUpdating || false;
 
   let {
     recommendations,
@@ -176,19 +116,6 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     Number.isFinite(parsedLastUpdated) &&
     parsedLastUpdated > 0 &&
     Date.now() - parsedLastUpdated > staleMs;
-
-  if (
-    isStale &&
-    !isUpdating &&
-    !hasListenHistoryProfile(listenHistoryProfile) &&
-    Date.now() - getDiscoveryRevalidateAt() > DISCOVERY_REVALIDATE_COOLDOWN_MS
-  ) {
-    setDiscoveryRevalidateAt(Date.now());
-    const staleRefresh = enqueueDiscoveryRefresh({ reason: "stale" });
-    if (staleRefresh.enqueued) {
-      isUpdating = true;
-    }
-  }
 
   const cacheStrategy =
     recommendations.length > 0 || globalTop.length > 0

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -139,6 +139,17 @@ function resolveEnqueueRunAt(options) {
   return null;
 }
 
+function parseHonkerPayload(value) {
+  try {
+    const payload = typeof value === "string" ? JSON.parse(value) : value;
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? payload
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function createHonkerQueue({
   name,
   visibilityTimeoutS,
@@ -397,19 +408,61 @@ export function bootstrapHonkerSchedules() {
 }
 
 export function enqueueHonkerStartupTasks() {
+  const enqueueIfAbsent = (payload, options) => {
+    const existing = findActiveHonkerJob(
+      "system-task",
+      (candidate) => candidate?.kind === payload.kind,
+      { recoverExpired: true },
+    );
+    return existing?.id || enqueueSystemTaskJob(payload, options);
+  };
   const migration = dbOps.getJSONSetting(PLAYLIST_STARTUP_MIGRATION_SETTING);
   if (
     migration?.version !== PLAYLIST_STARTUP_MIGRATION_VERSION ||
     path.resolve(String(migration?.rootPath || "")) !== resolvePlaylistRoot()
   ) {
-    enqueueSystemTaskJob(
+    enqueueIfAbsent(
       { kind: "playlist-startup-migration" },
       { delaySeconds: 3, priority: 10 },
     );
   }
-  enqueueSystemTaskJob({ kind: "weekly-flow-startup-check" }, { delaySeconds: 5, priority: 5 });
-  enqueueSystemTaskJob({ kind: "discovery-bootstrap" }, { delaySeconds: 15, priority: 5 });
-  enqueueSystemTaskJob({ kind: "library-index-bootstrap" }, { delaySeconds: 8, priority: 0 });
+  enqueueIfAbsent({ kind: "weekly-flow-startup-check" }, { delaySeconds: 5, priority: 5 });
+  enqueueIfAbsent({ kind: "discovery-bootstrap" }, { delaySeconds: 15, priority: 5 });
+  enqueueIfAbsent({ kind: "library-index-bootstrap" }, { delaySeconds: 8, priority: 0 });
+}
+
+export function findActiveHonkerJob(
+  queueName,
+  predicate = () => true,
+  { recoverExpired = false } = {},
+) {
+  const safeQueue = String(queueName || "").trim();
+  if (!safeQueue) return null;
+  const queue = getHonkerQueueByName(safeQueue);
+  if (recoverExpired) {
+    try {
+      queue?.sweepExpired();
+    } catch {}
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const rows = getHonkerDb().query(
+    `
+      SELECT id, payload, state, run_at, claim_expires_at, attempts
+      FROM _honker_live
+      WHERE queue = ?
+        AND (
+          state = 'pending'
+          OR (state = 'processing' AND (claim_expires_at IS NULL OR claim_expires_at > ?))
+        )
+      ORDER BY id ASC
+    `,
+    [safeQueue, now],
+  );
+  for (const row of rows) {
+    const payload = parseHonkerPayload(row.payload);
+    if (predicate(payload, row)) return { ...row, payload };
+  }
+  return null;
 }
 
 export function startHonkerScheduler() {

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,3 +1,4 @@
+import { db } from "../config/db-sqlite.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
 import {
@@ -8,12 +9,19 @@ import { getNearbyShows } from "./nearbyShowsService.js";
 import { getUserDiscovery } from "./discovery/userDiscovery.js";
 import { logger } from "./logger.js";
 import { getNewsForUser, getNewsPreferences } from "./newsService.js";
+import {
+  enqueueSystemTaskJob,
+  findActiveHonkerJob,
+  getHonkerDb,
+  withHonkerLock,
+} from "./honkerDb.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RELEASE_PAST_DAYS = 30;
 const RELEASE_FUTURE_DAYS = 90;
 const CONTENT_TTL_MS = 30 * DAY_MS;
 const REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
+const INBOX_REFRESH_STATUS_PREFIX = "inboxRefresh:";
 const refreshState = new Map();
 const refreshInflight = new Map();
 
@@ -45,6 +53,119 @@ const getEnabledKinds = (preferences) =>
   })
     .filter(([, enabled]) => enabled)
     .map(([kind]) => kind);
+
+const normalizeUserId = (userId) => {
+  const normalized = Number(userId);
+  return Number.isInteger(normalized) && normalized > 0 ? normalized : null;
+};
+
+const getInboxRefreshStatusKey = (userId) =>
+  `${INBOX_REFRESH_STATUS_PREFIX}${normalizeUserId(userId)}`;
+
+const parsePayload = (value) => {
+  try {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
+};
+
+const getInboxRefreshJob = (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) return null;
+  const rows = getHonkerDb().query(
+    `
+      SELECT id, payload, state, run_at, claim_expires_at
+      FROM _honker_live
+      WHERE queue = 'system-task'
+        AND state IN ('pending', 'processing')
+      ORDER BY id ASC
+    `,
+  );
+  return rows.find((row) => {
+    const payload = parsePayload(row.payload);
+    return payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId;
+  }) || null;
+};
+
+const getStoredRefreshStatus = (userId) =>
+  dbOps.getJSONSetting(getInboxRefreshStatusKey(userId)) || {
+    status: "idle",
+    stale: false,
+    error: null,
+    updatedAt: null,
+    lastSuccessAt: null,
+    jobId: null,
+  };
+
+const setStoredRefreshStatus = (userId, status) => {
+  dbOps.setJSONSetting(getInboxRefreshStatusKey(userId), {
+    ...getStoredRefreshStatus(userId),
+    ...status,
+    updatedAt: Date.now(),
+  });
+};
+
+export function getInboxRefreshStatus(userId) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return {
+      status: "idle",
+      stale: false,
+      error: null,
+      updatedAt: null,
+      lastSuccessAt: null,
+      jobId: null,
+    };
+  }
+
+  const stored = getStoredRefreshStatus(normalizedUserId);
+  const job = getInboxRefreshJob(normalizedUserId);
+  if (job) {
+    const leaseExpired =
+      job.state === "processing" &&
+      job.claim_expires_at != null &&
+      Number(job.claim_expires_at) <= Math.floor(Date.now() / 1000);
+    const active =
+      !leaseExpired &&
+      (job.state === "pending" ||
+        job.claim_expires_at == null ||
+        Number(job.claim_expires_at) > Math.floor(Date.now() / 1000));
+    if (active) {
+      const status = job.state === "processing" ? "running" : "queued";
+      return {
+        ...stored,
+        status,
+        stale: false,
+        error: null,
+        jobId: Number(job.id),
+      };
+    }
+    if (leaseExpired) {
+      return {
+        ...stored,
+        status: "stale",
+        stale: true,
+        error: stored.error || "Inbox refresh worker lease expired",
+        jobId: Number(job.id),
+      };
+    }
+  }
+
+  if (refreshInflight.has(normalizedUserId)) {
+    return { ...stored, status: "running", stale: false, error: null };
+  }
+
+  if (stored.status === "queued" || stored.status === "running") {
+    return {
+      ...stored,
+      status: "stale",
+      stale: true,
+      error: stored.error || "Inbox refresh job is no longer active",
+    };
+  }
+  return stored;
+}
 
 const upsertAll = (items) => {
   for (const item of items) dbOps.upsertInboxItem(item);
@@ -134,11 +255,13 @@ async function buildDiscoveryItems(userId, now) {
     .filter(Boolean);
 }
 
-async function buildShowItems(userId, now, req, zipCode, libraryArtists) {
+async function buildShowItems(userId, now, req, ipAddress, zipCode, libraryArtists) {
   const apiKey = getTicketmasterApiKey();
-  if (!apiKey || !req || !Array.isArray(libraryArtists) || libraryArtists.length === 0) return [];
+  if (!apiKey || (!req && !ipAddress) || !Array.isArray(libraryArtists) || libraryArtists.length === 0) {
+    return [];
+  }
   const result = await getNearbyShows({
-    req,
+    req: req || { headers: {}, ip: ipAddress },
     zipCode,
     libraryArtists,
     recommendedArtists: [],
@@ -236,11 +359,21 @@ const dismissBlockedNewsItems = (userId) => {
   }
 };
 
-export async function refreshInboxForUser(userId, { req = null, zipCode = "", force = false } = {}) {
-  const normalizedUserId = Number(userId);
-  if (!Number.isInteger(normalizedUserId) || normalizedUserId <= 0) return false;
+export async function refreshInboxForUser(
+  userId,
+  {
+    req = null,
+    ipAddress = "",
+    zipCode = "",
+    force = false,
+    throwOnFailure = false,
+    jobId = null,
+  } = {},
+) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) return false;
   const state = refreshState.get(normalizedUserId);
-  const hasLocationRequest = Boolean(req);
+  const hasLocationRequest = Boolean(req || ipAddress);
   if (
     !force &&
     state &&
@@ -253,6 +386,12 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
 
   const promise = (async () => {
     const now = Date.now();
+    setStoredRefreshStatus(normalizedUserId, {
+      status: "running",
+      stale: false,
+      error: null,
+      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+    });
     const preferences = getInboxPreferences();
     const libraryArtists = preferences.shows
       ? [...iterateCanonicalArtistProjection({ pageSize: 100 })]
@@ -265,21 +404,65 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
     const results = await Promise.allSettled([
       preferences.releases ? buildReleaseItems(normalizedUserId, now) : [],
       preferences.discoveries ? buildDiscoveryItems(normalizedUserId, now) : [],
-      preferences.shows ? buildShowItems(normalizedUserId, now, req, zipCode, libraryArtists) : [],
+      preferences.shows
+        ? buildShowItems(normalizedUserId, now, req, ipAddress, zipCode, libraryArtists)
+        : [],
       enabledNewsKinds.size > 0 ? buildNewsItems(normalizedUserId, now, enabledNewsKinds) : [],
     ]);
-    const items = results.flatMap((result) => {
-      if (result.status === "fulfilled") return result.value;
-      logger.warn("inbox", "Inbox source refresh failed", { error: result.reason?.message });
-      return [];
-    });
-    upsertAll(items.flat());
-    dismissBlockedNewsItems(normalizedUserId);
+    const sourceNames = ["releases", "discoveries", "shows", "news"];
+    const failures = results
+      .map((result, index) => ({ result, source: sourceNames[index] }))
+      .filter(({ result }) => result.status === "rejected");
+    for (const { result, source } of failures) {
+      logger.warn("inbox", "Inbox source refresh failed", {
+        source,
+        error: result.reason?.message,
+      });
+    }
+    const items = results
+      .filter((result) => result.status === "fulfilled")
+      .flatMap((result) => result.value);
+    db.transaction(() => {
+      upsertAll(items);
+      dismissBlockedNewsItems(normalizedUserId);
+    })();
     refreshState.set(normalizedUserId, { at: now, hadLocationRequest: hasLocationRequest });
-    return true;
+    const refreshStatus = failures.length === 0
+      ? "complete"
+      : failures.length === results.length
+        ? "failed"
+        : "stale";
+    const errorMessage = failures.length > 0
+      ? failures.map(({ result, source }) => `${source}: ${result.reason?.message || "failed"}`).join("; ")
+      : null;
+    setStoredRefreshStatus(normalizedUserId, {
+      status: refreshStatus,
+      stale: failures.length > 0,
+      error: errorMessage,
+      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+      lastSuccessAt:
+        failures.length === 0
+          ? now
+          : getStoredRefreshStatus(normalizedUserId).lastSuccessAt,
+    });
+    if (failures.length > 0 && throwOnFailure) {
+      const error = new Error(errorMessage);
+      error.inboxStatusWritten = true;
+      throw error;
+    }
+    return failures.length === 0;
   })().catch((error) => {
     logger.warn("inbox", "Inbox refresh failed", { userId: normalizedUserId, error: error.message });
     refreshState.set(normalizedUserId, { at: Date.now(), hadLocationRequest: hasLocationRequest });
+    if (!error.inboxStatusWritten) {
+      setStoredRefreshStatus(normalizedUserId, {
+        status: "failed",
+        stale: true,
+        error: error.message,
+        jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+      });
+    }
+    if (throwOnFailure) throw error;
     return false;
   }).finally(() => {
     refreshInflight.delete(normalizedUserId);
@@ -289,23 +472,73 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
   return promise;
 }
 
-export async function refreshInboxForAllUsers() {
-  for (const user of userOps.getAllUsers()) {
-    await refreshInboxForUser(user.id);
-  }
+export async function enqueueInboxRefreshForUser(
+  userId,
+  { reason = "manual", zipCode = "", ipAddress = "" } = {},
+) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) throw new Error("A valid user is required");
+  return withHonkerLock(`inbox-refresh:${normalizedUserId}`, async () => {
+    const existing = findActiveHonkerJob(
+      "system-task",
+      (payload) =>
+        payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId,
+      { recoverExpired: true },
+    );
+    if (existing) {
+      return {
+        queued: false,
+        jobId: Number(existing.id),
+        status: existing.state === "processing" ? "running" : "queued",
+      };
+    }
+
+    const jobId = enqueueSystemTaskJob({
+      kind: "inbox-refresh",
+      userId: normalizedUserId,
+      reason: String(reason || "manual"),
+      zipCode: String(zipCode || "").trim(),
+      ipAddress: String(ipAddress || "").trim(),
+    }, { priority: reason === "manual" ? 5 : 0 });
+    setStoredRefreshStatus(normalizedUserId, {
+      status: "queued",
+      stale: false,
+      error: null,
+      reason,
+      jobId: Number(jobId),
+    });
+    return { queued: true, jobId: Number(jobId), status: "queued" };
+  });
 }
 
-export async function getInboxForUser(userId, options = {}) {
-  const refreshPromise = refreshInboxForUser(userId, options);
-  if (options.awaitRefresh !== false) await refreshPromise;
+export async function enqueueInboxRefreshForAllUsers(options = {}) {
+  const jobs = [];
+  for (const user of userOps.getAllUsers()) {
+    jobs.push(await enqueueInboxRefreshForUser(user.id, options));
+  }
+  return jobs;
+}
+
+export async function refreshInboxForAllUsers(options = {}) {
+  return enqueueInboxRefreshForAllUsers({ reason: "scheduled", ...options });
+}
+
+export function getInboxForUser(userId, options = {}) {
   const kinds = getEnabledKinds(getInboxPreferences());
+  const refreshStatus = getInboxRefreshStatus(userId);
   if (kinds.length === 0) {
-    return { items: [], unreadCount: 0, refreshing: refreshInflight.has(Number(userId)) };
+    return {
+      items: [],
+      unreadCount: 0,
+      refreshing: refreshStatus.status === "queued" || refreshStatus.status === "running",
+      refreshStatus,
+    };
   }
   return {
     items: dbOps.getInboxItems(userId, { limit: options.limit || 50, kinds }),
     unreadCount: dbOps.getInboxUnreadCount(userId, kinds),
-    refreshing: refreshInflight.has(Number(userId)),
+    refreshing: refreshStatus.status === "queued" || refreshStatus.status === "running",
+    refreshStatus,
   };
 }
 

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -208,7 +208,13 @@ export const disableNewsFeed = (sourceUrl, sourceName) => {
   return nextNews;
 };
 
-export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "matched" } = {}) {
+export async function getNewsForUser({
+  limit = 60,
+  offset = 0,
+  userId,
+  mode = "matched",
+  refresh = false,
+} = {}) {
   const settings = getNewsSettings();
   const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   const recommendedArtists = userId
@@ -219,9 +225,11 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     ...recommendedArtists.map((artist) => ({ ...artist, newsType: "recommended" })),
   ]);
   const preferences = getNewsPreferences(userId);
-  const refresh = await refreshFeeds();
+  const refreshResult = refresh
+    ? await refreshFeeds()
+    : { state: getStoredState(), warning: null };
   const activeFeedUrls = new Set(getEnabledFeeds(settings).map((feed) => feed.url));
-  const activeArticles = refresh.state.articles.filter((article) => activeFeedUrls.has(article.sourceUrl));
+  const activeArticles = refreshResult.state.articles.filter((article) => activeFeedUrls.has(article.sourceUrl));
   const matchedArticles = matchNewsArticles(
     activeArticles,
     artists,
@@ -242,7 +250,9 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     : matchedArticles;
   if (mode === "top") {
     const page = articles.slice(safeOffset, safeOffset + safeLimit);
-    const enrichedPage = await enrichArticleImages(page, refresh.state);
+    const enrichedPage = refresh
+      ? await enrichArticleImages(page, refreshResult.state)
+      : page;
     const enrichedById = new Map(enrichedPage.map((article) => [article.id, article]));
     articles = articles.map((article) => enrichedById.get(article.id) || article);
   }
@@ -254,9 +264,9 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     hasMore: safeOffset + safeLimit < articles.length,
     blockedPublishers: preferences.blockedPublishers,
     refresh: {
-      checkedAt: refresh.state.checkedAt || null,
-      failedFeeds: refresh.state.failedFeeds,
-      warning: refresh.warning || null,
+      checkedAt: refreshResult.state.checkedAt || null,
+      failedFeeds: refreshResult.state.failedFeeds,
+      warning: refreshResult.warning || null,
     },
   };
 }
@@ -264,7 +274,7 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
 export const getLibraryNews = getNewsForUser;
 
 export async function refreshLibraryNews() {
-  return getNewsForUser();
+  return getNewsForUser({ refresh: true });
 }
 
 export const getNewsFeedState = () => {

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -33,6 +33,7 @@ const STORAGE_HEALTH_CACHE_TTL_MS = Math.max(
   0,
   Math.floor(Number(process.env.AURRAL_STORAGE_HEALTH_CACHE_MS) || 60 * 1000),
 );
+const STORAGE_HEALTH_SNAPSHOT_KEY = "storageHealthSnapshot";
 const MEDIA_HEALTH_SAMPLE_LIMIT = Math.max(
   50,
   Math.floor(Number(process.env.AURRAL_MEDIA_HEALTH_SAMPLE_LIMIT) || 500),
@@ -996,6 +997,7 @@ export async function runStorageHealthCheck({ force = false } = {}) {
       storageHealthCache = result;
       storageHealthCacheKey = cacheKey;
       storageHealthCacheExpiresAt = Date.now() + STORAGE_HEALTH_CACHE_TTL_MS;
+      dbOps.setJSONSetting(STORAGE_HEALTH_SNAPSHOT_KEY, result);
       return result;
     })
     .finally(() => {
@@ -1004,4 +1006,8 @@ export async function runStorageHealthCheck({ force = false } = {}) {
     });
 
   return storageHealthInflight;
+}
+
+export function getStorageHealthSnapshot() {
+  return dbOps.getJSONSetting(STORAGE_HEALTH_SNAPSHOT_KEY);
 }

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -8,7 +8,7 @@ import { cleanExpiredSessions } from "../config/session-helpers.js";
 import { dbOps } from "../db/helpers/index.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 
-export async function processSystemTask(payload = {}) {
+export async function processSystemTask(payload = {}, job = null) {
   const kind = String(payload?.kind || "").trim();
   switch (kind) {
     case "weekly-flow-refresh": {
@@ -76,8 +76,24 @@ export async function processSystemTask(payload = {}) {
       return;
     }
     case "inbox-refresh": {
-      const { refreshInboxForAllUsers } = await import("./inboxService.js");
-      await refreshInboxForAllUsers();
+      const {
+        enqueueInboxRefreshForAllUsers,
+        refreshInboxForUser,
+      } = await import("./inboxService.js");
+      const userId = Number(payload.userId);
+      if (Number.isInteger(userId) && userId > 0) {
+        await refreshInboxForUser(userId, {
+          force: true,
+          throwOnFailure: true,
+          jobId: job?.id || payload.jobId || null,
+          zipCode: payload.zipCode || "",
+          ipAddress: payload.ipAddress || "",
+        });
+      } else {
+        await enqueueInboxRefreshForAllUsers({
+          reason: payload.reason || "scheduled",
+        });
+      }
       return;
     }
     case "news-refresh": {

--- a/frontend/src/hooks/useStorageHealth.js
+++ b/frontend/src/hooks/useStorageHealth.js
@@ -1,6 +1,9 @@
 import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getStorageHealth } from "../utils/api/endpoints/settings.js";
+import {
+  getStorageHealth,
+  runStorageHealthCheck,
+} from "../utils/api/endpoints/settings.js";
 import { queryClient, queryKeys } from "../queryClient.js";
 
 const toSnapshot = (result, dataUpdatedAt = 0) => ({
@@ -34,7 +37,8 @@ export function setStorageHealthResult(result) {
 export function refreshStorageHealth({ force = false } = {}) {
   return queryClient.fetchQuery({
     queryKey: queryKeys.storageHealth,
-    queryFn: ({ signal }) => getStorageHealth({ force, signal }),
+    queryFn: ({ signal }) =>
+      force ? runStorageHealthCheck({ signal }) : getStorageHealth({ signal }),
     staleTime: force ? 0 : 120_000,
   });
 }

--- a/frontend/src/utils/api/endpoints/settings.js
+++ b/frontend/src/utils/api/endpoints/settings.js
@@ -100,11 +100,11 @@ export const testLidarrLibraryAccess = (url, apiKey) =>
     params: lidarrCredentialParams(url, apiKey),
   });
 
-export const getStorageHealth = ({ force = false, signal } = {}) =>
-  getData("/settings/storage-health", {
-    params: force ? { force: "1" } : undefined,
-    signal,
-  });
+export const getStorageHealth = ({ signal } = {}) =>
+  getData("/settings/storage-health", { signal });
+
+export const runStorageHealthCheck = ({ signal } = {}) =>
+  postData("/settings/storage-health/check", {}, { signal });
 
 export const getSettingsTasks = ({ signal } = {}) => getData("/settings/tasks", { signal });
 


### PR DESCRIPTION
## Summary

- keep inbox, discovery, news, storage-health, and weekly-flow stream reads free of provider, filesystem-health, and migration work
- move inbox refreshes onto durable per-user jobs with deduplication, restart recovery, explicit stale/failed state, and cached-row preservation
- deduplicate startup bootstrap jobs and keep scheduled refreshes explicit

## Why

Page loads should return persisted state immediately. Provider refreshes and expensive checks now run only from scheduled jobs or explicit mutations, preventing ordinary navigation from creating overlapping background work.

## Verification

- `npm test` — 794 passed
- focused queue/storage/weekly-flow tests — 45 passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm run docs:build` — passed
- `npm run test:integration` — 53 passed, 1 failed
  - the failing Navidrome temporary-path fixture reproduces unchanged on the base branch

## Dependency

Stacked on #681; review this PR against `perf/canonical-stable-reads`.