### PR TITLE
perf(library): enforce measured query budgets

### DIFF
--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -30,6 +30,7 @@ const RESET_TABLES = [
   "library_albums",
   "library_artists",
   "library_scan_runs",
+  "library_search_documents",
   "settings",
 ];
 

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, queryService, libraryStore] = await setupIsolatedBackend(
+  "measured-query-slice",
+  "backend/config/db-sqlite.js",
+  "backend/services/libraryQueryService.js",
+  "backend/services/libraryMediaStore.js",
+);
+
+let artist;
+let album;
+let track;
+
+test.before(() => {
+  resetDatabase(db);
+  artist = libraryStore.upsertLibraryArtist({
+    identityKey: "measured:artist",
+    name: "Measured Artist",
+  });
+  album = libraryStore.upsertLibraryAlbum({
+    identityKey: "measured:album",
+    artistId: artist.id,
+    title: "Measured Album",
+    albumArtist: artist.name,
+  });
+  track = libraryStore.upsertLibraryTrack({
+    identityKey: "measured:track",
+    title: "Needle Song",
+    artistName: artist.name,
+  });
+  libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  libraryStore.upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: "/tmp/measured-query-slice.flac",
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("substring search uses the trigram index and stays order-sort free", (t) => {
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  const result = queryService.getCanonicalSearchPage({
+    source: "all",
+    query: "Needle",
+    artistLimit: 20,
+    albumLimit: 20,
+    songLimit: 20,
+  });
+  assert.deepEqual(result.tracks.tracks.map((entry) => entry.title), ["Needle Song"]);
+  const searchSql = prepared.find((sql) =>
+    sql.includes("FROM library_tracks AS track") && sql.includes("library_search_fts"));
+  assert.ok(searchSql);
+  assert.match(searchSql, /MATCH \?/);
+  assert.doesNotMatch(searchSql, /ORDER BY/);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${searchSql}`).all(
+    '"nee" AND "eed" AND "edl" AND "dle"',
+    "%needle%",
+    "%needle%",
+    "%needle%",
+    20,
+    0,
+  );
+  assert.ok(plan.some((row) => row.detail.includes("SCAN search_fts VIRTUAL TABLE")));
+  assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE FOR ORDER BY")), false);
+});
+
+test("unchanged canonical upserts do not rewrite search documents", () => {
+  db.exec(`
+    CREATE TEMP TABLE search_update_probe (count INTEGER NOT NULL);
+    INSERT INTO search_update_probe VALUES (0);
+    CREATE TEMP TRIGGER search_update_probe_trigger
+    AFTER UPDATE ON library_search_documents
+    BEGIN
+      UPDATE search_update_probe SET count = count + 1;
+    END;
+  `);
+  try {
+    libraryStore.upsertLibraryArtist({
+      identityKey: "measured:artist",
+      name: "Measured Artist",
+    });
+    libraryStore.upsertLibraryAlbum({
+      identityKey: "measured:album",
+      artistId: artist.id,
+      title: "Measured Album",
+      albumArtist: artist.name,
+    });
+    libraryStore.upsertLibraryTrack({
+      identityKey: "measured:track",
+      title: "Needle Song",
+      artistName: artist.name,
+    });
+    assert.equal(db.prepare("SELECT count FROM search_update_probe").get().count, 0);
+  } finally {
+    db.exec(`
+      DROP TRIGGER search_update_probe_trigger;
+      DROP TABLE search_update_probe;
+    `);
+  }
+});
+
+test("canonical page search uses FTS and genre reads use the stored scan snapshot", (t) => {
+  queryService.rebuildCanonicalGenreStats();
+  queryService.invalidateCanonicalLibraryCache({ persistedGenres: false });
+  const storedBefore = db.prepare(
+    "SELECT key, value FROM settings WHERE key LIKE 'libraryGenreStats:%' ORDER BY key",
+  ).all();
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  const page = queryService.getCanonicalLibraryPage({
+    kind: "tracks",
+    page: 1,
+    pageSize: 20,
+    query: "Needle",
+  });
+  assert.deepEqual(page.tracks.map((entry) => entry.title), ["Needle Song"]);
+  const pageSearchSql = prepared.find((sql) =>
+    sql.includes("COUNT(DISTINCT track.id)") && sql.includes("library_search_fts MATCH ?"));
+  assert.ok(pageSearchSql);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${pageSearchSql}`).all(
+    '"nee" AND "eed" AND "edl" AND "dle"',
+    "%needle%",
+    "%needle%",
+    "%needle%",
+  );
+  assert.ok(plan.some((row) => row.detail.includes("SCAN search_fts VIRTUAL TABLE")));
+  assert.ok(plan.some((row) =>
+    row.detail.includes("idx_library_media_files_track_album_source_available")));
+  assert.deepEqual(
+    prepare("SELECT key, value FROM settings WHERE key LIKE 'libraryGenreStats:%' ORDER BY key").all(),
+    storedBefore,
+  );
+});
+
+test("search documents update transactionally and random reads use rowid sampling", (t) => {
+  libraryStore.upsertLibraryTrack({
+    identityKey: "measured:track",
+    title: "Renamed Needle Song",
+    artistName: artist.name,
+  });
+  assert.equal(
+    queryService.getCanonicalSearchPage({ query: "Renamed Needle", songLimit: 20 }).tracks.tracks[0].title,
+    "Renamed Needle Song",
+  );
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  t.mock.method(Math, "random", () => 0.999);
+  const result = queryService.getCanonicalTrackPage({
+    source: "all",
+    availableOnly: true,
+    random: true,
+    limit: 1,
+  });
+  assert.equal(result.tracks.length, 1);
+  const randomSql = prepared.find((sql) => sql.includes("FROM library_tracks AS track") && sql.includes("track.id >= ?"));
+  assert.ok(randomSql);
+  assert.match(randomSql, /ORDER BY track\.id/);
+  assert.doesNotMatch(randomSql, /random\(\)/i);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${randomSql}`).all(2, 1);
+  assert.ok(plan.some((row) => row.detail.includes("SEARCH track USING INTEGER PRIMARY KEY")));
+  assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE")), false);
+});

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -188,3 +188,139 @@ test("search documents update transactionally and random reads use rowid samplin
   assert.ok(plan.some((row) => row.detail.includes("SEARCH track USING INTEGER PRIMARY KEY")));
   assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE")), false);
 });
+
+test("artist pages project a large discography without canonical row hydration", (t) => {
+  const key = `measured-artist-page-${process.pid}-${Date.now()}`;
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "A Huge Discography",
+  });
+  const albumCount = 120;
+  for (let index = 0; index < albumCount; index += 1) {
+    const album = libraryStore.upsertLibraryAlbum({
+      identityKey: `${key}:album:${index}`,
+      artistId: artist.id,
+      title: `Huge Album ${index}`,
+    });
+    const track = libraryStore.upsertLibraryTrack({
+      identityKey: `${key}:track:${index}`,
+      title: `Huge Track ${index}`,
+      artistName: artist.name,
+    });
+    libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+    libraryStore.upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "aurral",
+      path: `/tmp/${key}/${index}.flac`,
+    });
+  }
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  try {
+    const page = queryService.getCanonicalLibraryPage({
+      source: "aurral",
+      kind: "artists",
+      page: 1,
+      pageSize: 1,
+    });
+    assert.equal(page.total, 1);
+    assert.equal(page.items[0].albumCount, albumCount);
+    assert.deepEqual(page.items[0].albumIds, []);
+    assert.equal(
+      prepared.filter((sql) =>
+        sql.includes("track.id AS track_id") && sql.includes("media.id AS media_id"),
+      ).length,
+      0,
+    );
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id IN (SELECT id FROM library_albums WHERE identity_key LIKE ?)").run(`${key}:album:%`);
+    db.prepare("DELETE FROM library_tracks WHERE identity_key LIKE ?").run(`${key}:track:%`);
+    db.prepare("DELETE FROM library_albums WHERE identity_key LIKE ?").run(`${key}:album:%`);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("album track pages count and hydrate only the requested track slice", (t) => {
+  const key = `measured-album-page-${process.pid}-${Date.now()}`;
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}:artist-mbid`,
+    name: "A Huge Album",
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}:album-mbid`,
+    releaseGroupMbid: `${key}:release-group`,
+    artistId: artist.id,
+    title: "A Huge Album",
+  });
+  const trackCount = 140;
+  for (let index = 0; index < trackCount; index += 1) {
+    const track = libraryStore.upsertLibraryTrack({
+      identityKey: `${key}:track:${index}`,
+      title: `Album Track ${String(index).padStart(3, "0")}`,
+      artistName: artist.name,
+    });
+    libraryStore.linkLibraryAlbumTrack({
+      albumId: album.id,
+      trackId: track.id,
+      trackNumber: index + 1,
+    });
+    if (index % 2 === 0) {
+      libraryStore.upsertLibraryMediaFile({
+        trackId: track.id,
+        albumId: album.id,
+        source: "aurral",
+        path: `/tmp/${key}/${index}.flac`,
+      });
+    }
+  }
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  try {
+    const page = queryService.getCanonicalLibraryPage({
+      source: "aurral",
+      kind: "tracks",
+      albumId: album.id,
+      page: 2,
+      pageSize: 3,
+      sort: "name",
+      direction: "desc",
+    });
+    const hydration = prepared.filter((sql) =>
+      sql.includes("track.id AS track_id") && sql.includes("media.id AS media_id"),
+    );
+    assert.equal(hydration.length, 1);
+    assert.match(hydration[0], /track\.id IN \(\?,\?,\?\)/);
+    assert.equal(page.total, trackCount);
+    assert.equal(page.items.length, 3);
+    assert.equal(page.albums[0].trackCount, trackCount);
+    assert.equal(page.albums[0].availableTrackCount, trackCount / 2);
+    assert.equal(page.albums[0].trackIds.length, 3);
+    assert.equal(page.albums[0].identityKey, `${key}:album`);
+    assert.equal(page.artists[0].identityKey, `${key}:artist`);
+    assert.ok(page.items.some((track) => track.files.length === 0));
+    assert.ok(page.items.every((track) =>
+      track.albums.every((relation) => relation.albumId === album.id)));
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE identity_key LIKE ?").run(`${key}:track:%`);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -132,6 +132,7 @@ test("canonical page search uses FTS and genre reads use the stored scan snapsho
     kind: "tracks",
     page: 1,
     pageSize: 20,
+    source: "lidarr",
     query: "Needle",
   });
   assert.deepEqual(page.tracks.map((entry) => entry.title), ["Needle Song"]);
@@ -140,6 +141,7 @@ test("canonical page search uses FTS and genre reads use the stored scan snapsho
   assert.ok(pageSearchSql);
   const plan = prepare(`EXPLAIN QUERY PLAN ${pageSearchSql}`).all(
     '"nee" AND "eed" AND "edl" AND "dle"',
+    "lidarr",
     "%needle%",
     "%needle%",
     "%needle%",

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -21,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -16000");
-db.pragma("mmap_size = 16777216");
+db.pragma("cache_size = -24000");
+db.pragma("mmap_size = 25165824");
 
 function tryAddColumn(sql) {
   try {

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import path from "path";
 import fs from "fs";
 import { initializeSchemaOnStartup } from "./schema-migration-v2.js";
+import { initializeLibrarySearchIndex } from "./library-search-index.js";
 import { syncDownloadFolderPath } from "../services/downloadFolderConfig.js";
 import { ensureDataDir } from "./data-dir.js";
 
@@ -20,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -64000");
-db.pragma("mmap_size = 268435456");
+db.pragma("cache_size = -32000");
+db.pragma("mmap_size = 33554432");
 
 function tryAddColumn(sql) {
   try {
@@ -454,6 +455,8 @@ if (hasUniqueIndex(["path"])) {
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available
     ON library_media_files (album_id, source, available);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_track_album_source_available
+    ON library_media_files (track_id, album_id, source, available);
 `);
 
 const duplicateLidarrArtistIds = db
@@ -604,6 +607,7 @@ export const dbHelpers = {
 };
 
 initializeSchemaOnStartup(db, dbHelpers);
+initializeLibrarySearchIndex(db);
 
 const existingDownloadFolder = db
   .prepare("SELECT value FROM settings WHERE key = ?")

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -21,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -32000");
-db.pragma("mmap_size = 33554432");
+db.pragma("cache_size = -16000");
+db.pragma("mmap_size = 16777216");
 
 function tryAddColumn(sql) {
   try {

--- a/backend/config/library-search-index.js
+++ b/backend/config/library-search-index.js
@@ -1,0 +1,223 @@
+const SEARCH_INDEX_VERSION = "2";
+const GENRE_STATS_SETTING_PREFIX = "libraryGenreStats:";
+
+const genreMediaExists = (kind, sourceFilter, availableOnly) => {
+  const filters = [];
+  const parameters = [];
+  if (sourceFilter) {
+    filters.push("page_media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly) filters.push("page_media.available = 1");
+  const filterSql = filters.length ? filters.join(" AND ") : "1 = 1";
+  if (kind === "artists") {
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM library_albums AS page_album
+        JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
+        JOIN library_media_files AS page_media
+          ON page_media.track_id = page_album_track.track_id
+          AND (page_media.album_id = page_album_track.album_id OR page_media.album_id IS NULL)
+        WHERE page_album.artist_id = artist.id AND ${filterSql}
+      )`,
+      parameters,
+    };
+  }
+  if (kind === "albums") {
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM library_album_tracks AS page_album_track
+        JOIN library_media_files AS page_media
+          ON page_media.track_id = page_album_track.track_id
+          AND (page_media.album_id = page_album_track.album_id OR page_media.album_id IS NULL)
+        WHERE page_album_track.album_id = album.id AND ${filterSql}
+      )`,
+      parameters,
+    };
+  }
+  return {
+    sql: `EXISTS (
+      SELECT 1 FROM library_media_files AS page_media
+      WHERE page_media.track_id = track.id AND ${filterSql}
+    )`,
+    parameters,
+  };
+};
+
+export function computeLibraryGenreStats(db, { sourceFilter = null, availableOnly = false } = {}) {
+  const entities = [
+    ["artists", "library_artists AS artist", "artist.id", "artist.metadata_json"],
+    [
+      "albums",
+      "library_albums AS album JOIN library_artists AS artist ON artist.id = album.artist_id",
+      "album.id",
+      "album.metadata_json",
+    ],
+    ["tracks", "library_tracks AS track", "track.id", "track.metadata_json"],
+  ];
+  const parameters = [];
+  const rows = entities.map(([kind, from, id, metadata]) => {
+    const media = genreMediaExists(kind, sourceFilter, availableOnly);
+    parameters.push(...media.parameters);
+    const validMetadata = `CASE WHEN json_valid(${metadata}) THEN ${metadata} ELSE '{}' END`;
+    return `SELECT '${kind}' AS entity_kind, ${id} AS entity_id,
+      TRIM(CAST(genre_value.value AS TEXT)) AS name
+      FROM ${from}
+      JOIN json_each(json_array(
+        json_extract(${validMetadata}, '$.genres'),
+        json_extract(${validMetadata}, '$.genre'),
+        json_extract(${validMetadata}, '$.common.genre'),
+        json_extract(${validMetadata}, '$.tags.genre')
+      )) AS selected_genre
+      JOIN json_each(CASE
+        WHEN selected_genre.type IN ('array', 'object') THEN selected_genre.value
+        ELSE json_array(selected_genre.value)
+      END) AS genre_value
+      WHERE selected_genre.value IS NOT NULL
+        AND TRIM(CAST(genre_value.value AS TEXT)) <> ''
+        AND ${media.sql}`;
+  });
+  return db.prepare(
+    `WITH genre_entities AS (
+       SELECT DISTINCT entity_kind, entity_id, name
+       FROM (${rows.join(" UNION ALL ")})
+     )
+     SELECT name,
+       SUM(entity_kind = 'artists') AS artists,
+       SUM(entity_kind = 'albums') AS albums,
+       SUM(entity_kind = 'tracks') AS tracks
+     FROM genre_entities
+     GROUP BY name
+     ORDER BY name COLLATE NOCASE`,
+  ).all(...parameters).map((row) => ({
+    name: row.name,
+    artists: Number(row.artists || 0),
+    albums: Number(row.albums || 0),
+    tracks: Number(row.tracks || 0),
+  }));
+}
+
+export function rebuildStoredLibraryGenreStats(db) {
+  for (const availableOnly of [false, true]) {
+    const cacheKey = `all:${availableOnly ? "available" : "all"}`;
+    const stats = computeLibraryGenreStats(db, { availableOnly });
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+      .run(`${GENRE_STATS_SETTING_PREFIX}${cacheKey}`, JSON.stringify(stats));
+  }
+}
+
+const createSearchSchema = (db) => {
+  const fts5Enabled = db
+    .prepare("SELECT sqlite_compileoption_used(?) AS enabled")
+    .get("ENABLE_FTS5")?.enabled;
+  if (!fts5Enabled) return false;
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS library_search_documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_kind TEXT NOT NULL,
+      entity_id INTEGER NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      artist_name TEXT NOT NULL DEFAULT '',
+      album_name TEXT NOT NULL DEFAULT '',
+      UNIQUE (entity_kind, entity_id)
+    );
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS library_search_fts USING fts5(
+      entity_kind UNINDEXED,
+      entity_id UNINDEXED,
+      title,
+      artist_name,
+      album_name,
+      content='library_search_documents',
+      content_rowid='id',
+      tokenize='trigram',
+      detail='none'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_ai
+    AFTER INSERT ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES (new.id, new.entity_kind, new.entity_id, new.title, new.artist_name, new.album_name);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_au
+    AFTER UPDATE ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(library_search_fts, rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES ('delete', old.id, old.entity_kind, old.entity_id, old.title, old.artist_name, old.album_name);
+      INSERT INTO library_search_fts(rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES (new.id, new.entity_kind, new.entity_id, new.title, new.artist_name, new.album_name);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_ad
+    AFTER DELETE ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(library_search_fts, rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES ('delete', old.id, old.entity_kind, old.entity_id, old.title, old.artist_name, old.album_name);
+    END;
+  `);
+  return true;
+};
+
+export const populateLibrarySearchDocuments = (db) => {
+  db.exec(`
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT 'artist', artist.id, artist.name, '', ''
+    FROM library_artists AS artist;
+
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT
+      'album',
+      album.id,
+      album.title,
+      trim(coalesce(artist.name, '') || ' ' || coalesce(album.album_artist, '')),
+      ''
+    FROM library_albums AS album
+    JOIN library_artists AS artist ON artist.id = album.artist_id;
+
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT
+      'track',
+      track.id,
+      track.title,
+      trim(coalesce(track.artist_name, '') || ' ' || coalesce(group_concat(DISTINCT artist.name), '')),
+      trim(coalesce(group_concat(DISTINCT album.title), '') || ' ' || coalesce(group_concat(DISTINCT album.album_artist), ''))
+    FROM library_tracks AS track
+    LEFT JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+    LEFT JOIN library_albums AS album ON album.id = album_track.album_id
+    LEFT JOIN library_artists AS artist ON artist.id = album.artist_id
+    GROUP BY track.id;
+  `);
+};
+
+export function initializeLibrarySearchIndex(db) {
+  const hadSearchIndex = Boolean(
+    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get("library_search_fts"),
+  );
+  const version = db
+    .prepare("SELECT value FROM settings WHERE key = ?")
+    .get("librarySearchIndexVersion")?.value;
+  if (version && version !== SEARCH_INDEX_VERSION) {
+    db.exec(`
+      DROP TRIGGER IF EXISTS library_search_documents_ai;
+      DROP TRIGGER IF EXISTS library_search_documents_au;
+      DROP TRIGGER IF EXISTS library_search_documents_ad;
+      DROP TABLE IF EXISTS library_search_fts;
+    `);
+  }
+  if (!createSearchSchema(db)) return false;
+  if (version === SEARCH_INDEX_VERSION && hadSearchIndex) return true;
+
+  db.transaction(() => {
+    db.prepare("DELETE FROM library_search_documents").run();
+    populateLibrarySearchDocuments(db);
+    db.prepare("INSERT INTO library_search_fts(library_search_fts) VALUES ('rebuild')").run();
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+      .run("librarySearchIndexVersion", SEARCH_INDEX_VERSION);
+    rebuildStoredLibraryGenreStats(db);
+  })();
+  return true;
+}

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -175,6 +175,7 @@ export async function scanMusicRoot({
   filePaths = null,
   metadataReader = parseFile,
   metadataEnricher = null,
+  syncSearch = true,
 } = {}) {
   const resolvedRoot = path.resolve(String(rootPath || ""));
   await fs.mkdir(resolvedRoot, { recursive: true });
@@ -214,6 +215,7 @@ export async function scanMusicRoot({
             mbid: record.artistMbid,
             name: record.artistName,
             metadata: record.artistMetadata,
+            syncSearch,
           });
           const album = upsertLibraryAlbum({
             identityKey: record.albumKey,
@@ -224,6 +226,7 @@ export async function scanMusicRoot({
             albumArtist: record.albumArtist,
             releaseDate: record.releaseDate,
             metadata: record.albumMetadata,
+            syncSearch,
           });
           const track = upsertLibraryTrack({
             identityKey: record.trackKey,
@@ -231,12 +234,14 @@ export async function scanMusicRoot({
             title: record.title,
             artistName: record.artistName,
             metadata: record.trackMetadata,
+            syncSearch,
           });
           linkLibraryAlbumTrack({
             albumId: album.id,
             trackId: track.id,
             discNumber: record.discNumber,
             trackNumber: record.trackNumber,
+            syncSearch,
           });
           upsertLibraryMediaFile({
             trackId: track.id,

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -3,6 +3,8 @@ import { db } from "../config/db-sqlite.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 import { scanMusicRoot } from "./libraryFileScanner.js";
 import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
+import { rebuildLibrarySearchIndex } from "./librarySearchIndex.js";
+import { rebuildCanonicalGenreStats } from "./libraryQueryService.js";
 
 function getAurralJobMetadataByPath() {
   const rows = db
@@ -38,24 +40,31 @@ export async function scanConfiguredLibrary({
   includeLidarr = true,
 } = {}) {
   const jobMetadataByPath = getAurralJobMetadataByPath();
-  const local = await scanMusicRoot({
-    rootPath: musicRoot,
-    source: "aurral",
-    metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
-  });
+  let local;
   let lidarr = { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
-  if (includeLidarr) {
-    try {
-      lidarr = await indexLidarrLibrary({ client: lidarrClient });
-    } catch (error) {
-      lidarr = {
-        skipped: false,
-        error: error.message,
-        filesSeen: 0,
-        filesIndexed: 0,
-        filesFailed: 0,
-      };
+  try {
+    local = await scanMusicRoot({
+      rootPath: musicRoot,
+      source: "aurral",
+      metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
+      syncSearch: false,
+    });
+    if (includeLidarr) {
+      try {
+        lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });
+      } catch (error) {
+        lidarr = {
+          skipped: false,
+          error: error.message,
+          filesSeen: 0,
+          filesIndexed: 0,
+          filesFailed: 0,
+        };
+      }
     }
+  } finally {
+    rebuildLibrarySearchIndex();
+    rebuildCanonicalGenreStats();
   }
   return { local, lidarr };
 }

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -148,7 +148,7 @@ async function readFileStats(filePath) {
   }
 }
 
-export async function indexLidarrLibrary({ client } = {}) {
+export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
   if (!client || typeof client.isConfigured !== "function" || !client.isConfigured()) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
@@ -200,6 +200,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         name: artistName,
         sortName: artist.sortName || null,
         metadata: artist,
+        syncSearch,
       });
       const albumProviderId = text(album.foreignAlbumId);
       const albumKey =
@@ -218,6 +219,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         albumArtist: artistName,
         releaseDate: album.releaseDate || null,
         metadata: album,
+        syncSearch,
       });
       let albumFilesIndexed = 0;
 
@@ -233,6 +235,7 @@ export async function indexLidarrLibrary({ client } = {}) {
           title: text(track.title || track.trackTitle) || "Unknown Track",
           artistName,
           metadata: track,
+          syncSearch,
         });
         const trackNumber = Number(track.trackNumber || track.absoluteTrackNumber) || 0;
         linkLibraryAlbumTrack({
@@ -240,6 +243,7 @@ export async function indexLidarrLibrary({ client } = {}) {
           trackId: trackRecord.id,
           discNumber: Number(track.mediumNumber || track.discNumber) || 1,
           trackNumber,
+          syncSearch,
         });
 
         const resolvedFile = resolveTrackFile(
@@ -274,7 +278,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         albumFilesIndexed === 0 &&
         Number(album.statistics?.sizeOnDisk || 0) === 0
       ) {
-        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr");
+        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr", { syncSearch });
       }
     }
     if (result.filesFailed === 0 && result.filesIndexed > 0) {

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -1,5 +1,10 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
 import { invalidateCanonicalLibraryCache } from "./libraryQueryService.js";
+import {
+  syncLibrarySearchAlbum,
+  syncLibrarySearchArtist,
+  syncLibrarySearchTrack,
+} from "./librarySearchIndex.js";
 
 const now = () => Date.now();
 
@@ -70,23 +75,35 @@ export function finishLibraryScan(scanId, {
   );
 }
 
-export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName = null, metadata = null }) {
+export function upsertLibraryArtist({
+  identityKey,
+  mbid = null,
+  name,
+  sortName = null,
+  metadata = null,
+  syncSearch = true,
+}) {
   const timestamp = now();
   const key = normalizeText(identityKey);
   const artistName = normalizeText(name);
   if (!key || !artistName) throw new Error("Library artist identityKey and name are required");
-  db.prepare(
-    `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_artists.mbid),
-       name = excluded.name,
-       sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
-       metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+  const artist = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_artists.mbid),
+         name = excluded.name,
+         sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
+         metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+    const row = db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+    if (syncSearch) syncLibrarySearchArtist(row?.id);
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+  return artist;
 }
 
 export function upsertLibraryAlbum({
@@ -98,6 +115,7 @@ export function upsertLibraryAlbum({
   albumArtist = null,
   releaseDate = null,
   metadata = null,
+  syncSearch = true,
 }) {
   const timestamp = now();
   const key = normalizeText(identityKey);
@@ -105,33 +123,45 @@ export function upsertLibraryAlbum({
   if (!key || !Number.isSafeInteger(Number(artistId)) || !albumTitle) {
     throw new Error("Library album identityKey, artistId, and title are required");
   }
-  db.prepare(
-    `INSERT INTO library_albums
-      (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_albums.mbid),
-       release_group_mbid = COALESCE(excluded.release_group_mbid, library_albums.release_group_mbid),
-       artist_id = excluded.artist_id,
-       title = excluded.title,
-       album_artist = COALESCE(excluded.album_artist, library_albums.album_artist),
-       release_date = COALESCE(excluded.release_date, library_albums.release_date),
-       metadata_json = COALESCE(excluded.metadata_json, library_albums.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(
-    key,
-    mbid || null,
-    releaseGroupMbid || null,
-    Number(artistId),
-    albumTitle,
-    albumArtist || null,
-    releaseDate || null,
-    stringify(metadata),
-    timestamp,
-    timestamp,
-  );
+  const album = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_albums
+        (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_albums.mbid),
+         release_group_mbid = COALESCE(excluded.release_group_mbid, library_albums.release_group_mbid),
+         artist_id = excluded.artist_id,
+         title = excluded.title,
+         album_artist = COALESCE(excluded.album_artist, library_albums.album_artist),
+         release_date = COALESCE(excluded.release_date, library_albums.release_date),
+         metadata_json = COALESCE(excluded.metadata_json, library_albums.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(
+      key,
+      mbid || null,
+      releaseGroupMbid || null,
+      Number(artistId),
+      albumTitle,
+      albumArtist || null,
+      releaseDate || null,
+      stringify(metadata),
+      timestamp,
+      timestamp,
+    );
+    const row = db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+    const searchChanged = syncSearch && syncLibrarySearchAlbum(row?.id);
+    if (row?.id && searchChanged) {
+      for (const track of db.prepare(
+        "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+      ).all(row.id)) {
+        syncLibrarySearchTrack(track.track_id);
+      }
+    }
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+  return album;
 }
 
 export function upsertLibraryTrack({
@@ -140,56 +170,79 @@ export function upsertLibraryTrack({
   title,
   artistName = null,
   metadata = null,
+  syncSearch = true,
 }) {
   const timestamp = now();
   const key = normalizeText(identityKey);
   const trackTitle = normalizeText(title);
   if (!key || !trackTitle) throw new Error("Library track identityKey and title are required");
-  db.prepare(
-    `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_tracks.mbid),
-       title = excluded.title,
-       artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
-       metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+  const track = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_tracks.mbid),
+         title = excluded.title,
+         artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
+         metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+    const row = db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+    if (syncSearch) syncLibrarySearchTrack(row?.id);
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+  return track;
 }
 
-export function linkLibraryAlbumTrack({ albumId, trackId, discNumber = 1, trackNumber = 0 }) {
-  db.prepare(
-    `INSERT OR IGNORE INTO library_album_tracks
-      (album_id, track_id, disc_number, track_number, created_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+export function linkLibraryAlbumTrack({
+  albumId,
+  trackId,
+  discNumber = 1,
+  trackNumber = 0,
+  syncSearch = true,
+}) {
+  db.transaction(() => {
+    db.prepare(
+      `INSERT OR IGNORE INTO library_album_tracks
+        (album_id, track_id, disc_number, track_number, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+    if (syncSearch) syncLibrarySearchTrack(trackId);
+  })();
   invalidateLibraryCache();
 }
 
-export function removeLibraryAlbumTracksWithoutMedia(albumId, source) {
+export function removeLibraryAlbumTracksWithoutMedia(albumId, source, { syncSearch = true } = {}) {
   const mediaSource = normalizeText(source);
-  db.prepare(
-    `DELETE FROM library_album_tracks
-     WHERE album_id = ?
-       AND NOT EXISTS (
-         SELECT 1
-         FROM library_media_files AS media
-         WHERE media.track_id = library_album_tracks.track_id
-           AND media.album_id = library_album_tracks.album_id
-           AND media.source = ?
-           AND media.available = 1
-       )
-       AND NOT EXISTS (
-         SELECT 1
-         FROM library_media_files AS media
-         WHERE media.track_id = library_album_tracks.track_id
-           AND media.album_id = library_album_tracks.album_id
-           AND media.source != ?
-           AND media.available = 1
-       )`,
-  ).run(Number(albumId), mediaSource, mediaSource);
+  db.transaction(() => {
+    const trackIds = db.prepare(
+      "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+    ).all(Number(albumId)).map((row) => row.track_id);
+    db.prepare(
+      `DELETE FROM library_album_tracks
+       WHERE album_id = ?
+         AND NOT EXISTS (
+           SELECT 1
+           FROM library_media_files AS media
+           WHERE media.track_id = library_album_tracks.track_id
+             AND media.album_id = library_album_tracks.album_id
+             AND media.source = ?
+             AND media.available = 1
+         )
+         AND NOT EXISTS (
+           SELECT 1
+           FROM library_media_files AS media
+           WHERE media.track_id = library_album_tracks.track_id
+             AND media.album_id = library_album_tracks.album_id
+             AND media.source != ?
+             AND media.available = 1
+         )`,
+    ).run(Number(albumId), mediaSource, mediaSource);
+    if (syncSearch) {
+      for (const trackId of trackIds) syncLibrarySearchTrack(trackId);
+    }
+  })();
   invalidateLibraryCache();
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -20,6 +20,12 @@ const parseJson = (value) => {
   }
 };
 
+const parseSources = (value) => String(value || "")
+  .split(",")
+  .map((source) => source.trim())
+  .filter(Boolean)
+  .sort();
+
 function normalizeSource(source) {
   const value = String(source || "").trim().toLowerCase();
   if (!value || value === "all") return null;
@@ -736,6 +742,7 @@ export function getCanonicalArtistPage({
   limit = null,
   includeStats = false,
   searchMatch = null,
+  artistIds = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("artists", sourceFilter, availableOnly);
@@ -761,14 +768,18 @@ export function getCanonicalArtistPage({
     conditions.push("lower(search_document.title) LIKE ? ESCAPE '\\'");
     parameters.push(`%${escapeLike(normalizedQuery)}%`);
   }
-  const ids = db.prepare(
-    `SELECT artist.id
-     FROM library_artists AS artist
-     ${searchJoin}
-     WHERE ${conditions.join(" AND ")}
-     ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
-     ${pageSql}`,
-  ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
+  const ids = Array.isArray(artistIds)
+    ? [...new Set(artistIds
+      .map((value) => Number(value))
+      .filter((value) => Number.isSafeInteger(value) && value > 0))]
+    : db.prepare(
+      `SELECT artist.id
+       FROM library_artists AS artist
+       ${searchJoin}
+       WHERE ${conditions.join(" AND ")}
+       ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
+       ${pageSql}`,
+    ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
 
   if (!includeStats) {
@@ -838,6 +849,7 @@ export function getCanonicalArtistPage({
        COUNT(DISTINCT album.id) AS album_count,
        COUNT(DISTINCT album_track.track_id) AS track_count,
        COALESCE(SUM(media.size), 0) AS size_on_disk,
+       GROUP_CONCAT(DISTINCT media.source) AS sources,
        MAX(media.available) AS available
      FROM library_artists AS artist
      JOIN library_albums AS album ON album.artist_id = artist.id
@@ -859,7 +871,7 @@ export function getCanonicalArtistPage({
     albumCount: Number(row.album_count || 0),
     trackCount: Number(row.track_count || 0),
     sizeOnDisk: Number(row.size_on_disk || 0),
-    sources: [],
+    sources: parseSources(row.sources),
     available: Boolean(row.available),
   }]));
   return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
@@ -1419,7 +1431,7 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) 
   return buildLibraryFromRows(rows);
 }
 
-function getAlbumTrackLibrary(
+function buildAlbumTrackPageQuery(
   albumId,
   sourceFilter,
   { query = "", genre = "", sort = "album", direction = "asc", artistId = null } = {},
@@ -1464,6 +1476,97 @@ function getAlbumTrackLibrary(
     : sort === "artist"
       ? `artist.name COLLATE NOCASE ${orderDirection}, track.title COLLATE NOCASE ${orderDirection}`
       : `track.title COLLATE NOCASE ${orderDirection}`;
+  return {
+    from: `FROM library_tracks AS track
+      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+      JOIN library_albums AS album ON album.id = album_track.album_id
+      JOIN library_artists AS artist ON artist.id = album.artist_id
+      LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}`,
+    where: conditions.join(" AND "),
+    parameters,
+    orderBy,
+  };
+}
+
+function getAlbumTrackSummary(albumId, sourceFilter) {
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  parameters.push(Number(albumId));
+  const row = db.prepare(
+    `SELECT
+       artist.id AS artist_id,
+       artist.identity_key AS artist_identity_key,
+       artist.mbid AS artist_mbid,
+       artist.name AS artist_name,
+       artist.sort_name AS artist_sort_name,
+       artist.metadata_json AS artist_metadata_json,
+       album.id AS album_id,
+       album.identity_key AS album_identity_key,
+       album.mbid AS album_mbid,
+       album.release_group_mbid AS album_release_group_mbid,
+       album.title AS album_title,
+       album.album_artist AS album_artist,
+       album.release_date AS album_release_date,
+       album.metadata_json AS album_metadata_json,
+       GROUP_CONCAT(DISTINCT media.source) AS sources,
+       MAX(media.available) AS available
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE album.id = ?
+     GROUP BY album.id`,
+  ).get(...parameters);
+  if (!row) return { artist: null, album: null };
+  const sources = parseSources(row.sources);
+  return {
+    artist: {
+      id: row.artist_id,
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata: parseJson(row.artist_metadata_json),
+      albumIds: [row.album_id],
+      sources,
+      available: Boolean(row.available),
+    },
+    album: {
+      id: row.album_id,
+      identityKey: row.album_identity_key,
+      mbid: row.album_mbid,
+      releaseGroupMbid: row.album_release_group_mbid,
+      artistId: row.artist_id,
+      title: row.album_title,
+      albumArtist: row.album_artist,
+      releaseDate: row.album_release_date,
+      metadata: parseJson(row.album_metadata_json),
+      trackIds: [],
+      sources,
+      available: Boolean(row.available),
+    },
+  };
+}
+
+function getAlbumTrackPageLibrary(albumId, sourceFilter, ids) {
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  parameters.push(Number(albumId), ...ids);
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
@@ -1471,38 +1574,55 @@ function getAlbumTrackLibrary(
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
      LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
-     WHERE ${conditions.join(" AND ")}
-     ORDER BY ${orderBy}, album_track.disc_number, album_track.track_number,
-       media.path COLLATE NOCASE`,
+     WHERE album.id = ? AND track.id IN (${ids.map(() => "?").join(",")})
+     ORDER BY album_track.disc_number, album_track.track_number,
+       track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
   ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 
 function getAlbumTrackPage(albumId, sourceFilter, page, currentPageSize, options = {}) {
-  const completeLibrary = getAlbumTrackLibrary(albumId, sourceFilter);
-  const library = getAlbumTrackLibrary(albumId, sourceFilter, options);
-  const album = completeLibrary.albums[0] || null;
-  const artist = album
-    ? completeLibrary.artists.find((candidate) => candidate.id === album.artistId) || null
-    : null;
-  const tracks = library.tracks;
-  const availableTrackCount = completeLibrary.tracks.filter((track) => track.available).length;
-  const pageItems = tracks.slice((page - 1) * currentPageSize, page * currentPageSize);
+  const queryDefinition = buildAlbumTrackPageQuery(albumId, sourceFilter, options);
+  const total = Number(db.prepare(
+    `SELECT COUNT(DISTINCT track.id) AS total
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}`,
+  ).get(...queryDefinition.parameters)?.total || 0);
+  const pageIds = db.prepare(
+    `SELECT track.id AS page_id
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}
+     GROUP BY track.id
+     ORDER BY ${queryDefinition.orderBy}, album_track.disc_number, album_track.track_number,
+       media.path COLLATE NOCASE
+     LIMIT ? OFFSET ?`,
+  ).all(
+    ...queryDefinition.parameters,
+    currentPageSize,
+    (page - 1) * currentPageSize,
+  ).map((row) => row.page_id);
+  const library = getAlbumTrackPageLibrary(albumId, sourceFilter, pageIds);
+  const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+  const pageItems = pageIds.map((id) => tracksById.get(id)).filter(Boolean);
+  const summary = getAlbumTrackSummary(albumId, sourceFilter);
+  const stats = getAlbumStats([Number(albumId)], sourceFilter).get(String(albumId));
+  const album = summary.album;
   const albums = album
     ? [{
         ...album,
-        trackCount: tracks.length,
-        availableTrackCount,
+        trackIds: pageItems.map((track) => track.id),
+        trackCount: total,
+        availableTrackCount: stats?.availableTrackCount ?? 0,
       }]
     : [];
   return {
     kind: "tracks",
     page,
     pageSize: currentPageSize,
-    total: tracks.length,
-    hasMore: page * currentPageSize < tracks.length,
+    total,
+    hasMore: page * currentPageSize < total,
     items: pageItems,
-    artists: artist ? [artist] : [],
+    artists: summary.artist ? [summary.artist] : [],
     albums,
     tracks: pageItems,
     genres: getCanonicalGenreStats({ sourceFilter, availableOnly: false }),
@@ -1631,6 +1751,28 @@ export function getCanonicalLibraryPage({
     currentPageSize,
     (currentPage - 1) * currentPageSize,
   ).map((row) => row.page_id);
+  if (normalizedKind === "artists") {
+    const library = getCanonicalArtistPage({
+      source: sourceFilter,
+      availableOnly,
+      artistIds: ids,
+      includeStats: true,
+    });
+    const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
+    const items = ids.map((id) => artistsById.get(String(id))).filter(Boolean);
+    return {
+      kind: normalizedKind,
+      page: currentPage,
+      pageSize: currentPageSize,
+      total,
+      hasMore: currentPage * currentPageSize < total,
+      items,
+      artists: items,
+      albums: [],
+      tracks: [],
+      genres: getCanonicalGenreStats({ sourceFilter, availableOnly }),
+    };
+  }
   const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly, albumId);
   const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
   const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1,4 +1,9 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
+import {
+  computeLibraryGenreStats,
+  rebuildStoredLibraryGenreStats,
+} from "../config/library-search-index.js";
+import { getLibrarySearchMatch } from "./librarySearchIndex.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
@@ -609,29 +614,13 @@ export function getCanonicalLibrary({ source = null, availableOnly = false, favo
 
 const text = (value) => String(value || "").trim();
 
-const metadataGenres = (entity) => {
-  const metadata = entity?.metadata || {};
-  return [metadata.genres, metadata.genre, metadata.common?.genre, metadata.tags?.genre]
-    .flatMap((value) => (Array.isArray(value) ? value : [value]))
-    .map(text)
-    .filter(Boolean)
-    .filter((value, index, values) => values.indexOf(value) === index);
-};
-
-const addGenreStats = (stats, metadata, kind) => {
-  metadataGenres({ metadata }).forEach((genre) => {
-    const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
-    entry[kind] += 1;
-    stats.set(genre, entry);
-  });
-};
-
 const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
 const pageSize = (value) =>
   Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
 
 const genreStatsCache = new Map();
+const GENRE_STATS_SETTING_PREFIX = "libraryGenreStats:";
 const GENRE_METADATA_PATHS = ["$.genres", "$.genre", "$.common.genre", "$.tags.genre"];
 
 const escapeLike = (value) => value.replace(/[\\%_]/g, "\\$&");
@@ -660,7 +649,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
     return `COALESCE((
       SELECT MAX(page_media.created_at)
       FROM library_album_tracks AS page_album_track
-      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
         ON page_media.track_id = page_album_track.track_id
       WHERE page_album_track.album_id = album.id
         AND ${albumMediaCondition("page_media", "page_album_track")}${mediaFilter}
@@ -668,7 +657,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
   }
   return `COALESCE((
     SELECT MAX(page_media.created_at)
-    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
     WHERE page_media.track_id = track.id${mediaFilter}
   ), 0) ${orderDirection}, track.title COLLATE NOCASE ${direction === "desc" ? "DESC" : "ASC"}`;
 };
@@ -683,7 +672,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
         SELECT 1
         FROM library_albums AS page_album
         JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
-        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
           ON page_media.track_id = page_album_track.track_id
         WHERE page_album.artist_id = artist.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
@@ -697,7 +686,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
       sql: `EXISTS (
         SELECT 1
         FROM library_album_tracks AS page_album_track
-        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
           ON page_media.track_id = page_album_track.track_id
         WHERE page_album_track.album_id = album.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
@@ -708,7 +697,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
   }
   return {
     sql: `EXISTS (
-      SELECT 1 FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+      SELECT 1 FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
       WHERE page_media.track_id = track.id AND ${conditionSql}
     )`,
     parameters,
@@ -746,13 +735,14 @@ export function getCanonicalArtistPage({
   offset = 0,
   limit = null,
   includeStats = false,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("artists", sourceFilter, availableOnly);
   const conditions = [media.sql];
   const parameters = [...media.parameters];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     conditions.push("lower(artist.name) LIKE ? ESCAPE '\\'");
     parameters.push(`%${escapeLike(normalizedQuery)}%`);
   }
@@ -760,12 +750,23 @@ export function getCanonicalArtistPage({
     ? null
     : pageLimit(limit);
   const pageSql = boundedLimit === null ? "" : "LIMIT ? OFFSET ?";
+  const searchJoin = searchMatch
+    ? `JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'artist' AND search_document.entity_id = artist.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?`
+    : "";
+  if (searchMatch) {
+    parameters.unshift(searchMatch);
+    conditions.push("lower(search_document.title) LIKE ? ESCAPE '\\'");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`);
+  }
   const ids = db.prepare(
     `SELECT artist.id
      FROM library_artists AS artist
+     ${searchJoin}
      WHERE ${conditions.join(" AND ")}
-     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
-       artist.name COLLATE NOCASE
+     ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
      ${pageSql}`,
   ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
@@ -890,13 +891,14 @@ export function getCanonicalAlbumPage({
   artistId = null,
   offset = 0,
   limit = 20,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("albums", sourceFilter, availableOnly);
   const conditions = [media.sql];
   const parameters = [...media.parameters];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     const fields = ["album.title", "album.album_artist", "artist.name"];
     const pattern = `%${escapeLike(normalizedQuery)}%`;
     conditions.push(`(${fields.map((field) =>
@@ -947,19 +949,48 @@ export function getCanonicalAlbumPage({
 
   const boundedLimit = pageLimit(limit, 20);
   if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const searchJoin = searchMatch
+    ? `JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'album' AND search_document.entity_id = album.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?`
+    : "";
+  if (searchMatch) {
+    parameters.unshift(searchMatch);
+    conditions.push("(lower(search_document.title) LIKE ? ESCAPE '\\' OR lower(search_document.artist_name) LIKE ? ESCAPE '\\')");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`, `%${escapeLike(normalizedQuery)}%`);
+  }
   const ids = db.prepare(
     `SELECT album.id
      FROM library_albums AS album
      JOIN library_artists AS artist ON artist.id = album.artist_id
+     ${searchJoin}
      WHERE ${conditions.join(" AND ")}
      GROUP BY album.id
-     ORDER BY ${orderBy}
+     ${searchMatch ? "" : `ORDER BY ${orderBy}`}
      LIMIT ? OFFSET ?`,
   ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
   const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
   const albumsById = new Map(library.albums.map((album) => [album.id, album]));
   library.albums = ids.map((id) => albumsById.get(id)).filter(Boolean);
   return library;
+}
+
+function getRandomTrackIds({ conditions, parameters, limit, offset }) {
+  const maximum = Number(db.prepare("SELECT max(id) AS maximum FROM library_tracks").get()?.maximum || 0);
+  if (!maximum) return [];
+  const needed = limit + offset;
+  const pivot = Math.floor(Math.random() * maximum) + 1;
+  const read = (operator, boundary, count) => db.prepare(
+    `SELECT track.id
+     FROM library_tracks AS track
+     WHERE ${conditions.join(" AND ")} AND track.id ${operator} ?
+     ORDER BY track.id
+     LIMIT ?`,
+  ).all(...parameters, boundary, count).map((row) => row.id);
+  const ids = read(">=", pivot, needed);
+  if (ids.length < needed) ids.push(...read("<", pivot, needed - ids.length));
+  return ids.slice(offset, offset + limit);
 }
 
 export function getCanonicalTrackPage({
@@ -973,6 +1004,7 @@ export function getCanonicalTrackPage({
   offset = 0,
   limit = 20,
   random = false,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("tracks", sourceFilter, availableOnly);
@@ -986,7 +1018,7 @@ export function getCanonicalTrackPage({
     "artist.name",
   ];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     const pattern = `%${escapeLike(normalizedQuery)}%`;
     conditions.push(`(${fields.map((field) =>
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
@@ -1014,6 +1046,47 @@ export function getCanonicalTrackPage({
   }
   const boundedLimit = pageLimit(limit, 20);
   if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const useSearchIndex = Boolean(searchMatch)
+    && !artistReference
+    && !(artistId !== null && artistId !== undefined && String(artistId).trim())
+    && !(albumId !== null && albumId !== undefined && String(albumId).trim())
+    && !normalizedGenre;
+  if (useSearchIndex) {
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    const searchConditions = [
+      ...conditions,
+      "(lower(search_document.title) LIKE ? ESCAPE '\\' OR lower(search_document.artist_name) LIKE ? ESCAPE '\\' OR lower(search_document.album_name) LIKE ? ESCAPE '\\')",
+    ];
+    const ids = db.prepare(
+      `SELECT track.id
+       FROM library_tracks AS track
+       JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'track' AND search_document.entity_id = track.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?
+       WHERE ${searchConditions.join(" AND ")}
+       LIMIT ? OFFSET ?`,
+    ).all(searchMatch, ...parameters, pattern, pattern, pattern, boundedLimit, pageOffset(offset))
+      .map((row) => row.id);
+    const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+    const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+    library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+    return library;
+  }
+  if (random && !normalizedQuery && !artistReference && !normalizedGenre
+    && !(artistId !== null && artistId !== undefined && String(artistId).trim())
+    && !(albumId !== null && albumId !== undefined && String(albumId).trim())) {
+    const ids = getRandomTrackIds({
+      conditions,
+      parameters,
+      limit: boundedLimit,
+      offset: pageOffset(offset),
+    });
+    const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+    const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+    library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+    return library;
+  }
   const orderBy = random
     ? "random()"
     : "artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number, track.title COLLATE NOCASE";
@@ -1045,12 +1118,14 @@ export function getCanonicalSearchPage({
   songLimit = 20,
   songOffset = 0,
 } = {}) {
+  const searchMatch = getLibrarySearchMatch(query);
   const albumLibrary = getCanonicalAlbumPage({
     source,
     availableOnly,
     query,
     limit: albumLimit,
     offset: albumOffset,
+    searchMatch,
   });
   const trackLibrary = getCanonicalTrackPage({
     source,
@@ -1058,9 +1133,17 @@ export function getCanonicalSearchPage({
     query,
     limit: songLimit,
     offset: songOffset,
+    searchMatch,
   });
   return {
-    artists: getCanonicalArtistPage({ source, availableOnly, query, limit: artistLimit, offset: artistOffset }).artists,
+    artists: getCanonicalArtistPage({
+      source,
+      availableOnly,
+      query,
+      limit: artistLimit,
+      offset: artistOffset,
+      searchMatch,
+    }).artists,
     albums: albumLibrary,
     tracks: trackLibrary,
   };
@@ -1171,12 +1254,16 @@ function buildPageQuery({
   const media = pageMediaExists(kind, sourceFilter, availableOnly);
   where.push(media.sql);
   parameters.push(...media.parameters);
+  const searchMatch = getLibrarySearchMatch(query);
 
   let from;
   let idExpression;
   let searchableFields;
   let genreAliases;
+  let entityKind;
+  let groupBy = null;
   if (kind === "artists") {
+    entityKind = "artist";
     from = "FROM library_artists AS artist";
     idExpression = "artist.id";
     searchableFields = ["artist.name"];
@@ -1190,6 +1277,7 @@ function buildPageQuery({
       parameters.push(Number(albumId));
     }
   } else if (kind === "albums") {
+    entityKind = "album";
     from = "FROM library_albums AS album JOIN library_artists AS artist ON artist.id = album.artist_id";
     idExpression = "album.id";
     searchableFields = ["album.title", "album.album_artist", "artist.name"];
@@ -1203,10 +1291,16 @@ function buildPageQuery({
       parameters.push(Number(albumId));
     }
   } else {
-    from = `FROM library_tracks AS track
-      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
-      JOIN library_albums AS album ON album.id = album_track.album_id
-      JOIN library_artists AS artist ON artist.id = album.artist_id`;
+    entityKind = "track";
+    const needsRelations = Boolean(artistId || albumId || genre || sort === "artist")
+      || Boolean(query && !searchMatch);
+    from = needsRelations
+      ? `FROM library_tracks AS track
+        JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+        JOIN library_albums AS album ON album.id = album_track.album_id
+        JOIN library_artists AS artist ON artist.id = album.artist_id`
+      : "FROM library_tracks AS track";
+    if (needsRelations) groupBy = "track.id";
     idExpression = "track.id";
     searchableFields = [
       "track.title",
@@ -1226,7 +1320,29 @@ function buildPageQuery({
     }
   }
 
-  if (query) {
+  if (searchMatch) {
+    from += `
+      JOIN library_search_documents AS search_document
+        ON search_document.entity_kind = '${entityKind}'
+        AND search_document.entity_id = ${idExpression}
+      JOIN library_search_fts AS search_fts
+        ON search_fts.rowid = search_document.id
+        AND library_search_fts MATCH ?`;
+    parameters.unshift(searchMatch);
+    const pattern = `%${escapeLike(query)}%`;
+    const indexedFields = kind === "artists"
+      ? ["search_document.title"]
+      : kind === "albums"
+        ? ["search_document.title", "search_document.artist_name"]
+        : [
+            "search_document.title",
+            "search_document.artist_name",
+            "search_document.album_name",
+          ];
+    where.push(`(${indexedFields.map((field) =>
+      `lower(${field}) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...indexedFields.map(() => pattern));
+  } else if (query) {
     const pattern = `%${escapeLike(query)}%`;
     where.push(`(${searchableFields.map((field) =>
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
@@ -1256,6 +1372,7 @@ function buildPageQuery({
     where: where.join(" AND "),
     parameters,
     orderBy,
+    groupBy,
   };
 }
 
@@ -1263,29 +1380,16 @@ function getCanonicalGenreStats({ sourceFilter, availableOnly }) {
   const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
   const cached = genreStatsCache.get(cacheKey);
   if (cached) return cached;
-  const artistMedia = pageMediaExists("artists", sourceFilter, availableOnly);
-  const albumMedia = pageMediaExists("albums", sourceFilter, availableOnly);
-  const trackMedia = pageMediaExists("tracks", sourceFilter, availableOnly);
-  const stats = new Map();
-  for (const row of db.prepare(
-    `SELECT artist.metadata_json FROM library_artists AS artist WHERE ${artistMedia.sql}`,
-  ).iterate(...artistMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "artists");
+  const settingKey = `${GENRE_STATS_SETTING_PREFIX}${cacheKey}`;
+  const stored = db.prepare("SELECT value FROM settings WHERE key = ?").get(settingKey)?.value;
+  if (stored) {
+    const parsed = parseJson(stored);
+    if (Array.isArray(parsed)) {
+      genreStatsCache.set(cacheKey, parsed);
+      return parsed;
+    }
   }
-  for (const row of db.prepare(
-    `SELECT album.metadata_json
-     FROM library_albums AS album
-     JOIN library_artists AS artist ON artist.id = album.artist_id
-     WHERE ${albumMedia.sql}`,
-  ).iterate(...albumMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "albums");
-  }
-  for (const row of db.prepare(
-    `SELECT track.metadata_json FROM library_tracks AS track WHERE ${trackMedia.sql}`,
-  ).iterate(...trackMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "tracks");
-  }
-  const sortedStats = [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+  const sortedStats = computeLibraryGenreStats(db, { sourceFilter, availableOnly });
   genreStatsCache.set(cacheKey, sortedStats);
   return sortedStats;
 }
@@ -1519,7 +1623,7 @@ export function getCanonicalLibraryPage({
     `SELECT ${queryDefinition.idExpression} AS page_id
      ${queryDefinition.from}
      WHERE ${queryDefinition.where}
-     GROUP BY ${queryDefinition.idExpression}
+     ${queryDefinition.groupBy ? `GROUP BY ${queryDefinition.groupBy}` : ""}
      ORDER BY ${queryDefinition.orderBy}
      LIMIT ? OFFSET ?`,
   ).all(
@@ -1577,9 +1681,18 @@ export function getCanonicalLibraryPage({
   };
 }
 
-export function invalidateCanonicalLibraryCache() {
+export function rebuildCanonicalGenreStats() {
+  db.prepare("DELETE FROM settings WHERE key LIKE ?").run(`${GENRE_STATS_SETTING_PREFIX}%`);
+  genreStatsCache.clear();
+  rebuildStoredLibraryGenreStats(db);
+}
+
+export function invalidateCanonicalLibraryCache({ persistedGenres = true } = {}) {
   libraryCache.clear();
   genreStatsCache.clear();
+  if (persistedGenres) {
+    db.prepare("DELETE FROM settings WHERE key LIKE ?").run(`${GENRE_STATS_SETTING_PREFIX}%`);
+  }
 }
 
 export { normalizeSource };

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -837,6 +837,7 @@ export function getCanonicalArtistPage({
     aggregateParameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
+  const mediaJoin = sourceFilter || availableOnly === true ? "JOIN" : "LEFT JOIN";
   aggregateParameters.push(...ids);
   const rows = db.prepare(
     `SELECT
@@ -854,7 +855,7 @@ export function getCanonicalArtistPage({
      FROM library_artists AS artist
      JOIN library_albums AS album ON album.artist_id = artist.id
      JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     ${mediaJoin} library_media_files AS media ON ${mediaConditions.join(" AND ")}
      WHERE artist.id IN (${ids.map(() => "?").join(",")})
      GROUP BY artist.id
      ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,

--- a/backend/services/librarySearchIndex.js
+++ b/backend/services/librarySearchIndex.js
@@ -1,0 +1,107 @@
+import { db } from "../config/db-sqlite.js";
+import { populateLibrarySearchDocuments } from "../config/library-search-index.js";
+
+const indexAvailable = Boolean(
+  db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get("library_search_fts"),
+);
+
+const normalize = (value) => String(value || "").trim().toLocaleLowerCase();
+
+export function getLibrarySearchMatch(value) {
+  const query = normalize(value);
+  if (!indexAvailable || query.length < 3) return null;
+  const trigrams = new Set();
+  for (let index = 0; index <= query.length - 3; index += 1) {
+    const trigram = query.slice(index, index + 3);
+    if (!/\s/.test(trigram)) trigrams.add(`"${trigram.replaceAll('"', '""')}"`);
+    if (trigrams.size >= 32) break;
+  }
+  return trigrams.size ? [...trigrams].join(" AND ") : null;
+}
+
+const upsertDocument = db.prepare(
+  `INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+   VALUES (?, ?, ?, ?, ?)
+   ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
+     title = excluded.title,
+     artist_name = excluded.artist_name,
+     album_name = excluded.album_name
+   WHERE title IS NOT excluded.title
+      OR artist_name IS NOT excluded.artist_name
+      OR album_name IS NOT excluded.album_name`,
+);
+
+export function syncLibrarySearchArtist(artistId) {
+  if (!indexAvailable) return false;
+  const artist = db.prepare(
+    "SELECT id, name FROM library_artists WHERE id = ?",
+  ).get(Number(artistId));
+  if (!artist) return false;
+  const changed = upsertDocument.run("artist", artist.id, artist.name, "", "").changes > 0;
+  if (!changed) return false;
+  for (const album of db.prepare(
+    "SELECT id FROM library_albums WHERE artist_id = ?",
+  ).all(artist.id)) {
+    syncLibrarySearchAlbum(album.id);
+    for (const track of db.prepare(
+      "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+    ).all(album.id)) {
+      syncLibrarySearchTrack(track.track_id);
+    }
+  }
+  return true;
+}
+
+export function syncLibrarySearchAlbum(albumId) {
+  if (!indexAvailable) return false;
+  const album = db.prepare(
+    `SELECT album.id, album.title, album.album_artist, artist.name AS artist_name
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE album.id = ?`,
+  ).get(Number(albumId));
+  if (!album) return false;
+  return upsertDocument.run(
+    "album",
+    album.id,
+    album.title,
+    `${album.artist_name || ""} ${album.album_artist || ""}`.trim(),
+    "",
+  ).changes > 0;
+}
+
+export function syncLibrarySearchTrack(trackId) {
+  if (!indexAvailable) return false;
+  const track = db.prepare(
+    `SELECT
+       track.id,
+       track.title,
+       trim(coalesce(track.artist_name, '') || ' ' || coalesce(group_concat(DISTINCT artist.name), '')) AS artist_name,
+       trim(coalesce(group_concat(DISTINCT album.title), '') || ' ' || coalesce(group_concat(DISTINCT album.album_artist), '')) AS album_name
+     FROM library_tracks AS track
+     LEFT JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+     LEFT JOIN library_albums AS album ON album.id = album_track.album_id
+     LEFT JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE track.id = ?
+     GROUP BY track.id`,
+  ).get(Number(trackId));
+  if (!track) return false;
+  return upsertDocument.run(
+    "track",
+    track.id,
+    track.title,
+    track.artist_name || "",
+    track.album_name || "",
+  ).changes > 0;
+}
+
+export function rebuildLibrarySearchIndex() {
+  if (!indexAvailable) return false;
+  db.transaction(() => {
+    db.prepare("DELETE FROM library_search_documents").run();
+    populateLibrarySearchDocuments(db);
+    db.prepare("INSERT INTO library_search_fts(library_search_fts) VALUES ('rebuild')").run();
+  })();
+  return true;
+}

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1933,7 +1933,7 @@ function LibraryPage() {
             />
           </div>
           <span className="native-library-card__meta">
-            {artist.albumIds?.length || 0} album{artist.albumIds?.length === 1 ? "" : "s"}
+            {artist.albumCount ?? artist.albumIds?.length ?? 0} album{(artist.albumCount ?? artist.albumIds?.length ?? 0) === 1 ? "" : "s"}
           </span>
         </div>
       </article>

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -111,10 +111,11 @@ function measure(operation) {
   const started = performance.now();
   const value = operation();
   const elapsedMs = performance.now() - started;
+  const serialized = JSON.stringify(value);
   const after = memoryStats();
   return {
     elapsedMs: Number(elapsedMs.toFixed(3)),
-    jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+    jsonBytes: Buffer.byteLength(serialized),
     memoryBefore: before,
     memoryAfter: after,
     rssDeltaBytes: after.rssBytes - before.rssBytes,
@@ -394,6 +395,7 @@ const before = process.memoryUsage();
 const started = performance.now();
 const value = read[operation]();
 const elapsedMs = performance.now() - started;
+const serialized = JSON.stringify(value);
 const after = process.memoryUsage();
 const counts = Array.isArray(value)
   ? { items: value.length }
@@ -404,7 +406,7 @@ const counts = Array.isArray(value)
     };
 console.log(JSON.stringify({
   elapsedMs: Number(elapsedMs.toFixed(3)),
-  jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+  jsonBytes: Buffer.byteLength(serialized),
   rssDeltaBytes: after.rss - before.rss,
   heapDeltaBytes: after.heapUsed - before.heapUsed,
   rssBytes: after.rss,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -419,6 +419,11 @@ function summarizeReadSamples(samples) {
   const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   return {
     samples,
+    sampleCount: samples.length,
+    completedCount: completed.length,
+    nonVacuous: samples.length > 0
+      && completed.length === samples.length
+      && completed.every((sample) => Number(sample.jsonBytes) > 0),
     responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
     medianMs: completed.length ? percentile(0.5) : null,
     p95Ms: completed.length ? percentile(0.95) : null,
@@ -525,11 +530,14 @@ async function main() {
     const imported = await import("../backend/config/db-sqlite.js");
     database = imported.db;
     const queryService = await import("../backend/services/libraryQueryService.js");
+    const { rebuildLibrarySearchIndex } = await import("../backend/services/librarySearchIndex.js");
     const { flowPlaylistConfig } = await import(
       "../backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js"
     );
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
+    rebuildLibrarySearchIndex();
+    queryService.rebuildCanonicalGenreStats();
     const benchmarkUser = seedSubsonicFavorite(database);
     flowPlaylistConfig.createSharedPlaylist({
       name: "Benchmark Playlist",
@@ -548,7 +556,7 @@ async function main() {
     for (const [name, pageOptions] of pageCases) {
       pages[name] = collectPageSamples(
         () => queryService.getCanonicalLibraryPage(pageOptions),
-        queryService.invalidateCanonicalLibraryCache,
+        () => queryService.invalidateCanonicalLibraryCache({ persistedGenres: false }),
         options.repeats,
       );
     }
@@ -599,13 +607,41 @@ async function main() {
     }
     const expectedBulkIndexerCalls = 5;
     const expectedFallbackIndexerCalls = 5;
-    const pageP95 = Object.fromEntries(
-      Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
-    );
+    const measuredReadNames = ["search3", "randomSongs"];
+    const measuredReads = measuredReadNames.map((name) => subsonicReads[name]);
+    const measuredQueryChecks = {
+      nonVacuousCompletedSamples: measuredReads.every((read) => read.nonVacuous),
+      coldP95Under750ms: measuredReads.every((read) => read.p95Ms < 750),
+      responseUnder2MiB: measuredReads.every((read) =>
+        read.responseBytes.length > 0
+        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: measuredReads.every((read) =>
+        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+    };
+    const pageBudgetChecks = {
+      warmP95Under250ms: Object.values(pages).every((page) => page.warm.p95Ms < 250),
+      coldP95Under750ms: Object.values(pages).every((page) => page.cold.p95Ms < 750),
+      responseUnder2MiB: Object.values(pages).every((page) =>
+        [...page.cold.samples, ...page.warm.samples]
+          .every((sample) => sample.jsonBytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: Object.values(pages).every((page) =>
+        [...page.cold.samples, ...page.warm.samples]
+          .every((sample) => sample.rssDeltaBytes < 64 * 1024 * 1024)),
+    };
+    const compatibilityReadChecks = {
+      responseUnder2MiB: Object.values(subsonicReads).every((read) =>
+        read.responseBytes.length > 0
+        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: Object.values(subsonicReads).every((read) =>
+        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+    };
     const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
-      read.samples.every((sample) => sample.status === "completed"));
+      read.nonVacuous);
     const checks = {
       boundedReadCompleted,
+      measuredQueryBudgets: Object.values(measuredQueryChecks).every(Boolean),
+      pageBudgets: Object.values(pageBudgetChecks).every(Boolean),
+      compatibilityReadBudgets: Object.values(compatibilityReadChecks).every(Boolean),
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
         && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
       fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
@@ -613,7 +649,6 @@ async function main() {
       fallbackIndexerStopsAtBulkFailure: indexerProbes.fallback.status === "completed"
         && indexerProbes.fallback.error === "bulk track-file read failed"
         && indexerProbes.fallback.maxActiveAlbums === 0,
-      pageWarmP95Under750ms: Object.values(pageP95).every((value) => value < 750),
     };
     output = {
       benchmark: "aurral-library",
@@ -626,6 +661,22 @@ async function main() {
       seed: { ...seed, elapsedMs: seedElapsedMs },
       subsonicReads,
       pages,
+      budgets: {
+        targets: {
+          warmPageP95Ms: 250,
+          coldPageP95Ms: 750,
+          responseBytes: 2 * 1024 * 1024,
+          requestRssDeltaBytes: 64 * 1024 * 1024,
+        },
+        measuredQueryChecks,
+        pageBudgetChecks,
+        compatibilityReadChecks,
+        deferredIntegrationChecks: [
+          "stableReadProviderCalls",
+          "readStartedJobs",
+          "restartMigrationRepeats",
+        ],
+      },
       indexer: {
         requestedAlbums: options.indexerAlbums,
         expectedBulkCalls: expectedBulkIndexerCalls,


### PR DESCRIPTION
## Summary

- add a transactionally synchronized SQLite FTS5 trigram index for canonical substring search
- replace `ORDER BY random()` with bounded primary-key sampling and remove unnecessary relationship joins from ordinary track pages
- persist genre aggregates at scan completion, batch derived-index rebuilds once per scan, and cap SQLite cache/mmap memory for constrained hosts
- turn the 100k/350k benchmark latency, response-size, RSS, compatibility-read, and indexer checks into hard failure gates

## Measured result

Exact commit: `f90a5017`

Both 100,000-track and 350,000-track `--check` runs pass every gate. At 350,000 tracks:

- canonical page cold p95: 0.043–165.080 ms
- canonical page warm p95: 0.002–164.514 ms
- largest canonical response: 117,801 bytes
- maximum canonical request RSS growth: 20,316,160 bytes
- Subsonic search p95: 284.874 ms; 14,815 bytes; 34,893,824 bytes RSS growth
- random-song p95: 1.945 ms; at most 11,703 bytes; 393,216 bytes RSS growth
- compatibility artist index p95: 48.329 ms; 620,815 bytes; 43,081,728 bytes RSS growth

Before this slice, the same 350,000-track probes measured 308–375 ms and about 238 MiB RSS for search, 160–172 ms and about 237 MiB RSS for random reads, up to 1,319 ms for cold canonical pages, and about 226 MiB RSS for the compatibility artist index.

## Verification

- `npm test` — 783 passed
- focused query/index/scan tests — passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm run docs:build` — passed
- `npm run test:integration` — 53 passed, 1 failed
  - the failing Navidrome temporary-path fixture reproduces unchanged on the base branch
- `npm run perf:library -- --tracks 100000 --repeats 3 --indexer-albums 1000 --check` — passed
- `npm run perf:library -- --tracks 350000 --repeats 3 --indexer-albums 1000 --check` — passed

## Dependency

Stacked on #682; review this PR against `perf/bound-subsonic-reads`.
