### PR TITLE
perf: validate canonical reads end to end

### DIFF
--- a/.tests/discovery/discovery-refresh-scheduler.test.js
+++ b/.tests/discovery/discovery-refresh-scheduler.test.js
@@ -117,6 +117,18 @@ test("discoveryNeedsRefresh returns true when cache is empty", () => {
   );
 });
 
+test("discoveryNeedsRefresh retries a recent empty cache", () => {
+  assert.equal(
+    discoveryNeedsRefresh({
+      recommendations: [],
+      globalTop: [],
+      topGenres: [],
+      lastUpdated: new Date().toISOString(),
+    }),
+    true,
+  );
+});
+
 test("discoveryNeedsRefresh returns false for fresh populated cache", () => {
   assert.equal(
     discoveryNeedsRefresh({
@@ -139,17 +151,22 @@ test("first discovery startup queues one refresh", async () => {
   assert.equal(payloads[0].scheduleOnly, false);
 });
 
-test("completed empty discovery cache stays fresh across two restarts", async () => {
+test("recent empty discovery cache queues one recovery refresh", async () => {
   process.env.LASTFM_API_KEY = "test-key";
-  setDiscoveryCache({ lastUpdated: new Date().toISOString() });
+  setDiscoveryCache({
+    recommendations: [],
+    globalTop: [],
+    topGenres: [],
+    lastUpdated: new Date().toISOString(),
+  });
 
   await bootstrapDiscoveryRefresh();
   await bootstrapDiscoveryRefresh();
 
   const payloads = discoveryRefreshPayloads();
   assert.equal(payloads.length, 1);
-  assert.equal(payloads[0].reason, "scheduled");
-  assert.equal(payloads[0].scheduleOnly, true);
+  assert.equal(payloads[0].reason, "startup");
+  assert.equal(payloads[0].scheduleOnly, false);
 });
 
 test("stale and incomplete discovery caches retry", async () => {

--- a/.tests/discovery/discovery-refresh-scheduler.test.js
+++ b/.tests/discovery/discovery-refresh-scheduler.test.js
@@ -16,12 +16,14 @@ const [isolatedState, honkerDbModule, refreshScheduler, discoveryIndex] =
 
 const {
   discoveryNeedsRefresh,
+  bootstrapDiscoveryRefresh,
   enqueueDiscoveryRefresh,
   markDiscoveryRefreshDequeued,
   recoverDeadDiscoveryRefresh,
   scheduleNextDiscoveryRefresh,
 } = refreshScheduler;
 const { getDiscoveryCache } = discoveryIndex;
+const originalLastfmApiKey = process.env.LASTFM_API_KEY;
 
 let heldGlobalRefreshLock = null;
 
@@ -69,13 +71,36 @@ function countDiscoveryRefreshJobs() {
   );
 }
 
+function discoveryRefreshPayloads() {
+  return honkerDbModule
+    .getHonkerDb()
+    .query("SELECT payload FROM _honker_live WHERE queue = ? ORDER BY id", [
+      "discovery-refresh",
+    ])
+    .map((row) => JSON.parse(row.payload));
+}
+
+function setDiscoveryCache(overrides = {}) {
+  Object.assign(getDiscoveryCache(), {
+    recommendations: [],
+    globalTop: [],
+    topGenres: [],
+    lastUpdated: null,
+    isUpdating: false,
+    ...overrides,
+  });
+}
+
 test.beforeEach(() => {
+  clearDiscoveryRefreshJobs();
   markDiscoveryRefreshDequeued();
-  getDiscoveryCache().isUpdating = false;
+  setDiscoveryCache();
   releaseHeldGlobalRefreshLock();
 });
 
 test.after(async () => {
+  if (originalLastfmApiKey === undefined) delete process.env.LASTFM_API_KEY;
+  else process.env.LASTFM_API_KEY = originalLastfmApiKey;
   releaseHeldGlobalRefreshLock();
   markDiscoveryRefreshDequeued();
   await cleanupIsolatedState(isolatedState);
@@ -101,6 +126,59 @@ test("discoveryNeedsRefresh returns false for fresh populated cache", () => {
     }),
     false,
   );
+});
+
+test("first discovery startup queues one refresh", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+
+  await bootstrapDiscoveryRefresh();
+
+  const payloads = discoveryRefreshPayloads();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].reason, "startup");
+  assert.equal(payloads[0].scheduleOnly, false);
+});
+
+test("completed empty discovery cache stays fresh across two restarts", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({ lastUpdated: new Date().toISOString() });
+
+  await bootstrapDiscoveryRefresh();
+  await bootstrapDiscoveryRefresh();
+
+  const payloads = discoveryRefreshPayloads();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].reason, "scheduled");
+  assert.equal(payloads[0].scheduleOnly, true);
+});
+
+test("stale and incomplete discovery caches retry", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({
+    recommendations: [{ id: "old" }],
+    topGenres: ["rock"],
+    lastUpdated: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+  });
+
+  await bootstrapDiscoveryRefresh();
+  assert.equal(discoveryRefreshPayloads()[0].reason, "startup");
+
+  clearDiscoveryRefreshJobs();
+  markDiscoveryRefreshDequeued();
+  setDiscoveryCache({ recommendations: [{ id: "partial" }] });
+
+  await bootstrapDiscoveryRefresh();
+  assert.equal(discoveryRefreshPayloads()[0].reason, "startup");
+});
+
+test("repeated startup checks do not create duplicate active refresh jobs", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({ lastUpdated: null });
+
+  await bootstrapDiscoveryRefresh();
+  await bootstrapDiscoveryRefresh();
+
+  assert.equal(countDiscoveryRefreshJobs(), 1);
 });
 
 test("enqueueDiscoveryRefresh deduplicates active refresh requests", () => {

--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -9,7 +9,10 @@ test("includes all artist inputs in the shows response cache key", () => {
   const base = {
     userId: 1,
     libraryArtists: [{ name: "Library Artist" }],
-    recommendedArtists: [{ name: "Recommended Artist" }],
+    recommendedArtists: [
+      { name: "Recommended Artist" },
+      { name: "Another Recommended Artist" },
+    ],
     trendingArtists: [{ name: "Trending Artist" }],
   };
   const key = buildShowsResponseCacheKey(base);

--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -35,3 +35,33 @@ test("marks an unresolved postal code instead of returning a normal empty locati
   assert.deepEqual(result.libraryShows, []);
   assert.deepEqual(result.recommendedShows, []);
 });
+
+test("reuses a cached shows response without rebuilding artist maps", async (t) => {
+  let artistReads = 0;
+  t.mock.method(axios, "get", async (url) => {
+    if (url.includes("zippopotam")) {
+      return {
+        data: {
+          places: [{ "place name": "Austin", latitude: "30.2672", longitude: "-97.7431" }],
+        },
+      };
+    }
+    return { data: { _embedded: { events: [] } } };
+  });
+
+  const options = {
+    zipCode: "78701",
+    responseCacheKey: "user-1",
+    libraryArtists: {
+      [Symbol.iterator]() {
+        artistReads += 1;
+        return [][Symbol.iterator]();
+      },
+    },
+  };
+  const first = await getNearbyShows(options);
+  const second = await getNearbyShows(options);
+
+  assert.strictEqual(second, first);
+  assert.equal(artistReads, 1);
+});

--- a/.tests/discovery/nearby-shows.test.js
+++ b/.tests/discovery/nearby-shows.test.js
@@ -2,7 +2,47 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import axios from "../../lib/axiosFetch.js";
 
+import { buildShowsResponseCacheKey } from "../../backend/routes/discovery/handlers/shows.js";
 import { getNearbyShows, groupShowsByEvent } from "../../backend/services/nearbyShowsService.js";
+
+test("includes all artist inputs in the shows response cache key", () => {
+  const base = {
+    userId: 1,
+    libraryArtists: [{ name: "Library Artist" }],
+    recommendedArtists: [{ name: "Recommended Artist" }],
+    trendingArtists: [{ name: "Trending Artist" }],
+  };
+  const key = buildShowsResponseCacheKey(base);
+
+  assert.notEqual(
+    buildShowsResponseCacheKey({
+      ...base,
+      libraryArtists: [{ name: "Different Library Artist" }],
+    }),
+    key,
+  );
+  assert.notEqual(
+    buildShowsResponseCacheKey({
+      ...base,
+      recommendedArtists: [{ name: "Different Recommended Artist" }],
+    }),
+    key,
+  );
+  assert.notEqual(
+    buildShowsResponseCacheKey({
+      ...base,
+      trendingArtists: [{ name: "Different Trending Artist" }],
+    }),
+    key,
+  );
+  assert.equal(
+    buildShowsResponseCacheKey({
+      ...base,
+      recommendedArtists: [...base.recommendedArtists].reverse(),
+    }),
+    key,
+  );
+});
 
 test("groups artists matched to the same Ticketmaster event", () => {
   const grouped = groupShowsByEvent([

--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -219,7 +219,7 @@ test("canonical recent releases exclude owned albums without loading old albums"
       "Missing Current",
     ]);
 
-    const scopedReleases = await getRecentMissingReleases(10, {
+    const scopedReleases = await getRecentMissingReleases(1, {
       artists: [projectedArtist],
       now: "2026-08-22T12:00:00Z",
     });

--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -178,6 +178,23 @@ test("canonical recent releases exclude owned albums without loading old albums"
   try {
     addAlbum({ suffix: 1, title: "Missing Current", releaseDate: "2026-08-20" });
     addAlbum({ suffix: 2, title: "Owned Current", releaseDate: "2026-08-19", available: true });
+    const unrelatedArtist = upsertLibraryArtist({
+      identityKey: `${key}:unrelated-artist`,
+      name: "Unrelated Release Artist",
+    });
+    const unrelatedAlbum = upsertLibraryAlbum({
+      identityKey: `${key}:unrelated-album`,
+      artistId: unrelatedArtist.id,
+      title: "Unrelated Newer Release",
+      releaseDate: "2026-08-21",
+    });
+    const unrelatedTrack = upsertLibraryTrack({
+      identityKey: `${key}:unrelated-track`,
+      title: "Unrelated Track",
+      artistName: "Unrelated Release Artist",
+    });
+    trackIds.push(unrelatedTrack.id);
+    linkLibraryAlbumTrack({ albumId: unrelatedAlbum.id, trackId: unrelatedTrack.id });
     for (let index = 0; index < 125; index += 1) {
       addAlbum({ suffix: index + 100, title: `Old Album ${index}`, releaseDate: "2000-01-01" });
     }
@@ -188,13 +205,25 @@ test("canonical recent releases exclude owned albums without loading old albums"
       to: "2026-08-22",
       limit: 10,
     });
-    assert.equal(projectedAlbums[0]?.artistId, projectedArtist?.id);
+    assert.equal(
+      projectedAlbums.find((album) => album.title === "Missing Current")?.artistId,
+      projectedArtist?.id,
+    );
 
     const releases = await getRecentMissingReleases(10, {
       now: "2026-08-22T12:00:00Z",
     });
 
-    assert.deepEqual(releases.map((album) => album.title), ["Missing Current"]);
+    assert.deepEqual(releases.map((album) => album.title), [
+      "Unrelated Newer Release",
+      "Missing Current",
+    ]);
+
+    const scopedReleases = await getRecentMissingReleases(10, {
+      artists: [projectedArtist],
+      now: "2026-08-22T12:00:00Z",
+    });
+    assert.deepEqual(scopedReleases.map((album) => album.title), ["Missing Current"]);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(canonicalArtist.id);

--- a/.tests/discovery/recent-releases.test.js
+++ b/.tests/discovery/recent-releases.test.js
@@ -2,9 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
+import { db } from "../../backend/config/db-sqlite.js";
 import { dbOps } from "../../backend/db/helpers/index.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
+import {
+  getCanonicalAlbumsByReleaseDate,
+  getCanonicalArtistProjection,
+} from "../../backend/services/libraryQueryService.js";
+import {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} from "../../backend/services/libraryMediaStore.js";
 
 const artist = {
   id: 1,
@@ -125,5 +137,71 @@ test("recent missing releases backfill direct Lidarr artists before mapping", as
   } finally {
     lidarrClient.isConfigured = originalIsConfigured;
     dbOps.deleteLidarrArtistIdMap(canonicalMbid);
+  }
+});
+
+test("canonical recent releases exclude owned albums without loading old albums", async () => {
+  const key = `recent-canonical-${process.pid}-${Date.now()}`;
+  const canonicalArtist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: "45454545-4545-4454-8454-454545454545",
+    name: "Canonical Release Artist",
+    metadata: { id: 4545 },
+  });
+  const trackIds = [];
+  const addAlbum = ({ suffix, title, releaseDate, available = false }) => {
+    const album = upsertLibraryAlbum({
+      identityKey: `${key}:album:${suffix}`,
+      releaseGroupMbid: `56565656-5656-4565-8565-${String(suffix).padStart(12, "0")}`,
+      artistId: canonicalArtist.id,
+      title,
+      releaseDate,
+    });
+    const track = upsertLibraryTrack({
+      identityKey: `${key}:track:${suffix}`,
+      title: `${title} Track`,
+      artistName: "Canonical Release Artist",
+    });
+    trackIds.push(track.id);
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+    if (available) {
+      upsertLibraryMediaFile({
+        trackId: track.id,
+        albumId: album.id,
+        source: "lidarr",
+        path: `/tmp/${key}/${suffix}.flac`,
+        available: true,
+      });
+    }
+  };
+
+  try {
+    addAlbum({ suffix: 1, title: "Missing Current", releaseDate: "2026-08-20" });
+    addAlbum({ suffix: 2, title: "Owned Current", releaseDate: "2026-08-19", available: true });
+    for (let index = 0; index < 125; index += 1) {
+      addAlbum({ suffix: index + 100, title: `Old Album ${index}`, releaseDate: "2000-01-01" });
+    }
+
+    const projectedArtist = getCanonicalArtistProjection({ reference: canonicalArtist.id })[0];
+    const projectedAlbums = getCanonicalAlbumsByReleaseDate({
+      from: "2026-08-01",
+      to: "2026-08-22",
+      limit: 10,
+    });
+    assert.equal(projectedAlbums[0]?.artistId, projectedArtist?.id);
+
+    const releases = await getRecentMissingReleases(10, {
+      now: "2026-08-22T12:00:00Z",
+    });
+
+    assert.deepEqual(releases.map((album) => album.title), ["Missing Current"]);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(canonicalArtist.id);
+    if (trackIds.length) {
+      db.prepare(
+        `DELETE FROM library_tracks WHERE id IN (${trackIds.map(() => "?").join(",")})`,
+      ).run(...trackIds);
+    }
   }
 });

--- a/.tests/discovery/recommendation-pipeline.test.js
+++ b/.tests/discovery/recommendation-pipeline.test.js
@@ -5,6 +5,7 @@ import {
   addRecommendationCandidate,
   buildDiscoverySeedList,
   finalizeRecommendationAccumulator,
+  filterRecommendationsForServe,
   mergeRetainedRecommendationPool,
   mergeResolvedRecommendations,
   rerankRecommendations,
@@ -125,6 +126,21 @@ test("mergeResolvedRecommendations collapses name and mbid variants of the same 
     merged[0].tags.sort(),
     ["dream-pop", "shoegaze"],
   );
+});
+
+test("mergeResolvedRecommendations does not expose provider IDs as artist routes", () => {
+  const [recommendation] = mergeResolvedRecommendations([
+    { id: 2278254, navigateTo: 2278254, name: "Discovery Artist" },
+  ]);
+
+  assert.equal(recommendation.id, null);
+  assert.equal(recommendation.navigateTo, null);
+
+  const [cachedRecommendation] = filterRecommendationsForServe([
+    { id: 2278254, navigateTo: 2278254, name: "Cached Discovery Artist" },
+  ]);
+  assert.equal(cachedRecommendation.id, null);
+  assert.equal(cachedRecommendation.navigateTo, null);
 });
 
 

--- a/.tests/frontend/library-query-invalidation.test.js
+++ b/.tests/frontend/library-query-invalidation.test.js
@@ -118,3 +118,38 @@ test("library requests forward caller cancellation", async (t) => {
   await assertQueryCancellation(() => getLibraryFavorites(), queryKeys.libraryFavorites);
   queryClient.clear();
 });
+
+test("artist batch lookup stays within the API batch limit", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { lookupArtistsInLibraryBatch } = await vite.ssrLoadModule(
+    "/src/utils/api/endpoints/library.js?artist-batch-limit-test",
+  );
+  const { queryClient } = await vite.ssrLoadModule("/src/queryClient.js");
+  const originalFetch = globalThis.fetch;
+  const requestSizes = [];
+  globalThis.fetch = async (_url, init) => {
+    const { mbids } = JSON.parse(init.body);
+    requestSizes.push(mbids.length);
+    return new Response(JSON.stringify(Object.fromEntries(mbids.map((id) => [id, true]))), {
+      status: mbids.length <= 100 ? 200 : 400,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const ids = Array.from({ length: 201 }, (_, index) => `artist-${index}`);
+    const result = await lookupArtistsInLibraryBatch(ids);
+    assert.deepEqual(requestSizes, [100, 100, 1]);
+    assert.equal(Object.keys(result).length, 201);
+  } finally {
+    globalThis.fetch = originalFetch;
+    queryClient.clear();
+  }
+});

--- a/.tests/helpers/backendTestHarness.js
+++ b/.tests/helpers/backendTestHarness.js
@@ -30,6 +30,7 @@ const RESET_TABLES = [
   "library_albums",
   "library_artists",
   "library_scan_runs",
+  "library_search_documents",
   "settings",
 ];
 

--- a/.tests/honker/honker-db-config.test.js
+++ b/.tests/honker/honker-db-config.test.js
@@ -79,6 +79,7 @@ test("startup only queues due bootstrap work and a pending migration", () => {
 
   clearQueue();
   honkerDb.enqueueHonkerStartupTasks();
+  honkerDb.enqueueHonkerStartupTasks();
   assert.deepEqual(queuedKinds(), [
     "playlist-startup-migration",
     "weekly-flow-startup-check",

--- a/.tests/honker/honker-db-config.test.js
+++ b/.tests/honker/honker-db-config.test.js
@@ -16,14 +16,15 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("schedule bootstrap reconciles config without resetting next fire state", () => {
+test("schedule bootstrap skips missed runs while reconciling config", () => {
   honkerDb.bootstrapHonkerSchedules();
   const scheduler = honkerDb.getHonkerDb().scheduler();
+  const now = Math.floor(Date.now() / 1000);
 
   const tx = honkerDb.getHonkerDb().transaction();
   tx.execute(
     "UPDATE _honker_scheduler_tasks SET next_fire_at = ?, priority = ? WHERE name = ?",
-    [42, 99, "weekly-flow-refresh"],
+    [now - 3 * 60 * 60, 99, "weekly-flow-refresh"],
   );
   tx.commit();
 
@@ -35,7 +36,7 @@ test("schedule bootstrap reconciles config without resetting next fire state", (
     (row) => row.name === "playlist-mbid-enrichment-sweep",
   );
 
-  assert.equal(weeklyFlow?.next_fire_at, 42);
+  assert.ok(weeklyFlow?.next_fire_at > now);
   assert.equal(weeklyFlow?.priority, 0);
   assert.equal(enrichment?.max_attempts, 4);
   assert.equal(rows.length, honkerDb.SCHEDULED_SYSTEM_TASKS.length);

--- a/.tests/honker/honker-db-config.test.js
+++ b/.tests/honker/honker-db-config.test.js
@@ -16,7 +16,7 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("schedule bootstrap skips missed runs while reconciling config", () => {
+test("schedule bootstrap skips stale runs without postponing recently due work", () => {
   honkerDb.bootstrapHonkerSchedules();
   const scheduler = honkerDb.getHonkerDb().scheduler();
   const now = Math.floor(Date.now() / 1000);
@@ -38,6 +38,21 @@ test("schedule bootstrap skips missed runs while reconciling config", () => {
 
   assert.ok(weeklyFlow?.next_fire_at > now);
   assert.equal(weeklyFlow?.priority, 0);
+
+  const recentlyDue = now - 60;
+  const recentTx = honkerDb.getHonkerDb().transaction();
+  recentTx.execute(
+    "UPDATE _honker_scheduler_tasks SET next_fire_at = ? WHERE name = ?",
+    [recentlyDue, "weekly-flow-refresh"],
+  );
+  recentTx.commit();
+
+  honkerDb.bootstrapHonkerSchedules();
+
+  const preserved = scheduler
+    .list()
+    .find((row) => row.name === "weekly-flow-refresh");
+  assert.equal(preserved?.next_fire_at, recentlyDue);
   assert.equal(enrichment?.max_attempts, 4);
   assert.equal(rows.length, honkerDb.SCHEDULED_SYSTEM_TASKS.length);
 });

--- a/.tests/inbox-refresh-queue.test.js
+++ b/.tests/inbox-refresh-queue.test.js
@@ -135,8 +135,8 @@ test("a removed queued refresh is reported stale", async () => {
 });
 
 test("expired inbox leases are reported stale and recovered without overlap", async () => {
-  const queue = getSystemTaskQueue();
-  const jobId = queue.enqueue({ kind: "inbox-refresh", userId });
+  const refresh = await inboxService.enqueueInboxRefreshForUser(userId, { reason: "retry" });
+  const jobId = refresh.jobId;
   const expiredAt = Math.floor(Date.now() / 1000) - 10;
   const transaction = getHonkerDb().transaction();
   transaction.execute(
@@ -150,9 +150,13 @@ test("expired inbox leases are reported stale and recovered without overlap", as
   const staleStatus = getInboxRefreshStatus(userId);
   assert.equal(staleStatus.status, "stale");
   assert.equal(staleStatus.stale, true);
-  assert.match(staleStatus.error, /lease expired/i);
+  assert.match(staleStatus.error, /no longer active/i);
+  assert.equal(
+    getHonkerDb().query("SELECT state FROM _honker_live WHERE id = ?", [jobId])[0]?.state,
+    "processing",
+  );
 
-  const recovered = await enqueueInboxRefreshForUser(userId, { reason: "retry" });
+  const recovered = await inboxService.enqueueInboxRefreshForUser(userId, { reason: "retry" });
   assert.equal(recovered.queued, true);
   assert.notEqual(recovered.jobId, jobId);
   assert.equal(

--- a/.tests/inbox-refresh-queue.test.js
+++ b/.tests/inbox-refresh-queue.test.js
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  setupIsolatedBackend,
+} from "./helpers/backendTestHarness.js";
+
+const [
+  isolatedState,
+  { db },
+  { dbOps, userOps },
+  inboxService,
+  honkerDb,
+  systemTaskWorker,
+  { upsertLibraryArtist },
+  axios,
+] = await setupIsolatedBackend(
+  "inbox-refresh-queue",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+  "backend/services/inboxService.js",
+  "backend/services/honkerDb.js",
+  "backend/services/systemTaskWorker.js",
+  "backend/services/libraryMediaStore.js",
+  "lib/axiosFetch.js",
+);
+
+const {
+  enqueueInboxRefreshForUser,
+  getInboxForUser,
+  getInboxRefreshStatus,
+  refreshInboxForUser,
+} = inboxService;
+const { enqueueHonkerStartupTasks, getHonkerDb, getSystemTaskQueue } = honkerDb;
+const { processSystemTask } = systemTaskWorker;
+
+let userId;
+
+function clearRefreshState() {
+  const transaction = getHonkerDb().transaction();
+  transaction.execute("DELETE FROM _honker_live");
+  transaction.commit();
+  db.prepare("DELETE FROM inbox_items").run();
+  db.prepare("DELETE FROM settings WHERE key LIKE 'inboxRefresh:%'").run();
+}
+
+test.before(() => {
+  getSystemTaskQueue();
+  userId = userOps.createUser("inbox-refresh-user", "password-hash").id;
+  upsertLibraryArtist({
+    identityKey: "artist:inbox-refresh",
+    mbid: "artist-mbid",
+    name: "Inbox Refresh Artist",
+  });
+});
+
+test.beforeEach(() => {
+  clearRefreshState();
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("GET inbox reads cached rows without creating refresh work", () => {
+  const result = getInboxForUser(userId);
+  const jobs = getHonkerDb().query(
+    "SELECT id FROM _honker_live WHERE queue = 'system-task'",
+  );
+
+  assert.equal(result.refreshStatus.status, "idle");
+  assert.equal(result.refreshing, false);
+  assert.equal(jobs.length, 0);
+});
+
+test("manual refreshes deduplicate per user and survive a Honker reopen", async () => {
+  const queue = getSystemTaskQueue();
+  const originalEnqueue = queue.enqueue;
+  queue.enqueue = function enqueueWithFutureRunAt(payload, options = {}) {
+    return originalEnqueue.call(this, payload, {
+      ...options,
+      runAt: Math.floor(Date.now() / 1000) + 120,
+    });
+  };
+
+  let first;
+  let second;
+  try {
+    first = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+    second = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+  } finally {
+    queue.enqueue = originalEnqueue;
+  }
+
+  assert.equal(first.queued, true);
+  assert.equal(second.queued, false);
+  assert.equal(second.jobId, first.jobId);
+  assert.equal(
+    getHonkerDb().query(
+      "SELECT id FROM _honker_live WHERE queue = 'system-task' AND state = 'pending'",
+    ).length,
+    1,
+  );
+
+  honkerDb.closeHonkerDb();
+  const statusAfterReopen = getInboxRefreshStatus(userId);
+  assert.equal(statusAfterReopen.status, "queued");
+  assert.equal(statusAfterReopen.jobId, first.jobId);
+});
+
+test("a removed queued refresh is reported stale", async () => {
+  const queue = getSystemTaskQueue();
+  const originalEnqueue = queue.enqueue;
+  queue.enqueue = function enqueueWithFutureRunAt(payload, options = {}) {
+    return originalEnqueue.call(this, payload, {
+      ...options,
+      runAt: Math.floor(Date.now() / 1000) + 120,
+    });
+  };
+  let refresh;
+  try {
+    refresh = await enqueueInboxRefreshForUser(userId, { reason: "manual" });
+  } finally {
+    queue.enqueue = originalEnqueue;
+  }
+  const transaction = getHonkerDb().transaction();
+  transaction.execute("DELETE FROM _honker_live WHERE id = ?", [refresh.jobId]);
+  transaction.commit();
+
+  const status = getInboxRefreshStatus(userId);
+  assert.equal(status.status, "stale");
+  assert.equal(status.stale, true);
+  assert.match(status.error, /no longer active/i);
+});
+
+test("expired inbox leases are reported stale and recovered without overlap", async () => {
+  const queue = getSystemTaskQueue();
+  const jobId = queue.enqueue({ kind: "inbox-refresh", userId });
+  const expiredAt = Math.floor(Date.now() / 1000) - 10;
+  const transaction = getHonkerDb().transaction();
+  transaction.execute(
+    `UPDATE _honker_live
+     SET state = 'processing', worker_id = ?, claim_expires_at = ?
+     WHERE id = ?`,
+    ["stale-worker", expiredAt, jobId],
+  );
+  transaction.commit();
+
+  const staleStatus = getInboxRefreshStatus(userId);
+  assert.equal(staleStatus.status, "stale");
+  assert.equal(staleStatus.stale, true);
+  assert.match(staleStatus.error, /lease expired/i);
+
+  const recovered = await enqueueInboxRefreshForUser(userId, { reason: "retry" });
+  assert.equal(recovered.queued, true);
+  assert.notEqual(recovered.jobId, jobId);
+  assert.equal(
+    getHonkerDb().query(
+      `SELECT id FROM _honker_live
+       WHERE queue = 'system-task'
+         AND (state = 'pending' OR (state = 'processing' AND claim_expires_at > ?))`,
+      [Math.floor(Date.now() / 1000)],
+    ).length,
+    1,
+  );
+});
+
+test("provider failure preserves rows and marks the inbox stale", async () => {
+  const previous = dbOps.upsertInboxItem({
+    userId,
+    kind: "release",
+    sourceKey: "prior:release",
+    title: "Previously cached release",
+  });
+  const originalAxiosGet = axios.default.get;
+  const originalTicketmasterKey = process.env.TICKETMASTER_API_KEY;
+  process.env.TICKETMASTER_API_KEY = "test-ticketmaster-key";
+  axios.default.get = (url, options) => {
+    if (String(url).includes("zippopotam.us")) {
+      return Promise.resolve({
+        data: {
+          places: [{
+            "place name": "New York",
+            state: "New York",
+            "state abbreviation": "NY",
+            latitude: "40.71",
+            longitude: "-74.00",
+          }],
+        },
+      });
+    }
+    if (String(url).includes("ticketmaster.com")) {
+      return Promise.reject(new Error("Ticketmaster unavailable"));
+    }
+    return originalAxiosGet(url, options);
+  };
+
+  try {
+    const refreshed = await refreshInboxForUser(userId, {
+      force: true,
+      ipAddress: "127.0.0.1",
+      zipCode: "10001",
+    });
+    assert.equal(refreshed, false);
+    const status = getInboxRefreshStatus(userId);
+    assert.equal(status.status, "stale");
+    assert.equal(status.stale, true);
+    assert.match(status.error, /shows: Ticketmaster unavailable/);
+    assert.equal(dbOps.getInboxItem(userId, previous.id)?.title, "Previously cached release");
+  } finally {
+    axios.default.get = originalAxiosGet;
+    if (originalTicketmasterKey === undefined) delete process.env.TICKETMASTER_API_KEY;
+    else process.env.TICKETMASTER_API_KEY = originalTicketmasterKey;
+  }
+});
+
+test("failed refreshes are explicit and a worker retry can complete", async () => {
+  const previous = dbOps.upsertInboxItem({
+    userId,
+    kind: "release",
+    sourceKey: "failed:release",
+    title: "Retained while refresh fails",
+  });
+  const originalGetSettings = dbOps.getSettings;
+  dbOps.getSettings = () => {
+    throw new Error("Inbox provider unavailable");
+  };
+
+  try {
+    await assert.rejects(
+      processSystemTask({ kind: "inbox-refresh", userId }, { id: 9001 }),
+      /Inbox provider unavailable/,
+    );
+    const failed = getInboxRefreshStatus(userId);
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.stale, true);
+    assert.match(failed.error, /Inbox provider unavailable/);
+    assert.equal(dbOps.getInboxItem(userId, previous.id)?.title, "Retained while refresh fails");
+  } finally {
+    dbOps.getSettings = originalGetSettings;
+  }
+
+  await processSystemTask({ kind: "inbox-refresh", userId }, { id: 9002 });
+  const recovered = getInboxRefreshStatus(userId);
+  assert.equal(recovered.status, "complete");
+  assert.equal(recovered.stale, false);
+  assert.equal(recovered.lastSuccessAt > 0, true);
+});
+
+test("startup markers prevent duplicate bootstrap jobs on restart", () => {
+  enqueueHonkerStartupTasks();
+  enqueueHonkerStartupTasks();
+  const kinds = getHonkerDb()
+    .query("SELECT payload FROM _honker_live WHERE queue = 'system-task'")
+    .map((row) => JSON.parse(row.payload).kind);
+
+  assert.equal(kinds.filter((kind) => kind === "weekly-flow-startup-check").length, 1);
+  assert.equal(kinds.filter((kind) => kind === "discovery-bootstrap").length, 1);
+  assert.equal(kinds.filter((kind) => kind === "library-index-bootstrap").length, 1);
+});

--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -69,9 +69,38 @@ test("canonical read model maps the existing root to Library-shaped records", ()
   ]);
   assert.equal(result.albums[0].mbid, "release-1");
   assert.equal(result.albums[0].releaseGroupMbid, "album-1");
+  assert.equal(result.artists[0].foreignArtistId, "artist-1");
   assert.equal(result.albums[0].statistics.sizeOnDisk, 123);
   assert.equal(result.artists[0].statistics.sizeOnDisk, 123);
   assert.equal(result.tracks[0].path, "/music/Root Artist/Root Album/01 Root Track.flac");
+});
+
+test("canonical read model preserves non-MBID provider artist identity", () => {
+  const result = buildCanonicalLibraryReadModel({
+    artists: [
+      {
+        id: 4,
+        identityKey: "lidarr-artist:705@deezer",
+        mbid: null,
+        name: "Provider Artist",
+        sortName: "Provider Artist",
+        metadata: {
+          id: 42,
+          foreignArtistId: "705@deezer",
+          librarySource: "lidarr",
+        },
+        albumIds: [],
+        sources: ["lidarr"],
+        available: false,
+      },
+    ],
+    albums: [],
+    tracks: [],
+  });
+
+  assert.equal(result.artists[0].providerId, 42);
+  assert.equal(result.artists[0].mbid, null);
+  assert.equal(result.artists[0].foreignArtistId, "705@deezer");
 });
 
 test("canonical read model keeps flow-like records out when the index excludes them", () => {

--- a/.tests/library/canonical-read-routes.test.js
+++ b/.tests/library/canonical-read-routes.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { db } from "../../backend/config/db-sqlite.js";
+import { registerAlbums } from "../../backend/routes/library/handlers/albums.js";
 import { registerTracks } from "../../backend/routes/library/handlers/tracks.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
 
@@ -126,6 +127,53 @@ test("canonical track reads remove nested filesystem paths", async () => {
     assert.deepEqual(body[0].quality, { audioFormat: "FLAC", nested: {} });
     assert.match(body[0].streamPath, /\/library\/canonical-stream\/\d+\/\d+$/);
     assert.equal(body[0].streamFormat, "flac");
+
+    await routes.get("/tracks")(
+      {
+        query: {
+          readPath: "canonical",
+          albumId: "999999999",
+          releaseGroupMbid: "72222222-2222-4222-8222-222222222222",
+        },
+      },
+      {
+        json(value) {
+          body = value;
+          return this;
+        },
+        status() {
+          return this;
+        },
+      },
+    );
+    assert.deepEqual(body.map((track) => track.title), ["Route Track"]);
+
+    registerAlbums({
+      get(routePath, ...handlers) {
+        routes.set(routePath, handlers.at(-1));
+      },
+      post() {},
+      delete() {},
+      put() {},
+    });
+    const artist = db.prepare(
+      "SELECT id, identity_key AS identityKey, mbid FROM library_artists WHERE mbid = ?",
+    ).get("71111111-1111-4111-8111-111111111111");
+    for (const artistId of [artist.id, artist.identityKey, artist.mbid]) {
+      await routes.get("/albums")(
+        { query: { readPath: "canonical", artistId } },
+        {
+          json(value) {
+            body = value;
+            return this;
+          },
+          status() {
+            return this;
+          },
+        },
+      );
+      assert.deepEqual(body.map((album) => album.title), ["Route Album"]);
+    }
   } finally {
     const track = db.prepare(
       "SELECT track_id AS trackId FROM library_media_files WHERE source = ? AND path = ?",

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import {
+  beginLibraryScan,
+  finishLibraryScan,
+  upsertLibraryArtist,
+} from "../../backend/services/libraryMediaStore.js";
+import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
+import { lidarrClient } from "../../backend/services/lidarrClient.js";
+import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+
+test("stable artist and discovery reads do not call Lidarr", async (t) => {
+  const identityKey = `stable-read-test:${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey,
+    mbid: "11111111-1111-4111-8111-111111111111",
+    name: "Stable Read Artist",
+    metadata: { id: 9911, monitored: true },
+  });
+  const originalConfigured = lidarrClient.isConfigured;
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("stable reads must not call Lidarr");
+  });
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    throw new Error("stable reads must not call Lidarr");
+  });
+  lidarrClient.isConfigured = () => true;
+
+  try {
+    const artists = await libraryManager.getAllArtists();
+    const releases = await getRecentMissingReleases(10, {
+      now: "2026-08-22T12:00:00Z",
+    });
+
+    assert.equal(artists.some((candidate) => candidate.providerId === "9911"), true);
+    assert.deepEqual(releases, []);
+    assert.equal(request.mock.callCount(), 0);
+  } finally {
+    lidarrClient.isConfigured = originalConfigured;
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("stable artist reads remain local when Lidarr is absent", async (t) => {
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("absent Lidarr must not be called");
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+
+  const artists = await libraryManager.getAllArtists();
+
+  assert.ok(Array.isArray(artists));
+  assert.equal(request.mock.callCount(), 0);
+});
+
+test("explicit artist synchronization retains its Lidarr request", async (t) => {
+  const originalConfigured = lidarrClient.isConfigured;
+  const request = t.mock.method(lidarrClient, "request", async () => []);
+  t.mock.method(libraryManager, "backfillLidarrArtistMappings", async () => {});
+  lidarrClient.isConfigured = () => true;
+
+  try {
+    await libraryManager.syncLidarrArtists({ forceRefresh: true });
+    assert.deepEqual(request.mock.calls.map((call) => call.arguments[0]), ["/artist"]);
+  } finally {
+    lidarrClient.isConfigured = originalConfigured;
+  }
+});
+
+test("a failed provider scan keeps the canonical artist and marks it stale", () => {
+  const identityKey = `stale-read-test:${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey,
+    mbid: "22222222-2222-4222-8222-222222222222",
+    name: "Stale Read Artist",
+  });
+  const scanId = beginLibraryScan({ source: "lidarr" });
+
+  try {
+    finishLibraryScan(scanId, { status: "failed", error: "provider unavailable" });
+    const projection = getCanonicalArtistProjection({ reference: artist.id });
+    assert.equal(projection[0]?.name, "Stale Read Artist");
+    assert.equal(projection[0]?.stale, true);
+  } finally {
+    db.prepare("DELETE FROM library_scan_runs WHERE id = ?").run(scanId);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -15,9 +15,12 @@ import { getRecentMissingReleases } from "../../backend/services/discovery/recen
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import {
+  getCanonicalAlbumPage,
+  getCanonicalArtistPage,
   getCanonicalArtistKeyProjection,
   getCanonicalArtistProjection,
   getCanonicalLibraryPage,
+  getCanonicalTrackPage,
 } from "../../backend/services/libraryQueryService.js";
 import {
   clearScheduledLibraryScan,
@@ -26,6 +29,7 @@ import {
 import { getLibraryScanQueue } from "../../backend/services/honkerDb.js";
 import { getCanonicalLidarrArtist } from "../../backend/routes/artists/handlers/details.js";
 import { registerArtists } from "../../backend/routes/library/handlers/artists.js";
+import { getLibrarySearchMatch } from "../../backend/services/librarySearchIndex.js";
 
 test("stable artist and discovery reads do not call Lidarr", async (t) => {
   const identityKey = `stable-read-test:${Date.now()}`;
@@ -244,6 +248,136 @@ test("canonical artist compatibility reads apply SQL pagination", async () => {
     db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(...paths);
     db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(...artists.map((artist) => artist.id));
     db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(...tracks.map((track) => track.id));
+  }
+});
+
+test("canonical paginated reads keep tied rows stable", () => {
+  const key = `canonical-stable-order:${process.pid}:${Date.now()}`;
+  const artistName = `${key} Artist`;
+  const albumTitle = `${key} Album`;
+  const trackTitle = `${key} Track`;
+  const artists = [];
+  const albums = [];
+  const tracks = [];
+  const paths = [];
+
+  try {
+    for (const index of [0, 1]) {
+      const artist = upsertLibraryArtist({
+        identityKey: `${key}:artist:${index}`,
+        name: artistName,
+        sortName: artistName,
+      });
+      const album = upsertLibraryAlbum({
+        identityKey: `${key}:album:${index}`,
+        artistId: artist.id,
+        title: albumTitle,
+      });
+      const track = upsertLibraryTrack({
+        identityKey: `${key}:track:${index}`,
+        title: trackTitle,
+        artistName,
+      });
+      const filePath = `/tmp/${key}/${index}.flac`;
+      linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+      upsertLibraryMediaFile({
+        trackId: track.id,
+        albumId: album.id,
+        source: "lidarr",
+        path: filePath,
+        available: true,
+      });
+      artists.push(artist);
+      albums.push(album);
+      tracks.push(track);
+      paths.push(filePath);
+    }
+
+    const expectedProjectionIds = artists.map((artist) => String(artist.id));
+    const expectedIds = artists.map((artist) => artist.id);
+    const projectionOffset = db.prepare(
+      `SELECT COUNT(*) AS count
+       FROM library_artists
+       WHERE sort_name COLLATE NOCASE < ?
+          OR (sort_name COLLATE NOCASE = ? AND name COLLATE NOCASE < ?)`,
+    ).get(artistName, artistName, artistName).count;
+    assert.deepEqual(
+      getCanonicalArtistProjection({ pageSize: 2, offset: projectionOffset })
+        .map((artist) => artist.id),
+      expectedProjectionIds,
+    );
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalArtistProjection({
+        pageSize: 1,
+        offset: projectionOffset + offset,
+      })[0]?.id),
+      expectedProjectionIds,
+    );
+
+    const artistSearchMatch = getLibrarySearchMatch(artistName);
+    const albumSearchMatch = getLibrarySearchMatch(albumTitle);
+    const trackSearchMatch = getLibrarySearchMatch(trackTitle);
+    assert.ok(artistSearchMatch && albumSearchMatch && trackSearchMatch);
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalArtistPage({
+        source: "lidarr",
+        availableOnly: true,
+        query: artistName,
+        searchMatch: artistSearchMatch,
+        limit: 1,
+        offset,
+      }).artists[0]?.id),
+      expectedIds,
+    );
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalAlbumPage({
+        source: "lidarr",
+        availableOnly: true,
+        query: albumTitle,
+        searchMatch: albumSearchMatch,
+        limit: 1,
+        offset,
+      }).albums[0]?.id),
+      albums.map((album) => album.id),
+    );
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalTrackPage({
+        source: "lidarr",
+        availableOnly: true,
+        query: trackTitle,
+        searchMatch: trackSearchMatch,
+        limit: 1,
+        offset,
+      }).tracks[0]?.id),
+      tracks.map((track) => track.id),
+    );
+  } finally {
+    if (paths.length) {
+      db.prepare(
+        `DELETE FROM library_media_files WHERE path IN (${paths.map(() => "?").join(",")})`,
+      ).run(...paths);
+    }
+    for (const [kind, ids] of [
+      ["artist", artists.map((artist) => artist.id)],
+      ["album", albums.map((album) => album.id)],
+      ["track", tracks.map((track) => track.id)],
+    ]) {
+      if (!ids.length) continue;
+      db.prepare(
+        `DELETE FROM library_search_documents
+         WHERE entity_kind = ? AND entity_id IN (${ids.map(() => "?").join(",")})`,
+      ).run(kind, ...ids);
+    }
+    if (artists.length) {
+      db.prepare(
+        `DELETE FROM library_artists WHERE id IN (${artists.map(() => "?").join(",")})`,
+      ).run(...artists.map((artist) => artist.id));
+    }
+    if (tracks.length) {
+      db.prepare(
+        `DELETE FROM library_tracks WHERE id IN (${tracks.map(() => "?").join(",")})`,
+      ).run(...tracks.map((track) => track.id));
+    }
   }
 });
 

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -23,6 +23,7 @@ import {
 } from "../../backend/services/libraryScanWorker.js";
 import { getLibraryScanQueue } from "../../backend/services/honkerDb.js";
 import { getCanonicalLidarrArtist } from "../../backend/routes/artists/handlers/details.js";
+import { registerArtists } from "../../backend/routes/library/handlers/artists.js";
 
 test("stable artist and discovery reads do not call Lidarr", async (t) => {
   const identityKey = `stable-read-test:${Date.now()}`;
@@ -145,6 +146,60 @@ test("stable artist reads remain local when Lidarr is absent", async (t) => {
 
   assert.ok(Array.isArray(artists));
   assert.equal(request.mock.callCount(), 0);
+});
+
+test("legacy artist list bounds the projection before materialization", async (t) => {
+  const prefix = `zzzzzzzzzz-artist-page-${process.pid}-${Date.now()}`;
+  const artists = Array.from({ length: 101 }, (_, index) => upsertLibraryArtist({
+    identityKey: `${prefix}:${index}`,
+    name: `${prefix}-${String(index).padStart(3, "0")}`,
+    sortName: `${prefix}-${String(index).padStart(3, "0")}`,
+  }));
+  t.mock.method(libraryManager, "getAllArtists", async () => {
+    throw new Error("legacy artist list must not materialize all projection pages");
+  });
+
+  const routes = new Map();
+  registerArtists({
+    get(path, ...handlers) {
+      routes.set(`GET ${path}`, handlers.at(-1));
+    },
+    post(path, ...handlers) {
+      routes.set(`POST ${path}`, handlers.at(-1));
+    },
+    put(path, ...handlers) {
+      routes.set(`PUT ${path}`, handlers.at(-1));
+    },
+    delete(path, ...handlers) {
+      routes.set(`DELETE ${path}`, handlers.at(-1));
+    },
+  });
+
+  let statusCode = 200;
+  let body;
+  try {
+    await routes.get("GET /artists")(
+      { query: { limit: "1", offset: "100" } },
+      {
+        status(code) {
+          statusCode = code;
+          return this;
+        },
+        json(value) {
+          body = value;
+          return this;
+        },
+      },
+    );
+
+    assert.equal(statusCode, 200);
+    assert.deepEqual(body.map((artist) => artist.id), [String(artists[100].id)]);
+    assert.equal(body[0].added, body[0].addedAt);
+  } finally {
+    db.prepare(
+      `DELETE FROM library_artists WHERE id IN (${artists.map(() => "?").join(",")})`,
+    ).run(...artists.map((artist) => artist.id));
+  }
 });
 
 test("artist details do not expose Lidarr state for Aurral-only artists", () => {

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -351,6 +351,28 @@ test("canonical paginated reads keep tied rows stable", () => {
       }).albums[0]?.id),
       albums.map((album) => album.id),
     );
+    for (const sort of ["name", "artist", "newest"]) {
+      const expectedTrackIds = getCanonicalLibraryPage({
+        source: "lidarr",
+        availableOnly: true,
+        kind: "tracks",
+        query: trackTitle,
+        sort,
+        pageSize: 2,
+      }).tracks.map((track) => track.id);
+      assert.deepEqual(
+        [0, 1].map((offset) => getCanonicalLibraryPage({
+          source: "lidarr",
+          availableOnly: true,
+          kind: "tracks",
+          query: trackTitle,
+          sort,
+          pageSize: 1,
+          offset,
+        }).tracks[0]?.id),
+        expectedTrackIds,
+      );
+    }
 
     const artistSearchMatch = getLibrarySearchMatch(artistName);
     const albumSearchMatch = getLibrarySearchMatch(albumTitle);

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -15,6 +15,7 @@ import { getRecentMissingReleases } from "../../backend/services/discovery/recen
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import {
+  getCanonicalArtistKeyProjection,
   getCanonicalArtistProjection,
   getCanonicalLibraryPage,
 } from "../../backend/services/libraryQueryService.js";
@@ -56,6 +57,41 @@ test("stable artist and discovery reads do not call Lidarr", async (t) => {
     assert.equal(request.mock.callCount(), 0);
   } finally {
     lidarrClient.isConfigured = originalConfigured;
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("artist key reads use identity columns and preserve metadata foreign IDs", (t) => {
+  const identityKey = `artist-key-read:${Date.now()}`;
+  const foreignArtistId = "artist-key-foreign-id";
+  const artist = upsertLibraryArtist({
+    identityKey,
+    name: "Artist Key Read",
+    metadata: { foreignArtistId },
+  });
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  try {
+    const projection = getCanonicalArtistKeyProjection().find(
+      (candidate) => candidate.id === String(artist.id),
+    );
+    assert.deepEqual(projection, {
+      id: String(artist.id),
+      mbid: null,
+      foreignArtistId,
+      name: "Artist Key Read",
+      artistName: "Artist Key Read",
+    });
+    const sql = prepared.find((entry) => entry.includes("FROM library_artists"));
+    assert.ok(sql);
+    assert.match(sql, /SELECT id, identity_key, mbid, name, metadata_json/);
+    assert.doesNotMatch(sql, /JOIN|COUNT|library_albums/);
+  } finally {
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
   }
 });

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -192,6 +192,7 @@ test("deleting a Lidarr artist clears canonical provider state for both IDs", as
 test("canonical artist compatibility reads apply SQL pagination", async () => {
   const key = `canonical-artist-route:${process.pid}:${Date.now()}`;
   const artists = [];
+  const albums = [];
   const tracks = [];
   const paths = [];
   for (const name of ["A", "B"]) {
@@ -220,6 +221,7 @@ test("canonical artist compatibility reads apply SQL pagination", async () => {
       available: true,
     });
     artists.push(artist);
+    albums.push(album);
     tracks.push(track);
     paths.push(filePath);
   }
@@ -246,6 +248,11 @@ test("canonical artist compatibility reads apply SQL pagination", async () => {
     assert.equal(body[0].added, body[0].addedAt);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(...paths);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id IN (?, ?) OR track_id IN (?, ?)").run(
+      ...albums.map((album) => album.id),
+      ...tracks.map((track) => track.id),
+    );
+    db.prepare("DELETE FROM library_albums WHERE id IN (?, ?)").run(...albums.map((album) => album.id));
     db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(...artists.map((artist) => artist.id));
     db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(...tracks.map((track) => track.id));
   }
@@ -260,8 +267,14 @@ test("canonical paginated reads keep tied rows stable", () => {
   const albums = [];
   const tracks = [];
   const paths = [];
+  let nullSortArtist;
 
   try {
+    nullSortArtist = upsertLibraryArtist({
+      identityKey: `${key}:null-sort-artist`,
+      name: `${key} Null Sort Artist`,
+      syncSearch: false,
+    });
     for (const index of [0, 1]) {
       const artist = upsertLibraryArtist({
         identityKey: `${key}:artist:${index}`,
@@ -298,9 +311,13 @@ test("canonical paginated reads keep tied rows stable", () => {
     const projectionOffset = db.prepare(
       `SELECT COUNT(*) AS count
        FROM library_artists
-       WHERE sort_name COLLATE NOCASE < ?
-          OR (sort_name COLLATE NOCASE = ? AND name COLLATE NOCASE < ?)`,
-    ).get(artistName, artistName, artistName).count;
+       WHERE sort_name IS NULL
+          OR sort_name COLLATE NOCASE < ?
+          OR (sort_name COLLATE NOCASE = ? AND (
+            name COLLATE NOCASE < ?
+            OR (name COLLATE NOCASE = ? AND id < ?)
+          ))`,
+    ).get(artistName, artistName, artistName, artistName, artists[0].id).count;
     assert.deepEqual(
       getCanonicalArtistProjection({ pageSize: 2, offset: projectionOffset })
         .map((artist) => artist.id),
@@ -312,6 +329,27 @@ test("canonical paginated reads keep tied rows stable", () => {
         offset: projectionOffset + offset,
       })[0]?.id),
       expectedProjectionIds,
+    );
+
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalArtistPage({
+        source: "lidarr",
+        availableOnly: true,
+        query: artistName,
+        limit: 1,
+        offset,
+      }).artists[0]?.id),
+      expectedIds,
+    );
+    assert.deepEqual(
+      [0, 1].map((offset) => getCanonicalAlbumPage({
+        source: "lidarr",
+        availableOnly: true,
+        query: albumTitle,
+        limit: 1,
+        offset,
+      }).albums[0]?.id),
+      albums.map((album) => album.id),
     );
 
     const artistSearchMatch = getLibrarySearchMatch(artistName);
@@ -368,6 +406,16 @@ test("canonical paginated reads keep tied rows stable", () => {
          WHERE entity_kind = ? AND entity_id IN (${ids.map(() => "?").join(",")})`,
       ).run(kind, ...ids);
     }
+    if (albums.length) {
+      db.prepare(
+        `DELETE FROM library_album_tracks
+         WHERE album_id IN (${albums.map(() => "?").join(",")})
+            OR track_id IN (${tracks.map(() => "?").join(",")})`,
+      ).run(...albums.map((album) => album.id), ...tracks.map((track) => track.id));
+      db.prepare(
+        `DELETE FROM library_albums WHERE id IN (${albums.map(() => "?").join(",")})`,
+      ).run(...albums.map((album) => album.id));
+    }
     if (artists.length) {
       db.prepare(
         `DELETE FROM library_artists WHERE id IN (${artists.map(() => "?").join(",")})`,
@@ -377,6 +425,9 @@ test("canonical paginated reads keep tied rows stable", () => {
       db.prepare(
         `DELETE FROM library_tracks WHERE id IN (${tracks.map(() => "?").join(",")})`,
       ).run(...tracks.map((track) => track.id));
+    }
+    if (nullSortArtist) {
+      db.prepare("DELETE FROM library_artists WHERE id = ?").run(nullSortArtist.id);
     }
   }
 });
@@ -489,6 +540,11 @@ test("canonical artist page totals match hydrated items", () => {
     assert.equal(page.total, 1);
     assert.deepEqual(page.items.map((artist) => artist.id), [populatedArtist.id]);
   } finally {
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? OR track_id = ?").run(
+      album.id,
+      track.id,
+    );
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
     db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(
       emptyArtist.id,
       populatedArtist.id,

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -8,6 +8,7 @@ import {
   linkLibraryAlbumTrack,
   upsertLibraryAlbum,
   upsertLibraryArtist,
+  upsertLibraryMediaFile,
   upsertLibraryTrack,
 } from "../../backend/services/libraryMediaStore.js";
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
@@ -99,15 +100,25 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
   }
 });
 
-test("deleting a Lidarr artist clears canonical provider state", async (t) => {
+test("deleting a Lidarr artist clears canonical provider state for both IDs", async (t) => {
   const mbid = "89898989-8989-4898-8989-898989898989";
+  const foreignArtistId = "8989@deezer";
   const artist = upsertLibraryArtist({
+    identityKey: `lidarr-artist:${foreignArtistId}`,
+    name: "Deleted Provider Artist",
+    metadata: {
+      id: 8989,
+      foreignArtistId,
+      librarySource: "lidarr",
+      monitored: true,
+    },
+  });
+  const resolvedArtist = upsertLibraryArtist({
     identityKey: `mbid:${mbid}`,
     mbid,
     name: "Deleted Provider Artist",
     metadata: {
       id: 8989,
-      foreignArtistId: mbid,
       librarySource: "lidarr",
       monitored: true,
     },
@@ -117,7 +128,7 @@ test("deleting a Lidarr artist clears canonical provider state", async (t) => {
   t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
     id: 8989,
     artistName: "Deleted Provider Artist",
-    foreignArtistId: mbid,
+    foreignArtistId,
   }));
   t.mock.method(lidarrClient, "deleteArtist", async () => true);
 
@@ -127,12 +138,76 @@ test("deleting a Lidarr artist clears canonical provider state", async (t) => {
     assert.equal(projection?.lidarrManaged, false);
     assert.equal(projection?.providerId, null);
     assert.equal(projection?.monitored, false);
+    assert.equal(getCanonicalArtistProjection({ reference: resolvedArtist.id })[0]?.providerId, null);
     assert.equal(getCanonicalLidarrArtist(mbid), null);
+    assert.equal(getCanonicalLidarrArtist(foreignArtistId), null);
   } finally {
     const jobId = getScheduledLibraryScanJobId();
     if (jobId) getLibraryScanQueue().cancel(jobId);
     clearScheduledLibraryScan();
-    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(artist.id, resolvedArtist.id);
+  }
+});
+
+test("canonical artist compatibility reads apply SQL pagination", async () => {
+  const key = `canonical-artist-route:${process.pid}:${Date.now()}`;
+  const artists = [];
+  const tracks = [];
+  const paths = [];
+  for (const name of ["A", "B"]) {
+    const artist = upsertLibraryArtist({
+      identityKey: `${key}:artist:${name}`,
+      name: `${key} ${name}`,
+      sortName: `${key} ${name}`,
+      metadata: { librarySource: "lidarr" },
+    });
+    const album = upsertLibraryAlbum({
+      identityKey: `${key}:album:${name}`,
+      artistId: artist.id,
+      title: `${key} Album ${name}`,
+    });
+    const track = upsertLibraryTrack({
+      identityKey: `${key}:track:${name}`,
+      title: `${key} Track ${name}`,
+    });
+    const filePath = `/tmp/${key}/${name}.flac`;
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+    upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "lidarr",
+      path: filePath,
+      available: true,
+    });
+    artists.push(artist);
+    tracks.push(track);
+    paths.push(filePath);
+  }
+
+  const routes = new Map();
+  registerArtists({
+    get(path, ...handlers) {
+      routes.set(`GET ${path}`, handlers.at(-1));
+    },
+    post() { return this; },
+    put() { return this; },
+    delete() { return this; },
+  });
+
+  let body;
+  try {
+    await routes.get("GET /artists")(
+      { query: { readPath: "canonical", source: "lidarr", limit: "1", offset: "1" } },
+      { json(value) { body = value; return this; } },
+    );
+    assert.deepEqual(body.map((artist) => artist.name), [`${key} B`]);
+    assert.equal(body[0].canonicalId, artists[1].id);
+    assert.equal(body[0].statistics.trackCount, 1);
+    assert.equal(body[0].added, body[0].addedAt);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(...paths);
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(...artists.map((artist) => artist.id));
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(...tracks.map((track) => track.id));
   }
 });
 

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -5,12 +5,18 @@ import { db } from "../../backend/config/db-sqlite.js";
 import {
   beginLibraryScan,
   finishLibraryScan,
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
   upsertLibraryArtist,
+  upsertLibraryTrack,
 } from "../../backend/services/libraryMediaStore.js";
 import { getRecentMissingReleases } from "../../backend/services/discovery/recentReleases.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
-import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+import {
+  getCanonicalArtistProjection,
+  getCanonicalLibraryPage,
+} from "../../backend/services/libraryQueryService.js";
 import {
   clearScheduledLibraryScan,
   getScheduledLibraryScanJobId,
@@ -78,7 +84,7 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
     jobId = getScheduledLibraryScanJobId();
     assert.ok(jobId);
     assert.deepEqual(JSON.parse(getLibraryScanQueue().getJob(jobId).payload), {
-      force: true,
+      force: false,
       includeLidarr: true,
     });
 
@@ -117,6 +123,40 @@ test("artist details do not expose Lidarr state for Aurral-only artists", () => 
     assert.equal(getCanonicalLidarrArtist(mbid), null);
   } finally {
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("canonical artist page totals match hydrated items", () => {
+  const key = `artist-page-shape:${process.pid}:${Date.now()}`;
+  const emptyArtist = upsertLibraryArtist({
+    identityKey: `${key}:empty`,
+    name: `${key} empty`,
+  });
+  const populatedArtist = upsertLibraryArtist({
+    identityKey: `${key}:populated`,
+    name: `${key} populated`,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: populatedArtist.id,
+    title: "Hydrated Album",
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${key}:track`,
+    title: "Hydrated Track",
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+
+  try {
+    const page = getCanonicalLibraryPage({ kind: "artists", query: key });
+    assert.equal(page.total, 1);
+    assert.deepEqual(page.items.map((artist) => artist.id), [populatedArtist.id]);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE id IN (?, ?)").run(
+      emptyArtist.id,
+      populatedArtist.id,
+    );
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
   }
 });
 

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -11,6 +11,12 @@ import { getRecentMissingReleases } from "../../backend/services/discovery/recen
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { getCanonicalArtistProjection } from "../../backend/services/libraryQueryService.js";
+import {
+  clearScheduledLibraryScan,
+  getScheduledLibraryScanJobId,
+} from "../../backend/services/libraryScanWorker.js";
+import { getLibraryScanQueue } from "../../backend/services/honkerDb.js";
+import { getCanonicalLidarrArtist } from "../../backend/routes/artists/handlers/details.js";
 
 test("stable artist and discovery reads do not call Lidarr", async (t) => {
   const identityKey = `stable-read-test:${Date.now()}`;
@@ -35,12 +41,54 @@ test("stable artist and discovery reads do not call Lidarr", async (t) => {
       now: "2026-08-22T12:00:00Z",
     });
 
-    assert.equal(artists.some((candidate) => candidate.providerId === "9911"), true);
+    const projectedArtist = artists.find((candidate) => candidate.providerId === "9911");
+    assert.equal(projectedArtist?.id, String(artist.id));
+    assert.equal(projectedArtist?.canonicalId, String(artist.id));
     assert.deepEqual(releases, []);
     assert.equal(request.mock.callCount(), 0);
   } finally {
     lidarrClient.isConfigured = originalConfigured;
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("artist monitoring mutations dedupe canonical reconciliation scans", async (t) => {
+  clearScheduledLibraryScan();
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
+    id: 9922,
+    artistName: "Monitoring Artist",
+    foreignArtistId: "33333333-3333-4333-8333-333333333333",
+    monitored: false,
+  }));
+  t.mock.method(lidarrClient, "updateArtistMonitoring", async () => ({}));
+  t.mock.method(lidarrClient, "getArtist", async () => ({
+    id: 9922,
+    artistName: "Monitoring Artist",
+    foreignArtistId: "33333333-3333-4333-8333-333333333333",
+    monitored: true,
+    monitor: "all",
+  }));
+
+  let jobId;
+  try {
+    await libraryManager.updateArtist("33333333-3333-4333-8333-333333333333", {
+      monitorOption: "all",
+    });
+    jobId = getScheduledLibraryScanJobId();
+    assert.ok(jobId);
+    assert.deepEqual(JSON.parse(getLibraryScanQueue().getJob(jobId).payload), {
+      force: true,
+      includeLidarr: true,
+    });
+
+    await libraryManager.updateArtist("33333333-3333-4333-8333-333333333333", {
+      monitorOption: "all",
+    });
+    assert.equal(getScheduledLibraryScanJobId(), jobId);
+  } finally {
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
   }
 });
 
@@ -56,6 +104,22 @@ test("stable artist reads remain local when Lidarr is absent", async (t) => {
   assert.equal(request.mock.callCount(), 0);
 });
 
+test("artist details do not expose Lidarr state for Aurral-only artists", () => {
+  const mbid = "67676767-6767-4676-8676-676767676767";
+  const artist = upsertLibraryArtist({
+    identityKey: `mbid:${mbid}`,
+    mbid,
+    name: "Aurral Only Artist",
+    metadata: { id: 6767, foreignArtistId: mbid },
+  });
+
+  try {
+    assert.equal(getCanonicalLidarrArtist(mbid), null);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("explicit artist synchronization retains its Lidarr request", async (t) => {
   const originalConfigured = lidarrClient.isConfigured;
   const request = t.mock.method(lidarrClient, "request", async () => []);
@@ -66,6 +130,9 @@ test("explicit artist synchronization retains its Lidarr request", async (t) => 
     await libraryManager.syncLidarrArtists({ forceRefresh: true });
     assert.deepEqual(request.mock.calls.map((call) => call.arguments[0]), ["/artist"]);
   } finally {
+    const jobId = getScheduledLibraryScanJobId();
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
     lidarrClient.isConfigured = originalConfigured;
   }
 });

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -98,6 +98,43 @@ test("artist monitoring mutations dedupe canonical reconciliation scans", async 
   }
 });
 
+test("deleting a Lidarr artist clears canonical provider state", async (t) => {
+  const mbid = "89898989-8989-4898-8989-898989898989";
+  const artist = upsertLibraryArtist({
+    identityKey: `mbid:${mbid}`,
+    mbid,
+    name: "Deleted Provider Artist",
+    metadata: {
+      id: 8989,
+      foreignArtistId: mbid,
+      librarySource: "lidarr",
+      monitored: true,
+    },
+  });
+  clearScheduledLibraryScan();
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async () => ({
+    id: 8989,
+    artistName: "Deleted Provider Artist",
+    foreignArtistId: mbid,
+  }));
+  t.mock.method(lidarrClient, "deleteArtist", async () => true);
+
+  try {
+    assert.deepEqual(await libraryManager.deleteArtist(mbid), { success: true });
+    const projection = getCanonicalArtistProjection({ reference: artist.id })[0];
+    assert.equal(projection?.lidarrManaged, false);
+    assert.equal(projection?.providerId, null);
+    assert.equal(projection?.monitored, false);
+    assert.equal(getCanonicalLidarrArtist(mbid), null);
+  } finally {
+    const jobId = getScheduledLibraryScanJobId();
+    if (jobId) getLibraryScanQueue().cancel(jobId);
+    clearScheduledLibraryScan();
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("stable artist reads remain local when Lidarr is absent", async (t) => {
   const request = t.mock.method(lidarrClient, "request", async () => {
     throw new Error("absent Lidarr must not be called");

--- a/.tests/library/library-search-index-contract.test.js
+++ b/.tests/library/library-search-index-contract.test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cleanupIsolatedState,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, libraryStore, searchIndex] = await setupIsolatedBackend(
+  "library-search-index-contract",
+  "backend/config/db-sqlite.js",
+  "backend/services/libraryMediaStore.js",
+  "backend/services/librarySearchIndex.js",
+);
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("album and track search syncs report changed and unchanged documents", () => {
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: "search-contract:artist",
+    name: "Search Contract Artist",
+    syncSearch: false,
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: "search-contract:album",
+    artistId: artist.id,
+    title: "Search Contract Album",
+    albumArtist: artist.name,
+    syncSearch: false,
+  });
+  const track = libraryStore.upsertLibraryTrack({
+    identityKey: "search-contract:track",
+    title: "Search Contract Track",
+    artistName: artist.name,
+    syncSearch: false,
+  });
+  libraryStore.linkLibraryAlbumTrack({
+    albumId: album.id,
+    trackId: track.id,
+    syncSearch: false,
+  });
+
+  assert.equal(searchIndex.syncLibrarySearchAlbum(album.id), true);
+  assert.equal(searchIndex.syncLibrarySearchAlbum(album.id), false);
+  assert.equal(searchIndex.syncLibrarySearchTrack(track.id), true);
+  assert.equal(searchIndex.syncLibrarySearchTrack(track.id), false);
+
+  assert.equal(
+    db.prepare(
+      "SELECT COUNT(*) AS count FROM library_search_documents WHERE entity_id IN (?, ?)",
+    ).get(album.id, track.id).count,
+    2,
+  );
+});

--- a/.tests/library/library-search-index.test.js
+++ b/.tests/library/library-search-index.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cleanupIsolatedState,
+  importFromRepo,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }] = await setupIsolatedBackend(
+  "library-search-index",
+  "backend/config/db-sqlite.js",
+);
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("search index service remains usable when the FTS schema is unavailable", async () => {
+  db.exec(`
+    DROP TRIGGER IF EXISTS library_search_documents_ai;
+    DROP TRIGGER IF EXISTS library_search_documents_au;
+    DROP TRIGGER IF EXISTS library_search_documents_ad;
+    DROP TABLE IF EXISTS library_search_fts;
+    DROP TABLE IF EXISTS library_search_documents;
+  `);
+
+  const searchIndex = await importFromRepo("backend/services/librarySearchIndex.js");
+
+  assert.equal(searchIndex.getLibrarySearchMatch("artist"), null);
+  assert.equal(searchIndex.syncLibrarySearchArtist(1), false);
+  assert.equal(searchIndex.syncLibrarySearchAlbum(1), false);
+  assert.equal(searchIndex.syncLibrarySearchTrack(1), false);
+  assert.equal(searchIndex.rebuildLibrarySearchIndex(), false);
+});

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -95,6 +95,54 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
   assert.deepEqual(calls, { queue: 6, history: 6, command: 6 });
 });
 
+test("invalidating a failed refresh allows immediate recovery", async (t) => {
+  let fail = false;
+  let refreshGate = null;
+  const calls = { queue: 0, history: 0, command: 0 };
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "isCircuitOpen", () => false);
+  t.mock.method(lidarrClient, "getQueue", async () => {
+    calls.queue += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+  t.mock.method(lidarrClient, "getHistory", async () => {
+    calls.history += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return { records: [] };
+  });
+  t.mock.method(lidarrClient, "request", async () => {
+    calls.command += 1;
+    if (refreshGate) await refreshGate.promise;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+
+  invalidateAllDownloadStatusesCache();
+  await getLidarrStatusSnapshot({ force: true });
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+
+  fail = true;
+  refreshGate = Promise.withResolvers();
+  const pending = getLidarrStatusSnapshot({ force: true });
+  while (calls.queue < 2 || calls.history < 2 || calls.command < 2) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  invalidateAllDownloadStatusesCache();
+  refreshGate.resolve();
+  const stale = await pending;
+  refreshGate = null;
+  assert.equal(stale.stale, true);
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  fail = false;
+  const recovered = await getLidarrStatusSnapshot();
+  assert.equal(recovered.stale, false);
+  assert.deepEqual(calls, { queue: 3, history: 3, command: 3 });
+});
+
 test("forced Lidarr status reads bypass the client cache", async (t) => {
   let calls = 0;
   const server = http.createServer((_request, response) => {

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import {
+  getLidarrStatusSnapshot,
+  hasActiveLidarrStatusSnapshot,
+  invalidateAllDownloadStatusesCache,
+} from "../../backend/routes/library/handlers/downloads.js";
+import { LidarrClient, lidarrClient } from "../../backend/services/lidarrClient.js";
+import { buildLidarrRequests } from "../../backend/services/lidarrRequestBuilder.js";
+
+test("Lidarr status consumers share refreshes, idle, failure, and recovery state", async (t) => {
+  let active = false;
+  let fail = false;
+  let queueGate = null;
+  const calls = { queue: 0, history: 0, command: 0 };
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "isCircuitOpen", () => false);
+  t.mock.method(lidarrClient, "getQueue", async (options) => {
+    assert.equal(options.forceRefresh, true);
+    calls.queue += 1;
+    if (fail) throw new Error("provider unavailable");
+    if (queueGate) await queueGate.promise;
+    return active ? [{ id: 1, albumId: 10, status: "downloading", size: 10, sizeleft: 5 }] : [];
+  });
+  t.mock.method(lidarrClient, "getHistory", async (...args) => {
+    assert.deepEqual(args, [1, 200, "date", "descending", { forceRefresh: true }]);
+    calls.history += 1;
+    if (fail) throw new Error("provider unavailable");
+    return { records: [] };
+  });
+  t.mock.method(lidarrClient, "request", async (endpoint, method, data, skip, options) => {
+    assert.equal(endpoint, "/command");
+    assert.deepEqual([method, data, skip, options], ["GET", null, false, { forceRefresh: true }]);
+    calls.command += 1;
+    if (fail) throw new Error("provider unavailable");
+    return [];
+  });
+
+  invalidateAllDownloadStatusesCache();
+  const [first, concurrent] = await Promise.all([
+    getLidarrStatusSnapshot({ force: true }),
+    getLidarrStatusSnapshot({ force: true }),
+  ]);
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+  assert.equal(first, concurrent);
+  assert.equal(first.active, false);
+  assert.equal((await getLidarrStatusSnapshot()).updatedAt, first.updatedAt);
+  assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+
+  active = true;
+  invalidateAllDownloadStatusesCache();
+  const activeSnapshot = await getLidarrStatusSnapshot();
+  assert.equal(activeSnapshot.active, true);
+  assert.equal(hasActiveLidarrStatusSnapshot(), true);
+  assert.equal(activeSnapshot.statuses[10].status, "downloading");
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  const requests = await buildLidarrRequests(lidarrClient, activeSnapshot.provider);
+  assert.equal(requests[0].albumId, "10");
+  assert.deepEqual(calls, { queue: 2, history: 2, command: 2 });
+
+  fail = true;
+  invalidateAllDownloadStatusesCache();
+  const stale = await getLidarrStatusSnapshot();
+  assert.equal(stale.stale, true);
+  assert.equal(stale.statuses[10].status, "downloading");
+  assert.match(stale.error, /provider unavailable/);
+  assert.equal((await getLidarrStatusSnapshot()).stale, true);
+  assert.deepEqual(calls, { queue: 3, history: 3, command: 3 });
+
+  fail = false;
+  active = false;
+  const recovered = await getLidarrStatusSnapshot({ force: true });
+  assert.equal(recovered.stale, false);
+  assert.equal(recovered.active, false);
+  assert.deepEqual(calls, { queue: 4, history: 4, command: 4 });
+
+  queueGate = Promise.withResolvers();
+  const pending = getLidarrStatusSnapshot({ force: true });
+  while (calls.queue < 5) await new Promise((resolve) => setImmediate(resolve));
+  invalidateAllDownloadStatusesCache();
+  queueGate.resolve();
+  await pending;
+  queueGate = null;
+  await getLidarrStatusSnapshot();
+  assert.deepEqual(calls, { queue: 6, history: 6, command: 6 });
+});
+
+test("forced Lidarr status reads bypass the client cache", async (t) => {
+  let calls = 0;
+  const server = http.createServer((_request, response) => {
+    calls += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify([{ id: calls }]));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${server.address().port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+  t.after(() => {
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  assert.equal((await client.getQueue())[0].id, 1);
+  assert.equal((await client.getQueue())[0].id, 1);
+  assert.equal((await client.getQueue({ forceRefresh: true }))[0].id, 2);
+  assert.equal(calls, 2);
+});

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -3,6 +3,7 @@ import http from "node:http";
 import test from "node:test";
 
 import {
+  getDownloadStatusesForAlbumIds,
   getLidarrStatusSnapshot,
   hasActiveLidarrStatusSnapshot,
   invalidateAllDownloadStatusesCache,
@@ -14,6 +15,7 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
   let active = false;
   let fail = false;
   let queueGate = null;
+  let albumCalls = 0;
   const calls = { queue: 0, history: 0, command: 0 };
   t.mock.method(lidarrClient, "isConfigured", () => true);
   t.mock.method(lidarrClient, "isCircuitOpen", () => false);
@@ -37,6 +39,10 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
     if (fail) throw new Error("provider unavailable");
     return [];
   });
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    albumCalls += 1;
+    return [];
+  });
 
   invalidateAllDownloadStatusesCache();
   const [first, concurrent] = await Promise.all([
@@ -44,6 +50,7 @@ test("Lidarr status consumers share refreshes, idle, failure, and recovery state
     getLidarrStatusSnapshot({ force: true }),
   ]);
   assert.deepEqual(calls, { queue: 1, history: 1, command: 1 });
+  assert.equal(albumCalls, 0);
   assert.equal(first, concurrent);
   assert.equal(first.active, false);
   assert.equal((await getLidarrStatusSnapshot()).updatedAt, first.updatedAt);
@@ -119,4 +126,70 @@ test("forced Lidarr status reads bypass the client cache", async (t) => {
   assert.equal((await client.getQueue())[0].id, 1);
   assert.equal((await client.getQueue({ forceRefresh: true }))[0].id, 2);
   assert.equal(calls, 2);
+});
+
+test("failed or stale history verifies albums with one bulk read", async (t) => {
+  const now = Date.now();
+  const calls = { bulk: 0, detail: 0 };
+  let bulkFailure = false;
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getAllAlbums", async () => {
+    calls.bulk += 1;
+    if (bulkFailure) throw new Error("provider unavailable");
+    return [
+      { id: 101, statistics: { trackFileCount: 2 } },
+      { id: 102, statistics: { trackFileCount: 0 } },
+    ];
+  });
+  t.mock.method(lidarrClient, "getAlbum", async () => {
+    calls.detail += 1;
+    return null;
+  });
+
+  const normal = await getDownloadStatusesForAlbumIds(["100"], {
+    queue: [],
+    history: {
+      records: [{ albumId: 100, eventType: "AlbumGrabbed", date: new Date(now).toISOString() }],
+    },
+    commands: [],
+  });
+  assert.equal(normal[100].status, "processing");
+  assert.deepEqual(calls, { bulk: 0, detail: 0 });
+
+  const verified = await getDownloadStatusesForAlbumIds(["101", "102"], {
+    queue: [],
+    history: {
+      records: [
+        {
+          albumId: 101,
+          eventType: "AlbumImportIncomplete",
+          date: new Date(now).toISOString(),
+        },
+        {
+          albumId: 102,
+          eventType: "AlbumGrabbed",
+          date: new Date(now - 16 * 60 * 1000).toISOString(),
+        },
+      ],
+    },
+    commands: [],
+  });
+  assert.equal(verified[101].status, "added");
+  assert.equal(verified[102].status, "failed");
+  assert.deepEqual(calls, { bulk: 1, detail: 0 });
+
+  bulkFailure = true;
+  const failedVerification = await getDownloadStatusesForAlbumIds(["101", "102"], {
+    queue: [],
+    history: {
+      records: [
+        { albumId: 101, eventType: "DownloadFailed", date: new Date(now).toISOString() },
+        { albumId: 102, eventType: "AlbumImportIncomplete", date: new Date(now).toISOString() },
+      ],
+    },
+    commands: [],
+  });
+  assert.equal(failedVerification[101].status, "failed");
+  assert.equal(failedVerification[102].status, "failed");
+  assert.deepEqual(calls, { bulk: 2, detail: 0 });
 });

--- a/.tests/library/malformed-metadata-index.test.js
+++ b/.tests/library/malformed-metadata-index.test.js
@@ -51,7 +51,10 @@ test("malformed artist metadata does not break startup or indexed reference look
             identityKey: "valid:artist",
             mbid: "valid-artist-mbid",
             name: "Valid Artist",
-            metadata: { id: "valid-provider-id" },
+            metadata: {
+              id: "valid-provider-id",
+              foreignArtistId: "valid-foreign-artist-id",
+            },
           });
           const album = upsertLibraryAlbum({
             identityKey: "valid:album",
@@ -69,19 +72,28 @@ test("malformed artist metadata does not break startup or indexed reference look
             source: "aurral",
             path: "/tmp/valid-track.flac",
           });
-          const result = getCanonicalLibraryForArtistReferences({
+          const providerResult = getCanonicalLibraryForArtistReferences({
             references: ["valid-provider-id"],
           });
+          const foreignResult = getCanonicalLibraryForArtistReferences({
+            references: ["valid-foreign-artist-id"],
+          });
           const expression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)";
-          const plan = db.prepare(
+          const foreignExpression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT)";
+          const providerPlan = db.prepare(
             "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + expression + " IN (?)",
           ).all("valid-provider-id");
+          const foreignPlan = db.prepare(
+            "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + foreignExpression + " IN (?)",
+          ).all("valid-foreign-artist-id");
           process.stdout.write(JSON.stringify({
-            artistNames: result.artists.map(({ name }) => name),
-            indexSql: db.prepare(
-              "SELECT sql FROM sqlite_master WHERE name = 'idx_library_artists_provider_id'",
-            ).get().sql,
-            plan,
+            artistNames: providerResult.artists.map(({ name }) => name),
+            foreignArtistNames: foreignResult.artists.map(({ name }) => name),
+            indexes: db.prepare(
+              "SELECT name, sql FROM sqlite_master WHERE name IN ('idx_library_artists_provider_id', 'idx_library_artists_foreign_artist_id') ORDER BY name",
+            ).all(),
+            providerPlan,
+            foreignPlan,
           }));
         `,
       ],
@@ -93,9 +105,21 @@ test("malformed artist metadata does not break startup or indexed reference look
     );
     const evidence = JSON.parse(output);
     assert.deepEqual(evidence.artistNames, ["Valid Artist"]);
-    assert.match(evidence.indexSql, /json_valid\(metadata_json\)/);
+    assert.deepEqual(evidence.foreignArtistNames, ["Valid Artist"]);
+    const indexes = new Map(evidence.indexes.map(({ name, sql }) => [name, sql]));
+    assert.match(indexes.get("idx_library_artists_provider_id"), /json_valid\(metadata_json\)/);
+    assert.match(indexes.get("idx_library_artists_provider_id"), /json_extract\(metadata_json, '\$\.id'\)/);
+    assert.match(indexes.get("idx_library_artists_foreign_artist_id"), /json_valid\(metadata_json\)/);
+    assert.match(
+      indexes.get("idx_library_artists_foreign_artist_id"),
+      /json_extract\(metadata_json, '\$\.foreignArtistId'\)/,
+    );
     assert.equal(
-      evidence.plan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      evidence.providerPlan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      true,
+    );
+    assert.equal(
+      evidence.foreignPlan.some(({ detail }) => detail.includes("idx_library_artists_foreign_artist_id")),
       true,
     );
   } finally {

--- a/.tests/library/malformed-metadata-index.test.js
+++ b/.tests/library/malformed-metadata-index.test.js
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("malformed artist metadata does not break startup or indexed reference lookup", () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "aurral-malformed-metadata-"));
+  const dbPath = path.join(dataDir, "aurral.db");
+  const seedDb = new Database(dbPath);
+  seedDb.exec(`
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE library_artists (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      identity_key TEXT NOT NULL UNIQUE,
+      mbid TEXT,
+      name TEXT NOT NULL,
+      sort_name TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    INSERT INTO library_artists
+      (identity_key, name, metadata_json, created_at, updated_at)
+    VALUES ('malformed:artist', 'Malformed Artist', '{', 1, 1);
+  `);
+  seedDb.close();
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          const { db } = await import("./backend/config/db-sqlite.js");
+          const {
+            linkLibraryAlbumTrack,
+            upsertLibraryAlbum,
+            upsertLibraryArtist,
+            upsertLibraryMediaFile,
+            upsertLibraryTrack,
+          } = await import("./backend/services/libraryMediaStore.js");
+          const { getCanonicalLibraryForArtistReferences } = await import("./backend/services/libraryQueryService.js");
+          const artist = upsertLibraryArtist({
+            identityKey: "valid:artist",
+            mbid: "valid-artist-mbid",
+            name: "Valid Artist",
+            metadata: { id: "valid-provider-id" },
+          });
+          const album = upsertLibraryAlbum({
+            identityKey: "valid:album",
+            artistId: artist.id,
+            title: "Valid Album",
+          });
+          const track = upsertLibraryTrack({
+            identityKey: "valid:track",
+            title: "Valid Track",
+          });
+          linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+          upsertLibraryMediaFile({
+            trackId: track.id,
+            albumId: album.id,
+            source: "aurral",
+            path: "/tmp/valid-track.flac",
+          });
+          const result = getCanonicalLibraryForArtistReferences({
+            references: ["valid-provider-id"],
+          });
+          const expression = "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)";
+          const plan = db.prepare(
+            "EXPLAIN QUERY PLAN SELECT id FROM library_artists WHERE " + expression + " IN (?)",
+          ).all("valid-provider-id");
+          process.stdout.write(JSON.stringify({
+            artistNames: result.artists.map(({ name }) => name),
+            indexSql: db.prepare(
+              "SELECT sql FROM sqlite_master WHERE name = 'idx_library_artists_provider_id'",
+            ).get().sql,
+            plan,
+          }));
+        `,
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, AURRAL_DATA_DIR: dataDir, AURRAL_DB_PATH: dbPath },
+        encoding: "utf8",
+      },
+    );
+    const evidence = JSON.parse(output);
+    assert.deepEqual(evidence.artistNames, ["Valid Artist"]);
+    assert.match(evidence.indexSql, /json_valid\(metadata_json\)/);
+    assert.equal(
+      evidence.plan.some(({ detail }) => detail.includes("idx_library_artists_provider_id")),
+      true,
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, queryService, libraryStore] = await setupIsolatedBackend(
+  "measured-query-slice",
+  "backend/config/db-sqlite.js",
+  "backend/services/libraryQueryService.js",
+  "backend/services/libraryMediaStore.js",
+);
+
+let artist;
+let album;
+let track;
+
+test.before(() => {
+  resetDatabase(db);
+  artist = libraryStore.upsertLibraryArtist({
+    identityKey: "measured:artist",
+    name: "Measured Artist",
+  });
+  album = libraryStore.upsertLibraryAlbum({
+    identityKey: "measured:album",
+    artistId: artist.id,
+    title: "Measured Album",
+    albumArtist: artist.name,
+  });
+  track = libraryStore.upsertLibraryTrack({
+    identityKey: "measured:track",
+    title: "Needle Song",
+    artistName: artist.name,
+  });
+  libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  libraryStore.upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: "/tmp/measured-query-slice.flac",
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("substring search uses the trigram index and stays order-sort free", (t) => {
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  const result = queryService.getCanonicalSearchPage({
+    source: "all",
+    query: "Needle",
+    artistLimit: 20,
+    albumLimit: 20,
+    songLimit: 20,
+  });
+  assert.deepEqual(result.tracks.tracks.map((entry) => entry.title), ["Needle Song"]);
+  const searchSql = prepared.find((sql) =>
+    sql.includes("FROM library_tracks AS track") && sql.includes("library_search_fts"));
+  assert.ok(searchSql);
+  assert.match(searchSql, /MATCH \?/);
+  assert.doesNotMatch(searchSql, /ORDER BY/);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${searchSql}`).all(
+    '"nee" AND "eed" AND "edl" AND "dle"',
+    "%needle%",
+    "%needle%",
+    "%needle%",
+    20,
+    0,
+  );
+  assert.ok(plan.some((row) => row.detail.includes("SCAN search_fts VIRTUAL TABLE")));
+  assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE FOR ORDER BY")), false);
+});
+
+test("unchanged canonical upserts do not rewrite search documents", () => {
+  db.exec(`
+    CREATE TEMP TABLE search_update_probe (count INTEGER NOT NULL);
+    INSERT INTO search_update_probe VALUES (0);
+    CREATE TEMP TRIGGER search_update_probe_trigger
+    AFTER UPDATE ON library_search_documents
+    BEGIN
+      UPDATE search_update_probe SET count = count + 1;
+    END;
+  `);
+  try {
+    libraryStore.upsertLibraryArtist({
+      identityKey: "measured:artist",
+      name: "Measured Artist",
+    });
+    libraryStore.upsertLibraryAlbum({
+      identityKey: "measured:album",
+      artistId: artist.id,
+      title: "Measured Album",
+      albumArtist: artist.name,
+    });
+    libraryStore.upsertLibraryTrack({
+      identityKey: "measured:track",
+      title: "Needle Song",
+      artistName: artist.name,
+    });
+    assert.equal(db.prepare("SELECT count FROM search_update_probe").get().count, 0);
+  } finally {
+    db.exec(`
+      DROP TRIGGER search_update_probe_trigger;
+      DROP TABLE search_update_probe;
+    `);
+  }
+});
+
+test("canonical page search uses FTS and genre reads use the stored scan snapshot", (t) => {
+  queryService.rebuildCanonicalGenreStats();
+  queryService.invalidateCanonicalLibraryCache({ persistedGenres: false });
+  const storedBefore = db.prepare(
+    "SELECT key, value FROM settings WHERE key LIKE 'libraryGenreStats:%' ORDER BY key",
+  ).all();
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  const page = queryService.getCanonicalLibraryPage({
+    kind: "tracks",
+    page: 1,
+    pageSize: 20,
+    query: "Needle",
+  });
+  assert.deepEqual(page.tracks.map((entry) => entry.title), ["Needle Song"]);
+  const pageSearchSql = prepared.find((sql) =>
+    sql.includes("COUNT(DISTINCT track.id)") && sql.includes("library_search_fts MATCH ?"));
+  assert.ok(pageSearchSql);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${pageSearchSql}`).all(
+    '"nee" AND "eed" AND "edl" AND "dle"',
+    "%needle%",
+    "%needle%",
+    "%needle%",
+  );
+  assert.ok(plan.some((row) => row.detail.includes("SCAN search_fts VIRTUAL TABLE")));
+  assert.ok(plan.some((row) =>
+    row.detail.includes("idx_library_media_files_track_album_source_available")));
+  assert.deepEqual(
+    prepare("SELECT key, value FROM settings WHERE key LIKE 'libraryGenreStats:%' ORDER BY key").all(),
+    storedBefore,
+  );
+});
+
+test("search documents update transactionally and random reads use rowid sampling", (t) => {
+  libraryStore.upsertLibraryTrack({
+    identityKey: "measured:track",
+    title: "Renamed Needle Song",
+    artistName: artist.name,
+  });
+  assert.equal(
+    queryService.getCanonicalSearchPage({ query: "Renamed Needle", songLimit: 20 }).tracks.tracks[0].title,
+    "Renamed Needle Song",
+  );
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  t.mock.method(Math, "random", () => 0.999);
+  const result = queryService.getCanonicalTrackPage({
+    source: "all",
+    availableOnly: true,
+    random: true,
+    limit: 1,
+  });
+  assert.equal(result.tracks.length, 1);
+  const randomSql = prepared.find((sql) => sql.includes("FROM library_tracks AS track") && sql.includes("track.id >= ?"));
+  assert.ok(randomSql);
+  assert.match(randomSql, /ORDER BY track\.id/);
+  assert.doesNotMatch(randomSql, /random\(\)/i);
+  const plan = prepare(`EXPLAIN QUERY PLAN ${randomSql}`).all(2, 1);
+  assert.ok(plan.some((row) => row.detail.includes("SEARCH track USING INTEGER PRIMARY KEY")));
+  assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE")), false);
+});

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -47,7 +47,7 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("substring search uses the trigram index and stays order-sort free", (t) => {
+test("substring search uses the trigram index with stable pagination", (t) => {
   const prepared = [];
   const prepare = db.prepare.bind(db);
   t.mock.method(db, "prepare", (sql) => {
@@ -67,7 +67,7 @@ test("substring search uses the trigram index and stays order-sort free", (t) =>
     sql.includes("FROM library_tracks AS track") && sql.includes("library_search_fts"));
   assert.ok(searchSql);
   assert.match(searchSql, /MATCH \?/);
-  assert.doesNotMatch(searchSql, /ORDER BY/);
+  assert.match(searchSql, /ORDER BY track\.id/);
   const plan = prepare(`EXPLAIN QUERY PLAN ${searchSql}`).all(
     '"nee" AND "eed" AND "edl" AND "dle"',
     "%needle%",
@@ -77,7 +77,6 @@ test("substring search uses the trigram index and stays order-sort free", (t) =>
     0,
   );
   assert.ok(plan.some((row) => row.detail.includes("SCAN search_fts VIRTUAL TABLE")));
-  assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE FOR ORDER BY")), false);
 });
 
 test("unchanged canonical upserts do not rewrite search documents", () => {

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -188,3 +188,139 @@ test("search documents update transactionally and random reads use rowid samplin
   assert.ok(plan.some((row) => row.detail.includes("SEARCH track USING INTEGER PRIMARY KEY")));
   assert.equal(plan.some((row) => row.detail.includes("USE TEMP B-TREE")), false);
 });
+
+test("artist pages project a large discography without canonical row hydration", (t) => {
+  const key = `measured-artist-page-${process.pid}-${Date.now()}`;
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "A Huge Discography",
+  });
+  const albumCount = 120;
+  for (let index = 0; index < albumCount; index += 1) {
+    const album = libraryStore.upsertLibraryAlbum({
+      identityKey: `${key}:album:${index}`,
+      artistId: artist.id,
+      title: `Huge Album ${index}`,
+    });
+    const track = libraryStore.upsertLibraryTrack({
+      identityKey: `${key}:track:${index}`,
+      title: `Huge Track ${index}`,
+      artistName: artist.name,
+    });
+    libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+    libraryStore.upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "aurral",
+      path: `/tmp/${key}/${index}.flac`,
+    });
+  }
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  try {
+    const page = queryService.getCanonicalLibraryPage({
+      source: "aurral",
+      kind: "artists",
+      page: 1,
+      pageSize: 1,
+    });
+    assert.equal(page.total, 1);
+    assert.equal(page.items[0].albumCount, albumCount);
+    assert.deepEqual(page.items[0].albumIds, []);
+    assert.equal(
+      prepared.filter((sql) =>
+        sql.includes("track.id AS track_id") && sql.includes("media.id AS media_id"),
+      ).length,
+      0,
+    );
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id IN (SELECT id FROM library_albums WHERE identity_key LIKE ?)").run(`${key}:album:%`);
+    db.prepare("DELETE FROM library_tracks WHERE identity_key LIKE ?").run(`${key}:track:%`);
+    db.prepare("DELETE FROM library_albums WHERE identity_key LIKE ?").run(`${key}:album:%`);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("album track pages count and hydrate only the requested track slice", (t) => {
+  const key = `measured-album-page-${process.pid}-${Date.now()}`;
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}:artist-mbid`,
+    name: "A Huge Album",
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}:album-mbid`,
+    releaseGroupMbid: `${key}:release-group`,
+    artistId: artist.id,
+    title: "A Huge Album",
+  });
+  const trackCount = 140;
+  for (let index = 0; index < trackCount; index += 1) {
+    const track = libraryStore.upsertLibraryTrack({
+      identityKey: `${key}:track:${index}`,
+      title: `Album Track ${String(index).padStart(3, "0")}`,
+      artistName: artist.name,
+    });
+    libraryStore.linkLibraryAlbumTrack({
+      albumId: album.id,
+      trackId: track.id,
+      trackNumber: index + 1,
+    });
+    if (index % 2 === 0) {
+      libraryStore.upsertLibraryMediaFile({
+        trackId: track.id,
+        albumId: album.id,
+        source: "aurral",
+        path: `/tmp/${key}/${index}.flac`,
+      });
+    }
+  }
+
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  try {
+    const page = queryService.getCanonicalLibraryPage({
+      source: "aurral",
+      kind: "tracks",
+      albumId: album.id,
+      page: 2,
+      pageSize: 3,
+      sort: "name",
+      direction: "desc",
+    });
+    const hydration = prepared.filter((sql) =>
+      sql.includes("track.id AS track_id") && sql.includes("media.id AS media_id"),
+    );
+    assert.equal(hydration.length, 1);
+    assert.match(hydration[0], /track\.id IN \(\?,\?,\?\)/);
+    assert.equal(page.total, trackCount);
+    assert.equal(page.items.length, 3);
+    assert.equal(page.albums[0].trackCount, trackCount);
+    assert.equal(page.albums[0].availableTrackCount, trackCount / 2);
+    assert.equal(page.albums[0].trackIds.length, 3);
+    assert.equal(page.albums[0].identityKey, `${key}:album`);
+    assert.equal(page.artists[0].identityKey, `${key}:artist`);
+    assert.ok(page.items.some((track) => track.files.length === 0));
+    assert.ok(page.items.every((track) =>
+      track.albums.every((relation) => relation.albumId === album.id)));
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE path LIKE ?").run(`/tmp/${key}/%`);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE identity_key LIKE ?").run(`${key}:track:%`);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});

--- a/.tests/library/measured-query-slice.test.js
+++ b/.tests/library/measured-query-slice.test.js
@@ -132,6 +132,7 @@ test("canonical page search uses FTS and genre reads use the stored scan snapsho
     kind: "tracks",
     page: 1,
     pageSize: 20,
+    source: "lidarr",
     query: "Needle",
   });
   assert.deepEqual(page.tracks.map((entry) => entry.title), ["Needle Song"]);
@@ -140,6 +141,7 @@ test("canonical page search uses FTS and genre reads use the stored scan snapsho
   assert.ok(pageSearchSql);
   const plan = prepare(`EXPLAIN QUERY PLAN ${pageSearchSql}`).all(
     '"nee" AND "eed" AND "edl" AND "dle"',
+    "lidarr",
     "%needle%",
     "%needle%",
     "%needle%",

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { db } from "../../backend/config/db-sqlite.js";
-import { getCanonicalLibraryPage } from "../../backend/services/libraryQueryService.js";
+import {
+  getCanonicalArtistProjection,
+  getCanonicalLibraryPage,
+} from "../../backend/services/libraryQueryService.js";
 import {
   getLibrarySnapshot,
   linkLibraryAlbumTrack,
@@ -355,6 +358,91 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
       "lidarr",
       filePath,
     );
+  }
+});
+
+test("indexLidarrLibrary keeps artists without albums and refreshes monitoring metadata", async () => {
+  const providerArtistId = "1212@deezer";
+  let monitored = false;
+  const client = {
+    isConfigured: () => true,
+    request: async () => [{
+      id: 1212,
+      artistName: "Albumless Artist",
+      foreignArtistId: providerArtistId,
+      monitored,
+      monitor: monitored ? "all" : "none",
+    }],
+    getAllAlbums: async () => [],
+    getRootFolders: async () => [],
+  };
+
+  try {
+    await indexLidarrLibrary({ client });
+    let projection = getCanonicalArtistProjection({ reference: providerArtistId })[0];
+    assert.equal(projection?.name, "Albumless Artist");
+    assert.equal(projection?.foreignArtistId, providerArtistId);
+    assert.equal(projection?.providerId, "1212");
+    assert.equal(projection?.id, projection?.canonicalId);
+    assert.deepEqual(projection?.sources, ["lidarr"]);
+    assert.equal(projection?.monitored, false);
+
+    monitored = true;
+    await indexLidarrLibrary({ client });
+    projection = getCanonicalArtistProjection({ reference: providerArtistId })[0];
+    assert.equal(projection?.monitored, true);
+    assert.equal(projection?.monitorOption, "all");
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(
+      `lidarr-artist:${providerArtistId}`,
+    );
+  }
+});
+
+test("indexLidarrLibrary keeps fully missing albums in canonical reads", async () => {
+  const artistMbid = "13131313-1313-4131-8131-131313131313";
+  const albumMbid = "14141414-1414-4141-8141-141414141414";
+  const trackMbid = "15151515-1515-4151-8151-151515151515";
+  const client = {
+    isConfigured: () => true,
+    request: async () => [{
+      id: 1313,
+      artistName: "Missing Album Artist",
+      foreignArtistId: artistMbid,
+    }],
+    getAllAlbums: async () => [{
+      id: 1414,
+      artistId: 1313,
+      title: "Fully Missing Album",
+      foreignAlbumId: albumMbid,
+      releaseDate: "2026-08-20",
+      statistics: { sizeOnDisk: 0 },
+    }],
+    getTracksByAlbumId: async () => [{
+      id: 1515,
+      albumId: 1414,
+      title: "Missing Track",
+      trackNumber: 1,
+      foreignRecordingId: trackMbid,
+    }],
+    getTrackFilesByAlbumId: async () => [],
+    getRootFolders: async () => [],
+  };
+
+  try {
+    await indexLidarrLibrary({ client });
+    const page = getCanonicalLibraryPage({
+      kind: "albums",
+      page: 1,
+      pageSize: 10,
+      query: "Fully Missing Album",
+    });
+
+    assert.equal(page.items[0]?.title, "Fully Missing Album");
+    assert.equal(page.items[0]?.availableTrackCount, 0);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE mbid = ?").run(artistMbid);
+    db.prepare("DELETE FROM library_tracks WHERE mbid = ?").run(trackMbid);
   }
 });
 

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -385,6 +385,7 @@ test("indexLidarrLibrary keeps artists without albums and refreshes monitoring m
     assert.equal(projection?.providerId, "1212");
     assert.equal(projection?.id, projection?.canonicalId);
     assert.deepEqual(projection?.sources, ["lidarr"]);
+    assert.equal(projection?.lidarrManaged, true);
     assert.equal(projection?.monitored, false);
 
     monitored = true;
@@ -440,6 +441,10 @@ test("indexLidarrLibrary keeps fully missing albums in canonical reads", async (
 
     assert.equal(page.items[0]?.title, "Fully Missing Album");
     assert.equal(page.items[0]?.availableTrackCount, 0);
+    const albumMetadata = db.prepare(
+      "SELECT metadata_json FROM library_albums WHERE mbid = ?",
+    ).get(albumMbid);
+    assert.equal(JSON.parse(albumMetadata.metadata_json).librarySource, "lidarr");
   } finally {
     db.prepare("DELETE FROM library_artists WHERE mbid = ?").run(artistMbid);
     db.prepare("DELETE FROM library_tracks WHERE mbid = ?").run(trackMbid);

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -466,7 +466,10 @@ test("artist and album reference reads resolve through indexed entity lookups", 
       assert.equal(plan.some(({ detail }) => /SCAN library_(artists|albums)/.test(detail)), false);
       assert.equal(plan.some(({ detail }) => /INDEX/.test(detail)), true);
     }
-    const hydration = prepared.filter((sql) => sql.includes("FROM library_tracks AS track"));
+    const hydration = prepared.filter((sql) =>
+      sql.includes("track.id AS track_id") && sql.includes("FROM library_tracks AS track"),
+    );
+    assert.ok(hydration.length > 0);
     assert.equal(hydration.every((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
     for (const sql of hydration) {
       const parameterCount = (sql.match(/\?/g) || []).length;
@@ -544,10 +547,20 @@ test("album-reference reads preserve identity keys and album-specific ownership"
     assert.equal(missing?.identityKey, missingAlbum.identity_key);
     assert.equal(owned?.statistics.trackFileCount, 1);
     assert.equal(missing?.statistics.trackFileCount, 1);
-    assert.equal(
-      readModel.tracks.find((entry) => entry.albumId === missingAlbum.id)?.hasFile,
-      false,
+    assert.deepEqual(
+      readModel.tracks
+        .filter((entry) => entry.albumId === missingAlbum.id)
+        .map((entry) => entry.title),
+      ["Owned Only By Missing Album"],
     );
+    db.prepare("UPDATE library_media_files SET available = 0 WHERE path = ?").run(missingAlbumPath);
+    const available = getCanonicalLibraryReadModelForAlbumReferences({
+      source: "aurral",
+      availableOnly: true,
+      references: [missingAlbum.identity_key],
+    });
+    assert.deepEqual(available.albums, []);
+    assert.deepEqual(available.tracks, []);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?)").run(
       ownedPath,

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -11,6 +11,7 @@ import {
   getCanonicalArtistMbids,
   getCanonicalLibrary,
   getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForArtists,
   getCanonicalLibraryPage,
   getCanonicalTrack,
@@ -410,6 +411,77 @@ test("scoped canonical reads keep ownership lookups off unrelated library record
       unrelatedArtist.id,
     );
     invalidateCanonicalLibraryCache();
+  }
+});
+
+test("artist and album reference reads resolve through indexed entity lookups", (t) => {
+  const key = `query-plan-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}:artist-mbid`,
+    name: "Query Plan Artist",
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}:album-mbid`,
+    releaseGroupMbid: `${key}:release-group`,
+    artistId: artist.id,
+    title: "Query Plan Album",
+  });
+  const track = upsertLibraryTrack({ identityKey: `${key}:track`, title: "Plan Track" });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: `/tmp/${key}.flac`,
+  });
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  const spy = t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+
+  try {
+    assert.deepEqual(
+      getCanonicalLibraryForArtistReferences({ references: [artist.mbid] }).artists.map(({ id }) => id),
+      [artist.id],
+    );
+    assert.deepEqual(
+      getCanonicalLibraryForAlbumReferences({ references: [album.release_group_mbid] }).albums.map(({ id }) => id),
+      [album.id],
+    );
+    spy.mock.restore();
+
+    const lookups = prepared.filter((sql) =>
+      /^SELECT id FROM library_(artists|albums)/.test(sql.trim()),
+    );
+    assert.equal(lookups.length, 2);
+    for (const sql of lookups) {
+      const parameterCount = (sql.match(/\?/g) || []).length;
+      const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(
+        ...Array.from({ length: parameterCount }, () => `${key}:missing`),
+      );
+      assert.equal(plan.some(({ detail }) => /SCAN library_(artists|albums)/.test(detail)), false);
+      assert.equal(plan.some(({ detail }) => /INDEX/.test(detail)), true);
+    }
+    const hydration = prepared.filter((sql) => sql.includes("FROM library_tracks AS track"));
+    assert.equal(hydration.every((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+    for (const sql of hydration) {
+      const parameterCount = (sql.match(/\?/g) || []).length;
+      const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(
+        ...Array.from({ length: parameterCount }, () => artist.id),
+      );
+      assert.equal(plan.some(({ detail }) => /SCAN (album|album_track)/.test(detail)), false);
+    }
+  } finally {
+    spy.mock.restore();
+    db.prepare("DELETE FROM library_media_files WHERE track_id = ?").run(track.id);
+    db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(track.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
   }
 });
 

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -420,6 +420,10 @@ test("artist and album reference reads resolve through indexed entity lookups", 
     identityKey: `${key}:artist`,
     mbid: `${key}:artist-mbid`,
     name: "Query Plan Artist",
+    metadata: {
+      id: `${key}:provider-id`,
+      foreignArtistId: `${key}:foreign-artist-id`,
+    },
   });
   const album = upsertLibraryAlbum({
     identityKey: `${key}:album`,
@@ -445,7 +449,14 @@ test("artist and album reference reads resolve through indexed entity lookups", 
 
   try {
     assert.deepEqual(
-      getCanonicalLibraryForArtistReferences({ references: [artist.mbid] }).artists.map(({ id }) => id),
+      getCanonicalLibraryForArtistReferences({
+        references: [
+          artist.mbid,
+          `${key}:provider-id`,
+          `${key}:foreign-artist-id`,
+          "QUERY PLAN ARTIST",
+        ],
+      }).artists.map(({ id }) => id),
       [artist.id],
     );
     assert.deepEqual(

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -66,6 +66,27 @@ test("retries transient Navidrome connection failures", async () => {
   assert.equal(attempts, 2);
 });
 
+test("does not retry transient failures for playlist mutations", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    throw new TypeError("fetch failed");
+  };
+
+  try {
+    await assert.rejects(
+      new NavidromeClient("http://navidrome.test", "user", "password")
+        .createPlaylist("Once", ["song-1"]),
+      /fetch failed/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(attempts, 1);
+});
+
 test("uses the fallback delay for invalid rate limit headers", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => new Response("", {

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -48,6 +48,24 @@ test("retries Navidrome rate limits", async () => {
   assert.equal(attempts, 2);
 });
 
+test("retries transient Navidrome connection failures", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) throw new TypeError("fetch failed");
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password").ping();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(attempts, 2);
+});
+
 test("uses the fallback delay for invalid rate limit headers", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => new Response("", {

--- a/.tests/news-service.test.js
+++ b/.tests/news-service.test.js
@@ -100,3 +100,10 @@ test("ignores malformed stored RSS feed URLs", () => {
   const feeds = config.normalizeNewsFeeds([{ name: "Broken", url: "http://", group: "custom" }]);
   assert.equal(feeds.some((feed) => feed.name === "Broken"), false);
 });
+
+test("reuses a cached news response without rebuilding matches", async () => {
+  const first = await newsService.getNewsForUser({ userId: null, mode: "top" });
+  const second = await newsService.getNewsForUser({ userId: null, mode: "top" });
+
+  assert.strictEqual(second, first);
+});

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -1,26 +1,76 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFile } from "node:fs/promises";
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
 
-const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const [isolatedState, { db }, subsonic, libraryStore] = await setupIsolatedBackend(
+  "subsonic-bounded-reads",
+  "backend/config/db-sqlite.js",
+  "backend/services/subsonicLibraryService.js",
+  "backend/services/libraryMediaStore.js",
+);
 
-test("hosted Subsonic single and paged reads do not use the complete-library helper", async () => {
-  const source = await read("../../backend/services/subsonicLibraryService.js");
-
-  assert.doesNotMatch(source, /\bfunction readLibrary\b/);
-  assert.doesNotMatch(source, /\bconst indexLibrary\b/);
-  assert.doesNotMatch(source, /getCanonicalLibrary\(\{\s*availableOnly:\s*false/);
+test.before(() => {
+  resetDatabase(db);
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: "bounded:artist",
+    mbid: "bounded-artist-mbid",
+    name: "Bounded Artist",
+    metadata: { genres: ["Rock"] },
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: "bounded:album",
+    mbid: "bounded-album-mbid",
+    releaseGroupMbid: "bounded-release-group",
+    artistId: artist.id,
+    title: "Bounded Album",
+    metadata: { genres: ["Rock"] },
+  });
+  const track = libraryStore.upsertLibraryTrack({
+    identityKey: "bounded:track",
+    title: "Bounded Track",
+    artistName: artist.name,
+    metadata: { genres: ["Rock"] },
+  });
+  libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  libraryStore.upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "lidarr",
+    path: "/tmp/bounded-track.flac",
+  });
 });
 
-test("legacy canonical compatibility reads select focused adapters", async () => {
-  const sources = await Promise.all([
-    read("../../backend/routes/library/handlers/artists.js"),
-    read("../../backend/routes/library/handlers/albums.js"),
-    read("../../backend/routes/library/handlers/tracks.js"),
-  ]);
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
 
-  for (const source of sources) {
-    assert.doesNotMatch(source, /getCanonicalLibraryReadModel\(/);
-    assert.doesNotMatch(source, /\bgetCanonicalLibrary\(/);
-  }
+test("focused Subsonic requests never execute an unfiltered complete-library query", (t) => {
+  const prepared = [];
+  const prepare = db.prepare.bind(db);
+  t.mock.method(db, "prepare", (sql) => {
+    prepared.push(String(sql));
+    return prepare(sql);
+  });
+  db.prepare("UPDATE library_tracks SET metadata_json = '{' WHERE identity_key = ?")
+    .run("bounded:track");
+
+  assert.ok(subsonic.listArtists().length);
+  assert.ok(subsonic.getArtist(`artist:${encodeURIComponent("bounded:artist")}`));
+  assert.ok(subsonic.getAlbum(`album:${encodeURIComponent("bounded:album")}`));
+  assert.ok(subsonic.searchLibrary("Bounded", { songCount: 1 }).song.length);
+  assert.ok(subsonic.getAlbumList({ size: 1 }).length);
+  assert.ok(subsonic.getSongsByGenre("Rock", { count: 1 }).length);
+  assert.deepEqual(subsonic.getGenres(), [{ albumCount: 1, songCount: 1, value: "Rock" }]);
+
+  const completeQueries = prepared.filter((sql) =>
+    sql.includes("FROM library_tracks AS track")
+      && sql.includes("LEFT JOIN library_media_files AS media")
+      && !/\bWHERE\b/.test(sql),
+  );
+  assert.deepEqual(completeQueries, []);
+  assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
 });

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("hosted Subsonic single and paged reads do not use the complete-library helper", async () => {
+  const source = await read("../../backend/services/subsonicLibraryService.js");
+
+  assert.doesNotMatch(source, /\bfunction readLibrary\b/);
+  assert.doesNotMatch(source, /\bconst indexLibrary\b/);
+  assert.doesNotMatch(source, /getCanonicalLibrary\(\{\s*availableOnly:\s*false/);
+});
+
+test("legacy canonical compatibility reads select focused adapters", async () => {
+  const sources = await Promise.all([
+    read("../../backend/routes/library/handlers/artists.js"),
+    read("../../backend/routes/library/handlers/albums.js"),
+    read("../../backend/routes/library/handlers/tracks.js"),
+  ]);
+
+  for (const source of sources) {
+    assert.doesNotMatch(source, /getCanonicalLibraryReadModel\(/);
+    assert.doesNotMatch(source, /\bgetCanonicalLibrary\(/);
+  }
+});

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -72,7 +72,11 @@ test("focused Subsonic requests never execute an unfiltered complete-library que
       && !/\bWHERE\b/.test(sql),
   );
   assert.deepEqual(completeQueries, []);
-  assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+  const hydration = prepared.filter((sql) =>
+    sql.includes("track.id AS track_id") && sql.includes("FROM library_tracks AS track"),
+  );
+  assert.ok(hydration.length > 0);
+  assert.equal(hydration.every((sql) => /WHERE (artist|album|track)\.id IN/.test(sql)), true);
   const artistIndexQuery = prepared.find((sql) =>
     sql.includes("COUNT(DISTINCT album.id) AS album_count")
       && sql.includes("FROM library_artists AS artist"),

--- a/.tests/subsonic/subsonic-bounded-reads.test.js
+++ b/.tests/subsonic/subsonic-bounded-reads.test.js
@@ -73,4 +73,10 @@ test("focused Subsonic requests never execute an unfiltered complete-library que
   );
   assert.deepEqual(completeQueries, []);
   assert.equal(prepared.some((sql) => /WHERE (artist|album)\.id IN/.test(sql)), true);
+  const artistIndexQuery = prepared.find((sql) =>
+    sql.includes("COUNT(DISTINCT album.id) AS album_count")
+      && sql.includes("FROM library_artists AS artist"),
+  );
+  assert.ok(artistIndexQuery);
+  assert.doesNotMatch(artistIndexQuery, /library_(album_tracks|media_files)/);
 });

--- a/.tests/subsonic/subsonic-library.test.js
+++ b/.tests/subsonic/subsonic-library.test.js
@@ -7,13 +7,15 @@ import {
   setupIsolatedBackend,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { getAlbumList, getTopSongs }, libraryStore] =
+const [isolatedState, { db }, subsonic, libraryStore] =
   await setupIsolatedBackend(
     "subsonic-library",
     "backend/config/db-sqlite.js",
     "backend/services/subsonicLibraryService.js",
     "backend/services/libraryMediaStore.js",
   );
+
+const { getAlbumList, getTopSongs, starMany } = subsonic;
 
 const {
   linkLibraryAlbumTrack,
@@ -46,6 +48,18 @@ function addAlbum({ artist, title, releaseDate, trackTitle }) {
   });
 }
 
+test("starMany validates duplicate and equivalent encoded canonical targets", () => {
+  const user = db.prepare(
+    "INSERT INTO users (username, password_hash, role, permissions) VALUES (?, '', 'user', '{}') RETURNING id",
+  ).get("subsonic-star-many");
+  const key = "test-track:Old Song";
+  const encoded = `song:${encodeURIComponent(key)}`;
+  const alternate = encoded.replaceAll("%3A", "%3a");
+  assert.equal(starMany(user, [encoded, encoded]), true);
+  assert.equal(starMany(user, [encoded, alternate]), true);
+  assert.equal(starMany(user, [encoded, "song:missing"]), false);
+});
+
 test.before(() => {
   resetDatabase(db);
   const artistA = upsertLibraryArtist({
@@ -74,20 +88,28 @@ test.before(() => {
     releaseDate: "2022-01-01",
     trackTitle: "Other Artist Song",
   });
+  db.prepare(
+    `UPDATE library_media_files
+     SET created_at = CASE
+       WHEN path LIKE '%Old Album%' THEN 300
+       WHEN path LIKE '%New Album%' THEN 200
+       ELSE 100
+     END`,
+  ).run();
 });
 
 test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("orders newest albums before applying pagination", () => {
+test("orders newest albums by media arrival before applying pagination", () => {
   assert.deepEqual(
     getAlbumList({ type: "newest", size: 1 }).map((album) => album.title),
-    ["New Album"],
+    ["Old Album"],
   );
   assert.deepEqual(
     getAlbumList({ type: "newest", size: 1, offset: 1 }).map((album) => album.title),
-    ["Artist A Collection"],
+    ["New Album"],
   );
   assert.deepEqual(
     getAlbumList({ type: "byYear", fromYear: 2024, toYear: 2010 }).map((album) => album.title),
@@ -99,4 +121,8 @@ test("returns top songs only for the requested artist", () => {
   const songs = getTopSongs("Artist A", { count: 10 });
   assert.deepEqual(songs.map((song) => song.title), ["New Song", "Old Song"]);
   assert.equal(songs.every((song) => song.artist === "Artist A"), true);
+  assert.deepEqual(
+    getTopSongs("  test-artist:artist-a  ", { count: 10 }).map((song) => song.title),
+    ["New Song", "Old Song"],
+  );
 });

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -21,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -16000");
-db.pragma("mmap_size = 16777216");
+db.pragma("cache_size = -24000");
+db.pragma("mmap_size = 25165824");
 
 function tryAddColumn(sql) {
   try {

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -284,6 +284,12 @@ db.exec(`
     ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
     ON library_artists (mbid);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
   CREATE INDEX IF NOT EXISTS idx_library_tracks_title
@@ -452,6 +458,12 @@ if (hasUniqueIndex(["path"])) {
 }
 
 db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available
     ON library_media_files (album_id, source, available);
 `);

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import path from "path";
 import fs from "fs";
 import { initializeSchemaOnStartup } from "./schema-migration-v2.js";
+import { initializeLibrarySearchIndex } from "./library-search-index.js";
 import { syncDownloadFolderPath } from "../services/downloadFolderConfig.js";
 import { ensureDataDir } from "./data-dir.js";
 
@@ -20,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -64000");
-db.pragma("mmap_size = 268435456");
+db.pragma("cache_size = -32000");
+db.pragma("mmap_size = 33554432");
 
 function tryAddColumn(sql) {
   try {
@@ -454,6 +455,8 @@ if (hasUniqueIndex(["path"])) {
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available
     ON library_media_files (album_id, source, available);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_track_album_source_available
+    ON library_media_files (track_id, album_id, source, available);
 `);
 
 const duplicateLidarrArtistIds = db
@@ -604,6 +607,7 @@ export const dbHelpers = {
 };
 
 initializeSchemaOnStartup(db, dbHelpers);
+initializeLibrarySearchIndex(db);
 
 const existingDownloadFolder = db
   .prepare("SELECT value FROM settings WHERE key = ?")

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -272,12 +272,18 @@ db.exec(`
     ON lidarr_artist_id_map (lidarr_foreign_artist_id);
   CREATE INDEX IF NOT EXISTS idx_library_albums_artist_id
     ON library_albums (artist_id);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_mbid
+    ON library_albums (mbid);
+  CREATE INDEX IF NOT EXISTS idx_library_albums_release_group_mbid
+    ON library_albums (release_group_mbid);
   CREATE INDEX IF NOT EXISTS idx_library_albums_title
     ON library_albums (title COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_albums_release_date
     ON library_albums (release_date DESC);
   CREATE INDEX IF NOT EXISTS idx_library_artists_sort_name_name
     ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
+    ON library_artists (mbid);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
   CREATE INDEX IF NOT EXISTS idx_library_tracks_title

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -285,9 +285,9 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
     ON library_artists (mbid);
   CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_name
     ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
@@ -459,9 +459,9 @@ if (hasUniqueIndex(["path"])) {
 
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
-    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+    ON library_artists (CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT));
   CREATE INDEX IF NOT EXISTS idx_library_artists_name
     ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -21,8 +21,8 @@ const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("busy_timeout = 5000");
 db.pragma("synchronous = NORMAL");
-db.pragma("cache_size = -32000");
-db.pragma("mmap_size = 33554432");
+db.pragma("cache_size = -16000");
+db.pragma("mmap_size = 16777216");
 
 function tryAddColumn(sql) {
   try {

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -285,6 +285,12 @@ db.exec(`
     ON library_artists (sort_name COLLATE NOCASE, name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_artists_mbid
     ON library_artists (mbid);
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_album_tracks_track_id
     ON library_album_tracks (track_id);
   CREATE INDEX IF NOT EXISTS idx_library_tracks_title
@@ -453,6 +459,12 @@ if (hasUniqueIndex(["path"])) {
 }
 
 db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_library_artists_provider_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.id') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_foreign_artist_id
+    ON library_artists (CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT));
+  CREATE INDEX IF NOT EXISTS idx_library_artists_name
+    ON library_artists (name COLLATE NOCASE);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_album_source_available
     ON library_media_files (album_id, source, available);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_track_album_source_available

--- a/backend/config/library-search-index.js
+++ b/backend/config/library-search-index.js
@@ -1,0 +1,223 @@
+const SEARCH_INDEX_VERSION = "2";
+const GENRE_STATS_SETTING_PREFIX = "libraryGenreStats:";
+
+const genreMediaExists = (kind, sourceFilter, availableOnly) => {
+  const filters = [];
+  const parameters = [];
+  if (sourceFilter) {
+    filters.push("page_media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly) filters.push("page_media.available = 1");
+  const filterSql = filters.length ? filters.join(" AND ") : "1 = 1";
+  if (kind === "artists") {
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM library_albums AS page_album
+        JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
+        JOIN library_media_files AS page_media
+          ON page_media.track_id = page_album_track.track_id
+          AND (page_media.album_id = page_album_track.album_id OR page_media.album_id IS NULL)
+        WHERE page_album.artist_id = artist.id AND ${filterSql}
+      )`,
+      parameters,
+    };
+  }
+  if (kind === "albums") {
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM library_album_tracks AS page_album_track
+        JOIN library_media_files AS page_media
+          ON page_media.track_id = page_album_track.track_id
+          AND (page_media.album_id = page_album_track.album_id OR page_media.album_id IS NULL)
+        WHERE page_album_track.album_id = album.id AND ${filterSql}
+      )`,
+      parameters,
+    };
+  }
+  return {
+    sql: `EXISTS (
+      SELECT 1 FROM library_media_files AS page_media
+      WHERE page_media.track_id = track.id AND ${filterSql}
+    )`,
+    parameters,
+  };
+};
+
+export function computeLibraryGenreStats(db, { sourceFilter = null, availableOnly = false } = {}) {
+  const entities = [
+    ["artists", "library_artists AS artist", "artist.id", "artist.metadata_json"],
+    [
+      "albums",
+      "library_albums AS album JOIN library_artists AS artist ON artist.id = album.artist_id",
+      "album.id",
+      "album.metadata_json",
+    ],
+    ["tracks", "library_tracks AS track", "track.id", "track.metadata_json"],
+  ];
+  const parameters = [];
+  const rows = entities.map(([kind, from, id, metadata]) => {
+    const media = genreMediaExists(kind, sourceFilter, availableOnly);
+    parameters.push(...media.parameters);
+    const validMetadata = `CASE WHEN json_valid(${metadata}) THEN ${metadata} ELSE '{}' END`;
+    return `SELECT '${kind}' AS entity_kind, ${id} AS entity_id,
+      TRIM(CAST(genre_value.value AS TEXT)) AS name
+      FROM ${from}
+      JOIN json_each(json_array(
+        json_extract(${validMetadata}, '$.genres'),
+        json_extract(${validMetadata}, '$.genre'),
+        json_extract(${validMetadata}, '$.common.genre'),
+        json_extract(${validMetadata}, '$.tags.genre')
+      )) AS selected_genre
+      JOIN json_each(CASE
+        WHEN selected_genre.type IN ('array', 'object') THEN selected_genre.value
+        ELSE json_array(selected_genre.value)
+      END) AS genre_value
+      WHERE selected_genre.value IS NOT NULL
+        AND TRIM(CAST(genre_value.value AS TEXT)) <> ''
+        AND ${media.sql}`;
+  });
+  return db.prepare(
+    `WITH genre_entities AS (
+       SELECT DISTINCT entity_kind, entity_id, name
+       FROM (${rows.join(" UNION ALL ")})
+     )
+     SELECT name,
+       SUM(entity_kind = 'artists') AS artists,
+       SUM(entity_kind = 'albums') AS albums,
+       SUM(entity_kind = 'tracks') AS tracks
+     FROM genre_entities
+     GROUP BY name
+     ORDER BY name COLLATE NOCASE`,
+  ).all(...parameters).map((row) => ({
+    name: row.name,
+    artists: Number(row.artists || 0),
+    albums: Number(row.albums || 0),
+    tracks: Number(row.tracks || 0),
+  }));
+}
+
+export function rebuildStoredLibraryGenreStats(db) {
+  for (const availableOnly of [false, true]) {
+    const cacheKey = `all:${availableOnly ? "available" : "all"}`;
+    const stats = computeLibraryGenreStats(db, { availableOnly });
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+      .run(`${GENRE_STATS_SETTING_PREFIX}${cacheKey}`, JSON.stringify(stats));
+  }
+}
+
+const createSearchSchema = (db) => {
+  const fts5Enabled = db
+    .prepare("SELECT sqlite_compileoption_used(?) AS enabled")
+    .get("ENABLE_FTS5")?.enabled;
+  if (!fts5Enabled) return false;
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS library_search_documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_kind TEXT NOT NULL,
+      entity_id INTEGER NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      artist_name TEXT NOT NULL DEFAULT '',
+      album_name TEXT NOT NULL DEFAULT '',
+      UNIQUE (entity_kind, entity_id)
+    );
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS library_search_fts USING fts5(
+      entity_kind UNINDEXED,
+      entity_id UNINDEXED,
+      title,
+      artist_name,
+      album_name,
+      content='library_search_documents',
+      content_rowid='id',
+      tokenize='trigram',
+      detail='none'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_ai
+    AFTER INSERT ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES (new.id, new.entity_kind, new.entity_id, new.title, new.artist_name, new.album_name);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_au
+    AFTER UPDATE ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(library_search_fts, rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES ('delete', old.id, old.entity_kind, old.entity_id, old.title, old.artist_name, old.album_name);
+      INSERT INTO library_search_fts(rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES (new.id, new.entity_kind, new.entity_id, new.title, new.artist_name, new.album_name);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS library_search_documents_ad
+    AFTER DELETE ON library_search_documents
+    BEGIN
+      INSERT INTO library_search_fts(library_search_fts, rowid, entity_kind, entity_id, title, artist_name, album_name)
+      VALUES ('delete', old.id, old.entity_kind, old.entity_id, old.title, old.artist_name, old.album_name);
+    END;
+  `);
+  return true;
+};
+
+export const populateLibrarySearchDocuments = (db) => {
+  db.exec(`
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT 'artist', artist.id, artist.name, '', ''
+    FROM library_artists AS artist;
+
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT
+      'album',
+      album.id,
+      album.title,
+      trim(coalesce(artist.name, '') || ' ' || coalesce(album.album_artist, '')),
+      ''
+    FROM library_albums AS album
+    JOIN library_artists AS artist ON artist.id = album.artist_id;
+
+    INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+    SELECT
+      'track',
+      track.id,
+      track.title,
+      trim(coalesce(track.artist_name, '') || ' ' || coalesce(group_concat(DISTINCT artist.name), '')),
+      trim(coalesce(group_concat(DISTINCT album.title), '') || ' ' || coalesce(group_concat(DISTINCT album.album_artist), ''))
+    FROM library_tracks AS track
+    LEFT JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+    LEFT JOIN library_albums AS album ON album.id = album_track.album_id
+    LEFT JOIN library_artists AS artist ON artist.id = album.artist_id
+    GROUP BY track.id;
+  `);
+};
+
+export function initializeLibrarySearchIndex(db) {
+  const hadSearchIndex = Boolean(
+    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get("library_search_fts"),
+  );
+  const version = db
+    .prepare("SELECT value FROM settings WHERE key = ?")
+    .get("librarySearchIndexVersion")?.value;
+  if (version && version !== SEARCH_INDEX_VERSION) {
+    db.exec(`
+      DROP TRIGGER IF EXISTS library_search_documents_ai;
+      DROP TRIGGER IF EXISTS library_search_documents_au;
+      DROP TRIGGER IF EXISTS library_search_documents_ad;
+      DROP TABLE IF EXISTS library_search_fts;
+    `);
+  }
+  if (!createSearchSchema(db)) return false;
+  if (version === SEARCH_INDEX_VERSION && hadSearchIndex) return true;
+
+  db.transaction(() => {
+    db.prepare("DELETE FROM library_search_documents").run();
+    populateLibrarySearchDocuments(db);
+    db.prepare("INSERT INTO library_search_fts(library_search_fts) VALUES ('rebuild')").run();
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+      .run("librarySearchIndexVersion", SEARCH_INDEX_VERSION);
+    rebuildStoredLibraryGenreStats(db);
+  })();
+  return true;
+}

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -11,6 +11,10 @@ import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildArtistRequestKey, pendingArtistRequests } from "../utils.js";
 import { getArtistByMbid } from "../../../services/providers/brainzmashProvider.js";
 import { getArtistTagPayload, buildArtistBase } from "../shared/transform.js";
+import {
+  findCanonicalArtist,
+  getCanonicalLibraryReadModelForArtists,
+} from "../../../services/canonicalLibraryReadAdapter.js";
 
 export function registerDetails(router) {
   const parseSelectedReleaseTypes = (value) =>
@@ -146,24 +150,26 @@ export function registerDetails(router) {
 
       logger.info("api", "Fetching artist details", { mbid });
 
-      const { lidarrClient } =
-        await import("../../../services/lidarrClient.js");
       let data = null;
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
 
-      let lidarrArtist = null;
-
-      if (lidarrClient.isConfigured()) {
-        try {
-          lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
-          if (lidarrArtist) {
-            logger.info("api", "Found artist in Lidarr", { artistName: lidarrArtist.artistName });
+      const canonical = getCanonicalLibraryReadModelForArtists({
+        source: "all",
+        availableOnly: false,
+        mbids: [mbid, resolvedMbid],
+      });
+      const canonicalArtist =
+        findCanonicalArtist(canonical.artists, resolvedMbid) ||
+        findCanonicalArtist(canonical.artists, mbid);
+      const lidarrArtist = canonicalArtist
+        ? {
+            id: canonicalArtist.providerId || canonicalArtist.id,
+            artistName: canonicalArtist.artistName,
+            monitored: canonicalArtist.monitored,
+            statistics: canonicalArtist.statistics,
           }
-        } catch (error) {
-          logger.warn("api", "Failed to fetch from Lidarr", { mbid, error: error.message });
-        }
-      }
+        : null;
 
       if (lidarrArtist) {
         const artistMbid = override?.musicbrainzId || mbid;

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -11,10 +11,18 @@ import { requireAuth } from "../../../middleware/requirePermission.js";
 import { buildArtistRequestKey, pendingArtistRequests } from "../utils.js";
 import { getArtistByMbid } from "../../../services/providers/brainzmashProvider.js";
 import { getArtistTagPayload, buildArtistBase } from "../shared/transform.js";
-import {
-  findCanonicalArtist,
-  getCanonicalLibraryReadModelForArtists,
-} from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+
+export function getCanonicalLidarrArtist(reference) {
+  const artist = getCanonicalArtistProjection({ reference })[0] || null;
+  if (!artist?.sources.includes("lidarr")) return null;
+  return {
+    id: artist.providerId || artist.id,
+    artistName: artist.artistName,
+    monitored: artist.monitored,
+    statistics: artist.statistics,
+  };
+}
 
 export function registerDetails(router) {
   const parseSelectedReleaseTypes = (value) =>
@@ -154,22 +162,9 @@ export function registerDetails(router) {
       const override = dbOps.getArtistOverride(mbid);
       const resolvedMbid = override?.musicbrainzId || mbid;
 
-      const canonical = getCanonicalLibraryReadModelForArtists({
-        source: "all",
-        availableOnly: false,
-        mbids: [mbid, resolvedMbid],
-      });
-      const canonicalArtist =
-        findCanonicalArtist(canonical.artists, resolvedMbid) ||
-        findCanonicalArtist(canonical.artists, mbid);
-      const lidarrArtist = canonicalArtist
-        ? {
-            id: canonicalArtist.providerId || canonicalArtist.id,
-            artistName: canonicalArtist.artistName,
-            monitored: canonicalArtist.monitored,
-            statistics: canonicalArtist.statistics,
-          }
-        : null;
+      const lidarrArtist =
+        getCanonicalLidarrArtist(resolvedMbid) ||
+        (resolvedMbid === mbid ? null : getCanonicalLidarrArtist(mbid));
 
       if (lidarrArtist) {
         const artistMbid = override?.musicbrainzId || mbid;

--- a/backend/routes/artists/handlers/details.js
+++ b/backend/routes/artists/handlers/details.js
@@ -15,7 +15,7 @@ import { getCanonicalArtistProjection } from "../../../services/libraryQueryServ
 
 export function getCanonicalLidarrArtist(reference) {
   const artist = getCanonicalArtistProjection({ reference })[0] || null;
-  if (!artist?.sources.includes("lidarr")) return null;
+  if (!artist?.lidarrManaged) return null;
   return {
     id: artist.providerId || artist.id,
     artistName: artist.artistName,

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -163,73 +163,13 @@ export function registerStream(router) {
             return;
           }
 
-          const { lidarrClient } = await import("../../../services/lidarrClient.js");
-          const { libraryManager } = await import("../../../services/libraryManager.js");
-
-          if (!lidarrClient.isConfigured()) return;
-
-          try {
-            const lidarrArtist = await lidarrClient.getArtistByMbid(mbid);
-            if (!lidarrArtist) {
-              if (isClientConnected()) {
-                sendSSE(res, "library", {
-                  exists: false,
-                  artist: null,
-                  albums: [],
-                });
-              }
-              return;
-            }
-            if (!isClientConnected()) return;
-
-            logger.info("stream", `Found artist in Lidarr: ${lidarrArtist.artistName}`);
-            const metadataArtist = await metadataArtistPromise;
-
-            sendArtist({
-              ...buildArtistBase(lidarrArtist.artistName, resolvedMbid, metadataArtist),
-              _lidarrData: {
-                id: lidarrArtist.id,
-                monitored: lidarrArtist.monitored,
-                statistics: lidarrArtist.statistics,
-              },
-            });
-
-            const libArtist = libraryManager.mapLidarrArtist(lidarrArtist);
+          if (isClientConnected()) {
             sendSSE(res, "library", {
-              exists: true,
-              artist: {
-                ...libArtist,
-                foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
-                added: libArtist.addedAt,
-              },
+              exists: false,
+              canonical: true,
+              artist: null,
               albums: [],
             });
-
-            const lidarrAlbums = await libraryManager.getAlbums(libArtist.id, lidarrArtist);
-
-            if (!isClientConnected()) return;
-
-            sendSSE(res, "library", {
-              exists: true,
-              artist: {
-                ...libArtist,
-                foreignArtistId: libArtist.foreignArtistId || libArtist.mbid,
-                added: libArtist.addedAt,
-              },
-              albums: lidarrAlbums.map((a) => ({
-                ...a,
-                foreignAlbumId: a.foreignAlbumId || a.mbid,
-                title: a.albumName,
-                albumType: "Album",
-                statistics: a.statistics || {
-                  trackCount: 0,
-                  sizeOnDisk: 0,
-                  percentOfTracks: 0,
-                },
-              })),
-            });
-          } catch (error) {
-            logger.warn("stream", `Failed to fetch from Lidarr: ${error.message}`);
           }
         })();
         tasks.push(libraryTask);

--- a/backend/routes/discovery/handlers/main.js
+++ b/backend/routes/discovery/handlers/main.js
@@ -4,8 +4,8 @@ import {
   getDiscoveryMode,
   serveCachedRecommendations,
 } from "../../../services/discovery/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import {
   buildArtistKeySet,
   isLibraryArtist,
@@ -63,7 +63,7 @@ export function registerMain(router) {
       let recommendations = discoveryCache.recommendations || [];
       let globalTop = discoveryCache.globalTop || [];
 
-      const libraryArtists = await libraryManager.getAllArtists();
+      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       const existingArtistKeys = buildArtistKeySet(libraryArtists);
 
       recommendations = recommendations.filter(

--- a/backend/routes/discovery/handlers/main.js
+++ b/backend/routes/discovery/handlers/main.js
@@ -5,7 +5,7 @@ import {
   serveCachedRecommendations,
 } from "../../../services/discovery/index.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
-import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+import { getCanonicalArtistKeyProjection } from "../../../services/libraryQueryService.js";
 import {
   buildArtistKeySet,
   isLibraryArtist,
@@ -63,8 +63,7 @@ export function registerMain(router) {
       let recommendations = discoveryCache.recommendations || [];
       let globalTop = discoveryCache.globalTop || [];
 
-      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-      const existingArtistKeys = buildArtistKeySet(libraryArtists);
+      const existingArtistKeys = buildArtistKeySet(getCanonicalArtistKeyProjection());
 
       recommendations = recommendations.filter(
         (artist) => !isLibraryArtist(artist, existingArtistKeys),

--- a/backend/routes/discovery/handlers/shows.js
+++ b/backend/routes/discovery/handlers/shows.js
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto";
 import { requireAuth } from "../../../middleware/requirePermission.js";
+import { db } from "../../../config/db-sqlite.js";
 import { dbOps, userOps } from "../../../db/helpers/index.js";
 import { getTicketmasterApiKey, getLastfmApiKey } from "../../../services/apiClients/index.js";
 import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
@@ -13,6 +15,34 @@ import {
   getListenHistoryProfile,
 } from "../../../services/listeningHistory.js";
 import { getNearbyShows } from "../../../services/nearbyShowsService.js";
+
+const libraryArtistNamesStmt = db.prepare(
+  "SELECT name FROM library_artists ORDER BY id",
+);
+
+const fingerprintArtists = (artists) => {
+  const names = [
+    ...new Set(
+      (Array.isArray(artists) ? artists : [])
+        .map((artist) => String(artist?.artistName || artist?.name || "").trim())
+        .filter(Boolean),
+    ),
+  ].sort();
+  return createHash("sha256").update(JSON.stringify(names)).digest("hex");
+};
+
+export const buildShowsResponseCacheKey = ({
+  userId,
+  libraryArtists,
+  recommendedArtists,
+  trendingArtists,
+}) =>
+  JSON.stringify([
+    userId,
+    fingerprintArtists(libraryArtists),
+    fingerprintArtists(recommendedArtists),
+    fingerprintArtists(trendingArtists),
+  ]);
 
 export function registerShows(router) {
   router.get("/nearby-shows", requireAuth, async (req, res) => {
@@ -57,6 +87,7 @@ export function registerShows(router) {
             feedback,
           }).slice(0, 18)
         : [];
+      const libraryArtistNames = libraryArtistNamesStmt.all();
       const nearbyShows = await getNearbyShows({
         req,
         zipCode,
@@ -65,7 +96,12 @@ export function registerShows(router) {
         trendingArtists,
         limit: req.query.limit,
         radiusMiles,
-        responseCacheKey: req.user.id,
+        responseCacheKey: buildShowsResponseCacheKey({
+          userId: req.user.id,
+          libraryArtists: libraryArtistNames,
+          recommendedArtists,
+          trendingArtists,
+        }),
       });
 
       res.set("Cache-Control", "no-cache, no-store, must-revalidate");

--- a/backend/routes/discovery/handlers/shows.js
+++ b/backend/routes/discovery/handlers/shows.js
@@ -1,7 +1,7 @@
 import { requireAuth } from "../../../middleware/requirePermission.js";
 import { dbOps, userOps } from "../../../db/helpers/index.js";
 import { getTicketmasterApiKey, getLastfmApiKey } from "../../../services/apiClients/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import {
   getDiscoveryCache,
   getDiscoveryFeedback,
@@ -39,7 +39,7 @@ export function registerShows(router) {
       const radiusMiles = Number.isFinite(configuredRadius)
         ? Math.max(5, Math.min(250, Math.floor(configuredRadius)))
         : undefined;
-      const libraryArtists = await libraryManager.getAllArtists();
+      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       const reqUser = userOps.getUserById(req.user.id);
       const userCacheNamespace = getLastfmApiKey()
         ? getListenHistoryCacheNamespace(getListenHistoryProfile(reqUser || {}))

--- a/backend/routes/discovery/handlers/shows.js
+++ b/backend/routes/discovery/handlers/shows.js
@@ -39,7 +39,6 @@ export function registerShows(router) {
       const radiusMiles = Number.isFinite(configuredRadius)
         ? Math.max(5, Math.min(250, Math.floor(configuredRadius)))
         : undefined;
-      const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       const reqUser = userOps.getUserById(req.user.id);
       const userCacheNamespace = getLastfmApiKey()
         ? getListenHistoryCacheNamespace(getListenHistoryProfile(reqUser || {}))
@@ -61,11 +60,12 @@ export function registerShows(router) {
       const nearbyShows = await getNearbyShows({
         req,
         zipCode,
-        libraryArtists,
+        libraryArtists: () => [...iterateCanonicalArtistProjection({ pageSize: 100 })],
         recommendedArtists,
         trendingArtists,
         limit: req.query.limit,
         radiusMiles,
+        responseCacheKey: req.user.id,
       });
 
       res.set("Cache-Control", "no-cache, no-store, must-revalidate");

--- a/backend/routes/discovery/handlers/tags.js
+++ b/backend/routes/discovery/handlers/tags.js
@@ -1,5 +1,5 @@
 import { getLastfmApiKey, lastfmRequest } from "../../../services/apiClients/index.js";
-import { libraryManager } from "../../../services/libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 import { getDiscoveryCache } from "../../../services/discovery/index.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import { extractLastfmImageUrl } from "../../artists/shared/transform.js";
@@ -124,7 +124,7 @@ export function registerTags(router) {
             offset: offsetInt,
             existingArtistKeys: includeLibraryFlag
               ? new Set()
-              : buildArtistKeySet(await libraryManager.getAllArtists()),
+              : buildArtistKeySet([...iterateCanonicalArtistProjection({ pageSize: 100 })]),
           });
           if (fallbackResult) {
             return res.json({

--- a/backend/routes/discovery/handlers/tags.js
+++ b/backend/routes/discovery/handlers/tags.js
@@ -1,5 +1,5 @@
 import { getLastfmApiKey, lastfmRequest } from "../../../services/apiClients/index.js";
-import { iterateCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+import { getCanonicalArtistKeyProjection } from "../../../services/libraryQueryService.js";
 import { getDiscoveryCache } from "../../../services/discovery/index.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import { extractLastfmImageUrl } from "../../artists/shared/transform.js";
@@ -124,7 +124,7 @@ export function registerTags(router) {
             offset: offsetInt,
             existingArtistKeys: includeLibraryFlag
               ? new Set()
-              : buildArtistKeySet([...iterateCanonicalArtistProjection({ pageSize: 100 })]),
+              : buildArtistKeySet(getCanonicalArtistKeyProjection()),
           });
           if (fallbackResult) {
             return res.json({

--- a/backend/routes/inbox.js
+++ b/backend/routes/inbox.js
@@ -4,8 +4,10 @@ import { hasPermission } from "../middleware/auth.js";
 import { requireAuth } from "../middleware/requirePermission.js";
 import { libraryManager } from "../services/libraryManager.js";
 import {
+  enqueueInboxRefreshForUser,
   getInboxForUser,
   getInboxRefreshCooldownMs,
+  getInboxRefreshStatus,
   markAllInboxItemsRead,
   updateInboxItem,
 } from "../services/inboxService.js";
@@ -56,9 +58,6 @@ router.get("/", requireAuth, async (req, res) => {
     const limit = Math.max(1, Math.min(50, Number.parseInt(req.query.limit, 10) || 50));
     const result = await getInboxForUser(getUserId(req), {
       limit,
-      zipCode: String(req.query.zip || "").trim(),
-      req,
-      awaitRefresh: false,
     });
     res.set("Cache-Control", "private, no-cache, no-store, must-revalidate");
     return res.json(result);
@@ -72,21 +71,37 @@ router.post("/refresh", requireAuth, async (req, res) => {
   const now = Date.now();
   const last = lastManualRefresh.get(userId) || 0;
   const cooldown = getInboxRefreshCooldownMs() * 3;
+  const current = getInboxRefreshStatus(userId);
+  if (current.status === "queued" || current.status === "running") {
+    return res.status(202).json({
+      accepted: false,
+      queued: false,
+      jobId: current.jobId,
+      status: current.status,
+      refreshStatus: current,
+    });
+  }
   if (now - last < cooldown) {
     return res.status(429).json({
       error: "Inbox refresh is rate limited",
       retryAfterSeconds: Math.ceil((cooldown - (now - last)) / 1000),
     });
   }
-  lastManualRefresh.set(userId, now);
   try {
-    const result = await getInboxForUser(userId, {
-      limit: 50,
+    const refresh = await enqueueInboxRefreshForUser(userId, {
+      reason: "manual",
       zipCode: String(req.body?.zip || req.query.zip || "").trim(),
-      req,
-      force: true,
+      ipAddress: req.ip || req.headers["x-forwarded-for"] || "",
     });
-    return res.json(result);
+    lastManualRefresh.set(userId, now);
+    const result = getInboxForUser(userId, { limit: 50 });
+    return res.status(202).json({
+      ...result,
+      accepted: refresh.queued,
+      queued: refresh.queued,
+      jobId: refresh.jobId,
+      status: refresh.status,
+    });
   } catch (error) {
     return res.status(500).json({ error: "Failed to refresh inbox", message: error.message });
   }

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -9,7 +9,6 @@ import {
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
 import {
-  findCanonicalAlbumsForArtist,
   getCanonicalLibraryReadModelForArtistReferences,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 
@@ -27,7 +26,7 @@ export function registerAlbums(router) {
           availableOnly: true,
           references: [artistId],
         });
-        return res.json(findCanonicalAlbumsForArtist(albums, artistId));
+        return res.json(albums);
       }
 
       const albums = await libraryManager.getAlbums(artistId);

--- a/backend/routes/library/handlers/albums.js
+++ b/backend/routes/library/handlers/albums.js
@@ -10,7 +10,7 @@ import {
 import { logger } from "../../../services/logger.js";
 import {
   findCanonicalAlbumsForArtist,
-  getCanonicalLibraryReadModel,
+  getCanonicalLibraryReadModelForArtistReferences,
 } from "../../../services/canonicalLibraryReadAdapter.js";
 
 export function registerAlbums(router) {
@@ -22,7 +22,11 @@ export function registerAlbums(router) {
       }
 
       if (req.query.readPath === "canonical") {
-        const { albums } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
+        const { albums } = getCanonicalLibraryReadModelForArtistReferences({
+          source: req.query.source || "all",
+          availableOnly: true,
+          references: [artistId],
+        });
         return res.json(findCanonicalAlbumsForArtist(albums, artistId));
       }
 

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -7,23 +7,21 @@ import {
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
 import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
+      const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
+      const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
       if (req.query.readPath === "canonical") {
         const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
-        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
-        const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
         return res.json(artists.slice(offset, offset + limit).map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));
       }
-      const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
-      const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
-      const artists = await libraryManager.getAllArtists();
-      const paged = artists.slice(offset, offset + limit);
-      const formatted = paged.map((artist) => ({
+      const artists = getCanonicalArtistProjection({ pageSize: limit, offset });
+      const formatted = artists.map((artist) => ({
         ...artist,
         foreignArtistId: artist.foreignArtistId || artist.mbid,
         added: artist.addedAt,

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -6,16 +6,32 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
-import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
-import { getCanonicalArtistProjection } from "../../../services/libraryQueryService.js";
+import { getCanonicalLibraryReadModelForArtistReferences } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalArtistProjection, getCanonicalLibraryPage } from "../../../services/libraryQueryService.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
       const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
       const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
       if (req.query.readPath === "canonical") {
-        const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
-        return res.json(artists.slice(offset, offset + limit).map((artist) => ({
+        const source = req.query.source || "all";
+        const page = getCanonicalLibraryPage({
+          source,
+          availableOnly: true,
+          kind: "artists",
+          pageSize: limit,
+          offset,
+        });
+        const readModel = getCanonicalLibraryReadModelForArtistReferences({
+          source,
+          availableOnly: true,
+          references: page.items.map((artist) => artist.id),
+        });
+        const artistsById = new Map(readModel.artists.map((artist) => [String(artist.id), artist]));
+        const artists = page.items
+          .map((artist) => artistsById.get(String(artist.id)))
+          .filter(Boolean);
+        return res.json(artists.map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));

--- a/backend/routes/library/handlers/artists.js
+++ b/backend/routes/library/handlers/artists.js
@@ -6,15 +6,19 @@ import {
   requirePermission,
 } from "../../../middleware/requirePermission.js";
 import { logger } from "../../../services/logger.js";
-import { getCanonicalLibraryReadModel } from "../../../services/canonicalLibraryReadAdapter.js";
+import { getCanonicalLibraryReadModelForArtistPage } from "../../../services/canonicalLibraryReadAdapter.js";
 export function registerArtists(router) {
   router.get("/artists", cacheMiddleware(120), async (req, res) => {
     try {
       if (req.query.readPath === "canonical") {
-        const { artists } = getCanonicalLibraryReadModel({ source: req.query.source || "all" });
         const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10000, 1), 10000);
         const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
-        return res.json(artists.slice(offset, offset + limit).map((artist) => ({
+        const { artists } = getCanonicalLibraryReadModelForArtistPage({
+          source: req.query.source || "all",
+          limit,
+          offset,
+        });
+        return res.json(artists.map((artist) => ({
           ...artist,
           added: artist.addedAt,
         })));

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -72,6 +72,13 @@ export const getDownloadStatusesForAlbumIds = async (
         queueByAlbumId.set(qAlbumId, q);
       }
 
+      let verifiedAlbumsPromise;
+      const getVerifiedAlbums = () =>
+        (verifiedAlbumsPromise ??= lidarrClient
+          .getAllAlbums()
+          .then((albums) => new Map(albums.map((album) => [String(album.id), album])))
+          .catch(() => new Map()));
+
       for (const albumId of albumIdArray) {
         if (!albumId || albumId === "undefined" || albumId === "null") continue;
         const lidarrAlbumId = parseInt(albumId, 10);
@@ -189,7 +196,7 @@ export const getDownloadStatusesForAlbumIds = async (
               updatedAt: new Date().toISOString(),
             };
           } else if (isFailedImport || isFailedDownload || isStaleGrabbed) {
-            const album = await lidarrClient.getAlbum(lidarrAlbumId).catch(() => null);
+            const album = (await getVerifiedAlbums()).get(String(lidarrAlbumId));
             statuses[albumId] = {
               status: albumHasTrackFiles(album) ? "added" : "failed",
               updatedAt: new Date().toISOString(),

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -11,12 +11,21 @@ import { logger } from "../../../services/logger.js";
 import { getCanonicalTrackOwnership } from "../../../services/libraryQueryService.js";
 
 const STALE_GRABBED_MS = 15 * 60 * 1000;
-const DOWNLOAD_STATUS_CACHE_MS = 5000;
+const ACTIVE_STATUS_CACHE_MS = 10 * 1000;
+const IDLE_STATUS_CACHE_MS = 60 * 1000;
+const MAX_STATUS_RETRY_MS = 2 * 60 * 1000;
 let allDownloadStatusesCache = {
-  at: 0,
-  statuses: null,
+  snapshot: null,
   pending: null,
+  failures: 0,
+  nextRefreshAt: 0,
+  revision: 0,
 };
+
+const activeDownloadStatuses = new Set(["searching", "downloading", "processing"]);
+
+const snapshotHasActiveWork = (statuses) =>
+  Object.values(statuses || {}).some((status) => activeDownloadStatuses.has(status?.status));
 
 const invalidateActivityRequestsCache = () =>
   import("../../requests.js")
@@ -33,13 +42,7 @@ export const getDownloadStatusesForAlbumIds = async (
 
   if (lidarrClient.isConfigured()) {
     try {
-      const { queue, history, commands } =
-        snapshot ||
-        (await Promise.all([
-          lidarrClient.getQueue(),
-          lidarrClient.getHistory(1, 200),
-          lidarrClient.request("/command").catch(() => []),
-        ]).then(([queue, history, commands]) => ({ queue, history, commands })));
+      const { queue, history, commands } = snapshot || (await getLidarrStatusSnapshot()).provider;
       const queueItems = Array.isArray(queue) ? queue : queue.records || [];
       const historyItems = Array.isArray(history) ? history : history.records || [];
       const searchContext = parseLidarrSearchContext({
@@ -221,85 +224,106 @@ export const getDownloadStatusesForAlbumIds = async (
   return statuses;
 };
 
-const computeAllDownloadStatuses = async () => {
+const computeLidarrStatusSnapshot = async () => {
   const { lidarrClient } = await import("../../../services/lidarrClient.js");
 
   if (!lidarrClient.isConfigured()) {
-    return {};
-  }
-  if (lidarrClient.isCircuitOpen()) {
-    return allDownloadStatusesCache.statuses || {};
+    return { provider: { queue: [], history: { records: [] }, commands: [] }, statuses: {} };
   }
 
-  try {
-    const [queue, history, commands] = await Promise.all([
-      lidarrClient.getQueue(),
-      lidarrClient.getHistory(1, 200),
-      lidarrClient.request("/command").catch(() => []),
-    ]);
-    const queueItems = Array.isArray(queue) ? queue : queue.records || [];
-    const historyItems = Array.isArray(history) ? history : history.records || [];
-    const oneHourAgo = Date.now() - 60 * 60 * 1000;
-    const albumIds = new Set();
-    const searchContext = parseLidarrSearchContext({
-      queue,
-      history,
-      commands,
-    });
+  const [queue, history, commands] = await Promise.all([
+    lidarrClient.getQueue({ forceRefresh: true }),
+    lidarrClient.getHistory(1, 200, "date", "descending", { forceRefresh: true }),
+    lidarrClient.request("/command", "GET", null, false, { forceRefresh: true }),
+  ]);
+  const provider = { queue, history, commands };
+  const queueItems = Array.isArray(queue) ? queue : queue.records || [];
+  const historyItems = Array.isArray(history) ? history : history.records || [];
+  const oneHourAgo = Date.now() - 60 * 60 * 1000;
+  const albumIds = new Set();
+  const searchContext = parseLidarrSearchContext({ queue, history, commands });
 
-    for (const item of queueItems) {
-      const albumId = item?.albumId ?? item?.album?.id;
-      if (albumId != null) albumIds.add(String(albumId));
-    }
-    for (const item of historyItems) {
-      if (item?.albumId == null) continue;
-      const historyTime = new Date(item?.date || item?.eventDate || 0).getTime();
-      if (historyTime > oneHourAgo) albumIds.add(String(item.albumId));
-    }
-    for (const albumId of searchContext.searchingAlbumIds) {
-      albumIds.add(String(albumId));
-    }
-
-    return getDownloadStatusesForAlbumIds([...albumIds], {
-      queue,
-      history,
-      commands,
-    });
-  } catch (error) {
-    logger.warn("downloads", "Failed to fetch Lidarr status:", { message: error.message });
-    return allDownloadStatusesCache.statuses || {};
+  for (const item of queueItems) {
+    const albumId = item?.albumId ?? item?.album?.id;
+    if (albumId != null) albumIds.add(String(albumId));
   }
+  for (const item of historyItems) {
+    if (item?.albumId == null) continue;
+    const historyTime = new Date(item?.date || item?.eventDate || 0).getTime();
+    if (historyTime > oneHourAgo) albumIds.add(String(item.albumId));
+  }
+  for (const albumId of searchContext.searchingAlbumIds) {
+    albumIds.add(String(albumId));
+  }
+
+  const statuses = await getDownloadStatusesForAlbumIds([...albumIds], provider);
+  return { provider, statuses };
 };
 
 export const invalidateAllDownloadStatusesCache = () => {
-  allDownloadStatusesCache.at = 0;
-  allDownloadStatusesCache.statuses = null;
-  allDownloadStatusesCache.pending = null;
+  allDownloadStatusesCache.revision += 1;
+  allDownloadStatusesCache.nextRefreshAt = 0;
 };
 
-export const getAllDownloadStatuses = async () => {
+export const hasActiveLidarrStatusSnapshot = () =>
+  allDownloadStatusesCache.snapshot?.active === true;
+
+const staleSnapshot = (error) => ({
+  ...(allDownloadStatusesCache.snapshot || {
+    provider: { queue: [], history: { records: [] }, commands: [] },
+    statuses: {},
+    updatedAt: null,
+    active: false,
+  }),
+  stale: true,
+  error: error?.message || String(error),
+});
+
+export const getLidarrStatusSnapshot = async ({ force = false } = {}) => {
   const { lidarrClient } = await import("../../../services/lidarrClient.js");
-  if (lidarrClient.isCircuitOpen() && allDownloadStatusesCache.statuses) {
-    return allDownloadStatusesCache.statuses;
+  if (lidarrClient.isCircuitOpen()) {
+    return staleSnapshot("Lidarr circuit is open");
   }
 
   const now = Date.now();
-  if (
-    allDownloadStatusesCache.statuses &&
-    now - allDownloadStatusesCache.at < DOWNLOAD_STATUS_CACHE_MS
-  ) {
-    return allDownloadStatusesCache.statuses;
+  if (!force && allDownloadStatusesCache.snapshot && now < allDownloadStatusesCache.nextRefreshAt) {
+    return allDownloadStatusesCache.snapshot;
   }
-
   if (allDownloadStatusesCache.pending) {
     return allDownloadStatusesCache.pending;
   }
 
-  allDownloadStatusesCache.pending = computeAllDownloadStatuses()
-    .then((statuses) => {
-      allDownloadStatusesCache.statuses = statuses;
-      allDownloadStatusesCache.at = Date.now();
-      return statuses;
+  const refreshRevision = allDownloadStatusesCache.revision;
+  allDownloadStatusesCache.pending = computeLidarrStatusSnapshot()
+    .then(({ provider, statuses }) => {
+      const active = snapshotHasActiveWork(statuses);
+      const refreshedAt = Date.now();
+      const snapshot = {
+        provider,
+        statuses,
+        updatedAt: new Date(refreshedAt).toISOString(),
+        active,
+        stale: false,
+        error: null,
+      };
+      allDownloadStatusesCache.snapshot = snapshot;
+      allDownloadStatusesCache.failures = 0;
+      allDownloadStatusesCache.nextRefreshAt =
+        refreshRevision === allDownloadStatusesCache.revision
+          ? refreshedAt + (active ? ACTIVE_STATUS_CACHE_MS : IDLE_STATUS_CACHE_MS)
+          : 0;
+      return snapshot;
+    })
+    .catch((error) => {
+      allDownloadStatusesCache.failures += 1;
+      allDownloadStatusesCache.nextRefreshAt = Date.now() + Math.min(
+        MAX_STATUS_RETRY_MS,
+        ACTIVE_STATUS_CACHE_MS * 2 ** (allDownloadStatusesCache.failures - 1),
+      );
+      logger.warn("downloads", "Failed to refresh Lidarr status:", { message: error.message });
+      const snapshot = staleSnapshot(error);
+      allDownloadStatusesCache.snapshot = snapshot;
+      return snapshot;
     })
     .finally(() => {
       allDownloadStatusesCache.pending = null;
@@ -307,6 +331,9 @@ export const getAllDownloadStatuses = async () => {
 
   return allDownloadStatusesCache.pending;
 };
+
+export const getAllDownloadStatuses = async () =>
+  (await getLidarrStatusSnapshot()).statuses;
 
 export function registerDownloads(router) {
   router.post("/downloads/track", requireAuth, requirePermission("addAlbum"), async (req, res) => {
@@ -549,7 +576,7 @@ export function registerDownloads(router) {
       if (!lidarrClient.isConfigured()) {
         return res.json([]);
       }
-      const queue = await lidarrClient.getQueue();
+      const queue = (await getLidarrStatusSnapshot()).provider.queue;
       const queueItems = Array.isArray(queue) ? queue : queue.records || [];
       res.json(
         queueItems.map((item) => ({

--- a/backend/routes/library/handlers/downloads.js
+++ b/backend/routes/library/handlers/downloads.js
@@ -323,10 +323,12 @@ export const getLidarrStatusSnapshot = async ({ force = false } = {}) => {
     })
     .catch((error) => {
       allDownloadStatusesCache.failures += 1;
-      allDownloadStatusesCache.nextRefreshAt = Date.now() + Math.min(
+      const retryAt = Date.now() + Math.min(
         MAX_STATUS_RETRY_MS,
         ACTIVE_STATUS_CACHE_MS * 2 ** (allDownloadStatusesCache.failures - 1),
       );
+      allDownloadStatusesCache.nextRefreshAt =
+        refreshRevision === allDownloadStatusesCache.revision ? retryAt : 0;
       logger.warn("downloads", "Failed to refresh Lidarr status:", { message: error.message });
       const snapshot = staleSnapshot(error);
       allDownloadStatusesCache.snapshot = snapshot;

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -95,7 +95,7 @@ export function registerTracks(router) {
       const { albumId, releaseGroupMbid } = req.query;
 
       if (req.query.readPath === "canonical") {
-        const canonical = albumId
+        let canonical = albumId
           ? getCanonicalLibraryReadModelForAlbumIds({
               source: req.query.source || "all",
               availableOnly: true,
@@ -106,6 +106,13 @@ export function registerTracks(router) {
               availableOnly: true,
               references: releaseGroupMbid ? [releaseGroupMbid] : [],
             });
+        if (albumId && canonical.albums.length === 0 && releaseGroupMbid) {
+          canonical = getCanonicalLibraryReadModelForAlbumReferences({
+            source: req.query.source || "all",
+            availableOnly: true,
+            references: [releaseGroupMbid],
+          });
+        }
         const { albums, tracks } = canonical;
         const album = [albumId, releaseGroupMbid]
           .filter(Boolean)

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -9,11 +9,11 @@ import fsp from "fs/promises";
 import path from "path";
 import { logger } from "../../../services/logger.js";
 import {
-  buildCanonicalLibraryReadModel,
   findCanonicalTracksForAlbum,
+  getCanonicalLibraryReadModelForAlbumIds,
+  getCanonicalLibraryReadModelForAlbumReferences,
   resolveCanonicalTrackPath,
 } from "../../../services/canonicalLibraryReadAdapter.js";
-import { getCanonicalLibrary } from "../../../services/libraryQueryService.js";
 import { stripFilesystemPaths } from "./canonical.js";
 import { streamAudioFile } from "../../../services/audioFileStream.js";
 
@@ -95,11 +95,18 @@ export function registerTracks(router) {
       const { albumId, releaseGroupMbid } = req.query;
 
       if (req.query.readPath === "canonical") {
-        const canonicalLibrary = getCanonicalLibrary({
-          source: req.query.source || "all",
-          availableOnly: true,
-        });
-        const { albums, tracks } = buildCanonicalLibraryReadModel(canonicalLibrary);
+        const canonical = albumId
+          ? getCanonicalLibraryReadModelForAlbumIds({
+              source: req.query.source || "all",
+              availableOnly: true,
+              ids: [albumId],
+            })
+          : getCanonicalLibraryReadModelForAlbumReferences({
+              source: req.query.source || "all",
+              availableOnly: true,
+              references: releaseGroupMbid ? [releaseGroupMbid] : [],
+            });
+        const { albums, tracks } = canonical;
         const album = [albumId, releaseGroupMbid]
           .filter(Boolean)
           .map((reference) =>

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -2,7 +2,10 @@ import express from "express";
 import { UUID_REGEX } from "../../lib/uuid.js";
 import { noCache } from "../middleware/cache.js";
 import { requireAuth, requirePermission } from "../middleware/requirePermission.js";
-import { invalidateAllDownloadStatusesCache } from "./library/handlers/downloads.js";
+import {
+  getLidarrStatusSnapshot,
+  invalidateAllDownloadStatusesCache,
+} from "./library/handlers/downloads.js";
 import { buildLidarrRequests } from "../services/lidarrRequestBuilder.js";
 import { getAurralHistoryRequests } from "../services/aurralHistoryService.js";
 
@@ -71,8 +74,11 @@ const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
 };
 
 const buildRequestsResponse = async (lidarrClient) => {
+  const snapshot = lidarrClient?.isConfigured()
+    ? await getLidarrStatusSnapshot()
+    : null;
   const [lidarrRequests, aurralRequests] = await Promise.all([
-    lidarrClient?.isConfigured() ? buildLidarrRequests(lidarrClient) : Promise.resolve([]),
+    snapshot ? buildLidarrRequests(lidarrClient, snapshot.provider) : Promise.resolve([]),
     getAurralHistoryRequests(lidarrClient),
   ]);
   const filteredAurral = filterRedundantAurralRequests(aurralRequests, lidarrRequests);

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -73,9 +73,9 @@ const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
   });
 };
 
-const buildRequestsResponse = async (lidarrClient) => {
+const buildRequestsResponse = async (lidarrClient, { force = false } = {}) => {
   const snapshot = lidarrClient?.isConfigured()
-    ? await getLidarrStatusSnapshot()
+    ? await getLidarrStatusSnapshot({ force })
     : null;
   const [lidarrRequests, aurralRequests] = await Promise.all([
     snapshot ? buildLidarrRequests(lidarrClient, snapshot.provider) : Promise.resolve([]),
@@ -87,9 +87,9 @@ const buildRequestsResponse = async (lidarrClient) => {
   );
 };
 
-const refreshRequestsCache = async (lidarrClient) => {
+const refreshRequestsCache = async (lidarrClient, options) => {
   if (pendingRequestsRefresh) return pendingRequestsRefresh;
-  pendingRequestsRefresh = buildRequestsResponse(lidarrClient)
+  pendingRequestsRefresh = buildRequestsResponse(lidarrClient, options)
     .then(updateRequestsCache)
     .finally(() => {
       pendingRequestsRefresh = null;
@@ -124,7 +124,7 @@ router.get("/", requireAuth, noCache, async (req, res) => {
       return res.json(filterDismissedRequests(lastRequestsResponse));
     }
 
-    const requests = await refreshRequestsCache(lidarrClient);
+    const requests = await refreshRequestsCache(lidarrClient, { force: forceRefresh });
     res.json(requests);
   } catch (error) {
     if (lastRequestsResponse) {

--- a/backend/routes/settings/handlers/storageHealth.js
+++ b/backend/routes/settings/handlers/storageHealth.js
@@ -2,12 +2,35 @@ import { noCache } from "../../../middleware/cache.js";
 import { logger } from "../../../services/logger.js";
 
 export function registerStorageHealth(router) {
-  router.get("/storage-health", noCache, async (req, res) => {
+  router.get("/storage-health", noCache, async (_req, res) => {
+    try {
+      const { getStorageHealthSnapshot } =
+        await import("../../../services/storageHealthService.js");
+      const result = getStorageHealthSnapshot() || {
+        ok: null,
+        partial: false,
+        checkedAt: null,
+        sections: [],
+        unavailable: true,
+      };
+      res.json({
+        success: result.ok === true,
+        ...result,
+      });
+    } catch (error) {
+      logger.error("settings", "Storage health check error:", error);
+      res.status(500).json({
+        error: "Storage health check failed",
+        message: error.message,
+      });
+    }
+  });
+
+  router.post("/storage-health/check", noCache, async (_req, res) => {
     try {
       const { runStorageHealthCheck } =
         await import("../../../services/storageHealthService.js");
-      const force = req.query.force === "1" || req.query.force === "true";
-      const result = await runStorageHealthCheck({ force });
+      const result = await runStorageHealthCheck({ force: true });
       res.json({
         success: result.ok,
         ...result,

--- a/backend/routes/weeklyFlow/handlers/stream.js
+++ b/backend/routes/weeklyFlow/handlers/stream.js
@@ -51,9 +51,6 @@ export function registerStream(router) {
     if (!resolved) {
       return res.status(404).json({ error: "Track file missing" });
     }
-    if (resolved.migratedFrom) {
-      downloadTracker.setDone(job.id, resolved.path, job.albumName || null);
-    }
     const safePath = resolved.path;
     try {
       await fsp.access(safePath);

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,10 @@ import { authMiddleware, isProxyAuthEnabled } from "./middleware/auth.js";
 import { handleOidcCallback, isOidcEnabled } from "./services/oidcAuth.js";
 import { logger } from "./services/logger.js";
 import { websocketService } from "./services/websocketService.js";
-import { getAllDownloadStatuses } from "./routes/library/handlers/downloads.js";
+import {
+  getLidarrStatusSnapshot,
+  hasActiveLidarrStatusSnapshot,
+} from "./routes/library/handlers/downloads.js";
 import { getWeeklyFlowStatusSnapshot } from "./services/weeklyFlow/weeklyFlowStatusSnapshot.js";
 
 import settingsRouter from "./routes/settings/index.js";
@@ -302,17 +305,19 @@ const broadcastDownloadStatuses = async () => {
   if (downloadStatusBroadcastInFlight) return;
   downloadStatusBroadcastInFlight = true;
   try {
-    if (!hasWsSubscribers("downloads")) return;
-    const { lidarrClient } = await import("./services/lidarrClient.js");
-    if (lidarrClient.isCircuitOpen()) return;
-    const statuses = await getAllDownloadStatuses();
-    const payload = JSON.stringify(statuses);
+    if (!hasWsSubscribers("downloads") && !hasActiveLidarrStatusSnapshot()) return;
+    const snapshot = await getLidarrStatusSnapshot();
+    const message = {
+      type: "download_statuses",
+      statuses: snapshot.statuses,
+      stale: snapshot.stale,
+      error: snapshot.error,
+      updatedAt: snapshot.updatedAt,
+    };
+    const payload = JSON.stringify(message);
     if (payload !== lastDownloadStatusesPayload) {
       lastDownloadStatusesPayload = payload;
-      websocketService.broadcast("downloads", {
-        type: "download_statuses",
-        statuses,
-      });
+      websocketService.broadcast("downloads", message);
     }
   } catch (error) {
     logger.warn("system", "Failed to broadcast download statuses:", { message: error.message });

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -38,7 +38,7 @@ const buildArtist = (artist, albumsByArtistId) => {
     canonicalId: artist.id,
     providerId,
     mbid: artist.mbid,
-    foreignArtistId: artist.mbid || artist.identityKey,
+    foreignArtistId: artist.metadata?.foreignArtistId || artist.mbid || artist.identityKey,
     artistName: artist.name,
     name: artist.name,
     sortName: artist.sortName,

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -1,5 +1,6 @@
 import {
   getCanonicalLibrary,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForAlbumReferences,
   getCanonicalLibraryForArtists,
   getCanonicalTrackPath,
@@ -163,6 +164,16 @@ export function getCanonicalLibraryReadModelForArtists({
 } = {}) {
   return buildCanonicalLibraryReadModel(
     getCanonicalLibraryForArtists({ source, availableOnly, mbids }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForArtistReferences({
+  source = "lidarr",
+  availableOnly = true,
+  references = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({ source, availableOnly, references }),
   );
 }
 

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -1,11 +1,11 @@
 import {
-  getCanonicalLibrary,
+  getCanonicalArtistPage,
+  getCanonicalLibraryForAlbumIds,
   getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryForArtists,
   getCanonicalTrackPath,
 } from "./libraryQueryService.js";
-
-const readModelCache = new WeakMap();
 
 const albumFiles = (track, albumId) =>
   (track.files || []).filter((file) => file.albumId == null || file.albumId === albumId);
@@ -30,8 +30,13 @@ const recordMatches = (record, reference) => {
 
 const buildArtist = (artist, albumsByArtistId) => {
   const artistAlbums = albumsByArtistId.get(artist.id) || [];
-  const trackCount = artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
-  const sizeOnDisk = artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
+  const hasSummary = artist.albumCount !== undefined;
+  const trackCount = hasSummary
+    ? Number(artist.trackCount || 0)
+    : artistAlbums.reduce((count, album) => count + album.trackIds.length, 0);
+  const sizeOnDisk = hasSummary
+    ? Number(artist.sizeOnDisk || 0)
+    : artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
   const providerId = artist.metadata?.id ?? null;
   return {
     id: artist.id,
@@ -51,7 +56,7 @@ const buildArtist = (artist, albumsByArtistId) => {
       "none",
     addOptions: artist.metadata?.addOptions || null,
     statistics: {
-      albumCount: artistAlbums.length,
+      albumCount: hasSummary ? Number(artist.albumCount || 0) : artistAlbums.length,
       trackCount,
       sizeOnDisk,
     },
@@ -147,13 +152,18 @@ export function buildCanonicalLibraryReadModel(library) {
   return { artists: readArtists, albums: readAlbums, tracks: readTracks };
 }
 
-export function getCanonicalLibraryReadModel({ source = "lidarr", availableOnly = true } = {}) {
-  const library = getCanonicalLibrary({ source, availableOnly });
-  const cached = readModelCache.get(library);
-  if (cached) return cached;
-  const readModel = buildCanonicalLibraryReadModel(library);
-  readModelCache.set(library, readModel);
-  return readModel;
+export function getCanonicalLibraryReadModelForArtistPage({
+  source = "lidarr",
+  availableOnly = true,
+  limit = 10000,
+  offset = 0,
+} = {}) {
+  const library = getCanonicalArtistPage({ source, availableOnly, limit, offset, includeStats: true });
+  return {
+    artists: library.artists.map((artist) => buildArtist(artist, new Map())),
+    albums: [],
+    tracks: [],
+  };
 }
 
 export function getCanonicalLibraryReadModelForArtists({
@@ -163,6 +173,26 @@ export function getCanonicalLibraryReadModelForArtists({
 } = {}) {
   return buildCanonicalLibraryReadModel(
     getCanonicalLibraryForArtists({ source, availableOnly, mbids }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForArtistReferences({
+  source = "all",
+  availableOnly = false,
+  references = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({ source, availableOnly, references }),
+  );
+}
+
+export function getCanonicalLibraryReadModelForAlbumIds({
+  source = "lidarr",
+  availableOnly = true,
+  ids = [],
+} = {}) {
+  return buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForAlbumIds({ source, availableOnly, ids }),
   );
 }
 

--- a/backend/services/discovery/playlists.js
+++ b/backend/services/discovery/playlists.js
@@ -1,6 +1,6 @@
 import { dbOps } from "../../db/helpers/index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { logger } from "../logger.js";
 import { buildExistingArtistKeySet } from "./recommendationPipeline.js";
 import { websocketService } from "../websocketService.js";
@@ -85,10 +85,7 @@ export const runQueuedDiscoverPlaylistBuild = async (payload = {}) => {
           recordDiscoverPlaylistBuildProgress("Building recommended playlists...");
         }
 
-        const allLibraryArtistsRaw = await libraryManager.getAllArtists();
-        const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-          ? allLibraryArtistsRaw
-          : [];
+        const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
         const existingArtistKeys = buildExistingArtistKeySet(allLibraryArtists);
         const { generateDiscoverPlaylists } =
           await import("./playlistBuilder.js");

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -13,7 +13,7 @@ import {
   getListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import {
   buildExistingArtistKeySet,
   buildDiscoverySeedList,
@@ -440,16 +440,9 @@ export const updateDiscoveryCache = async (options = {}) => {
     .catch((err) => { logger.warn('discovery', err); });
 
   try {
-    const { libraryManager, getCachedArtists } = await import("../libraryManager.js");
     recordDiscoveryUpdateProgress("loading_sources", "Loading library artists", 12);
-    const cachedArtists = getCachedArtists();
-    const [recentLibraryArtists, allLibraryArtistsRaw] = await Promise.all([
-      libraryManager.getRecentArtists(40),
-      cachedArtists.length > 0 ? cachedArtists : libraryManager.getAllArtists(),
-    ]);
-    const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-      ? allLibraryArtistsRaw
-      : [];
+    const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+    const recentLibraryArtists = allLibraryArtists.slice(0, 40);
     const libraryArtists =
       recentLibraryArtists.length > 0
         ? recentLibraryArtists
@@ -901,10 +894,7 @@ export const updateUserDiscoveryCache = async (
   }
 
   try {
-    const allLibraryArtistsRaw = await libraryManager.getAllArtists();
-    const allLibraryArtists = Array.isArray(allLibraryArtistsRaw)
-      ? allLibraryArtistsRaw
-      : [];
+    const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
     const existingArtistKeys = buildExistingArtistKeySet(allLibraryArtists);
 
     const lastfmHealth = { success: 0, failure: 0 };

--- a/backend/services/discovery/provider.js
+++ b/backend/services/discovery/provider.js
@@ -13,7 +13,10 @@ import {
   getListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
-import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
+import {
+  getCanonicalArtistKeyProjection,
+  iterateCanonicalArtistProjection,
+} from "../libraryQueryService.js";
 import {
   buildExistingArtistKeySet,
   buildDiscoverySeedList,
@@ -894,8 +897,7 @@ export const updateUserDiscoveryCache = async (
   }
 
   try {
-    const allLibraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-    const existingArtistKeys = buildExistingArtistKeySet(allLibraryArtists);
+    const existingArtistKeys = buildExistingArtistKeySet(getCanonicalArtistKeyProjection());
 
     const lastfmHealth = { success: 0, failure: 0 };
     const discoveryPeriod = getLastfmDiscoveryPeriod();

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -1,3 +1,4 @@
+import { getCanonicalLibraryPage, iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { libraryManager } from "../libraryManager.js";
 
 const RECENT_RELEASE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
@@ -31,26 +32,48 @@ function resolveDayMs(value) {
 }
 
 export async function getRecentMissingReleases(limit = 24, options = {}) {
-  const { lidarrClient } = await import("../lidarrClient.js");
-  if (!lidarrClient.isConfigured()) {
-    return [];
-  }
-
   const providedArtists =
     Array.isArray(options?.artists) && options.artists.length > 0 ? options.artists : null;
   const providedAlbums = Array.isArray(options?.albums) ? options.albums : null;
   let artists = providedArtists;
   let albums = providedAlbums;
+  let canonicalAlbums = false;
 
   if (!artists && !albums) {
-    [artists, albums] = await Promise.all([
-      lidarrClient.request("/artist"),
-      lidarrClient.getAllAlbums(),
-    ]);
+    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+    albums = [];
+    canonicalAlbums = true;
+    for (let page = 1; ; page += 1) {
+      const result = getCanonicalLibraryPage({
+        source: "all",
+        availableOnly: false,
+        kind: "albums",
+        page,
+        pageSize: 100,
+        sort: "newest",
+        direction: "desc",
+      });
+      albums.push(...result.items);
+      if (!result.hasMore) break;
+    }
   } else if (!artists) {
-    artists = await lidarrClient.request("/artist");
+    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   } else if (!albums) {
-    albums = await lidarrClient.getAllAlbums();
+    albums = [];
+    canonicalAlbums = true;
+    for (let page = 1; ; page += 1) {
+      const result = getCanonicalLibraryPage({
+        source: "all",
+        availableOnly: false,
+        kind: "albums",
+        page,
+        pageSize: 100,
+        sort: "newest",
+        direction: "desc",
+      });
+      albums.push(...result.items);
+      if (!result.hasMore) break;
+    }
   }
 
   if (!Array.isArray(albums) || albums.length === 0) {
@@ -59,10 +82,10 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
 
   const artistsById = new Map();
   if (Array.isArray(artists)) {
-    await libraryManager.backfillLidarrArtistMappings(artists);
+    if (!canonicalAlbums) await libraryManager.backfillLidarrArtistMappings(artists);
     artists.forEach((artist) => {
       if (artist?.id != null) {
-        const mappedArtist = libraryManager.mapLidarrArtist(artist);
+        const mappedArtist = canonicalAlbums ? artist : libraryManager.mapLidarrArtist(artist);
         mappedArtist.artistName = mappedArtist.artistName || artist.name || null;
         artistsById.set(artist.id, mappedArtist);
         artistsById.set(String(artist.id), mappedArtist);
@@ -74,6 +97,32 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
   const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
   const today = resolveDayMs(now);
   const includeFuture = options?.includeFuture !== false;
+
+  if (canonicalAlbums) {
+    return albums
+      .map((album) => {
+        const artist = artistsById.get(album.artistId) || artistsById.get(String(album.artistId));
+        const releaseDate = album.releaseDate || null;
+        const releaseTime = new Date(releaseDate).getTime();
+        if (!artist || !releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
+          return null;
+        }
+        const releaseDay = resolveDayMs(releaseDate);
+        if (!includeFuture && releaseDay != null && today != null && releaseDay > today) return null;
+        if (Number(album.statistics?.trackFileCount || 0) > 0 || Number(album.statistics?.sizeOnDisk || 0) > 0) {
+          return null;
+        }
+        return {
+          ...album,
+          artistName: artist.artistName || artist.name || null,
+          artistMbid: artist.mbid || artist.foreignArtistId || null,
+          foreignArtistId: artist.foreignArtistId || artist.mbid || null,
+        };
+      })
+      .filter(Boolean)
+      .sort((left, right) => String(right.releaseDate || "").localeCompare(String(left.releaseDate || "")))
+      .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+  }
 
   return albums
     .map((album) => {

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -1,4 +1,7 @@
-import { getCanonicalLibraryPage, iterateCanonicalArtistProjection } from "../libraryQueryService.js";
+import {
+  getCanonicalAlbumsByReleaseDate,
+  iterateCanonicalArtistProjection,
+} from "../libraryQueryService.js";
 import { libraryManager } from "../libraryManager.js";
 
 const RECENT_RELEASE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
@@ -32,6 +35,11 @@ function resolveDayMs(value) {
 }
 
 export async function getRecentMissingReleases(limit = 24, options = {}) {
+  const now = resolveTimeMs(options?.now);
+  const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
+  const today = resolveDayMs(now);
+  const includeFuture = options?.includeFuture !== false;
+  const normalizedLimit = Math.max(1, Math.round(Number(limit) || 24));
   const providedArtists =
     Array.isArray(options?.artists) && options.artists.length > 0 ? options.artists : null;
   const providedAlbums = Array.isArray(options?.albums) ? options.albums : null;
@@ -40,40 +48,23 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
   let canonicalAlbums = false;
 
   if (!artists && !albums) {
-    artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-    albums = [];
     canonicalAlbums = true;
-    for (let page = 1; ; page += 1) {
-      const result = getCanonicalLibraryPage({
-        source: "all",
-        availableOnly: false,
-        kind: "albums",
-        page,
-        pageSize: 100,
-        sort: "newest",
-        direction: "desc",
-      });
-      albums.push(...result.items);
-      if (!result.hasMore) break;
-    }
+    albums = getCanonicalAlbumsByReleaseDate({
+      from: new Date(recentCutoff).toISOString().slice(0, 10),
+      to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
+      limit: normalizedLimit,
+      missingOnly: true,
+    });
   } else if (!artists) {
     artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   } else if (!albums) {
-    albums = [];
     canonicalAlbums = true;
-    for (let page = 1; ; page += 1) {
-      const result = getCanonicalLibraryPage({
-        source: "all",
-        availableOnly: false,
-        kind: "albums",
-        page,
-        pageSize: 100,
-        sort: "newest",
-        direction: "desc",
-      });
-      albums.push(...result.items);
-      if (!result.hasMore) break;
-    }
+    albums = getCanonicalAlbumsByReleaseDate({
+      from: new Date(recentCutoff).toISOString().slice(0, 10),
+      to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
+      limit: normalizedLimit,
+      missingOnly: true,
+    });
   }
 
   if (!Array.isArray(albums) || albums.length === 0) {
@@ -93,35 +84,27 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
     });
   }
 
-  const now = resolveTimeMs(options?.now);
-  const recentCutoff = now - RECENT_RELEASE_WINDOW_MS;
-  const today = resolveDayMs(now);
-  const includeFuture = options?.includeFuture !== false;
-
   if (canonicalAlbums) {
     return albums
       .map((album) => {
-        const artist = artistsById.get(album.artistId) || artistsById.get(String(album.artistId));
         const releaseDate = album.releaseDate || null;
         const releaseTime = new Date(releaseDate).getTime();
-        if (!artist || !releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
+        if (!releaseDate || !Number.isFinite(releaseTime) || releaseTime < recentCutoff) {
           return null;
         }
         const releaseDay = resolveDayMs(releaseDate);
         if (!includeFuture && releaseDay != null && today != null && releaseDay > today) return null;
-        if (Number(album.statistics?.trackFileCount || 0) > 0 || Number(album.statistics?.sizeOnDisk || 0) > 0) {
-          return null;
-        }
+        if (Number(album.availableTrackCount || 0) > 0) return null;
         return {
           ...album,
-          artistName: artist.artistName || artist.name || null,
-          artistMbid: artist.mbid || artist.foreignArtistId || null,
-          foreignArtistId: artist.foreignArtistId || artist.mbid || null,
+          artistName: album.artistName || null,
+          artistMbid: album.artistMbid || album.foreignArtistId || null,
+          foreignArtistId: album.foreignArtistId || album.artistMbid || null,
         };
       })
       .filter(Boolean)
       .sort((left, right) => String(right.releaseDate || "").localeCompare(String(left.releaseDate || "")))
-      .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+      .slice(0, normalizedLimit);
   }
 
   return albums
@@ -153,5 +136,5 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
       const dateB = right.releaseDate || "";
       return dateB.localeCompare(dateA);
     })
-    .slice(0, Math.max(1, Math.round(Number(limit) || 24)));
+    .slice(0, normalizedLimit);
 }

--- a/backend/services/discovery/recentReleases.js
+++ b/backend/services/discovery/recentReleases.js
@@ -64,6 +64,7 @@ export async function getRecentMissingReleases(limit = 24, options = {}) {
       to: includeFuture ? null : new Date(today).toISOString().slice(0, 10),
       limit: normalizedLimit,
       missingOnly: true,
+      artistIds: providedArtists.map((artist) => artist?.canonicalId || artist?.id),
     });
   }
 

--- a/backend/services/discovery/recommendationPipeline.js
+++ b/backend/services/discovery/recommendationPipeline.js
@@ -738,9 +738,14 @@ export const rerankRecommendations = (recommendations = [], limit = 100, options
 };
 
 export const filterRecommendationsForServe = (recommendations = [], feedback = []) =>
-  (Array.isArray(recommendations) ? recommendations : []).filter(
-    (recommendation) => !feedbackBoostForCandidate(recommendation, feedback).hidden,
-  );
+  (Array.isArray(recommendations) ? recommendations : [])
+    .filter((recommendation) => !feedbackBoostForCandidate(recommendation, feedback).hidden)
+    .map((recommendation) => {
+      const mbid = normalizeMbid(recommendation?.id) || normalizeMbid(recommendation?.navigateTo);
+      return recommendation?.id === mbid && recommendation?.navigateTo === mbid
+        ? recommendation
+        : { ...recommendation, id: mbid, navigateTo: mbid };
+    });
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -867,9 +872,11 @@ export const mergeResolvedRecommendations = (
   for (const recommendation of Array.isArray(recommendations) ? recommendations : []) {
     const keys = normalizeArtistIdentityKeys(recommendation);
     if (keys.some((key) => existingArtistKeys.has(key))) continue;
+    const recommendationMbid =
+      normalizeMbid(recommendation?.id) || normalizeMbid(recommendation?.navigateTo);
 
     const identityKeys = [
-      normalizeMbid(recommendation?.id),
+      recommendationMbid,
       `name:${normalizeText(recommendation?.name)}`,
     ].filter(Boolean);
     if (identityKeys.length === 0) continue;
@@ -880,6 +887,8 @@ export const mergeResolvedRecommendations = (
     if (!existing) {
       const entry = {
         ...recommendation,
+        id: recommendationMbid,
+        navigateTo: recommendationMbid,
         tags: Array.isArray(recommendation?.tags) ? [...recommendation.tags] : [],
         matchedTags: Array.isArray(recommendation?.matchedTags)
           ? [...recommendation.matchedTags]
@@ -912,9 +921,8 @@ export const mergeResolvedRecommendations = (
       continue;
     }
 
-    existing.id = existing.id || recommendation.id || null;
-    existing.navigateTo =
-      existing.navigateTo || recommendation.navigateTo || recommendation.id || null;
+    existing.id = existing.id || recommendationMbid;
+    existing.navigateTo = existing.navigateTo || recommendationMbid;
     existing.image = existing.image || recommendation.image || null;
     existing.popularityLabel = existing.popularityLabel || recommendation.popularityLabel || null;
     existing.popularityRank = existing.popularityRank || recommendation.popularityRank || null;

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -1,6 +1,6 @@
 import { dbOps } from "../../db/helpers/index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
+import { getCanonicalArtistProjection } from "../libraryQueryService.js";
 import {
   enqueueDiscoveryRefreshJob,
   getHonkerDb,
@@ -143,16 +143,25 @@ export function markDiscoveryRefreshDequeued() {
 export async function isDiscoveryRefreshConfigured() {
   const hasLastfm = !!getLastfmApiKey();
   if (hasLastfm) return true;
-  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-  return libraryArtists.length > 0;
+  return getCanonicalArtistProjection({ page: 1, pageSize: 1 }).length > 0;
 }
 
 export function discoveryNeedsRefresh(cache = getDiscoveryCache()) {
   const lastUpdated = cache?.lastUpdated;
+  const hasRecommendations =
+    Array.isArray(cache?.recommendations) && cache.recommendations.length > 0;
+  const hasGlobalTop =
+    Array.isArray(cache?.globalTop) && cache.globalTop.length > 0;
+  const hasGenres = Array.isArray(cache?.topGenres) && cache.topGenres.length > 0;
   const refreshHours = getDiscoveryAutoRefreshHours();
   const staleCutoff = Date.now() - refreshHours * 60 * 60 * 1000;
   const lastUpdatedAt = new Date(lastUpdated || "").getTime();
-  return !Number.isFinite(lastUpdatedAt) || lastUpdatedAt < staleCutoff;
+  return (
+    !Number.isFinite(lastUpdatedAt) ||
+    lastUpdatedAt < staleCutoff ||
+    (!hasRecommendations && !hasGlobalTop) ||
+    !hasGenres
+  );
 }
 
 function emitDiscoveryQueued(reason) {

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -149,17 +149,10 @@ export async function isDiscoveryRefreshConfigured() {
 
 export function discoveryNeedsRefresh(cache = getDiscoveryCache()) {
   const lastUpdated = cache?.lastUpdated;
-  const hasRecommendations =
-    Array.isArray(cache?.recommendations) && cache.recommendations.length > 0;
-  const hasGenres = Array.isArray(cache?.topGenres) && cache.topGenres.length > 0;
   const refreshHours = getDiscoveryAutoRefreshHours();
   const staleCutoff = Date.now() - refreshHours * 60 * 60 * 1000;
-  return (
-    !lastUpdated ||
-    new Date(lastUpdated).getTime() < staleCutoff ||
-    !hasRecommendations ||
-    !hasGenres
-  );
+  const lastUpdatedAt = new Date(lastUpdated || "").getTime();
+  return !Number.isFinite(lastUpdatedAt) || lastUpdatedAt < staleCutoff;
 }
 
 function emitDiscoveryQueued(reason) {
@@ -286,16 +279,6 @@ export async function bootstrapDiscoveryRefresh() {
   const result = await enqueueDiscoveryRefreshIfNeeded({ reason: "startup" });
   if (result.reason === "fresh") {
     const latest = getDiscoveryCache();
-    if (
-      (!latest.recommendations?.length && !latest.globalTop?.length) ||
-      !latest.topGenres?.length
-    ) {
-      const retry = enqueueDiscoveryRefresh({ reason: "startup_incomplete" });
-      if (retry.enqueued) {
-        console.log("Discovery cache timestamp exists but data is incomplete. Re-queued refresh.");
-      }
-      return;
-    }
     console.log(
       `Discovery cache is fresh (last updated ${latest.lastUpdated}). Scheduling next refresh.`,
     );

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -1,6 +1,6 @@
 import { dbOps } from "../../db/helpers/index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import {
   enqueueDiscoveryRefreshJob,
   getHonkerDb,
@@ -143,7 +143,7 @@ export function markDiscoveryRefreshDequeued() {
 export async function isDiscoveryRefreshConfigured() {
   const hasLastfm = !!getLastfmApiKey();
   if (hasLastfm) return true;
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   return libraryArtists.length > 0;
 }
 

--- a/backend/services/discovery/userDiscovery.js
+++ b/backend/services/discovery/userDiscovery.js
@@ -12,7 +12,7 @@ import {
   serveCachedRecommendations,
 } from "./index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
-import { libraryManager } from "../libraryManager.js";
+import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
 import { dbOps, userOps } from "../../db/helpers/index.js";
 import {
   DISCOVERY_PROVIDER_LASTFM,
@@ -38,7 +38,7 @@ import { getTopPlayedArtists } from "../playEventService.js";
 
 export async function getUserDiscovery(userId, limit = 50, offset = 0) {
   const hasLastfmKey = !!getLastfmApiKey();
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
 
   const reqUser = userOps.getUserById(userId);
   const externalListenHistoryProfile = getListenHistoryProfile(reqUser || {});

--- a/backend/services/discovery/userDiscovery.js
+++ b/backend/services/discovery/userDiscovery.js
@@ -1,11 +1,7 @@
-import { logger } from "../logger.js";
 import {
   getDiscoveryCache,
   getDiscoveryUpdateStatus,
   getDiscoveryPlaylistBuildStatus,
-  requestUserDiscoveryRefresh,
-  getUserDiscoveryCacheStaleness,
-  isGlobalDiscoveryRefreshInProgress,
   getDiscoveryMode,
   getDiscoveryFeedback,
   filterBlockedArtistsForUser,
@@ -13,11 +9,10 @@ import {
 } from "./index.js";
 import { getLastfmApiKey } from "../apiClients/index.js";
 import { iterateCanonicalArtistProjection } from "../libraryQueryService.js";
-import { dbOps, userOps } from "../../db/helpers/index.js";
+import { userOps } from "../../db/helpers/index.js";
 import {
   DISCOVERY_PROVIDER_LASTFM,
   DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK,
-  buildListenbrainzFallbackDiscovery,
   getDiscoveryCapabilities,
 } from "../listenbrainzDiscoveryFallback.js";
 import {
@@ -25,13 +20,9 @@ import {
   getListenHistoryProfile,
   hasListenHistoryProfile,
 } from "../listeningHistory.js";
-import { enqueueDiscoveryRefresh } from "./refreshScheduler.js";
 import {
   buildArtistKeySet,
   isLibraryArtist,
-  getDiscoveryRevalidateAt,
-  setDiscoveryRevalidateAt,
-  DISCOVERY_REVALIDATE_COOLDOWN_MS,
   getDiscoveryStaleMs,
 } from "../../routes/discovery/handlers/utils.js";
 import { getTopPlayedArtists } from "../playEventService.js";
@@ -52,63 +43,12 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     : hasLocalListenHistory
       ? { listenHistoryProvider: "lastfm", listenHistoryUsername: `__aurral_local_${userId}` }
       : externalListenHistoryProfile;
-  const localOnly = !hasExternalListenHistory && hasLocalListenHistory;
   const userCacheNamespace =
     getListenHistoryCacheNamespace(listenHistoryProfile);
   const effectiveCacheNamespace = hasLastfmKey ? userCacheNamespace : null;
 
-  if (
-    hasListenHistoryProfile(listenHistoryProfile) &&
-    hasLastfmKey &&
-    !isGlobalDiscoveryRefreshInProgress()
-  ) {
-    const staleness = getUserDiscoveryCacheStaleness(userCacheNamespace);
-    const staleMs = await getDiscoveryStaleMs();
-    if (staleness > staleMs) {
-      requestUserDiscoveryRefresh(listenHistoryProfile, {
-        feedbackUserId: userId || null,
-        localOnly,
-      }).catch((err) => {
-        logger.error("discovery", `On-demand refresh for ${listenHistoryProfile.listenHistoryProvider}:${listenHistoryProfile.listenHistoryUsername} failed`, { error: err.message });
-      });
-    }
-  }
-
-  let discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
-
-  const hasData =
-    discoveryCache.recommendations?.length > 0 ||
-    discoveryCache.globalTop?.length > 0 ||
-    discoveryCache.topGenres?.length > 0 ||
-    discoveryCache.fallbackGenres?.length > 0;
-  const hasCompletedRefresh =
-    !!discoveryCache.lastUpdated &&
-    (discoveryCache.recommendations?.length > 0 ||
-      discoveryCache.globalTop?.length > 0 ||
-      discoveryCache.topGenres?.length > 0 ||
-      discoveryCache.fallbackGenres?.length > 0);
-
-  let isUpdating = discoveryCache.isUpdating || false;
-
-  if (
-    !hasLastfmKey &&
-    (!hasData ||
-      discoveryCache.provider !== DISCOVERY_PROVIDER_LISTENBRAINZ_FALLBACK)
-  ) {
-    const fallbackData = await buildListenbrainzFallbackDiscovery({
-      existingArtistKeys: buildArtistKeySet(libraryArtists),
-    });
-    dbOps.updateDiscoveryCache(fallbackData);
-    Object.assign(getDiscoveryCache(), fallbackData, { isUpdating: false });
-    discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
-    isUpdating = false;
-  } else if (!hasData && !hasCompletedRefresh && !isUpdating) {
-    setDiscoveryRevalidateAt(Date.now());
-    const lazyRefresh = enqueueDiscoveryRefresh({ reason: "lazy" });
-    if (lazyRefresh.enqueued) {
-      isUpdating = true;
-    }
-  }
+  const discoveryCache = getDiscoveryCache(effectiveCacheNamespace);
+  const isUpdating = discoveryCache.isUpdating || false;
 
   let {
     recommendations,
@@ -176,19 +116,6 @@ export async function getUserDiscovery(userId, limit = 50, offset = 0) {
     Number.isFinite(parsedLastUpdated) &&
     parsedLastUpdated > 0 &&
     Date.now() - parsedLastUpdated > staleMs;
-
-  if (
-    isStale &&
-    !isUpdating &&
-    !hasListenHistoryProfile(listenHistoryProfile) &&
-    Date.now() - getDiscoveryRevalidateAt() > DISCOVERY_REVALIDATE_COOLDOWN_MS
-  ) {
-    setDiscoveryRevalidateAt(Date.now());
-    const staleRefresh = enqueueDiscoveryRefresh({ reason: "stale" });
-    if (staleRefresh.enqueued) {
-      isUpdating = true;
-    }
-  }
 
   const cacheStrategy =
     recommendations.length > 0 || globalTop.length > 0

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -38,6 +38,7 @@ let honkerSchedulerAbort = null;
 let honkerSchedulerPromise = null;
 const WORKER_ID = `aurral-${process.pid}`;
 const DEFAULT_HONKER_WATCHER_POLL_MS = 25;
+const MISSED_FIRE_GRACE_S = 300;
 
 export function getHonkerOpenOptions() {
   const configured = Number(process.env.AURRAL_HONKER_WATCHER_POLL_MS);
@@ -393,7 +394,8 @@ export function bootstrapHonkerSchedules() {
     const updates = {};
     if (
       existing.cron_expr !== task.schedule ||
-      Number(existing.next_fire_at || 0) <= Math.floor(Date.now() / 1000)
+      Number(existing.next_fire_at || 0) <=
+        Math.floor(Date.now() / 1000) - MISSED_FIRE_GRACE_S
     ) {
       updates.schedule = task.schedule;
     }
@@ -460,6 +462,7 @@ export function findActiveHonkerJob(
           OR (state = 'processing' AND (claim_expires_at IS NULL OR claim_expires_at > ?))
         )
       ORDER BY id ASC
+      LIMIT 100
     `,
     [safeQueue, now],
   );

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -139,6 +139,17 @@ function resolveEnqueueRunAt(options) {
   return null;
 }
 
+function parseHonkerPayload(value) {
+  try {
+    const payload = typeof value === "string" ? JSON.parse(value) : value;
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? payload
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function createHonkerQueue({
   name,
   visibilityTimeoutS,
@@ -397,19 +408,61 @@ export function bootstrapHonkerSchedules() {
 }
 
 export function enqueueHonkerStartupTasks() {
+  const enqueueIfAbsent = (payload, options) => {
+    const existing = findActiveHonkerJob(
+      "system-task",
+      (candidate) => candidate?.kind === payload.kind,
+      { recoverExpired: true },
+    );
+    return existing?.id || enqueueSystemTaskJob(payload, options);
+  };
   const migration = dbOps.getJSONSetting(PLAYLIST_STARTUP_MIGRATION_SETTING);
   if (
     migration?.version !== PLAYLIST_STARTUP_MIGRATION_VERSION ||
     path.resolve(String(migration?.rootPath || "")) !== resolvePlaylistRoot()
   ) {
-    enqueueSystemTaskJob(
+    enqueueIfAbsent(
       { kind: "playlist-startup-migration" },
       { delaySeconds: 3, priority: 10 },
     );
   }
-  enqueueSystemTaskJob({ kind: "weekly-flow-startup-check" }, { delaySeconds: 5, priority: 5 });
-  enqueueSystemTaskJob({ kind: "discovery-bootstrap" }, { delaySeconds: 15, priority: 5 });
-  enqueueSystemTaskJob({ kind: "library-index-bootstrap" }, { delaySeconds: 8, priority: 0 });
+  enqueueIfAbsent({ kind: "weekly-flow-startup-check" }, { delaySeconds: 5, priority: 5 });
+  enqueueIfAbsent({ kind: "discovery-bootstrap" }, { delaySeconds: 15, priority: 5 });
+  enqueueIfAbsent({ kind: "library-index-bootstrap" }, { delaySeconds: 8, priority: 0 });
+}
+
+export function findActiveHonkerJob(
+  queueName,
+  predicate = () => true,
+  { recoverExpired = false } = {},
+) {
+  const safeQueue = String(queueName || "").trim();
+  if (!safeQueue) return null;
+  const queue = getHonkerQueueByName(safeQueue);
+  if (recoverExpired) {
+    try {
+      queue?.sweepExpired();
+    } catch {}
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const rows = getHonkerDb().query(
+    `
+      SELECT id, payload, state, run_at, claim_expires_at, attempts
+      FROM _honker_live
+      WHERE queue = ?
+        AND (
+          state = 'pending'
+          OR (state = 'processing' AND (claim_expires_at IS NULL OR claim_expires_at > ?))
+        )
+      ORDER BY id ASC
+    `,
+    [safeQueue, now],
+  );
+  for (const row of rows) {
+    const payload = parseHonkerPayload(row.payload);
+    if (predicate(payload, row)) return { ...row, payload };
+  }
+  return null;
 }
 
 export function startHonkerScheduler() {

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -391,7 +391,12 @@ export function bootstrapHonkerSchedules() {
     }
 
     const updates = {};
-    if (existing.cron_expr !== task.schedule) updates.schedule = task.schedule;
+    if (
+      existing.cron_expr !== task.schedule ||
+      Number(existing.next_fire_at || 0) <= Math.floor(Date.now() / 1000)
+    ) {
+      updates.schedule = task.schedule;
+    }
     if (existing.payload !== payloadText) updates.payload = task.payload;
     if (Number(existing.priority) !== priority) updates.priority = priority;
     if ((existing.expires_s ?? null) !== expiresS) updates.expiresS = expiresS;

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,7 +1,7 @@
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
 import {
-  getCanonicalLibraryPage,
+  getCanonicalAlbumsByReleaseDate,
   iterateCanonicalArtistProjection,
 } from "./libraryQueryService.js";
 import { getNearbyShows } from "./nearbyShowsService.js";
@@ -51,42 +51,23 @@ const upsertAll = (items) => {
 };
 
 async function buildReleaseItems(userId, now) {
-  const rawArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
-  const rawAlbums = [];
-  for (let page = 1; ; page += 1) {
-    const result = getCanonicalLibraryPage({
-      source: "all",
-      availableOnly: false,
-      kind: "albums",
-      page,
-      pageSize: 100,
-      sort: "newest",
-      direction: "desc",
-    });
-    rawAlbums.push(...result.items);
-    if (!result.hasMore) break;
-  }
-
-  const artistsById = new Map(
-    rawArtists.flatMap((artist) => [
-      [String(artist?.id), artist],
-      [artist?.id, artist],
-    ]),
-  );
   const cutoff = now - RELEASE_PAST_DAYS * DAY_MS;
   const horizon = now + RELEASE_FUTURE_DAYS * DAY_MS;
+  const rawAlbums = getCanonicalAlbumsByReleaseDate({
+    from: new Date(cutoff).toISOString().slice(0, 10),
+    to: new Date(horizon).toISOString().slice(0, 10),
+    limit: 1000,
+  });
   const seen = new Set();
 
   return rawAlbums
     .map((album) => {
-      const artist = artistsById.get(String(album?.artistId));
       const releaseMbid = String(album?.foreignAlbumId || "").trim();
       const releaseDate = album?.releaseDate || null;
       const releaseTime = toTime(releaseDate);
-      const artistMbid = String(artist?.foreignArtistId || "").trim();
-      const artistName = String(artist?.artistName || artist?.name || "").trim();
+      const artistMbid = String(album?.foreignArtistId || album?.artistMbid || "").trim();
+      const artistName = String(album?.artistName || "").trim();
       if (
-        !artist ||
         !releaseMbid ||
         !artistMbid ||
         !artistName ||

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,6 +1,9 @@
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
-import { libraryManager } from "./libraryManager.js";
+import {
+  getCanonicalLibraryPage,
+  iterateCanonicalArtistProjection,
+} from "./libraryQueryService.js";
 import { getNearbyShows } from "./nearbyShowsService.js";
 import { getUserDiscovery } from "./discovery/userDiscovery.js";
 import { logger } from "./logger.js";
@@ -48,13 +51,21 @@ const upsertAll = (items) => {
 };
 
 async function buildReleaseItems(userId, now) {
-  const { lidarrClient } = await import("./lidarrClient.js");
-  if (!lidarrClient?.isConfigured()) return [];
-  const [rawArtists, rawAlbums] = await Promise.all([
-    lidarrClient.request("/artist"),
-    lidarrClient.getAllAlbums(),
-  ]);
-  if (!Array.isArray(rawArtists) || !Array.isArray(rawAlbums)) return [];
+  const rawArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+  const rawAlbums = [];
+  for (let page = 1; ; page += 1) {
+    const result = getCanonicalLibraryPage({
+      source: "all",
+      availableOnly: false,
+      kind: "albums",
+      page,
+      pageSize: 100,
+      sort: "newest",
+      direction: "desc",
+    });
+    rawAlbums.push(...result.items);
+    if (!result.hasMore) break;
+  }
 
   const artistsById = new Map(
     rawArtists.flatMap((artist) => [
@@ -263,7 +274,7 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
     const now = Date.now();
     const preferences = getInboxPreferences();
     const libraryArtists = preferences.shows
-      ? await libraryManager.getAllArtists()
+      ? [...iterateCanonicalArtistProjection({ pageSize: 100 })]
       : [];
     const enabledNewsKinds = new Set(
       getEnabledKinds(preferences).filter((kind) =>

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -1,3 +1,4 @@
+import { db } from "../config/db-sqlite.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { getTicketmasterApiKey } from "./apiClients/index.js";
 import {
@@ -8,12 +9,19 @@ import { getNearbyShows } from "./nearbyShowsService.js";
 import { getUserDiscovery } from "./discovery/userDiscovery.js";
 import { logger } from "./logger.js";
 import { getNewsForUser, getNewsPreferences } from "./newsService.js";
+import {
+  enqueueSystemTaskJob,
+  findActiveHonkerJob,
+  getHonkerDb,
+  withHonkerLock,
+} from "./honkerDb.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RELEASE_PAST_DAYS = 30;
 const RELEASE_FUTURE_DAYS = 90;
 const CONTENT_TTL_MS = 30 * DAY_MS;
 const REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
+const INBOX_REFRESH_STATUS_PREFIX = "inboxRefresh:";
 const refreshState = new Map();
 const refreshInflight = new Map();
 
@@ -45,6 +53,119 @@ const getEnabledKinds = (preferences) =>
   })
     .filter(([, enabled]) => enabled)
     .map(([kind]) => kind);
+
+const normalizeUserId = (userId) => {
+  const normalized = Number(userId);
+  return Number.isInteger(normalized) && normalized > 0 ? normalized : null;
+};
+
+const getInboxRefreshStatusKey = (userId) =>
+  `${INBOX_REFRESH_STATUS_PREFIX}${normalizeUserId(userId)}`;
+
+const parsePayload = (value) => {
+  try {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
+};
+
+const getInboxRefreshJob = (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) return null;
+  const rows = getHonkerDb().query(
+    `
+      SELECT id, payload, state, run_at, claim_expires_at
+      FROM _honker_live
+      WHERE queue = 'system-task'
+        AND state IN ('pending', 'processing')
+      ORDER BY id ASC
+    `,
+  );
+  return rows.find((row) => {
+    const payload = parsePayload(row.payload);
+    return payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId;
+  }) || null;
+};
+
+const getStoredRefreshStatus = (userId) =>
+  dbOps.getJSONSetting(getInboxRefreshStatusKey(userId)) || {
+    status: "idle",
+    stale: false,
+    error: null,
+    updatedAt: null,
+    lastSuccessAt: null,
+    jobId: null,
+  };
+
+const setStoredRefreshStatus = (userId, status) => {
+  dbOps.setJSONSetting(getInboxRefreshStatusKey(userId), {
+    ...getStoredRefreshStatus(userId),
+    ...status,
+    updatedAt: Date.now(),
+  });
+};
+
+export function getInboxRefreshStatus(userId) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return {
+      status: "idle",
+      stale: false,
+      error: null,
+      updatedAt: null,
+      lastSuccessAt: null,
+      jobId: null,
+    };
+  }
+
+  const stored = getStoredRefreshStatus(normalizedUserId);
+  const job = getInboxRefreshJob(normalizedUserId);
+  if (job) {
+    const leaseExpired =
+      job.state === "processing" &&
+      job.claim_expires_at != null &&
+      Number(job.claim_expires_at) <= Math.floor(Date.now() / 1000);
+    const active =
+      !leaseExpired &&
+      (job.state === "pending" ||
+        job.claim_expires_at == null ||
+        Number(job.claim_expires_at) > Math.floor(Date.now() / 1000));
+    if (active) {
+      const status = job.state === "processing" ? "running" : "queued";
+      return {
+        ...stored,
+        status,
+        stale: false,
+        error: null,
+        jobId: Number(job.id),
+      };
+    }
+    if (leaseExpired) {
+      return {
+        ...stored,
+        status: "stale",
+        stale: true,
+        error: stored.error || "Inbox refresh worker lease expired",
+        jobId: Number(job.id),
+      };
+    }
+  }
+
+  if (refreshInflight.has(normalizedUserId)) {
+    return { ...stored, status: "running", stale: false, error: null };
+  }
+
+  if (stored.status === "queued" || stored.status === "running") {
+    return {
+      ...stored,
+      status: "stale",
+      stale: true,
+      error: stored.error || "Inbox refresh job is no longer active",
+    };
+  }
+  return stored;
+}
 
 const upsertAll = (items) => {
   for (const item of items) dbOps.upsertInboxItem(item);
@@ -134,11 +255,13 @@ async function buildDiscoveryItems(userId, now) {
     .filter(Boolean);
 }
 
-async function buildShowItems(userId, now, req, zipCode, libraryArtists) {
+async function buildShowItems(userId, now, req, ipAddress, zipCode, libraryArtists) {
   const apiKey = getTicketmasterApiKey();
-  if (!apiKey || !req || !Array.isArray(libraryArtists) || libraryArtists.length === 0) return [];
+  if (!apiKey || (!req && !ipAddress) || !Array.isArray(libraryArtists) || libraryArtists.length === 0) {
+    return [];
+  }
   const result = await getNearbyShows({
-    req,
+    req: req || { headers: {}, ip: ipAddress },
     zipCode,
     libraryArtists,
     recommendedArtists: [],
@@ -236,11 +359,21 @@ const dismissBlockedNewsItems = (userId) => {
   }
 };
 
-export async function refreshInboxForUser(userId, { req = null, zipCode = "", force = false } = {}) {
-  const normalizedUserId = Number(userId);
-  if (!Number.isInteger(normalizedUserId) || normalizedUserId <= 0) return false;
+export async function refreshInboxForUser(
+  userId,
+  {
+    req = null,
+    ipAddress = "",
+    zipCode = "",
+    force = false,
+    throwOnFailure = false,
+    jobId = null,
+  } = {},
+) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) return false;
   const state = refreshState.get(normalizedUserId);
-  const hasLocationRequest = Boolean(req);
+  const hasLocationRequest = Boolean(req || ipAddress);
   if (
     !force &&
     state &&
@@ -253,6 +386,12 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
 
   const promise = (async () => {
     const now = Date.now();
+    setStoredRefreshStatus(normalizedUserId, {
+      status: "running",
+      stale: false,
+      error: null,
+      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+    });
     const preferences = getInboxPreferences();
     const libraryArtists = preferences.shows
       ? [...iterateCanonicalArtistProjection({ pageSize: 100 })]
@@ -265,21 +404,65 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
     const results = await Promise.allSettled([
       preferences.releases ? buildReleaseItems(normalizedUserId, now) : [],
       preferences.discoveries ? buildDiscoveryItems(normalizedUserId, now) : [],
-      preferences.shows ? buildShowItems(normalizedUserId, now, req, zipCode, libraryArtists) : [],
+      preferences.shows
+        ? buildShowItems(normalizedUserId, now, req, ipAddress, zipCode, libraryArtists)
+        : [],
       enabledNewsKinds.size > 0 ? buildNewsItems(normalizedUserId, now, enabledNewsKinds) : [],
     ]);
-    const items = results.flatMap((result) => {
-      if (result.status === "fulfilled") return result.value;
-      logger.warn("inbox", "Inbox source refresh failed", { error: result.reason?.message });
-      return [];
-    });
-    upsertAll(items.flat());
-    dismissBlockedNewsItems(normalizedUserId);
+    const sourceNames = ["releases", "discoveries", "shows", "news"];
+    const failures = results
+      .map((result, index) => ({ result, source: sourceNames[index] }))
+      .filter(({ result }) => result.status === "rejected");
+    for (const { result, source } of failures) {
+      logger.warn("inbox", "Inbox source refresh failed", {
+        source,
+        error: result.reason?.message,
+      });
+    }
+    const items = results
+      .filter((result) => result.status === "fulfilled")
+      .flatMap((result) => result.value);
+    db.transaction(() => {
+      upsertAll(items);
+      dismissBlockedNewsItems(normalizedUserId);
+    })();
     refreshState.set(normalizedUserId, { at: now, hadLocationRequest: hasLocationRequest });
-    return true;
+    const refreshStatus = failures.length === 0
+      ? "complete"
+      : failures.length === results.length
+        ? "failed"
+        : "stale";
+    const errorMessage = failures.length > 0
+      ? failures.map(({ result, source }) => `${source}: ${result.reason?.message || "failed"}`).join("; ")
+      : null;
+    setStoredRefreshStatus(normalizedUserId, {
+      status: refreshStatus,
+      stale: failures.length > 0,
+      error: errorMessage,
+      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+      lastSuccessAt:
+        failures.length === 0
+          ? now
+          : getStoredRefreshStatus(normalizedUserId).lastSuccessAt,
+    });
+    if (failures.length > 0 && throwOnFailure) {
+      const error = new Error(errorMessage);
+      error.inboxStatusWritten = true;
+      throw error;
+    }
+    return failures.length === 0;
   })().catch((error) => {
     logger.warn("inbox", "Inbox refresh failed", { userId: normalizedUserId, error: error.message });
     refreshState.set(normalizedUserId, { at: Date.now(), hadLocationRequest: hasLocationRequest });
+    if (!error.inboxStatusWritten) {
+      setStoredRefreshStatus(normalizedUserId, {
+        status: "failed",
+        stale: true,
+        error: error.message,
+        jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+      });
+    }
+    if (throwOnFailure) throw error;
     return false;
   }).finally(() => {
     refreshInflight.delete(normalizedUserId);
@@ -289,23 +472,73 @@ export async function refreshInboxForUser(userId, { req = null, zipCode = "", fo
   return promise;
 }
 
-export async function refreshInboxForAllUsers() {
-  for (const user of userOps.getAllUsers()) {
-    await refreshInboxForUser(user.id);
-  }
+export async function enqueueInboxRefreshForUser(
+  userId,
+  { reason = "manual", zipCode = "", ipAddress = "" } = {},
+) {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) throw new Error("A valid user is required");
+  return withHonkerLock(`inbox-refresh:${normalizedUserId}`, async () => {
+    const existing = findActiveHonkerJob(
+      "system-task",
+      (payload) =>
+        payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId,
+      { recoverExpired: true },
+    );
+    if (existing) {
+      return {
+        queued: false,
+        jobId: Number(existing.id),
+        status: existing.state === "processing" ? "running" : "queued",
+      };
+    }
+
+    const jobId = enqueueSystemTaskJob({
+      kind: "inbox-refresh",
+      userId: normalizedUserId,
+      reason: String(reason || "manual"),
+      zipCode: String(zipCode || "").trim(),
+      ipAddress: String(ipAddress || "").trim(),
+    }, { priority: reason === "manual" ? 5 : 0 });
+    setStoredRefreshStatus(normalizedUserId, {
+      status: "queued",
+      stale: false,
+      error: null,
+      reason,
+      jobId: Number(jobId),
+    });
+    return { queued: true, jobId: Number(jobId), status: "queued" };
+  });
 }
 
-export async function getInboxForUser(userId, options = {}) {
-  const refreshPromise = refreshInboxForUser(userId, options);
-  if (options.awaitRefresh !== false) await refreshPromise;
+export async function enqueueInboxRefreshForAllUsers(options = {}) {
+  const jobs = [];
+  for (const user of userOps.getAllUsers()) {
+    jobs.push(await enqueueInboxRefreshForUser(user.id, options));
+  }
+  return jobs;
+}
+
+export async function refreshInboxForAllUsers(options = {}) {
+  return enqueueInboxRefreshForAllUsers({ reason: "scheduled", ...options });
+}
+
+export function getInboxForUser(userId, options = {}) {
   const kinds = getEnabledKinds(getInboxPreferences());
+  const refreshStatus = getInboxRefreshStatus(userId);
   if (kinds.length === 0) {
-    return { items: [], unreadCount: 0, refreshing: refreshInflight.has(Number(userId)) };
+    return {
+      items: [],
+      unreadCount: 0,
+      refreshing: refreshStatus.status === "queued" || refreshStatus.status === "running",
+      refreshStatus,
+    };
   }
   return {
     items: dbOps.getInboxItems(userId, { limit: options.limit || 50, kinds }),
     unreadCount: dbOps.getInboxUnreadCount(userId, kinds),
-    refreshing: refreshInflight.has(Number(userId)),
+    refreshing: refreshStatus.status === "queued" || refreshStatus.status === "running",
+    refreshStatus,
   };
 }
 

--- a/backend/services/inboxService.js
+++ b/backend/services/inboxService.js
@@ -12,7 +12,6 @@ import { getNewsForUser, getNewsPreferences } from "./newsService.js";
 import {
   enqueueSystemTaskJob,
   findActiveHonkerJob,
-  getHonkerDb,
   withHonkerLock,
 } from "./honkerDb.js";
 
@@ -62,32 +61,6 @@ const normalizeUserId = (userId) => {
 const getInboxRefreshStatusKey = (userId) =>
   `${INBOX_REFRESH_STATUS_PREFIX}${normalizeUserId(userId)}`;
 
-const parsePayload = (value) => {
-  try {
-    return typeof value === "string" ? JSON.parse(value) : value;
-  } catch {
-    return null;
-  }
-};
-
-const getInboxRefreshJob = (userId) => {
-  const normalizedUserId = normalizeUserId(userId);
-  if (!normalizedUserId) return null;
-  const rows = getHonkerDb().query(
-    `
-      SELECT id, payload, state, run_at, claim_expires_at
-      FROM _honker_live
-      WHERE queue = 'system-task'
-        AND state IN ('pending', 'processing')
-      ORDER BY id ASC
-    `,
-  );
-  return rows.find((row) => {
-    const payload = parsePayload(row.payload);
-    return payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId;
-  }) || null;
-};
-
 const getStoredRefreshStatus = (userId) =>
   dbOps.getJSONSetting(getInboxRefreshStatusKey(userId)) || {
     status: "idle",
@@ -99,11 +72,13 @@ const getStoredRefreshStatus = (userId) =>
   };
 
 const setStoredRefreshStatus = (userId, status) => {
-  dbOps.setJSONSetting(getInboxRefreshStatusKey(userId), {
-    ...getStoredRefreshStatus(userId),
-    ...status,
-    updatedAt: Date.now(),
-  });
+  db.transaction(() => {
+    dbOps.setJSONSetting(getInboxRefreshStatusKey(userId), {
+      ...getStoredRefreshStatus(userId),
+      ...status,
+      updatedAt: Date.now(),
+    });
+  })();
 };
 
 export function getInboxRefreshStatus(userId) {
@@ -120,36 +95,20 @@ export function getInboxRefreshStatus(userId) {
   }
 
   const stored = getStoredRefreshStatus(normalizedUserId);
-  const job = getInboxRefreshJob(normalizedUserId);
+  const job = findActiveHonkerJob(
+    "system-task",
+    (payload) =>
+      payload?.kind === "inbox-refresh" && Number(payload.userId) === normalizedUserId,
+    { recoverExpired: false },
+  );
   if (job) {
-    const leaseExpired =
-      job.state === "processing" &&
-      job.claim_expires_at != null &&
-      Number(job.claim_expires_at) <= Math.floor(Date.now() / 1000);
-    const active =
-      !leaseExpired &&
-      (job.state === "pending" ||
-        job.claim_expires_at == null ||
-        Number(job.claim_expires_at) > Math.floor(Date.now() / 1000));
-    if (active) {
-      const status = job.state === "processing" ? "running" : "queued";
-      return {
-        ...stored,
-        status,
-        stale: false,
-        error: null,
-        jobId: Number(job.id),
-      };
-    }
-    if (leaseExpired) {
-      return {
-        ...stored,
-        status: "stale",
-        stale: true,
-        error: stored.error || "Inbox refresh worker lease expired",
-        jobId: Number(job.id),
-      };
-    }
+    return {
+      ...stored,
+      status: job.state === "processing" ? "running" : "queued",
+      stale: false,
+      error: null,
+      jobId: Number(job.id),
+    };
   }
 
   if (refreshInflight.has(normalizedUserId)) {
@@ -390,7 +349,7 @@ export async function refreshInboxForUser(
       status: "running",
       stale: false,
       error: null,
-      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+      ...(jobId ? { jobId } : {}),
     });
     const preferences = getInboxPreferences();
     const libraryArtists = preferences.shows
@@ -439,11 +398,8 @@ export async function refreshInboxForUser(
       status: refreshStatus,
       stale: failures.length > 0,
       error: errorMessage,
-      jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
-      lastSuccessAt:
-        failures.length === 0
-          ? now
-          : getStoredRefreshStatus(normalizedUserId).lastSuccessAt,
+      ...(jobId ? { jobId } : {}),
+      ...(failures.length === 0 ? { lastSuccessAt: now } : {}),
     });
     if (failures.length > 0 && throwOnFailure) {
       const error = new Error(errorMessage);
@@ -459,7 +415,7 @@ export async function refreshInboxForUser(
         status: "failed",
         stale: true,
         error: error.message,
-        jobId: jobId || getStoredRefreshStatus(normalizedUserId).jobId,
+        ...(jobId ? { jobId } : {}),
       });
     }
     if (throwOnFailure) throw error;

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -175,6 +175,7 @@ export async function scanMusicRoot({
   filePaths = null,
   metadataReader = parseFile,
   metadataEnricher = null,
+  syncSearch = true,
 } = {}) {
   const resolvedRoot = path.resolve(String(rootPath || ""));
   await fs.mkdir(resolvedRoot, { recursive: true });
@@ -214,6 +215,7 @@ export async function scanMusicRoot({
             mbid: record.artistMbid,
             name: record.artistName,
             metadata: record.artistMetadata,
+            syncSearch,
           });
           const album = upsertLibraryAlbum({
             identityKey: record.albumKey,
@@ -224,6 +226,7 @@ export async function scanMusicRoot({
             albumArtist: record.albumArtist,
             releaseDate: record.releaseDate,
             metadata: record.albumMetadata,
+            syncSearch,
           });
           const track = upsertLibraryTrack({
             identityKey: record.trackKey,
@@ -231,12 +234,14 @@ export async function scanMusicRoot({
             title: record.title,
             artistName: record.artistName,
             metadata: record.trackMetadata,
+            syncSearch,
           });
           linkLibraryAlbumTrack({
             albumId: album.id,
             trackId: track.id,
             discNumber: record.discNumber,
             trackNumber: record.trackNumber,
+            syncSearch,
           });
           upsertLibraryMediaFile({
             trackId: track.id,

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -3,6 +3,8 @@ import { db } from "../config/db-sqlite.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 import { scanMusicRoot } from "./libraryFileScanner.js";
 import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
+import { rebuildLibrarySearchIndex } from "./librarySearchIndex.js";
+import { rebuildCanonicalGenreStats } from "./libraryQueryService.js";
 
 function getAurralJobMetadataByPath() {
   const rows = db
@@ -38,24 +40,31 @@ export async function scanConfiguredLibrary({
   includeLidarr = true,
 } = {}) {
   const jobMetadataByPath = getAurralJobMetadataByPath();
-  const local = await scanMusicRoot({
-    rootPath: musicRoot,
-    source: "aurral",
-    metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
-  });
+  let local;
   let lidarr = { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
-  if (includeLidarr) {
-    try {
-      lidarr = await indexLidarrLibrary({ client: lidarrClient });
-    } catch (error) {
-      lidarr = {
-        skipped: false,
-        error: error.message,
-        filesSeen: 0,
-        filesIndexed: 0,
-        filesFailed: 0,
-      };
+  try {
+    local = await scanMusicRoot({
+      rootPath: musicRoot,
+      source: "aurral",
+      metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
+      syncSearch: false,
+    });
+    if (includeLidarr) {
+      try {
+        lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });
+      } catch (error) {
+        lidarr = {
+          skipped: false,
+          error: error.message,
+          filesSeen: 0,
+          filesIndexed: 0,
+          filesFailed: 0,
+        };
+      }
     }
+  } finally {
+    rebuildLibrarySearchIndex();
+    rebuildCanonicalGenreStats();
   }
   return { local, lidarr };
 }

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -221,7 +221,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         title: text(album.title) || "Unknown Album",
         albumArtist: artistName,
         releaseDate: album.releaseDate || null,
-        metadata: album,
+        metadata: { ...album, librarySource: "lidarr" },
       });
       for (const track of tracksByAlbumId.get(String(album.id)) || []) {
         const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -5,7 +5,6 @@ import {
   buildIdentityKey,
   linkLibraryAlbumTrack,
   markUnseenFilesUnavailable,
-  removeLibraryAlbumTracksWithoutMedia,
   upsertLibraryAlbum,
   upsertLibraryArtist,
   upsertLibraryMediaFile,
@@ -185,22 +184,27 @@ export async function indexLidarrLibrary({ client } = {}) {
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
 
   return withLibraryScan("lidarr", rootPath, async (scanId) => {
-    for (const album of Array.isArray(albums) ? albums : []) {
-      const artist = artistById.get(String(album?.artistId));
-      if (!artist || !album?.id) continue;
+    const artistRecordsById = new Map();
+    for (const artist of artistById.values()) {
       const artistProviderId = text(artist.foreignArtistId);
       const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
       const artistKey =
         (artistProviderId &&
           buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
         buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
-      const artistRecord = upsertLibraryArtist({
+      artistRecordsById.set(String(artist.id), upsertLibraryArtist({
         identityKey: artistKey,
         mbid: isUuid(artistProviderId) ? artistProviderId : null,
         name: artistName,
         sortName: artist.sortName || null,
-        metadata: artist,
-      });
+        metadata: { ...artist, librarySource: "lidarr" },
+      }));
+    }
+    for (const album of Array.isArray(albums) ? albums : []) {
+      const artist = artistById.get(String(album?.artistId));
+      if (!artist || !album?.id) continue;
+      const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
+      const artistRecord = artistRecordsById.get(String(artist.id));
       const albumProviderId = text(album.foreignAlbumId);
       const albumKey =
         (albumProviderId &&
@@ -219,8 +223,6 @@ export async function indexLidarrLibrary({ client } = {}) {
         releaseDate: album.releaseDate || null,
         metadata: album,
       });
-      let albumFilesIndexed = 0;
-
       for (const track of tracksByAlbumId.get(String(album.id)) || []) {
         const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);
         const trackKey =
@@ -268,13 +270,6 @@ export async function indexLidarrLibrary({ client } = {}) {
           scanId,
         });
         result.filesIndexed += 1;
-        albumFilesIndexed += 1;
-      }
-      if (
-        albumFilesIndexed === 0 &&
-        Number(album.statistics?.sizeOnDisk || 0) === 0
-      ) {
-        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr");
       }
     }
     if (result.filesFailed === 0 && result.filesIndexed > 0) {

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -148,7 +148,7 @@ async function readFileStats(filePath) {
   }
 }
 
-export async function indexLidarrLibrary({ client } = {}) {
+export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
   if (!client || typeof client.isConfigured !== "function" || !client.isConfigured()) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
@@ -200,6 +200,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         name: artistName,
         sortName: artist.sortName || null,
         metadata: artist,
+        syncSearch,
       });
       const albumProviderId = text(album.foreignAlbumId);
       const albumKey =
@@ -218,6 +219,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         albumArtist: artistName,
         releaseDate: album.releaseDate || null,
         metadata: album,
+        syncSearch,
       });
       let albumFilesIndexed = 0;
 
@@ -233,6 +235,7 @@ export async function indexLidarrLibrary({ client } = {}) {
           title: text(track.title || track.trackTitle) || "Unknown Track",
           artistName,
           metadata: track,
+          syncSearch,
         });
         const trackNumber = Number(track.trackNumber || track.absoluteTrackNumber) || 0;
         linkLibraryAlbumTrack({
@@ -240,6 +243,7 @@ export async function indexLidarrLibrary({ client } = {}) {
           trackId: trackRecord.id,
           discNumber: Number(track.mediumNumber || track.discNumber) || 1,
           trackNumber,
+          syncSearch,
         });
 
         const resolvedFile = resolveTrackFile(
@@ -274,7 +278,7 @@ export async function indexLidarrLibrary({ client } = {}) {
         albumFilesIndexed === 0 &&
         Number(album.statistics?.sizeOnDisk || 0) === 0
       ) {
-        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr");
+        removeLibraryAlbumTracksWithoutMedia(albumRecord.id, "lidarr", { syncSearch });
       }
     }
     if (result.filesFailed === 0 && result.filesIndexed > 0) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -53,7 +53,7 @@ const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
 
 function scheduleCanonicalLibraryReconciliation() {
   invalidateCanonicalLibraryCache();
-  return scheduleLibraryScan({ force: true, includeLidarr: true });
+  return scheduleLibraryScan({ includeLidarr: true });
 }
 
 function buildTrackFileIndex(trackFiles) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -9,6 +9,10 @@ import {
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
 import { scheduleLibraryScan } from "./libraryScanWorker.js";
+import {
+  clearCanonicalLidarrAlbum,
+  clearCanonicalLidarrArtist,
+} from "./libraryMediaStore.js";
 const normalizeTypeName = (value) =>
   String(value || "")
     .toLowerCase()
@@ -1111,6 +1115,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
+      clearCanonicalLidarrArtist(mbid);
       scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
@@ -1561,6 +1566,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
+      clearCanonicalLidarrAlbum(id);
       scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1116,6 +1116,7 @@ export class LibraryManager {
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
       clearCanonicalLidarrArtist(mbid);
+      clearCanonicalLidarrArtist(lidarrArtist.foreignArtistId);
       scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -3,6 +3,7 @@ import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
 import {
+  iterateCanonicalArtistProjection,
   getCanonicalLibraryPage,
   getCanonicalTrack,
   invalidateCanonicalLibraryCache,
@@ -318,6 +319,7 @@ export class LibraryManager {
       logger.info('library', `[LibraryManager] Added artist "${artistName}" to Lidarr`);
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);
+      invalidateCanonicalLibraryCache();
       import("./aurralHistoryService.js")
         .then(({ recordArtistAdded }) =>
           recordArtistAdded({
@@ -832,7 +834,11 @@ export class LibraryManager {
       });
   }
 
-  async getAllArtists({ forceRefresh = false } = {}) {
+  async getAllArtists() {
+    return [...iterateCanonicalArtistProjection({ pageSize: 100 })];
+  }
+
+  async syncLidarrArtists({ forceRefresh = false } = {}) {
     if (
       forceRefresh !== true &&
       _cachedArtists.length > 0 &&
@@ -1078,6 +1084,7 @@ export class LibraryManager {
           monitor: normalizedMonitorOption,
         };
         upsertCachedArtist(mapped);
+        invalidateCanonicalLibraryCache();
         return mapped;
       }
       return this.mapLidarrArtist(lidarrArtist);
@@ -1097,6 +1104,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
+      invalidateCanonicalLibraryCache();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
     } catch (error) {
@@ -1173,7 +1181,9 @@ export class LibraryManager {
           .catch(() => existingAlbum);
         const refreshedArtist = await lidarr.getArtist(artistId).catch(() => fallbackArtist);
         if (!refreshedArtist) return null;
-        return this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
+        const mapped = this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
+        invalidateCanonicalLibraryCache();
+        return mapped;
       };
       let lidarrArtist = null;
       const artistResolveAttempts = 8;
@@ -1273,7 +1283,9 @@ export class LibraryManager {
         lidarrAlbum = await lidarr.getAlbum(lidarrAlbum.id).catch(() => lidarrAlbum);
       }
       const updatedArtist = await lidarr.getArtist(artistId);
-      return this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
+      const mapped = this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
+      invalidateCanonicalLibraryCache();
+      return mapped;
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to add album to Lidarr: ${error.message}`);      return { error: error.message };
     }
@@ -1513,7 +1525,9 @@ export class LibraryManager {
         }
         const updated = await lidarr.getAlbum(id);
         const lidarrArtist = await lidarr.getArtist(updated.artistId);
-        return this.mapLidarrAlbum(updated, lidarrArtist);
+        const mapped = this.mapLidarrAlbum(updated, lidarrArtist);
+        invalidateCanonicalLibraryCache();
+        return mapped;
       } catch (error) {
         const msg = error.message || "";
         const isTransient =
@@ -1540,6 +1554,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
+      invalidateCanonicalLibraryCache();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete album from Lidarr: ${error.message}`);      return { success: false, error: error.message };

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -8,6 +8,7 @@ import {
   getCanonicalTrack,
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
+import { scheduleLibraryScan } from "./libraryScanWorker.js";
 const normalizeTypeName = (value) =>
   String(value || "")
     .toLowerCase()
@@ -49,6 +50,11 @@ const _albumAddInflight = new Map();
 const _artistMappingInflight = new Map();
 const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
   "Album already exists in Lidarr under a different artist";
+
+function scheduleCanonicalLibraryReconciliation() {
+  invalidateCanonicalLibraryCache();
+  return scheduleLibraryScan({ force: true, includeLidarr: true });
+}
 
 function buildTrackFileIndex(trackFiles) {
   const index = new Map();
@@ -319,7 +325,7 @@ export class LibraryManager {
       logger.info('library', `[LibraryManager] Added artist "${artistName}" to Lidarr`);
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       import("./aurralHistoryService.js")
         .then(({ recordArtistAdded }) =>
           recordArtistAdded({
@@ -873,6 +879,7 @@ export class LibraryManager {
           await this.backfillLidarrArtistMappings(lidarrArtists);
           _cachedArtists = lidarrArtists.map((a) => this.mapLidarrArtist(a));
           _artistsCachedAt = Date.now();
+          scheduleCanonicalLibraryReconciliation();
           import("../../services/unifiedSearchService.js").then(({ clearSearchContextCache }) => clearSearchContextCache()).catch(() => {});
           return _cachedArtists;
         } catch (error) {
@@ -1084,7 +1091,7 @@ export class LibraryManager {
           monitor: normalizedMonitorOption,
         };
         upsertCachedArtist(mapped);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       }
       return this.mapLidarrArtist(lidarrArtist);
@@ -1104,7 +1111,7 @@ export class LibraryManager {
       await lidarr.deleteArtist(lidarrArtist.id, deleteFiles);
       dbOps.deleteLidarrArtistIdMap(mbid);
       removeCachedArtistByMbid(mbid);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       logger.info('library', `[LibraryManager] Deleted artist "${lidarrArtist.artistName}" from Lidarr`);
       return { success: true };
     } catch (error) {
@@ -1182,7 +1189,7 @@ export class LibraryManager {
         const refreshedArtist = await lidarr.getArtist(artistId).catch(() => fallbackArtist);
         if (!refreshedArtist) return null;
         const mapped = this.mapLidarrAlbum(refreshedExisting, refreshedArtist);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       };
       let lidarrArtist = null;
@@ -1284,7 +1291,7 @@ export class LibraryManager {
       }
       const updatedArtist = await lidarr.getArtist(artistId);
       const mapped = this.mapLidarrAlbum(lidarrAlbum, updatedArtist);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return mapped;
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to add album to Lidarr: ${error.message}`);      return { error: error.message };
@@ -1526,7 +1533,7 @@ export class LibraryManager {
         const updated = await lidarr.getAlbum(id);
         const lidarrArtist = await lidarr.getArtist(updated.artistId);
         const mapped = this.mapLidarrAlbum(updated, lidarrArtist);
-        invalidateCanonicalLibraryCache();
+        scheduleCanonicalLibraryReconciliation();
         return mapped;
       } catch (error) {
         const msg = error.message || "";
@@ -1554,7 +1561,7 @@ export class LibraryManager {
     }
     try {
       await lidarr.deleteAlbum(id, deleteFiles);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete album from Lidarr: ${error.message}`);      return { success: false, error: error.message };
@@ -1605,7 +1612,7 @@ export class LibraryManager {
       }
 
       await lidarr.deleteTrackFile(trackFileId);
-      invalidateCanonicalLibraryCache();
+      scheduleCanonicalLibraryReconciliation();
       return { success: true };
     } catch (error) {
       logger.error('library', `[LibraryManager] Failed to delete track file: ${error.message}`);

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -15,6 +15,19 @@ const normalizeKeyPart = (value) =>
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
 
+const LIDARR_METADATA_KEYS = [
+  "librarySource",
+  "id",
+  "monitored",
+  "monitor",
+  "monitorNewItems",
+  "addOptions",
+  "path",
+  "qualityProfile",
+  "rootFolderPath",
+  "statistics",
+];
+
 let libraryScanDepth = 0;
 let libraryCacheInvalidationPending = false;
 
@@ -87,6 +100,48 @@ export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName =
   ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
   invalidateLibraryCache();
   return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+}
+
+function clearLidarrMetadata(table, where, parameters) {
+  const row = db.prepare(`SELECT id, metadata_json FROM ${table} WHERE ${where} LIMIT 1`)
+    .get(...parameters);
+  if (!row) return false;
+  let metadata = {};
+  try {
+    const parsed = JSON.parse(row.metadata_json || "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadata = parsed;
+  } catch {}
+  for (const key of LIDARR_METADATA_KEYS) delete metadata[key];
+  db.prepare(`UPDATE ${table} SET metadata_json = ?, updated_at = ? WHERE id = ?`)
+    .run(stringify(metadata), now(), row.id);
+  invalidateLibraryCache();
+  return true;
+}
+
+export function clearCanonicalLidarrArtist(reference) {
+  const value = normalizeText(reference);
+  if (!value) return false;
+  return clearLidarrMetadata(
+    "library_artists",
+    `mbid = ? OR identity_key = ? OR (
+      json_valid(metadata_json)
+      AND CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT) = ?
+    )`,
+    [value, value, value],
+  );
+}
+
+export function clearCanonicalLidarrAlbum(reference) {
+  const value = normalizeText(reference);
+  if (!value) return false;
+  return clearLidarrMetadata(
+    "library_albums",
+    `mbid = ? OR release_group_mbid = ? OR identity_key = ? OR (
+      json_valid(metadata_json)
+      AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?
+    )`,
+    [value, value, value, value],
+  );
 }
 
 export function upsertLibraryAlbum({

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -1,5 +1,10 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
 import { invalidateCanonicalLibraryCache } from "./libraryQueryService.js";
+import {
+  syncLibrarySearchAlbum,
+  syncLibrarySearchArtist,
+  syncLibrarySearchTrack,
+} from "./librarySearchIndex.js";
 
 const now = () => Date.now();
 
@@ -70,23 +75,35 @@ export function finishLibraryScan(scanId, {
   );
 }
 
-export function upsertLibraryArtist({ identityKey, mbid = null, name, sortName = null, metadata = null }) {
+export function upsertLibraryArtist({
+  identityKey,
+  mbid = null,
+  name,
+  sortName = null,
+  metadata = null,
+  syncSearch = true,
+}) {
   const timestamp = now();
   const key = normalizeText(identityKey);
   const artistName = normalizeText(name);
   if (!key || !artistName) throw new Error("Library artist identityKey and name are required");
-  db.prepare(
-    `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_artists.mbid),
-       name = excluded.name,
-       sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
-       metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+  const artist = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_artists.mbid),
+         name = excluded.name,
+         sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
+         metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+    const row = db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+    if (syncSearch) syncLibrarySearchArtist(row?.id);
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+  return artist;
 }
 
 export function upsertLibraryAlbum({
@@ -98,6 +115,7 @@ export function upsertLibraryAlbum({
   albumArtist = null,
   releaseDate = null,
   metadata = null,
+  syncSearch = true,
 }) {
   const timestamp = now();
   const key = normalizeText(identityKey);
@@ -105,33 +123,45 @@ export function upsertLibraryAlbum({
   if (!key || !Number.isSafeInteger(Number(artistId)) || !albumTitle) {
     throw new Error("Library album identityKey, artistId, and title are required");
   }
-  db.prepare(
-    `INSERT INTO library_albums
-      (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_albums.mbid),
-       release_group_mbid = COALESCE(excluded.release_group_mbid, library_albums.release_group_mbid),
-       artist_id = excluded.artist_id,
-       title = excluded.title,
-       album_artist = COALESCE(excluded.album_artist, library_albums.album_artist),
-       release_date = COALESCE(excluded.release_date, library_albums.release_date),
-       metadata_json = COALESCE(excluded.metadata_json, library_albums.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(
-    key,
-    mbid || null,
-    releaseGroupMbid || null,
-    Number(artistId),
-    albumTitle,
-    albumArtist || null,
-    releaseDate || null,
-    stringify(metadata),
-    timestamp,
-    timestamp,
-  );
+  const album = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_albums
+        (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_albums.mbid),
+         release_group_mbid = COALESCE(excluded.release_group_mbid, library_albums.release_group_mbid),
+         artist_id = excluded.artist_id,
+         title = excluded.title,
+         album_artist = COALESCE(excluded.album_artist, library_albums.album_artist),
+         release_date = COALESCE(excluded.release_date, library_albums.release_date),
+         metadata_json = COALESCE(excluded.metadata_json, library_albums.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(
+      key,
+      mbid || null,
+      releaseGroupMbid || null,
+      Number(artistId),
+      albumTitle,
+      albumArtist || null,
+      releaseDate || null,
+      stringify(metadata),
+      timestamp,
+      timestamp,
+    );
+    const row = db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+    const searchChanged = syncSearch && syncLibrarySearchAlbum(row?.id);
+    if (row?.id && searchChanged) {
+      for (const track of db.prepare(
+        "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+      ).all(row.id)) {
+        syncLibrarySearchTrack(track.track_id);
+      }
+    }
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+  return album;
 }
 
 export function upsertLibraryTrack({
@@ -140,56 +170,79 @@ export function upsertLibraryTrack({
   title,
   artistName = null,
   metadata = null,
+  syncSearch = true,
 }) {
   const timestamp = now();
   const key = normalizeText(identityKey);
   const trackTitle = normalizeText(title);
   if (!key || !trackTitle) throw new Error("Library track identityKey and title are required");
-  db.prepare(
-    `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(identity_key) DO UPDATE SET
-       mbid = COALESCE(excluded.mbid, library_tracks.mbid),
-       title = excluded.title,
-       artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
-       metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
-       updated_at = excluded.updated_at`,
-  ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+  const track = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(identity_key) DO UPDATE SET
+         mbid = COALESCE(excluded.mbid, library_tracks.mbid),
+         title = excluded.title,
+         artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
+         metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
+         updated_at = excluded.updated_at`,
+    ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+    const row = db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+    if (syncSearch) syncLibrarySearchTrack(row?.id);
+    return row;
+  })();
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+  return track;
 }
 
-export function linkLibraryAlbumTrack({ albumId, trackId, discNumber = 1, trackNumber = 0 }) {
-  db.prepare(
-    `INSERT OR IGNORE INTO library_album_tracks
-      (album_id, track_id, disc_number, track_number, created_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+export function linkLibraryAlbumTrack({
+  albumId,
+  trackId,
+  discNumber = 1,
+  trackNumber = 0,
+  syncSearch = true,
+}) {
+  db.transaction(() => {
+    db.prepare(
+      `INSERT OR IGNORE INTO library_album_tracks
+        (album_id, track_id, disc_number, track_number, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
+    if (syncSearch) syncLibrarySearchTrack(trackId);
+  })();
   invalidateLibraryCache();
 }
 
-export function removeLibraryAlbumTracksWithoutMedia(albumId, source) {
+export function removeLibraryAlbumTracksWithoutMedia(albumId, source, { syncSearch = true } = {}) {
   const mediaSource = normalizeText(source);
-  db.prepare(
-    `DELETE FROM library_album_tracks
-     WHERE album_id = ?
-       AND NOT EXISTS (
-         SELECT 1
-         FROM library_media_files AS media
-         WHERE media.track_id = library_album_tracks.track_id
-           AND media.album_id = library_album_tracks.album_id
-           AND media.source = ?
-           AND media.available = 1
-       )
-       AND NOT EXISTS (
-         SELECT 1
-         FROM library_media_files AS media
-         WHERE media.track_id = library_album_tracks.track_id
-           AND media.album_id = library_album_tracks.album_id
-           AND media.source != ?
-           AND media.available = 1
-       )`,
-  ).run(Number(albumId), mediaSource, mediaSource);
+  db.transaction(() => {
+    const trackIds = db.prepare(
+      "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+    ).all(Number(albumId)).map((row) => row.track_id);
+    db.prepare(
+      `DELETE FROM library_album_tracks
+       WHERE album_id = ?
+         AND NOT EXISTS (
+           SELECT 1
+           FROM library_media_files AS media
+           WHERE media.track_id = library_album_tracks.track_id
+             AND media.album_id = library_album_tracks.album_id
+             AND media.source = ?
+             AND media.available = 1
+         )
+         AND NOT EXISTS (
+           SELECT 1
+           FROM library_media_files AS media
+           WHERE media.track_id = library_album_tracks.track_id
+             AND media.album_id = library_album_tracks.album_id
+             AND media.source != ?
+             AND media.available = 1
+         )`,
+    ).run(Number(albumId), mediaSource, mediaSource);
+    if (syncSearch) {
+      for (const trackId of trackIds) syncLibrarySearchTrack(trackId);
+    }
+  })();
   invalidateLibraryCache();
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -770,6 +770,20 @@ export function getCanonicalArtistPage({
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
 
   if (!includeStats) {
+    const filterAlbums = Boolean(sourceFilter) || availableOnly === true;
+    const albumJoin = filterAlbums ? "JOIN" : "LEFT JOIN";
+    const albumFilter = filterAlbums
+      ? `AND EXISTS (
+          SELECT 1
+          FROM library_album_tracks AS album_track
+          JOIN library_media_files AS media
+            ON media.track_id = album_track.track_id
+            AND ${albumMediaCondition("media", "album_track")}
+          WHERE album_track.album_id = album.id
+            ${sourceFilter ? "AND media.source = ?" : ""}
+            ${availableOnly === true ? "AND media.available = 1" : ""}
+        )`
+      : "";
     const rows = db.prepare(
       `SELECT
          artist.id AS artist_id,
@@ -780,18 +794,9 @@ export function getCanonicalArtistPage({
          artist.metadata_json AS artist_metadata_json,
          COUNT(DISTINCT album.id) AS album_count
        FROM library_artists AS artist
-       JOIN library_albums AS album ON album.artist_id = artist.id
+       ${albumJoin} library_albums AS album ON album.artist_id = artist.id
        WHERE artist.id IN (${ids.map(() => "?").join(",")})
-         AND EXISTS (
-           SELECT 1
-           FROM library_album_tracks AS album_track
-           JOIN library_media_files AS media
-             ON media.track_id = album_track.track_id
-             AND ${albumMediaCondition("media", "album_track")}
-           WHERE album_track.album_id = album.id
-             ${sourceFilter ? "AND media.source = ?" : ""}
-             ${availableOnly === true ? "AND media.available = 1" : ""}
-         )
+         ${albumFilter}
        GROUP BY artist.id`,
     ).all(...ids, ...(sourceFilter ? [sourceFilter] : []));
     const byId = new Map(rows.map((row) => [row.artist_id, {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -64,13 +64,13 @@ const CANONICAL_SELECT = `SELECT
 const albumMediaCondition = (mediaAlias, albumTrackAlias) =>
   `(${mediaAlias}.album_id = ${albumTrackAlias}.album_id OR ${mediaAlias}.album_id IS NULL)`;
 
-const CANONICAL_FROM = `FROM library_media_files AS media
-  JOIN library_tracks AS track ON track.id = media.track_id
-  JOIN library_album_tracks AS album_track
-    ON album_track.track_id = track.id
-    AND ${albumMediaCondition("media", "album_track")}
-  JOIN library_albums AS album ON album.id = album_track.album_id
-  JOIN library_artists AS artist ON artist.id = album.artist_id`;
+const CANONICAL_FROM = `FROM library_artists AS artist
+  JOIN library_albums AS album ON album.artist_id = artist.id
+  JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+  JOIN library_tracks AS track ON track.id = album_track.track_id
+  LEFT JOIN library_media_files AS media
+    ON media.track_id = track.id
+    AND ${albumMediaCondition("media", "album_track")}`;
 
 function buildLibraryFromRows(rows) {
   const artists = new Map();
@@ -219,6 +219,110 @@ export function getCanonicalArtistMbids({ source = null, availableOnly = false, 
      WHERE ${conditions.join(" AND ")}`,
   ).all(...parameters);
   return new Set(rows.map((row) => row.mbid).filter(Boolean));
+}
+
+const canonicalArtistProjection = (row) => {
+  const metadata = parseJson(row.metadata_json) || {};
+  const providerId = metadata.id == null ? null : String(metadata.id);
+  const monitorOption = metadata.monitor || metadata.addOptions?.monitor || "none";
+  return {
+    id: providerId || String(row.id),
+    canonicalId: String(row.id),
+    providerId,
+    mbid: row.mbid || null,
+    foreignArtistId: row.mbid || row.identity_key,
+    artistName: row.name,
+    name: row.name,
+    sortName: row.sort_name || row.name,
+    path: metadata.path || null,
+    addedAt: metadata.added || (row.created_at ? new Date(row.created_at).toISOString() : null),
+    monitored: metadata.monitored === true,
+    monitorOption,
+    monitorNewItems: metadata.monitorNewItems || "none",
+    addOptions: metadata.addOptions || { monitor: monitorOption },
+    quality: metadata.qualityProfile?.name || "standard",
+    albumFolders: true,
+    statistics: {
+      albumCount: Number(row.album_count || 0),
+      trackCount: Number(row.track_count || 0),
+      sizeOnDisk: Number(row.size_on_disk || 0),
+    },
+    sources: String(row.sources || "")
+      .split(",")
+      .map((source) => source.trim())
+      .filter(Boolean),
+    available: Boolean(row.available),
+    stale: Boolean(row.stale),
+  };
+};
+
+export function getCanonicalArtistProjection({ page = 1, pageSize = 100, reference = null } = {}) {
+  const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
+  const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
+  const references = normalizeLookupValues(reference == null ? [] : [reference]);
+  const parameters = [];
+  const where = [];
+  if (references.length) {
+    where.push(`(
+      artist.id IN (${references.map(() => "?").join(",")}) OR
+      artist.mbid IN (${references.map(() => "?").join(",")}) OR
+      artist.identity_key IN (${references.map(() => "?").join(",")}) OR
+      CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
+      lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
+    )`);
+    parameters.push(...references, ...references, ...references, ...references, ...references);
+  }
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const limit = references.length ? "" : "LIMIT ? OFFSET ?";
+  if (!references.length) {
+    parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
+  }
+  const rows = db.prepare(`
+    SELECT
+      artist.id,
+      artist.identity_key,
+      artist.mbid,
+      artist.name,
+      artist.sort_name,
+      artist.metadata_json,
+      artist.created_at,
+      COUNT(DISTINCT album.id) AS album_count,
+      COUNT(DISTINCT album_track.track_id) AS track_count,
+      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk,
+      GROUP_CONCAT(DISTINCT media.source) AS sources,
+      MAX(CASE WHEN media.available = 1 THEN 1 ELSE 0 END) AS available,
+      CASE WHEN EXISTS (
+        SELECT 1
+        FROM library_scan_runs AS scan
+        WHERE scan.source = 'lidarr'
+          AND scan.status = 'failed'
+          AND scan.id > COALESCE((
+            SELECT complete.id
+            FROM library_scan_runs AS complete
+            WHERE complete.source = 'lidarr' AND complete.status = 'complete'
+            ORDER BY complete.id DESC
+            LIMIT 1
+          ), 0)
+      ) THEN 1 ELSE 0 END AS stale
+    FROM library_artists AS artist
+    LEFT JOIN library_albums AS album ON album.artist_id = artist.id
+    LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+    LEFT JOIN library_media_files AS media ON media.track_id = album_track.track_id
+      AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
+    ${whereSql}
+    GROUP BY artist.id
+    ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+    ${limit}
+  `).all(...parameters);
+  return rows.map(canonicalArtistProjection);
+}
+
+export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
+  for (let page = 1; ; page += 1) {
+    const artists = getCanonicalArtistProjection({ page, pageSize });
+    yield* artists;
+    if (artists.length < Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100))) break;
+  }
 }
 
 export function getCanonicalTrackPath(albumReference, trackReference) {
@@ -426,6 +530,28 @@ export function getCanonicalLibraryForArtists({
     availableOnly,
     conditions: [`artist.mbid IN (${references.map(() => "?").join(",")})`],
     parameters: references,
+  });
+}
+
+export function getCanonicalLibraryForArtistReferences({
+  source = null,
+  availableOnly = false,
+  references: requestedReferences = [],
+} = {}) {
+  const references = normalizeLookupValues(requestedReferences);
+  if (!references.length) return { artists: [], albums: [], tracks: [] };
+  const placeholders = references.map(() => "?").join(",");
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`(
+      artist.id IN (${placeholders}) OR
+      artist.mbid IN (${placeholders}) OR
+      artist.identity_key IN (${placeholders}) OR
+      CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${placeholders}) OR
+      lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
+    )`],
+    parameters: [...references, ...references, ...references, ...references, ...references],
   });
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -346,7 +346,7 @@ function buildCanonicalArtistProjectionQuery({
         artist.created_at
       FROM library_artists AS artist
       ${whereSql}
-      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, artist.id
       ${limit}
     )
     SELECT
@@ -381,7 +381,7 @@ function buildCanonicalArtistProjectionQuery({
     LEFT JOIN library_media_files AS media ON media.track_id = album_track.track_id
       AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
     GROUP BY artist.id
-    ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+    ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, artist.id
   `,
   };
 }
@@ -1095,7 +1095,9 @@ export function getCanonicalArtistPage({
        FROM library_artists AS artist
        ${searchJoin}
        WHERE ${conditions.join(" AND ")}
-       ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
+       ${searchMatch
+         ? "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE, artist.id"
+         : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
        ${pageSql}`,
     ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
@@ -1298,7 +1300,7 @@ export function getCanonicalAlbumPage({
      ${searchJoin}
      WHERE ${conditions.join(" AND ")}
      GROUP BY album.id
-     ${searchMatch ? "" : `ORDER BY ${orderBy}`}
+     ${searchMatch ? `ORDER BY ${orderBy}, album.id` : `ORDER BY ${orderBy}`}
      LIMIT ? OFFSET ?`,
   ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
   const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
@@ -1396,6 +1398,7 @@ export function getCanonicalTrackPage({
        JOIN library_search_fts AS search_fts
          ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?
        WHERE ${searchConditions.join(" AND ")}
+       ORDER BY track.id
        LIMIT ? OFFSET ?`,
     ).all(searchMatch, ...parameters, pattern, pattern, pattern, boundedLimit, pageOffset(offset))
       .map((row) => row.id);

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -20,6 +20,12 @@ const parseJson = (value) => {
   }
 };
 
+const parseSources = (value) => String(value || "")
+  .split(",")
+  .map((source) => source.trim())
+  .filter(Boolean)
+  .sort();
+
 function normalizeSource(source) {
   const value = String(source || "").trim().toLowerCase();
   if (!value || value === "all") return null;
@@ -736,6 +742,7 @@ export function getCanonicalArtistPage({
   limit = null,
   includeStats = false,
   searchMatch = null,
+  artistIds = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("artists", sourceFilter, availableOnly);
@@ -761,14 +768,18 @@ export function getCanonicalArtistPage({
     conditions.push("lower(search_document.title) LIKE ? ESCAPE '\\'");
     parameters.push(`%${escapeLike(normalizedQuery)}%`);
   }
-  const ids = db.prepare(
-    `SELECT artist.id
-     FROM library_artists AS artist
-     ${searchJoin}
-     WHERE ${conditions.join(" AND ")}
-     ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
-     ${pageSql}`,
-  ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
+  const ids = Array.isArray(artistIds)
+    ? [...new Set(artistIds
+      .map((value) => Number(value))
+      .filter((value) => Number.isSafeInteger(value) && value > 0))]
+    : db.prepare(
+      `SELECT artist.id
+       FROM library_artists AS artist
+       ${searchJoin}
+       WHERE ${conditions.join(" AND ")}
+       ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
+       ${pageSql}`,
+    ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
 
   if (!includeStats) {
@@ -838,6 +849,7 @@ export function getCanonicalArtistPage({
        COUNT(DISTINCT album.id) AS album_count,
        COUNT(DISTINCT album_track.track_id) AS track_count,
        COALESCE(SUM(media.size), 0) AS size_on_disk,
+       GROUP_CONCAT(DISTINCT media.source) AS sources,
        MAX(media.available) AS available
      FROM library_artists AS artist
      JOIN library_albums AS album ON album.artist_id = artist.id
@@ -859,7 +871,7 @@ export function getCanonicalArtistPage({
     albumCount: Number(row.album_count || 0),
     trackCount: Number(row.track_count || 0),
     sizeOnDisk: Number(row.size_on_disk || 0),
-    sources: [],
+    sources: parseSources(row.sources),
     available: Boolean(row.available),
   }]));
   return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
@@ -1419,7 +1431,7 @@ function getPageLibrary(kind, ids, sourceFilter, availableOnly, albumId = null) 
   return buildLibraryFromRows(rows);
 }
 
-function getAlbumTrackLibrary(
+function buildAlbumTrackPageQuery(
   albumId,
   sourceFilter,
   { query = "", genre = "", sort = "album", direction = "asc", artistId = null } = {},
@@ -1464,6 +1476,97 @@ function getAlbumTrackLibrary(
     : sort === "artist"
       ? `artist.name COLLATE NOCASE ${orderDirection}, track.title COLLATE NOCASE ${orderDirection}`
       : `track.title COLLATE NOCASE ${orderDirection}`;
+  return {
+    from: `FROM library_tracks AS track
+      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+      JOIN library_albums AS album ON album.id = album_track.album_id
+      JOIN library_artists AS artist ON artist.id = album.artist_id
+      LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}`,
+    where: conditions.join(" AND "),
+    parameters,
+    orderBy,
+  };
+}
+
+function getAlbumTrackSummary(albumId, sourceFilter) {
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  parameters.push(Number(albumId));
+  const row = db.prepare(
+    `SELECT
+       artist.id AS artist_id,
+       artist.identity_key AS artist_identity_key,
+       artist.mbid AS artist_mbid,
+       artist.name AS artist_name,
+       artist.sort_name AS artist_sort_name,
+       artist.metadata_json AS artist_metadata_json,
+       album.id AS album_id,
+       album.identity_key AS album_identity_key,
+       album.mbid AS album_mbid,
+       album.release_group_mbid AS album_release_group_mbid,
+       album.title AS album_title,
+       album.album_artist AS album_artist,
+       album.release_date AS album_release_date,
+       album.metadata_json AS album_metadata_json,
+       GROUP_CONCAT(DISTINCT media.source) AS sources,
+       MAX(media.available) AS available
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE album.id = ?
+     GROUP BY album.id`,
+  ).get(...parameters);
+  if (!row) return { artist: null, album: null };
+  const sources = parseSources(row.sources);
+  return {
+    artist: {
+      id: row.artist_id,
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata: parseJson(row.artist_metadata_json),
+      albumIds: [row.album_id],
+      sources,
+      available: Boolean(row.available),
+    },
+    album: {
+      id: row.album_id,
+      identityKey: row.album_identity_key,
+      mbid: row.album_mbid,
+      releaseGroupMbid: row.album_release_group_mbid,
+      artistId: row.artist_id,
+      title: row.album_title,
+      albumArtist: row.album_artist,
+      releaseDate: row.album_release_date,
+      metadata: parseJson(row.album_metadata_json),
+      trackIds: [],
+      sources,
+      available: Boolean(row.available),
+    },
+  };
+}
+
+function getAlbumTrackPageLibrary(albumId, sourceFilter, ids) {
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  parameters.push(Number(albumId), ...ids);
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
@@ -1471,38 +1574,55 @@ function getAlbumTrackLibrary(
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
      LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
-     WHERE ${conditions.join(" AND ")}
-     ORDER BY ${orderBy}, album_track.disc_number, album_track.track_number,
-       media.path COLLATE NOCASE`,
+     WHERE album.id = ? AND track.id IN (${ids.map(() => "?").join(",")})
+     ORDER BY album_track.disc_number, album_track.track_number,
+       track.title COLLATE NOCASE, media.path COLLATE NOCASE`,
   ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 
 function getAlbumTrackPage(albumId, sourceFilter, page, currentPageSize, options = {}) {
-  const completeLibrary = getAlbumTrackLibrary(albumId, sourceFilter);
-  const library = getAlbumTrackLibrary(albumId, sourceFilter, options);
-  const album = completeLibrary.albums[0] || null;
-  const artist = album
-    ? completeLibrary.artists.find((candidate) => candidate.id === album.artistId) || null
-    : null;
-  const tracks = library.tracks;
-  const availableTrackCount = completeLibrary.tracks.filter((track) => track.available).length;
-  const pageItems = tracks.slice((page - 1) * currentPageSize, page * currentPageSize);
+  const queryDefinition = buildAlbumTrackPageQuery(albumId, sourceFilter, options);
+  const total = Number(db.prepare(
+    `SELECT COUNT(DISTINCT track.id) AS total
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}`,
+  ).get(...queryDefinition.parameters)?.total || 0);
+  const pageIds = db.prepare(
+    `SELECT track.id AS page_id
+     ${queryDefinition.from}
+     WHERE ${queryDefinition.where}
+     GROUP BY track.id
+     ORDER BY ${queryDefinition.orderBy}, album_track.disc_number, album_track.track_number,
+       media.path COLLATE NOCASE
+     LIMIT ? OFFSET ?`,
+  ).all(
+    ...queryDefinition.parameters,
+    currentPageSize,
+    (page - 1) * currentPageSize,
+  ).map((row) => row.page_id);
+  const library = getAlbumTrackPageLibrary(albumId, sourceFilter, pageIds);
+  const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+  const pageItems = pageIds.map((id) => tracksById.get(id)).filter(Boolean);
+  const summary = getAlbumTrackSummary(albumId, sourceFilter);
+  const stats = getAlbumStats([Number(albumId)], sourceFilter).get(String(albumId));
+  const album = summary.album;
   const albums = album
     ? [{
         ...album,
-        trackCount: tracks.length,
-        availableTrackCount,
+        trackIds: pageItems.map((track) => track.id),
+        trackCount: total,
+        availableTrackCount: stats?.availableTrackCount ?? 0,
       }]
     : [];
   return {
     kind: "tracks",
     page,
     pageSize: currentPageSize,
-    total: tracks.length,
-    hasMore: page * currentPageSize < tracks.length,
+    total,
+    hasMore: page * currentPageSize < total,
     items: pageItems,
-    artists: artist ? [artist] : [],
+    artists: summary.artist ? [summary.artist] : [],
     albums,
     tracks: pageItems,
     genres: getCanonicalGenreStats({ sourceFilter, availableOnly: false }),
@@ -1631,6 +1751,28 @@ export function getCanonicalLibraryPage({
     currentPageSize,
     (currentPage - 1) * currentPageSize,
   ).map((row) => row.page_id);
+  if (normalizedKind === "artists") {
+    const library = getCanonicalArtistPage({
+      source: sourceFilter,
+      availableOnly,
+      artistIds: ids,
+      includeStats: true,
+    });
+    const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
+    const items = ids.map((id) => artistsById.get(String(id))).filter(Boolean);
+    return {
+      kind: normalizedKind,
+      page: currentPage,
+      pageSize: currentPageSize,
+      total,
+      hasMore: currentPage * currentPageSize < total,
+      items,
+      artists: items,
+      albums: [],
+      tracks: [],
+      genres: getCanonicalGenreStats({ sourceFilter, availableOnly }),
+    };
+  }
   const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly, albumId);
   const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));
   const albumsById = new Map(library.albums.map((album) => [String(album.id), album]));

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -443,6 +443,25 @@ function getCanonicalLibraryForIds(kind, ids, source, availableOnly) {
   });
 }
 
+function resolveCanonicalReferenceIds(table, references, columns) {
+  const numericIds = references
+    .filter((reference) => /^\d+$/.test(reference))
+    .map(Number);
+  const queries = [];
+  const parameters = [];
+  if (numericIds.length) {
+    queries.push(`SELECT id FROM ${table} WHERE id IN (${numericIds.map(() => "?").join(",")})`);
+    parameters.push(...numericIds);
+  }
+  for (const column of columns) {
+    queries.push(
+      `SELECT id FROM ${table} WHERE ${column} IN (${references.map(() => "?").join(",")})`,
+    );
+    parameters.push(...references);
+  }
+  return db.prepare(queries.join(" UNION ")).all(...parameters).map((row) => row.id);
+}
+
 export function getCanonicalLibraryForArtistReferences({
   source = null,
   availableOnly = false,
@@ -450,23 +469,12 @@ export function getCanonicalLibraryForArtistReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-  const conditions = [];
-  const parameters = [];
-  for (const reference of references) {
-    if (/^\d+$/.test(reference)) {
-      conditions.push("artist.id = ?");
-      parameters.push(Number(reference));
-    } else {
-      conditions.push("(artist.identity_key = ? OR artist.mbid = ?)");
-      parameters.push(reference, reference);
-    }
-  }
-  return getScopedCanonicalLibrary({
-    source,
-    availableOnly,
-    conditions: [`(${conditions.join(" OR ")})`],
-    parameters,
-  });
+  const ids = resolveCanonicalReferenceIds(
+    "library_artists",
+    references,
+    ["identity_key", "mbid"],
+  );
+  return getCanonicalLibraryForIds("artists", ids, source, availableOnly);
 }
 
 export function getCanonicalLibraryForAlbumIds({
@@ -503,56 +511,34 @@ export function getCanonicalLibraryForAlbumReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-
+  const ids = resolveCanonicalReferenceIds(
+    "library_albums",
+    references,
+    ["identity_key", "mbid", "release_group_mbid"],
+  );
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
   const sourceFilter = normalizeSource(source);
-  const referenceCondition = `(
-    album.mbid IN (${references.map(() => "?").join(",")}) OR
-    album.release_group_mbid IN (${references.map(() => "?").join(",")}) OR
-    album.identity_key IN (${references.map(() => "?").join(",")})
-  )`;
-  const albumParameters = [];
   const mediaConditions = [
     "media.track_id = album_track.track_id",
     albumMediaCondition("media", "album_track"),
   ];
+  const parameters = [];
   if (sourceFilter) {
     mediaConditions.push("media.source = ?");
-    albumParameters.push(sourceFilter);
+    parameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
-  albumParameters.push(...references, ...references, ...references);
-
-  const albumIds = db.prepare(
-    `SELECT DISTINCT album.id AS id
-     FROM library_albums AS album
-     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
-     WHERE ${referenceCondition}`,
-  ).all(...albumParameters).map((row) => row.id);
-  if (!albumIds.length) return { artists: [], albums: [], tracks: [] };
-
-  const trackMediaConditions = [
-    "media.track_id = album_track.track_id",
-    albumMediaCondition("media", "album_track"),
-  ];
-  const trackParameters = [];
-  if (sourceFilter) {
-    trackMediaConditions.push("media.source = ?");
-    trackParameters.push(sourceFilter);
-  }
-  if (availableOnly === true) trackMediaConditions.push("media.available = 1");
-  trackParameters.push(...albumIds);
-
+  parameters.push(...ids);
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
-     LEFT JOIN library_media_files AS media ON ${trackMediaConditions.join(" AND ")}
-     WHERE album.id IN (${albumIds.map(() => "?").join(",")})
+     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE album.id IN (${ids.map(() => "?").join(",")})
      ${canonicalOrder}`,
-  ).iterate(...trackParameters);
+  ).iterate(...parameters);
   return buildLibraryFromRows(rows);
 }
 
@@ -734,10 +720,10 @@ const genrePredicate = (aliases, genre) => {
   aliases.forEach((alias) => {
     GENRE_METADATA_PATHS.forEach((path) => {
       clauses.push(
-        `EXISTS (
-          SELECT 1 FROM json_each(COALESCE(${alias}.metadata_json, '{}'), '${path}') AS genre_value
+        `(json_valid(${alias}.metadata_json) AND EXISTS (
+          SELECT 1 FROM json_each(${alias}.metadata_json, '${path}') AS genre_value
           WHERE lower(CAST(genre_value.value AS TEXT)) = lower(?)
-        )`,
+        ))`,
       );
       parameters.push(genre);
     });
@@ -942,7 +928,7 @@ export function getCanonicalAlbumPage({
   if (type === "random") {
     orderBy = "random()";
   } else if (type === "newest" || type === "recent") {
-    orderBy = "CASE WHEN album.release_date GLOB '[0-9][0-9][0-9][0-9]*' THEN album.release_date END DESC, album.title COLLATE NOCASE";
+    orderBy = recentMediaOrder("albums", sourceFilter, availableOnly, "asc");
   } else if (type === "alphabeticalByArtist") {
     orderBy = "coalesce(album.album_artist, artist.name) COLLATE NOCASE, album.title COLLATE NOCASE";
   } else if (type === "byYear") {
@@ -1000,10 +986,11 @@ export function getCanonicalTrackPage({
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
     parameters.push(...fields.map(() => pattern));
   }
-  const normalizedArtist = text(artist).toLocaleLowerCase();
+  const artistReference = text(artist);
+  const normalizedArtist = artistReference.toLocaleLowerCase();
   if (normalizedArtist) {
     conditions.push("(lower(artist.name) = ? OR lower(coalesce(track.artist_name, '')) = ? OR artist.identity_key = ?)");
-    parameters.push(normalizedArtist, normalizedArtist, artist);
+    parameters.push(normalizedArtist, normalizedArtist, artistReference);
   }
   if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
     conditions.push("artist.id = ?");
@@ -1094,51 +1081,72 @@ export function getCanonicalGenres({ source = null, availableOnly = false } = {}
     parameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
-  const albums = new Map();
-  for (const row of db.prepare(
-    `SELECT
-       album.id AS album_id,
-       track.id AS track_id,
-       artist.metadata_json AS artist_metadata_json,
-       album.metadata_json AS album_metadata_json,
-       track.metadata_json AS track_metadata_json
-     FROM library_albums AS album
-     JOIN library_artists AS artist ON artist.id = album.artist_id
-     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_tracks AS track ON track.id = album_track.track_id
-     WHERE EXISTS (
-       SELECT 1
-       FROM library_media_files AS media
-       WHERE ${mediaConditions.join(" AND ")}
+  const genreRows = (column) => GENRE_METADATA_PATHS.map((path) => `
+    SELECT album_id, track_id, TRIM(CAST(genre_value.value AS TEXT)) AS genre
+    FROM eligible_tracks
+    JOIN json_each(
+      CASE WHEN json_valid(${column}) THEN ${column} ELSE '{}' END,
+      '${path}'
+    ) AS genre_value
+    WHERE json_valid(${column})
+      AND TRIM(CAST(genre_value.value AS TEXT)) <> ''`).join(" UNION ");
+  return db.prepare(
+    `WITH eligible_tracks AS MATERIALIZED (
+       SELECT DISTINCT
+         album.id AS album_id,
+         track.id AS track_id,
+         artist.metadata_json AS artist_metadata_json,
+         album.metadata_json AS album_metadata_json,
+         track.metadata_json AS track_metadata_json
+       FROM library_albums AS album
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+       JOIN library_tracks AS track ON track.id = album_track.track_id
+       WHERE EXISTS (
+         SELECT 1
+         FROM library_media_files AS media
+         WHERE ${mediaConditions.join(" AND ")}
+       )
+     ),
+     direct_genres AS (
+       SELECT DISTINCT album_id, genre FROM (
+         ${genreRows("artist_metadata_json")}
+         UNION
+         ${genreRows("album_metadata_json")}
+       )
+     ),
+     track_genres AS (
+       SELECT DISTINCT album_id, track_id, genre FROM (
+         ${genreRows("track_metadata_json")}
+       )
+     ),
+     track_counts AS (
+       SELECT album_id, COUNT(*) AS song_count
+       FROM eligible_tracks
+       GROUP BY album_id
+     ),
+     album_genres AS (
+       SELECT direct.album_id, direct.genre, tracks.song_count
+       FROM direct_genres AS direct
+       JOIN track_counts AS tracks ON tracks.album_id = direct.album_id
+       UNION ALL
+       SELECT track.album_id, track.genre, COUNT(*) AS song_count
+       FROM track_genres AS track
+       WHERE NOT EXISTS (
+         SELECT 1 FROM direct_genres AS direct
+         WHERE direct.album_id = track.album_id AND direct.genre = track.genre
+       )
+       GROUP BY track.album_id, track.genre
      )
-     GROUP BY album.id, track.id`,
-  ).iterate(...parameters)) {
-    const album = albums.get(row.album_id) || {
-      artistGenres: metadataGenres({ metadata: parseJson(row.artist_metadata_json) }),
-      albumGenres: metadataGenres({ metadata: parseJson(row.album_metadata_json) }),
-      tracks: new Map(),
-    };
-    album.tracks.set(row.track_id, metadataGenres({ metadata: parseJson(row.track_metadata_json) }));
-    albums.set(row.album_id, album);
-  }
-  const genres = new Map();
-  for (const album of albums.values()) {
-    const trackCount = album.tracks.size;
-    const albumGenres = new Set([
-      ...album.artistGenres,
-      ...album.albumGenres,
-      ...[...album.tracks.values()].flat(),
-    ]);
-    for (const name of albumGenres) {
-      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
-      value.albumCount += 1;
-      value.songCount += album.artistGenres.includes(name) || album.albumGenres.includes(name)
-        ? trackCount
-        : [...album.tracks.values()].filter((trackGenres) => trackGenres.includes(name)).length;
-      genres.set(name, value);
-    }
-  }
-  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+     SELECT genre AS value, COUNT(*) AS albumCount, SUM(song_count) AS songCount
+     FROM album_genres
+     GROUP BY genre
+     ORDER BY genre COLLATE NOCASE`,
+  ).all(...parameters).map((row) => ({
+    albumCount: Number(row.albumCount || 0),
+    songCount: Number(row.songCount || 0),
+    value: row.value,
+  }));
 }
 
 function buildPageQuery({

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1694,14 +1694,17 @@ function buildPageQuery({
   if (sort === "newest" && (kind === "albums" || kind === "tracks")) {
     orderBy = recentMediaOrder(kind, sourceFilter, availableOnly, direction);
     if (kind === "albums") orderBy += ", album.id";
+    else orderBy += ", track.id";
   } else if (sort === "artist" && kind !== "artists") {
     orderBy = `artist.name COLLATE NOCASE ${orderDirection}, ${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
     if (kind === "albums") orderBy += ", album.id";
+    else orderBy += ", track.id";
   } else if (kind === "artists") {
     orderBy = `coalesce(artist.sort_name, artist.name) COLLATE NOCASE ${orderDirection}, artist.name COLLATE NOCASE ${orderDirection}, artist.id ${orderDirection}`;
   } else {
     orderBy = `${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
     if (kind === "albums") orderBy += `, album.id ${orderDirection}`;
+    else orderBy += `, track.id ${orderDirection}`;
   }
 
   return {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1,4 +1,9 @@
 import { db, dbHelpers } from "../config/db-sqlite.js";
+import {
+  computeLibraryGenreStats,
+  rebuildStoredLibraryGenreStats,
+} from "../config/library-search-index.js";
+import { getLibrarySearchMatch } from "./librarySearchIndex.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
@@ -609,29 +614,13 @@ export function getCanonicalLibrary({ source = null, availableOnly = false, favo
 
 const text = (value) => String(value || "").trim();
 
-const metadataGenres = (entity) => {
-  const metadata = entity?.metadata || {};
-  return [metadata.genres, metadata.genre, metadata.common?.genre, metadata.tags?.genre]
-    .flatMap((value) => (Array.isArray(value) ? value : [value]))
-    .map(text)
-    .filter(Boolean)
-    .filter((value, index, values) => values.indexOf(value) === index);
-};
-
-const addGenreStats = (stats, metadata, kind) => {
-  metadataGenres({ metadata }).forEach((genre) => {
-    const entry = stats.get(genre) || { name: genre, artists: 0, albums: 0, tracks: 0 };
-    entry[kind] += 1;
-    stats.set(genre, entry);
-  });
-};
-
 const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
 const pageSize = (value) =>
   Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
 
 const genreStatsCache = new Map();
+const GENRE_STATS_SETTING_PREFIX = "libraryGenreStats:";
 const GENRE_METADATA_PATHS = ["$.genres", "$.genre", "$.common.genre", "$.tags.genre"];
 
 const escapeLike = (value) => value.replace(/[\\%_]/g, "\\$&");
@@ -660,7 +649,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
     return `COALESCE((
       SELECT MAX(page_media.created_at)
       FROM library_album_tracks AS page_album_track
-      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
         ON page_media.track_id = page_album_track.track_id
       WHERE page_album_track.album_id = album.id
         AND ${albumMediaCondition("page_media", "page_album_track")}${mediaFilter}
@@ -668,7 +657,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
   }
   return `COALESCE((
     SELECT MAX(page_media.created_at)
-    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
     WHERE page_media.track_id = track.id${mediaFilter}
   ), 0) ${orderDirection}, track.title COLLATE NOCASE ${direction === "desc" ? "DESC" : "ASC"}`;
 };
@@ -683,7 +672,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
         SELECT 1
         FROM library_albums AS page_album
         JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
-        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
           ON page_media.track_id = page_album_track.track_id
         WHERE page_album.artist_id = artist.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
@@ -697,7 +686,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
       sql: `EXISTS (
         SELECT 1
         FROM library_album_tracks AS page_album_track
-        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+        JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
           ON page_media.track_id = page_album_track.track_id
         WHERE page_album_track.album_id = album.id
           AND ${albumMediaCondition("page_media", "page_album_track")}
@@ -708,7 +697,7 @@ const pageMediaExists = (kind, sourceFilter, availableOnly) => {
   }
   return {
     sql: `EXISTS (
-      SELECT 1 FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_source_available
+      SELECT 1 FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
       WHERE page_media.track_id = track.id AND ${conditionSql}
     )`,
     parameters,
@@ -746,13 +735,14 @@ export function getCanonicalArtistPage({
   offset = 0,
   limit = null,
   includeStats = false,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("artists", sourceFilter, availableOnly);
   const conditions = [media.sql];
   const parameters = [...media.parameters];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     conditions.push("lower(artist.name) LIKE ? ESCAPE '\\'");
     parameters.push(`%${escapeLike(normalizedQuery)}%`);
   }
@@ -760,12 +750,23 @@ export function getCanonicalArtistPage({
     ? null
     : pageLimit(limit);
   const pageSql = boundedLimit === null ? "" : "LIMIT ? OFFSET ?";
+  const searchJoin = searchMatch
+    ? `JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'artist' AND search_document.entity_id = artist.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?`
+    : "";
+  if (searchMatch) {
+    parameters.unshift(searchMatch);
+    conditions.push("lower(search_document.title) LIKE ? ESCAPE '\\'");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`);
+  }
   const ids = db.prepare(
     `SELECT artist.id
      FROM library_artists AS artist
+     ${searchJoin}
      WHERE ${conditions.join(" AND ")}
-     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
-       artist.name COLLATE NOCASE
+     ${searchMatch ? "" : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
      ${pageSql}`,
   ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
@@ -890,13 +891,14 @@ export function getCanonicalAlbumPage({
   artistId = null,
   offset = 0,
   limit = 20,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("albums", sourceFilter, availableOnly);
   const conditions = [media.sql];
   const parameters = [...media.parameters];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     const fields = ["album.title", "album.album_artist", "artist.name"];
     const pattern = `%${escapeLike(normalizedQuery)}%`;
     conditions.push(`(${fields.map((field) =>
@@ -947,19 +949,48 @@ export function getCanonicalAlbumPage({
 
   const boundedLimit = pageLimit(limit, 20);
   if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const searchJoin = searchMatch
+    ? `JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'album' AND search_document.entity_id = album.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?`
+    : "";
+  if (searchMatch) {
+    parameters.unshift(searchMatch);
+    conditions.push("(lower(search_document.title) LIKE ? ESCAPE '\\' OR lower(search_document.artist_name) LIKE ? ESCAPE '\\')");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`, `%${escapeLike(normalizedQuery)}%`);
+  }
   const ids = db.prepare(
     `SELECT album.id
      FROM library_albums AS album
      JOIN library_artists AS artist ON artist.id = album.artist_id
+     ${searchJoin}
      WHERE ${conditions.join(" AND ")}
      GROUP BY album.id
-     ORDER BY ${orderBy}
+     ${searchMatch ? "" : `ORDER BY ${orderBy}`}
      LIMIT ? OFFSET ?`,
   ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
   const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
   const albumsById = new Map(library.albums.map((album) => [album.id, album]));
   library.albums = ids.map((id) => albumsById.get(id)).filter(Boolean);
   return library;
+}
+
+function getRandomTrackIds({ conditions, parameters, limit, offset }) {
+  const maximum = Number(db.prepare("SELECT max(id) AS maximum FROM library_tracks").get()?.maximum || 0);
+  if (!maximum) return [];
+  const needed = limit + offset;
+  const pivot = Math.floor(Math.random() * maximum) + 1;
+  const read = (operator, boundary, count) => db.prepare(
+    `SELECT track.id
+     FROM library_tracks AS track
+     WHERE ${conditions.join(" AND ")} AND track.id ${operator} ?
+     ORDER BY track.id
+     LIMIT ?`,
+  ).all(...parameters, boundary, count).map((row) => row.id);
+  const ids = read(">=", pivot, needed);
+  if (ids.length < needed) ids.push(...read("<", pivot, needed - ids.length));
+  return ids.slice(offset, offset + limit);
 }
 
 export function getCanonicalTrackPage({
@@ -973,6 +1004,7 @@ export function getCanonicalTrackPage({
   offset = 0,
   limit = 20,
   random = false,
+  searchMatch = null,
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("tracks", sourceFilter, availableOnly);
@@ -986,7 +1018,7 @@ export function getCanonicalTrackPage({
     "artist.name",
   ];
   const normalizedQuery = text(query).toLocaleLowerCase();
-  if (normalizedQuery) {
+  if (normalizedQuery && !searchMatch) {
     const pattern = `%${escapeLike(normalizedQuery)}%`;
     conditions.push(`(${fields.map((field) =>
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
@@ -1014,6 +1046,47 @@ export function getCanonicalTrackPage({
   }
   const boundedLimit = pageLimit(limit, 20);
   if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const useSearchIndex = Boolean(searchMatch)
+    && !artistReference
+    && !(artistId !== null && artistId !== undefined && String(artistId).trim())
+    && !(albumId !== null && albumId !== undefined && String(albumId).trim())
+    && !normalizedGenre;
+  if (useSearchIndex) {
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    const searchConditions = [
+      ...conditions,
+      "(lower(search_document.title) LIKE ? ESCAPE '\\' OR lower(search_document.artist_name) LIKE ? ESCAPE '\\' OR lower(search_document.album_name) LIKE ? ESCAPE '\\')",
+    ];
+    const ids = db.prepare(
+      `SELECT track.id
+       FROM library_tracks AS track
+       JOIN library_search_documents AS search_document
+         ON search_document.entity_kind = 'track' AND search_document.entity_id = track.id
+       JOIN library_search_fts AS search_fts
+         ON search_fts.rowid = search_document.id AND library_search_fts MATCH ?
+       WHERE ${searchConditions.join(" AND ")}
+       LIMIT ? OFFSET ?`,
+    ).all(searchMatch, ...parameters, pattern, pattern, pattern, boundedLimit, pageOffset(offset))
+      .map((row) => row.id);
+    const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+    const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+    library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+    return library;
+  }
+  if (random && !normalizedQuery && !artistReference && !normalizedGenre
+    && !(artistId !== null && artistId !== undefined && String(artistId).trim())
+    && !(albumId !== null && albumId !== undefined && String(albumId).trim())) {
+    const ids = getRandomTrackIds({
+      conditions,
+      parameters,
+      limit: boundedLimit,
+      offset: pageOffset(offset),
+    });
+    const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+    const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+    library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+    return library;
+  }
   const orderBy = random
     ? "random()"
     : "artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number, track.title COLLATE NOCASE";
@@ -1045,12 +1118,14 @@ export function getCanonicalSearchPage({
   songLimit = 20,
   songOffset = 0,
 } = {}) {
+  const searchMatch = getLibrarySearchMatch(query);
   const albumLibrary = getCanonicalAlbumPage({
     source,
     availableOnly,
     query,
     limit: albumLimit,
     offset: albumOffset,
+    searchMatch,
   });
   const trackLibrary = getCanonicalTrackPage({
     source,
@@ -1058,9 +1133,17 @@ export function getCanonicalSearchPage({
     query,
     limit: songLimit,
     offset: songOffset,
+    searchMatch,
   });
   return {
-    artists: getCanonicalArtistPage({ source, availableOnly, query, limit: artistLimit, offset: artistOffset }).artists,
+    artists: getCanonicalArtistPage({
+      source,
+      availableOnly,
+      query,
+      limit: artistLimit,
+      offset: artistOffset,
+      searchMatch,
+    }).artists,
     albums: albumLibrary,
     tracks: trackLibrary,
   };
@@ -1171,12 +1254,16 @@ function buildPageQuery({
   const media = pageMediaExists(kind, sourceFilter, availableOnly);
   where.push(media.sql);
   parameters.push(...media.parameters);
+  const searchMatch = getLibrarySearchMatch(query);
 
   let from;
   let idExpression;
   let searchableFields;
   let genreAliases;
+  let entityKind;
+  let groupBy = null;
   if (kind === "artists") {
+    entityKind = "artist";
     from = "FROM library_artists AS artist";
     idExpression = "artist.id";
     searchableFields = ["artist.name"];
@@ -1190,6 +1277,7 @@ function buildPageQuery({
       parameters.push(Number(albumId));
     }
   } else if (kind === "albums") {
+    entityKind = "album";
     from = "FROM library_albums AS album JOIN library_artists AS artist ON artist.id = album.artist_id";
     idExpression = "album.id";
     searchableFields = ["album.title", "album.album_artist", "artist.name"];
@@ -1203,10 +1291,16 @@ function buildPageQuery({
       parameters.push(Number(albumId));
     }
   } else {
-    from = `FROM library_tracks AS track
-      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
-      JOIN library_albums AS album ON album.id = album_track.album_id
-      JOIN library_artists AS artist ON artist.id = album.artist_id`;
+    entityKind = "track";
+    const needsRelations = Boolean(artistId || albumId || genre || sort === "artist")
+      || Boolean(query && !searchMatch);
+    from = needsRelations
+      ? `FROM library_tracks AS track
+        JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+        JOIN library_albums AS album ON album.id = album_track.album_id
+        JOIN library_artists AS artist ON artist.id = album.artist_id`
+      : "FROM library_tracks AS track";
+    if (needsRelations) groupBy = "track.id";
     idExpression = "track.id";
     searchableFields = [
       "track.title",
@@ -1226,7 +1320,29 @@ function buildPageQuery({
     }
   }
 
-  if (query) {
+  if (searchMatch) {
+    from += `
+      JOIN library_search_documents AS search_document
+        ON search_document.entity_kind = '${entityKind}'
+        AND search_document.entity_id = ${idExpression}
+      JOIN library_search_fts AS search_fts
+        ON search_fts.rowid = search_document.id
+        AND library_search_fts MATCH ?`;
+    parameters.unshift(searchMatch);
+    const pattern = `%${escapeLike(query)}%`;
+    const indexedFields = kind === "artists"
+      ? ["search_document.title"]
+      : kind === "albums"
+        ? ["search_document.title", "search_document.artist_name"]
+        : [
+            "search_document.title",
+            "search_document.artist_name",
+            "search_document.album_name",
+          ];
+    where.push(`(${indexedFields.map((field) =>
+      `lower(${field}) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...indexedFields.map(() => pattern));
+  } else if (query) {
     const pattern = `%${escapeLike(query)}%`;
     where.push(`(${searchableFields.map((field) =>
       `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
@@ -1256,6 +1372,7 @@ function buildPageQuery({
     where: where.join(" AND "),
     parameters,
     orderBy,
+    groupBy,
   };
 }
 
@@ -1263,29 +1380,16 @@ function getCanonicalGenreStats({ sourceFilter, availableOnly }) {
   const cacheKey = `${sourceFilter || "all"}:${availableOnly === true ? "available" : "all"}`;
   const cached = genreStatsCache.get(cacheKey);
   if (cached) return cached;
-  const artistMedia = pageMediaExists("artists", sourceFilter, availableOnly);
-  const albumMedia = pageMediaExists("albums", sourceFilter, availableOnly);
-  const trackMedia = pageMediaExists("tracks", sourceFilter, availableOnly);
-  const stats = new Map();
-  for (const row of db.prepare(
-    `SELECT artist.metadata_json FROM library_artists AS artist WHERE ${artistMedia.sql}`,
-  ).iterate(...artistMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "artists");
+  const settingKey = `${GENRE_STATS_SETTING_PREFIX}${cacheKey}`;
+  const stored = db.prepare("SELECT value FROM settings WHERE key = ?").get(settingKey)?.value;
+  if (stored) {
+    const parsed = parseJson(stored);
+    if (Array.isArray(parsed)) {
+      genreStatsCache.set(cacheKey, parsed);
+      return parsed;
+    }
   }
-  for (const row of db.prepare(
-    `SELECT album.metadata_json
-     FROM library_albums AS album
-     JOIN library_artists AS artist ON artist.id = album.artist_id
-     WHERE ${albumMedia.sql}`,
-  ).iterate(...albumMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "albums");
-  }
-  for (const row of db.prepare(
-    `SELECT track.metadata_json FROM library_tracks AS track WHERE ${trackMedia.sql}`,
-  ).iterate(...trackMedia.parameters)) {
-    addGenreStats(stats, parseJson(row.metadata_json), "tracks");
-  }
-  const sortedStats = [...stats.values()].sort((left, right) => left.name.localeCompare(right.name));
+  const sortedStats = computeLibraryGenreStats(db, { sourceFilter, availableOnly });
   genreStatsCache.set(cacheKey, sortedStats);
   return sortedStats;
 }
@@ -1519,7 +1623,7 @@ export function getCanonicalLibraryPage({
     `SELECT ${queryDefinition.idExpression} AS page_id
      ${queryDefinition.from}
      WHERE ${queryDefinition.where}
-     GROUP BY ${queryDefinition.idExpression}
+     ${queryDefinition.groupBy ? `GROUP BY ${queryDefinition.groupBy}` : ""}
      ORDER BY ${queryDefinition.orderBy}
      LIMIT ? OFFSET ?`,
   ).all(
@@ -1577,9 +1681,18 @@ export function getCanonicalLibraryPage({
   };
 }
 
-export function invalidateCanonicalLibraryCache() {
+export function rebuildCanonicalGenreStats() {
+  db.prepare("DELETE FROM settings WHERE key LIKE ?").run(`${GENRE_STATS_SETTING_PREFIX}%`);
+  genreStatsCache.clear();
+  rebuildStoredLibraryGenreStats(db);
+}
+
+export function invalidateCanonicalLibraryCache({ persistedGenres = true } = {}) {
   libraryCache.clear();
   genreStatsCache.clear();
+  if (persistedGenres) {
+    db.prepare("DELETE FROM settings WHERE key LIKE ?").run(`${GENRE_STATS_SETTING_PREFIX}%`);
+  }
 }
 
 export { normalizeSource };

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -5,6 +5,7 @@ const libraryCache = new Map();
 const PAGE_KINDS = new Set(["artists", "albums", "tracks", "genres"]);
 const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 100;
+const MAX_ARTIST_PROJECTION_PAGE_SIZE = 10000;
 
 const parseJson = (value) => {
   if (!value) return null;
@@ -261,9 +262,20 @@ const canonicalArtistProjection = (row) => {
   };
 };
 
-function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, reference = null } = {}) {
+function buildCanonicalArtistProjectionQuery({
+  page = 1,
+  pageSize = 100,
+  offset = null,
+  reference = null,
+} = {}) {
   const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
-  const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
+  const normalizedPageSize = Math.min(
+    MAX_ARTIST_PROJECTION_PAGE_SIZE,
+    Math.max(1, Number.parseInt(pageSize, 10) || 100),
+  );
+  const normalizedOffset = offset == null
+    ? (normalizedPage - 1) * normalizedPageSize
+    : Math.max(0, Number.parseInt(offset, 10) || 0);
   const references = normalizeLookupValues(reference == null ? [] : [reference]);
   const parameters = [];
   const where = [];
@@ -288,7 +300,7 @@ function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, referen
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const limit = references.length ? "" : "LIMIT ? OFFSET ?";
   if (!references.length) {
-    parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
+    parameters.push(normalizedPageSize, normalizedOffset);
   }
   return {
     parameters,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -429,6 +429,73 @@ export function getCanonicalLibraryForArtists({
   });
 }
 
+function getCanonicalLibraryForIds(kind, ids, source, availableOnly) {
+  const values = [...new Set((Array.isArray(ids) ? ids : [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0))];
+  if (!values.length) return { artists: [], albums: [], tracks: [] };
+  const alias = kind === "artists" ? "artist" : kind === "albums" ? "album" : "track";
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`${alias}.id IN (${values.map(() => "?").join(",")})`],
+    parameters: values,
+  });
+}
+
+export function getCanonicalLibraryForArtistReferences({
+  source = null,
+  availableOnly = false,
+  references: requestedReferences = [],
+} = {}) {
+  const references = normalizeLookupValues(requestedReferences);
+  if (!references.length) return { artists: [], albums: [], tracks: [] };
+  const conditions = [];
+  const parameters = [];
+  for (const reference of references) {
+    if (/^\d+$/.test(reference)) {
+      conditions.push("artist.id = ?");
+      parameters.push(Number(reference));
+    } else {
+      conditions.push("(artist.identity_key = ? OR artist.mbid = ?)");
+      parameters.push(reference, reference);
+    }
+  }
+  return getScopedCanonicalLibrary({
+    source,
+    availableOnly,
+    conditions: [`(${conditions.join(" OR ")})`],
+    parameters,
+  });
+}
+
+export function getCanonicalLibraryForAlbumIds({
+  source = null,
+  availableOnly = false,
+  ids = [],
+} = {}) {
+  return getCanonicalLibraryForIds("albums", ids, source, availableOnly);
+}
+
+export function getCanonicalLibraryForTrackIds({
+  source = null,
+  availableOnly = false,
+  ids = [],
+  albumId = null,
+} = {}) {
+  const values = [...new Set((Array.isArray(ids) ? ids : [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0))];
+  if (!values.length) return { artists: [], albums: [], tracks: [] };
+  const conditions = [`track.id IN (${values.map(() => "?").join(",")})`];
+  const parameters = [...values];
+  if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
+    conditions.push("album.id = ?");
+    parameters.push(Number(albumId));
+  }
+  return getScopedCanonicalLibrary({ source, availableOnly, conditions, parameters });
+}
+
 export function getCanonicalLibraryForAlbumReferences({
   source = null,
   availableOnly = false,
@@ -677,6 +744,402 @@ const genrePredicate = (aliases, genre) => {
   });
   return { sql: `(${clauses.join(" OR ")})`, parameters };
 };
+
+const pageLimit = (value, fallback = 10000) => {
+  if (value === null || value === undefined || value === "") return fallback;
+  return Math.min(10000, Math.max(0, Number.parseInt(value, 10) || 0));
+};
+
+const pageOffset = (value) => Math.max(0, Number.parseInt(value, 10) || 0);
+
+export function getCanonicalArtistPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  offset = 0,
+  limit = null,
+  includeStats = false,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("artists", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    conditions.push("lower(artist.name) LIKE ? ESCAPE '\\'");
+    parameters.push(`%${escapeLike(normalizedQuery)}%`);
+  }
+  const boundedLimit = limit === null || limit === undefined || limit === ""
+    ? null
+    : pageLimit(limit);
+  const pageSql = boundedLimit === null ? "" : "LIMIT ? OFFSET ?";
+  const ids = db.prepare(
+    `SELECT artist.id
+     FROM library_artists AS artist
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
+       artist.name COLLATE NOCASE
+     ${pageSql}`,
+  ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
+  if (!ids.length) return { artists: [], albums: [], tracks: [] };
+
+  if (!includeStats) {
+    const rows = db.prepare(
+      `SELECT
+         artist.id AS artist_id,
+         artist.identity_key AS artist_identity_key,
+         artist.mbid AS artist_mbid,
+         artist.name AS artist_name,
+         artist.sort_name AS artist_sort_name,
+         artist.metadata_json AS artist_metadata_json,
+         COUNT(DISTINCT album.id) AS album_count
+       FROM library_artists AS artist
+       JOIN library_albums AS album ON album.artist_id = artist.id
+       WHERE artist.id IN (${ids.map(() => "?").join(",")})
+         AND EXISTS (
+           SELECT 1
+           FROM library_album_tracks AS album_track
+           JOIN library_media_files AS media
+             ON media.track_id = album_track.track_id
+             AND ${albumMediaCondition("media", "album_track")}
+           WHERE album_track.album_id = album.id
+             ${sourceFilter ? "AND media.source = ?" : ""}
+             ${availableOnly === true ? "AND media.available = 1" : ""}
+         )
+       GROUP BY artist.id`,
+    ).all(...ids, ...(sourceFilter ? [sourceFilter] : []));
+    const byId = new Map(rows.map((row) => [row.artist_id, {
+      id: row.artist_id,
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata: parseJson(row.artist_metadata_json),
+      albumIds: [],
+      albumCount: Number(row.album_count || 0),
+      sources: [],
+      available: availableOnly === true,
+    }]));
+    return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
+  }
+
+  const aggregateParameters = [];
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    aggregateParameters.push(sourceFilter);
+  }
+  if (availableOnly === true) mediaConditions.push("media.available = 1");
+  aggregateParameters.push(...ids);
+  const rows = db.prepare(
+    `SELECT
+       artist.id AS artist_id,
+       artist.identity_key AS artist_identity_key,
+       artist.mbid AS artist_mbid,
+       artist.name AS artist_name,
+       artist.sort_name AS artist_sort_name,
+       artist.metadata_json AS artist_metadata_json,
+       COUNT(DISTINCT album.id) AS album_count,
+       COUNT(DISTINCT album_track.track_id) AS track_count,
+       COALESCE(SUM(media.size), 0) AS size_on_disk,
+       MAX(media.available) AS available
+     FROM library_artists AS artist
+     JOIN library_albums AS album ON album.artist_id = artist.id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     WHERE artist.id IN (${ids.map(() => "?").join(",")})
+     GROUP BY artist.id
+     ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
+       artist.name COLLATE NOCASE`,
+  ).all(...aggregateParameters);
+  const byId = new Map(rows.map((row) => [row.artist_id, {
+    id: row.artist_id,
+    identityKey: row.artist_identity_key,
+    mbid: row.artist_mbid,
+    name: row.artist_name,
+    sortName: row.artist_sort_name,
+    metadata: parseJson(row.artist_metadata_json),
+    albumIds: [],
+    albumCount: Number(row.album_count || 0),
+    trackCount: Number(row.track_count || 0),
+    sizeOnDisk: Number(row.size_on_disk || 0),
+    sources: [],
+    available: Boolean(row.available),
+  }]));
+  return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
+}
+
+function albumGenrePredicate(genre) {
+  const direct = genrePredicate(["artist", "album"], genre);
+  const tracks = genrePredicate(["track"], genre);
+  return {
+    sql: `(${direct.sql} OR EXISTS (
+      SELECT 1
+      FROM library_album_tracks AS genre_album_track
+      JOIN library_tracks AS track ON track.id = genre_album_track.track_id
+      WHERE genre_album_track.album_id = album.id
+        AND ${tracks.sql}
+    ))`,
+    parameters: [...direct.parameters, ...tracks.parameters],
+  };
+}
+
+export function getCanonicalAlbumPage({
+  source = null,
+  availableOnly = false,
+  type = "alphabeticalByName",
+  genre = "",
+  fromYear = null,
+  toYear = null,
+  query = "",
+  artistId = null,
+  offset = 0,
+  limit = 20,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("albums", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    const fields = ["album.title", "album.album_artist", "artist.name"];
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    conditions.push(`(${fields.map((field) =>
+      `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...fields.map(() => pattern));
+  }
+  if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
+    conditions.push("album.artist_id = ?");
+    parameters.push(Number(artistId));
+  }
+  const normalizedGenre = text(genre);
+  if (normalizedGenre) {
+    const predicate = albumGenrePredicate(normalizedGenre);
+    conditions.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+  const parsedFromYear = Number.parseInt(fromYear, 10);
+  const parsedToYear = Number.parseInt(toYear, 10);
+  const lowerYear = Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear)
+    ? Math.min(parsedFromYear, parsedToYear)
+    : parsedFromYear;
+  const upperYear = Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear)
+    ? Math.max(parsedFromYear, parsedToYear)
+    : parsedToYear;
+  if (Number.isFinite(lowerYear)) {
+    conditions.push("CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) >= ?");
+    parameters.push(lowerYear);
+  }
+  if (Number.isFinite(upperYear)) {
+    conditions.push("CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) <= ?");
+    parameters.push(upperYear);
+  }
+
+  let orderBy;
+  if (type === "random") {
+    orderBy = "random()";
+  } else if (type === "newest" || type === "recent") {
+    orderBy = "CASE WHEN album.release_date GLOB '[0-9][0-9][0-9][0-9]*' THEN album.release_date END DESC, album.title COLLATE NOCASE";
+  } else if (type === "alphabeticalByArtist") {
+    orderBy = "coalesce(album.album_artist, artist.name) COLLATE NOCASE, album.title COLLATE NOCASE";
+  } else if (type === "byYear") {
+    orderBy = `CAST(substr(COALESCE(album.release_date, ''), 1, 4) AS INTEGER) ${Number.isFinite(parsedFromYear) && Number.isFinite(parsedToYear) && parsedFromYear > parsedToYear ? "DESC" : "ASC"}, album.title COLLATE NOCASE`;
+  } else if (type === "byGenre") {
+    orderBy = "coalesce(artist.name, album.album_artist) COLLATE NOCASE, album.title COLLATE NOCASE";
+  } else {
+    orderBy = "album.title COLLATE NOCASE, coalesce(album.album_artist, artist.name) COLLATE NOCASE";
+  }
+
+  const boundedLimit = pageLimit(limit, 20);
+  if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const ids = db.prepare(
+    `SELECT album.id
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE ${conditions.join(" AND ")}
+     GROUP BY album.id
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+  ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
+  const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
+  const albumsById = new Map(library.albums.map((album) => [album.id, album]));
+  library.albums = ids.map((id) => albumsById.get(id)).filter(Boolean);
+  return library;
+}
+
+export function getCanonicalTrackPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  genre = "",
+  artist = "",
+  artistId = null,
+  albumId = null,
+  offset = 0,
+  limit = 20,
+  random = false,
+} = {}) {
+  const sourceFilter = normalizeSource(source);
+  const media = pageMediaExists("tracks", sourceFilter, availableOnly);
+  const conditions = [media.sql];
+  const parameters = [...media.parameters];
+  const fields = [
+    "track.title",
+    "track.artist_name",
+    "album.title",
+    "album.album_artist",
+    "artist.name",
+  ];
+  const normalizedQuery = text(query).toLocaleLowerCase();
+  if (normalizedQuery) {
+    const pattern = `%${escapeLike(normalizedQuery)}%`;
+    conditions.push(`(${fields.map((field) =>
+      `lower(coalesce(${field}, '')) LIKE ? ESCAPE '\\'`).join(" OR ")})`);
+    parameters.push(...fields.map(() => pattern));
+  }
+  const normalizedArtist = text(artist).toLocaleLowerCase();
+  if (normalizedArtist) {
+    conditions.push("(lower(artist.name) = ? OR lower(coalesce(track.artist_name, '')) = ? OR artist.identity_key = ?)");
+    parameters.push(normalizedArtist, normalizedArtist, artist);
+  }
+  if (artistId !== null && artistId !== undefined && String(artistId).trim()) {
+    conditions.push("artist.id = ?");
+    parameters.push(Number(artistId));
+  }
+  if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
+    conditions.push("album.id = ?");
+    parameters.push(Number(albumId));
+  }
+  const normalizedGenre = text(genre);
+  if (normalizedGenre) {
+    const predicate = genrePredicate(["artist", "album", "track"], normalizedGenre);
+    conditions.push(predicate.sql);
+    parameters.push(...predicate.parameters);
+  }
+  const boundedLimit = pageLimit(limit, 20);
+  if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
+  const orderBy = random
+    ? "random()"
+    : "artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE, album.title COLLATE NOCASE, album_track.disc_number, album_track.track_number, track.title COLLATE NOCASE";
+  const ids = db.prepare(
+    `SELECT track.id
+     FROM library_tracks AS track
+     JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+     JOIN library_albums AS album ON album.id = album_track.album_id
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE ${conditions.join(" AND ")}
+     GROUP BY track.id
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+  ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
+  const library = getCanonicalLibraryForTrackIds({ source: sourceFilter, availableOnly, ids, albumId });
+  const tracksById = new Map(library.tracks.map((track) => [track.id, track]));
+  library.tracks = ids.map((id) => tracksById.get(id)).filter(Boolean);
+  return library;
+}
+
+export function getCanonicalSearchPage({
+  source = null,
+  availableOnly = false,
+  query = "",
+  artistLimit = 20,
+  artistOffset = 0,
+  albumLimit = 20,
+  albumOffset = 0,
+  songLimit = 20,
+  songOffset = 0,
+} = {}) {
+  const albumLibrary = getCanonicalAlbumPage({
+    source,
+    availableOnly,
+    query,
+    limit: albumLimit,
+    offset: albumOffset,
+  });
+  const trackLibrary = getCanonicalTrackPage({
+    source,
+    availableOnly,
+    query,
+    limit: songLimit,
+    offset: songOffset,
+  });
+  return {
+    artists: getCanonicalArtistPage({ source, availableOnly, query, limit: artistLimit, offset: artistOffset }).artists,
+    albums: albumLibrary,
+    tracks: trackLibrary,
+  };
+}
+
+export function getCanonicalTopTracks({
+  source = null,
+  availableOnly = false,
+  artist,
+  limit = 20,
+} = {}) {
+  return getCanonicalTrackPage({ source, availableOnly, artist, limit });
+}
+
+export function getCanonicalGenres({ source = null, availableOnly = false } = {}) {
+  const sourceFilter = normalizeSource(source);
+  const mediaConditions = [
+    "media.track_id = album_track.track_id",
+    albumMediaCondition("media", "album_track"),
+  ];
+  const parameters = [];
+  if (sourceFilter) {
+    mediaConditions.push("media.source = ?");
+    parameters.push(sourceFilter);
+  }
+  if (availableOnly === true) mediaConditions.push("media.available = 1");
+  const albums = new Map();
+  for (const row of db.prepare(
+    `SELECT
+       album.id AS album_id,
+       track.id AS track_id,
+       artist.metadata_json AS artist_metadata_json,
+       album.metadata_json AS album_metadata_json,
+       track.metadata_json AS track_metadata_json
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+     JOIN library_tracks AS track ON track.id = album_track.track_id
+     WHERE EXISTS (
+       SELECT 1
+       FROM library_media_files AS media
+       WHERE ${mediaConditions.join(" AND ")}
+     )
+     GROUP BY album.id, track.id`,
+  ).iterate(...parameters)) {
+    const album = albums.get(row.album_id) || {
+      artistGenres: metadataGenres({ metadata: parseJson(row.artist_metadata_json) }),
+      albumGenres: metadataGenres({ metadata: parseJson(row.album_metadata_json) }),
+      tracks: new Map(),
+    };
+    album.tracks.set(row.track_id, metadataGenres({ metadata: parseJson(row.track_metadata_json) }));
+    albums.set(row.album_id, album);
+  }
+  const genres = new Map();
+  for (const album of albums.values()) {
+    const trackCount = album.tracks.size;
+    const albumGenres = new Set([
+      ...album.artistGenres,
+      ...album.albumGenres,
+      ...[...album.tracks.values()].flat(),
+    ]);
+    for (const name of albumGenres) {
+      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
+      value.albumCount += 1;
+      value.songCount += album.artistGenres.includes(name) || album.albumGenres.includes(name)
+        ? trackCount
+        : [...album.tracks.values()].filter((trackGenres) => trackGenres.includes(name)).length;
+      genres.set(name, value);
+    }
+  }
+  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+}
 
 function buildPageQuery({
   kind,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -236,6 +236,7 @@ const canonicalArtistProjection = (row) => {
     id: String(row.id),
     canonicalId: String(row.id),
     providerId,
+    lidarrManaged: metadata.librarySource === "lidarr",
     mbid: row.mbid || null,
     foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
     artistName: row.name,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -529,13 +529,14 @@ export function getCanonicalLibraryForAlbumReferences({
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
   parameters.push(...ids);
+  const mediaJoin = sourceFilter || availableOnly === true ? "JOIN" : "LEFT JOIN";
   const rows = db.prepare(
     `${CANONICAL_SELECT}
      FROM library_tracks AS track
      JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
      JOIN library_albums AS album ON album.id = album_track.album_id
      JOIN library_artists AS artist ON artist.id = album.artist_id
-     LEFT JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     ${mediaJoin} library_media_files AS media ON ${mediaConditions.join(" AND ")}
      WHERE album.id IN (${ids.map(() => "?").join(",")})
      ${canonicalOrder}`,
   ).iterate(...parameters);

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -729,27 +729,14 @@ export function getCanonicalLibraryForArtistReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-  const placeholders = references.map(() => "?").join(",");
-  return getScopedCanonicalLibrary({
-    source,
-    availableOnly,
-    conditions: [`(
-      artist.id IN (${placeholders}) OR
-      artist.mbid IN (${placeholders}) OR
-      artist.identity_key IN (${placeholders}) OR
-      CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${placeholders}) OR
-      CAST(json_extract(artist.metadata_json, '$.foreignArtistId') AS TEXT) IN (${placeholders}) OR
-      lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
-    )`],
-    parameters: [
-      ...references,
-      ...references,
-      ...references,
-      ...references,
-      ...references,
-      ...references,
-    ],
-  });
+  const ids = resolveCanonicalReferenceIds("library_artists", references, [
+    "identity_key",
+    "mbid",
+    "CAST(json_extract(metadata_json, '$.id') AS TEXT)",
+    "CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT)",
+    "name COLLATE NOCASE",
+  ]);
+  return getCanonicalLibraryForIds("artists", ids, source, availableOnly);
 }
 
 export function getCanonicalLibraryForAlbumIds({

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -871,8 +871,8 @@ const addGenreStats = (stats, metadata, kind) => {
 
 const pageNumber = (value) => Math.max(1, Number.parseInt(value, 10) || 1);
 
-const pageSize = (value) =>
-  Math.min(MAX_PAGE_SIZE, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
+const pageSize = (value, max = MAX_PAGE_SIZE) =>
+  Math.min(max, Math.max(1, Number.parseInt(value, 10) || DEFAULT_PAGE_SIZE));
 
 const genreStatsCache = new Map();
 const GENRE_METADATA_PATHS = ["$.genres", "$.genre", "$.common.genre", "$.tags.genre"];
@@ -1287,6 +1287,7 @@ export function getCanonicalLibraryPage({
   kind = "albums",
   page = 1,
   pageSize: requestedPageSize = DEFAULT_PAGE_SIZE,
+  offset = null,
   query = "",
   genre = "",
   sort = null,
@@ -1306,7 +1307,13 @@ export function getCanonicalLibraryPage({
     text(sort).toLocaleLowerCase() ||
     (normalizedKind === "tracks" && albumId ? "album" : "name");
   const currentPage = pageNumber(page);
-  const currentPageSize = pageSize(requestedPageSize);
+  const currentPageSize = pageSize(
+    requestedPageSize,
+    normalizedKind === "artists" ? MAX_ARTIST_PROJECTION_PAGE_SIZE : MAX_PAGE_SIZE,
+  );
+  const currentOffset = offset == null
+    ? (currentPage - 1) * currentPageSize
+    : Math.max(0, Number.parseInt(offset, 10) || 0);
 
   if (normalizedKind === "genres") {
     let collection = getCanonicalGenreStats({ sourceFilter, availableOnly });
@@ -1371,7 +1378,7 @@ export function getCanonicalLibraryPage({
   ).all(
     ...queryDefinition.parameters,
     currentPageSize,
-    (currentPage - 1) * currentPageSize,
+    currentOffset,
   ).map((row) => row.page_id);
   const library = getPageLibrary(normalizedKind, ids, sourceFilter, availableOnly, albumId);
   const artistsById = new Map(library.artists.map((artist) => [String(artist.id), artist]));

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -225,12 +225,19 @@ const canonicalArtistProjection = (row) => {
   const metadata = parseJson(row.metadata_json) || {};
   const providerId = metadata.id == null ? null : String(metadata.id);
   const monitorOption = metadata.monitor || metadata.addOptions?.monitor || "none";
+  const sources = new Set(
+    String(row.sources || "")
+      .split(",")
+      .map((source) => source.trim())
+      .filter(Boolean),
+  );
+  if (metadata.librarySource === "lidarr") sources.add("lidarr");
   return {
-    id: providerId || String(row.id),
+    id: String(row.id),
     canonicalId: String(row.id),
     providerId,
     mbid: row.mbid || null,
-    foreignArtistId: row.mbid || row.identity_key,
+    foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
     artistName: row.name,
     name: row.name,
     sortName: row.sort_name || row.name,
@@ -247,16 +254,13 @@ const canonicalArtistProjection = (row) => {
       trackCount: Number(row.track_count || 0),
       sizeOnDisk: Number(row.size_on_disk || 0),
     },
-    sources: String(row.sources || "")
-      .split(",")
-      .map((source) => source.trim())
-      .filter(Boolean),
+    sources: [...sources].sort(),
     available: Boolean(row.available),
     stale: Boolean(row.stale),
   };
 };
 
-export function getCanonicalArtistProjection({ page = 1, pageSize = 100, reference = null } = {}) {
+function buildCanonicalArtistProjectionQuery({ page = 1, pageSize = 100, reference = null } = {}) {
   const normalizedPage = Math.max(1, Number.parseInt(page, 10) || 1);
   const normalizedPageSize = Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100));
   const references = normalizeLookupValues(reference == null ? [] : [reference]);
@@ -268,16 +272,40 @@ export function getCanonicalArtistProjection({ page = 1, pageSize = 100, referen
       artist.mbid IN (${references.map(() => "?").join(",")}) OR
       artist.identity_key IN (${references.map(() => "?").join(",")}) OR
       CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
+      CAST(json_extract(artist.metadata_json, '$.foreignArtistId') AS TEXT) IN (${references.map(() => "?").join(",")}) OR
       lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
     )`);
-    parameters.push(...references, ...references, ...references, ...references, ...references);
+    parameters.push(
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+    );
   }
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const limit = references.length ? "" : "LIMIT ? OFFSET ?";
   if (!references.length) {
     parameters.push(normalizedPageSize, (normalizedPage - 1) * normalizedPageSize);
   }
-  const rows = db.prepare(`
+  return {
+    parameters,
+    sql: `
+    WITH artist_page AS MATERIALIZED (
+      SELECT
+        artist.id,
+        artist.identity_key,
+        artist.mbid,
+        artist.name,
+        artist.sort_name,
+        artist.metadata_json,
+        artist.created_at
+      FROM library_artists AS artist
+      ${whereSql}
+      ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
+      ${limit}
+    )
     SELECT
       artist.id,
       artist.identity_key,
@@ -304,17 +332,26 @@ export function getCanonicalArtistProjection({ page = 1, pageSize = 100, referen
             LIMIT 1
           ), 0)
       ) THEN 1 ELSE 0 END AS stale
-    FROM library_artists AS artist
+    FROM artist_page AS artist
     LEFT JOIN library_albums AS album ON album.artist_id = artist.id
     LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
     LEFT JOIN library_media_files AS media ON media.track_id = album_track.track_id
       AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
-    ${whereSql}
     GROUP BY artist.id
     ORDER BY artist.sort_name COLLATE NOCASE, artist.name COLLATE NOCASE
-    ${limit}
-  `).all(...parameters);
+  `,
+  };
+}
+
+export function getCanonicalArtistProjection(options = {}) {
+  const query = buildCanonicalArtistProjectionQuery(options);
+  const rows = db.prepare(query.sql).all(...query.parameters);
   return rows.map(canonicalArtistProjection);
+}
+
+export function getCanonicalArtistProjectionQueryPlan(options = {}) {
+  const query = buildCanonicalArtistProjectionQuery(options);
+  return db.prepare(`EXPLAIN QUERY PLAN ${query.sql}`).all(...query.parameters);
 }
 
 export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
@@ -323,6 +360,104 @@ export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
     yield* artists;
     if (artists.length < Math.min(100, Math.max(1, Number.parseInt(pageSize, 10) || 100))) break;
   }
+}
+
+const canonicalDateAlbumProjection = (row) => {
+  const metadata = parseJson(row.metadata_json) || {};
+  const artistMetadata = parseJson(row.artist_metadata_json) || {};
+  const trackCount = Number(row.track_count || 0);
+  const availableTrackCount = Number(row.available_track_count || 0);
+  return {
+    id: String(row.id),
+    canonicalId: String(row.id),
+    providerId: metadata.id == null ? null : String(metadata.id),
+    artistId: String(row.artist_id),
+    providerArtistId: artistMetadata.id == null ? null : String(artistMetadata.id),
+    artistName: row.artist_name,
+    artistMbid: row.artist_mbid || null,
+    foreignArtistId:
+      artistMetadata.foreignArtistId || row.artist_mbid || row.artist_identity_key,
+    mbid: row.mbid || row.release_group_mbid || null,
+    releaseGroupMbid: row.release_group_mbid || null,
+    foreignAlbumId: row.mbid || row.release_group_mbid || row.identity_key,
+    albumName: row.title,
+    title: row.title,
+    releaseDate: row.release_date,
+    monitored: metadata.monitored === true,
+    albumType: metadata.albumType || metadata.releaseType || null,
+    trackCount,
+    availableTrackCount,
+    statistics: {
+      trackCount,
+      trackFileCount: availableTrackCount,
+      sizeOnDisk: Number(row.size_on_disk || 0),
+      percentOfTracks: trackCount > 0 && availableTrackCount === trackCount ? 100 : 0,
+    },
+  };
+};
+
+export function getCanonicalAlbumsByReleaseDate({
+  from,
+  to = null,
+  limit = 100,
+  missingOnly = false,
+} = {}) {
+  const fromDate = String(from || "").trim();
+  const toDate = String(to || "").trim();
+  if (!fromDate) return [];
+  const conditions = ["album.release_date >= ?"];
+  const parameters = [fromDate];
+  if (toDate) {
+    conditions.push("album.release_date <= ?");
+    parameters.push(toDate);
+  }
+  if (missingOnly === true) {
+    conditions.push(`NOT EXISTS (
+      SELECT 1
+      FROM library_album_tracks AS owned_relation
+      JOIN library_media_files AS owned_media
+        ON owned_media.track_id = owned_relation.track_id
+        AND (owned_media.album_id = owned_relation.album_id OR owned_media.album_id IS NULL)
+      WHERE owned_relation.album_id = album.id
+        AND owned_media.available = 1
+    )`);
+  }
+  parameters.push(Math.min(1000, Math.max(1, Number.parseInt(limit, 10) || 100)));
+  const rows = db.prepare(`
+    WITH date_albums AS MATERIALIZED (
+      SELECT
+        album.id,
+        album.identity_key,
+        album.mbid,
+        album.release_group_mbid,
+        album.artist_id,
+        album.title,
+        album.release_date,
+        album.metadata_json,
+        artist.identity_key AS artist_identity_key,
+        artist.mbid AS artist_mbid,
+        artist.name AS artist_name,
+        artist.metadata_json AS artist_metadata_json
+      FROM library_albums AS album
+      JOIN library_artists AS artist ON artist.id = album.artist_id
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY album.release_date DESC, album.id DESC
+      LIMIT ?
+    )
+    SELECT
+      album.*,
+      COUNT(DISTINCT album_track.track_id) AS track_count,
+      COUNT(DISTINCT CASE WHEN media.available = 1 THEN album_track.track_id END) AS available_track_count,
+      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk
+    FROM date_albums AS album
+    LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
+    LEFT JOIN library_media_files AS media
+      ON media.track_id = album_track.track_id
+      AND (media.album_id = album_track.album_id OR media.album_id IS NULL)
+    GROUP BY album.id
+    ORDER BY album.release_date DESC, album.id DESC
+  `).all(...parameters);
+  return rows.map(canonicalDateAlbumProjection);
 }
 
 export function getCanonicalTrackPath(albumReference, trackReference) {
@@ -549,9 +684,17 @@ export function getCanonicalLibraryForArtistReferences({
       artist.mbid IN (${placeholders}) OR
       artist.identity_key IN (${placeholders}) OR
       CAST(json_extract(artist.metadata_json, '$.id') AS TEXT) IN (${placeholders}) OR
+      CAST(json_extract(artist.metadata_json, '$.foreignArtistId') AS TEXT) IN (${placeholders}) OR
       lower(artist.name) IN (${references.map(() => "lower(?)").join(",")})
     )`],
-    parameters: [...references, ...references, ...references, ...references, ...references],
+    parameters: [
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+      ...references,
+    ],
   });
 }
 
@@ -746,6 +889,9 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
 };
 
 const pageMediaExists = (kind, sourceFilter, availableOnly) => {
+  if (!sourceFilter && availableOnly !== true) {
+    return { sql: "1 = 1", parameters: [] };
+  }
   const { conditions, parameters } = mediaSourceClause(sourceFilter);
   if (availableOnly === true) conditions.push("page_media.available = 1");
   const conditionSql = conditions.length ? conditions.join(" AND ") : "1 = 1";

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -391,7 +391,9 @@ const canonicalDateAlbumProjection = (row) => {
       trackCount,
       trackFileCount: availableTrackCount,
       sizeOnDisk: Number(row.size_on_disk || 0),
-      percentOfTracks: trackCount > 0 && availableTrackCount === trackCount ? 100 : 0,
+      percentOfTracks: trackCount > 0
+        ? Math.round((availableTrackCount / trackCount) * 100)
+        : 0,
     },
   };
 };
@@ -401,6 +403,7 @@ export function getCanonicalAlbumsByReleaseDate({
   to = null,
   limit = 100,
   missingOnly = false,
+  artistIds = [],
 } = {}) {
   const fromDate = String(from || "").trim();
   const toDate = String(to || "").trim();
@@ -410,6 +413,18 @@ export function getCanonicalAlbumsByReleaseDate({
   if (toDate) {
     conditions.push("album.release_date <= ?");
     parameters.push(toDate);
+  }
+  const canonicalArtistIds = [...new Set(
+    (Array.isArray(artistIds) ? artistIds : [])
+      .map((value) => Number(value))
+      .filter((value) => Number.isSafeInteger(value) && value > 0),
+  )];
+  if (Array.isArray(artistIds) && artistIds.length > 0) {
+    if (!canonicalArtistIds.length) return [];
+    conditions.push(
+      "album.artist_id IN (SELECT CAST(value AS INTEGER) FROM json_each(?))",
+    );
+    parameters.push(JSON.stringify(canonicalArtistIds));
   }
   if (missingOnly === true) {
     conditions.push(`NOT EXISTS (
@@ -890,6 +905,29 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
 
 const pageMediaExists = (kind, sourceFilter, availableOnly) => {
   if (!sourceFilter && availableOnly !== true) {
+    if (kind === "artists") {
+      return {
+        sql: `EXISTS (
+          SELECT 1
+          FROM library_albums AS page_album
+          JOIN library_album_tracks AS page_album_track ON page_album_track.album_id = page_album.id
+          JOIN library_tracks AS page_track ON page_track.id = page_album_track.track_id
+          WHERE page_album.artist_id = artist.id
+        )`,
+        parameters: [],
+      };
+    }
+    if (kind === "albums") {
+      return {
+        sql: `EXISTS (
+          SELECT 1
+          FROM library_album_tracks AS page_album_track
+          JOIN library_tracks AS page_track ON page_track.id = page_album_track.track_id
+          WHERE page_album_track.album_id = album.id
+        )`,
+        parameters: [],
+      };
+    }
     return { sql: "1 = 1", parameters: [] };
   }
   const { conditions, parameters } = mediaSourceClause(sourceFilter);

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -475,8 +475,8 @@ export function getCanonicalLibraryForArtistReferences({
     [
       "identity_key",
       "mbid",
-      "CAST(json_extract(metadata_json, '$.id') AS TEXT)",
-      "CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT)",
+      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.foreignArtistId') END AS TEXT)",
       "name COLLATE NOCASE",
     ],
   );

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -837,6 +837,7 @@ export function getCanonicalArtistPage({
     aggregateParameters.push(sourceFilter);
   }
   if (availableOnly === true) mediaConditions.push("media.available = 1");
+  const mediaJoin = sourceFilter || availableOnly === true ? "JOIN" : "LEFT JOIN";
   aggregateParameters.push(...ids);
   const rows = db.prepare(
     `SELECT
@@ -854,7 +855,7 @@ export function getCanonicalArtistPage({
      FROM library_artists AS artist
      JOIN library_albums AS album ON album.artist_id = artist.id
      JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
-     JOIN library_media_files AS media ON ${mediaConditions.join(" AND ")}
+     ${mediaJoin} library_media_files AS media ON ${mediaConditions.join(" AND ")}
      WHERE artist.id IN (${ids.map(() => "?").join(",")})
      GROUP BY artist.id
      ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -472,7 +472,13 @@ export function getCanonicalLibraryForArtistReferences({
   const ids = resolveCanonicalReferenceIds(
     "library_artists",
     references,
-    ["identity_key", "mbid"],
+    [
+      "identity_key",
+      "mbid",
+      "CAST(json_extract(metadata_json, '$.id') AS TEXT)",
+      "CAST(json_extract(metadata_json, '$.foreignArtistId') AS TEXT)",
+      "name COLLATE NOCASE",
+    ],
   );
   return getCanonicalLibraryForIds("artists", ids, source, availableOnly);
 }

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -1097,7 +1097,7 @@ export function getCanonicalArtistPage({
        WHERE ${conditions.join(" AND ")}
        ${searchMatch
          ? "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE, artist.id"
-         : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE"}
+         : "ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE, artist.name COLLATE NOCASE, artist.id"}
        ${pageSql}`,
     ).all(...parameters, ...(boundedLimit === null ? [] : [boundedLimit, pageOffset(offset)])).map((row) => row.id);
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
@@ -1280,6 +1280,7 @@ export function getCanonicalAlbumPage({
     orderBy = "album.title COLLATE NOCASE, coalesce(album.album_artist, artist.name) COLLATE NOCASE";
   }
 
+  const paginatedOrderBy = type === "random" ? orderBy : `${orderBy}, album.id`;
   const boundedLimit = pageLimit(limit, 20);
   if (boundedLimit === 0) return { artists: [], albums: [], tracks: [] };
   const searchJoin = searchMatch
@@ -1300,7 +1301,7 @@ export function getCanonicalAlbumPage({
      ${searchJoin}
      WHERE ${conditions.join(" AND ")}
      GROUP BY album.id
-     ${searchMatch ? `ORDER BY ${orderBy}, album.id` : `ORDER BY ${orderBy}`}
+     ORDER BY ${paginatedOrderBy}
      LIMIT ? OFFSET ?`,
   ).all(...parameters, boundedLimit, pageOffset(offset)).map((row) => row.id);
   const library = getCanonicalLibraryForAlbumIds({ source: sourceFilter, availableOnly, ids });
@@ -1692,12 +1693,15 @@ function buildPageQuery({
   let orderBy;
   if (sort === "newest" && (kind === "albums" || kind === "tracks")) {
     orderBy = recentMediaOrder(kind, sourceFilter, availableOnly, direction);
+    if (kind === "albums") orderBy += ", album.id";
   } else if (sort === "artist" && kind !== "artists") {
     orderBy = `artist.name COLLATE NOCASE ${orderDirection}, ${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
+    if (kind === "albums") orderBy += ", album.id";
   } else if (kind === "artists") {
-    orderBy = `coalesce(artist.sort_name, artist.name) COLLATE NOCASE ${orderDirection}, artist.name COLLATE NOCASE ${orderDirection}`;
+    orderBy = `coalesce(artist.sort_name, artist.name) COLLATE NOCASE ${orderDirection}, artist.name COLLATE NOCASE ${orderDirection}, artist.id ${orderDirection}`;
   } else {
     orderBy = `${kind === "albums" ? "album.title" : "track.title"} COLLATE NOCASE ${orderDirection}`;
+    if (kind === "albums") orderBy += `, album.id ${orderDirection}`;
   }
 
   return {

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -273,6 +273,25 @@ const canonicalArtistProjection = (row) => {
   };
 };
 
+const canonicalArtistKeyProjection = (row) => {
+  const metadata = parseJson(row.metadata_json) || {};
+  return {
+    id: String(row.id),
+    mbid: row.mbid || null,
+    foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
+    name: row.name,
+    artistName: row.name,
+  };
+};
+
+export function getCanonicalArtistKeyProjection() {
+  const rows = db.prepare(
+    `SELECT id, identity_key, mbid, name, metadata_json
+     FROM library_artists`,
+  ).all();
+  return rows.map(canonicalArtistKeyProjection);
+}
+
 function buildCanonicalArtistProjectionQuery({
   page = 1,
   pageSize = 100,

--- a/backend/services/librarySearchIndex.js
+++ b/backend/services/librarySearchIndex.js
@@ -20,17 +20,23 @@ export function getLibrarySearchMatch(value) {
   return trigrams.size ? [...trigrams].join(" AND ") : null;
 }
 
-const upsertDocument = db.prepare(
-  `INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
-   VALUES (?, ?, ?, ?, ?)
-   ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
-     title = excluded.title,
-     artist_name = excluded.artist_name,
-     album_name = excluded.album_name
-   WHERE title IS NOT excluded.title
-      OR artist_name IS NOT excluded.artist_name
-      OR album_name IS NOT excluded.album_name`,
-);
+let upsertDocument;
+
+function upsertSearchDocument(...values) {
+  if (!indexAvailable) return false;
+  upsertDocument ??= db.prepare(
+    `INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
+       title = excluded.title,
+       artist_name = excluded.artist_name,
+       album_name = excluded.album_name
+     WHERE title IS NOT excluded.title
+        OR artist_name IS NOT excluded.artist_name
+        OR album_name IS NOT excluded.album_name`,
+  );
+  return upsertDocument.run(...values).changes > 0;
+}
 
 export function syncLibrarySearchArtist(artistId) {
   if (!indexAvailable) return false;
@@ -38,7 +44,7 @@ export function syncLibrarySearchArtist(artistId) {
     "SELECT id, name FROM library_artists WHERE id = ?",
   ).get(Number(artistId));
   if (!artist) return false;
-  const changed = upsertDocument.run("artist", artist.id, artist.name, "", "").changes > 0;
+  const changed = upsertSearchDocument("artist", artist.id, artist.name, "", "");
   if (!changed) return false;
   for (const album of db.prepare(
     "SELECT id FROM library_albums WHERE artist_id = ?",
@@ -62,7 +68,7 @@ export function syncLibrarySearchAlbum(albumId) {
      WHERE album.id = ?`,
   ).get(Number(albumId));
   if (!album) return false;
-  return upsertDocument.run(
+  return upsertSearchDocument(
     "album",
     album.id,
     album.title,
@@ -87,7 +93,7 @@ export function syncLibrarySearchTrack(trackId) {
      GROUP BY track.id`,
   ).get(Number(trackId));
   if (!track) return false;
-  return upsertDocument.run(
+  return upsertSearchDocument(
     "track",
     track.id,
     track.title,

--- a/backend/services/librarySearchIndex.js
+++ b/backend/services/librarySearchIndex.js
@@ -74,7 +74,7 @@ export function syncLibrarySearchAlbum(albumId) {
     album.title,
     `${album.artist_name || ""} ${album.album_artist || ""}`.trim(),
     "",
-  ).changes > 0;
+  );
 }
 
 export function syncLibrarySearchTrack(trackId) {
@@ -99,7 +99,7 @@ export function syncLibrarySearchTrack(trackId) {
     track.title,
     track.artist_name || "",
     track.album_name || "",
-  ).changes > 0;
+  );
 }
 
 export function rebuildLibrarySearchIndex() {

--- a/backend/services/librarySearchIndex.js
+++ b/backend/services/librarySearchIndex.js
@@ -1,0 +1,107 @@
+import { db } from "../config/db-sqlite.js";
+import { populateLibrarySearchDocuments } from "../config/library-search-index.js";
+
+const indexAvailable = Boolean(
+  db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get("library_search_fts"),
+);
+
+const normalize = (value) => String(value || "").trim().toLocaleLowerCase();
+
+export function getLibrarySearchMatch(value) {
+  const query = normalize(value);
+  if (!indexAvailable || query.length < 3) return null;
+  const trigrams = new Set();
+  for (let index = 0; index <= query.length - 3; index += 1) {
+    const trigram = query.slice(index, index + 3);
+    if (!/\s/.test(trigram)) trigrams.add(`"${trigram.replaceAll('"', '""')}"`);
+    if (trigrams.size >= 32) break;
+  }
+  return trigrams.size ? [...trigrams].join(" AND ") : null;
+}
+
+const upsertDocument = db.prepare(
+  `INSERT INTO library_search_documents (entity_kind, entity_id, title, artist_name, album_name)
+   VALUES (?, ?, ?, ?, ?)
+   ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
+     title = excluded.title,
+     artist_name = excluded.artist_name,
+     album_name = excluded.album_name
+   WHERE title IS NOT excluded.title
+      OR artist_name IS NOT excluded.artist_name
+      OR album_name IS NOT excluded.album_name`,
+);
+
+export function syncLibrarySearchArtist(artistId) {
+  if (!indexAvailable) return false;
+  const artist = db.prepare(
+    "SELECT id, name FROM library_artists WHERE id = ?",
+  ).get(Number(artistId));
+  if (!artist) return false;
+  const changed = upsertDocument.run("artist", artist.id, artist.name, "", "").changes > 0;
+  if (!changed) return false;
+  for (const album of db.prepare(
+    "SELECT id FROM library_albums WHERE artist_id = ?",
+  ).all(artist.id)) {
+    syncLibrarySearchAlbum(album.id);
+    for (const track of db.prepare(
+      "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+    ).all(album.id)) {
+      syncLibrarySearchTrack(track.track_id);
+    }
+  }
+  return true;
+}
+
+export function syncLibrarySearchAlbum(albumId) {
+  if (!indexAvailable) return false;
+  const album = db.prepare(
+    `SELECT album.id, album.title, album.album_artist, artist.name AS artist_name
+     FROM library_albums AS album
+     JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE album.id = ?`,
+  ).get(Number(albumId));
+  if (!album) return false;
+  return upsertDocument.run(
+    "album",
+    album.id,
+    album.title,
+    `${album.artist_name || ""} ${album.album_artist || ""}`.trim(),
+    "",
+  ).changes > 0;
+}
+
+export function syncLibrarySearchTrack(trackId) {
+  if (!indexAvailable) return false;
+  const track = db.prepare(
+    `SELECT
+       track.id,
+       track.title,
+       trim(coalesce(track.artist_name, '') || ' ' || coalesce(group_concat(DISTINCT artist.name), '')) AS artist_name,
+       trim(coalesce(group_concat(DISTINCT album.title), '') || ' ' || coalesce(group_concat(DISTINCT album.album_artist), '')) AS album_name
+     FROM library_tracks AS track
+     LEFT JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+     LEFT JOIN library_albums AS album ON album.id = album_track.album_id
+     LEFT JOIN library_artists AS artist ON artist.id = album.artist_id
+     WHERE track.id = ?
+     GROUP BY track.id`,
+  ).get(Number(trackId));
+  if (!track) return false;
+  return upsertDocument.run(
+    "track",
+    track.id,
+    track.title,
+    track.artist_name || "",
+    track.album_name || "",
+  ).changes > 0;
+}
+
+export function rebuildLibrarySearchIndex() {
+  if (!indexAvailable) return false;
+  db.transaction(() => {
+    db.prepare("DELETE FROM library_search_documents").run();
+    populateLibrarySearchDocuments(db);
+    db.prepare("INSERT INTO library_search_fts(library_search_fts) VALUES ('rebuild')").run();
+  })();
+  return true;
+}

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -443,7 +443,7 @@ export class LidarrClient {
     const isStatusRequest =
       method === "GET" &&
       (endpoint === "/queue" || endpoint === "/command" || endpoint.startsWith("/history"));
-    if (isStatusRequest) {
+    if (isStatusRequest && !options.forceRefresh) {
       const cached = this._statusCache.get(endpoint);
       if (cached && now - cached.at < LIDARR_STATUS_CACHE_MS) {
         return cached.data;
@@ -1484,8 +1484,8 @@ export class LidarrClient {
     });
   }
 
-  async getQueue() {
-    const response = await this.request("/queue");
+  async getQueue(options = {}) {
+    const response = await this.request("/queue", "GET", null, false, options);
     if (response && Array.isArray(response)) {
       return response;
     }
@@ -1496,14 +1496,20 @@ export class LidarrClient {
     return this.request(`/queue/${queueId}`);
   }
 
-  async getHistory(page = 1, pageSize = 20, sortKey = "date", sortDirection = "descending") {
+  async getHistory(
+    page = 1,
+    pageSize = 20,
+    sortKey = "date",
+    sortDirection = "descending",
+    options = {},
+  ) {
     const params = new URLSearchParams({
       page: page.toString(),
       pageSize: pageSize.toString(),
       sortKey,
       sortDirection,
     });
-    return this.request(`/history?${params.toString()}`);
+    return this.request(`/history?${params.toString()}`, "GET", null, false, options);
   }
 
   async getHistoryForAlbum(albumId) {

--- a/backend/services/lidarrRequestBuilder.js
+++ b/backend/services/lidarrRequestBuilder.js
@@ -8,11 +8,13 @@ const toIso = (value) => {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 };
 
-export const buildLidarrRequests = async (lidarrClient) => {
-  const [queue, history] = await Promise.all([
-    lidarrClient.getQueue().catch(() => []),
-    lidarrClient.getHistory(1, 200).catch(() => ({ records: [] })),
-  ]);
+export const buildLidarrRequests = async (lidarrClient, snapshot = null) => {
+  const [queue, history] = snapshot
+    ? [snapshot.queue, snapshot.history]
+    : await Promise.all([
+        lidarrClient.getQueue().catch(() => []),
+        lidarrClient.getHistory(1, 200).catch(() => ({ records: [] })),
+      ]);
 
   const requestsByAlbumId = new Map();
   const queueItems = Array.isArray(queue) ? queue : queue?.records || [];

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -11,6 +11,12 @@ const NAVIDROME_RATE_LIMIT_RETRIES = 2;
 const NAVIDROME_RATE_LIMIT_DELAY_MS = 250;
 const NAVIDROME_RATE_LIMIT_MAX_DELAY_MS = 5_000;
 const NAVIDROME_NETWORK_RETRIES = 2;
+const NAVIDROME_RETRYABLE_READ_ENDPOINTS = new Set([
+  "ping",
+  "search3",
+  "getPlaylists",
+  "getPlaylist",
+]);
 
 const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
@@ -83,7 +89,9 @@ export class NavidromeClient {
         } catch (error) {
           const isNetworkFailure = error instanceof TypeError && !error?.response;
           if (isNetworkFailure) {
-            if (attempt >= NAVIDROME_NETWORK_RETRIES) throw error;
+            if (!NAVIDROME_RETRYABLE_READ_ENDPOINTS.has(endpoint) || attempt >= NAVIDROME_NETWORK_RETRIES) {
+              throw error;
+            }
             await wait(NAVIDROME_RATE_LIMIT_DELAY_MS);
             continue;
           }

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -10,6 +10,7 @@ const NAVIDROME_SONG_PAGE_SIZE = 1_000;
 const NAVIDROME_RATE_LIMIT_RETRIES = 2;
 const NAVIDROME_RATE_LIMIT_DELAY_MS = 250;
 const NAVIDROME_RATE_LIMIT_MAX_DELAY_MS = 5_000;
+const NAVIDROME_NETWORK_RETRIES = 2;
 
 const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
@@ -80,7 +81,14 @@ export class NavidromeClient {
 
           return response.data["subsonic-response"];
         } catch (error) {
-          if (error?.response?.status !== 429 || attempt >= NAVIDROME_RATE_LIMIT_RETRIES) throw error;
+          const isNetworkFailure = error instanceof TypeError && !error?.response;
+          if (isNetworkFailure) {
+            if (attempt >= NAVIDROME_NETWORK_RETRIES) throw error;
+            await wait(NAVIDROME_RATE_LIMIT_DELAY_MS);
+            continue;
+          }
+          if (!error?.response) throw error;
+          if (error.response.status !== 429 || attempt >= NAVIDROME_RATE_LIMIT_RETRIES) throw error;
           const retryAfterHeader = error.response.headers?.["retry-after"]?.trim();
           const retryAfter = Number(retryAfterHeader);
           const delay = retryAfterHeader && Number.isFinite(retryAfter) && retryAfter >= 0

--- a/backend/services/nearbyShowsService.js
+++ b/backend/services/nearbyShowsService.js
@@ -6,6 +6,7 @@ import { runSharedInflight } from "./sharedInflight.js";
 const ticketmasterEventCache = createCache(15 * 60);
 const ipLocationCache = createCache(30 * 60);
 const zipLocationCache = createCache(24 * 60 * 60);
+const nearbyShowsResponseCache = createCache(5 * 60, 100);
 const nearbyShowsInflight = new Map();
 
 const DEFAULT_RADIUS_MILES = 250;
@@ -394,6 +395,8 @@ const buildArtistMap = (artists, sourceType) => {
   return map;
 };
 
+const resolveArtists = (artists) => typeof artists === "function" ? artists() : artists;
+
 const sortShows = (shows) =>
   shows.sort((a, b) => {
     const aTime = a.dateTime || a.date || "";
@@ -412,12 +415,16 @@ export const getNearbyShows = async ({
   trendingArtists = [],
   radiusMiles = DEFAULT_RADIUS_MILES,
   limit = DEFAULT_SHOW_LIMIT,
+  responseCacheKey = null,
 }) => {
   const resolvedLimit = Math.max(1, Math.min(Number(limit) || DEFAULT_SHOW_LIMIT, MAX_SHOW_LIMIT));
   const sanitizedZipCode = sanitizeZipCode(zipCode);
-  const libraryArtistMap = buildArtistMap(libraryArtists, "library");
-  const recommendedArtistMap = buildArtistMap(recommendedArtists, "recommended");
-  const trendingArtistMap = buildArtistMap(trendingArtists, "trending");
+  const locationKey = sanitizedZipCode || getForwardedIp(req);
+  const resultCacheKey = responseCacheKey
+    ? JSON.stringify([responseCacheKey, locationKey, radiusMiles, resolvedLimit])
+    : null;
+  const cachedResult = resultCacheKey ? nearbyShowsResponseCache.get(resultCacheKey) : null;
+  if (cachedResult) return cachedResult;
 
   let location;
   if (sanitizedZipCode) {
@@ -439,16 +446,21 @@ export const getNearbyShows = async ({
   }
 
   if (location.resolved === false) {
-    return {
+    const result = {
       location,
       shows: [],
       libraryShows: [],
       recommendedShows: [],
       total: 0,
     };
+    if (resultCacheKey) nearbyShowsResponseCache.set(resultCacheKey, result);
+    return result;
   }
 
   const events = await fetchTicketmasterEvents({ location, radiusMiles });
+  const libraryArtistMap = buildArtistMap(resolveArtists(libraryArtists), "library");
+  const recommendedArtistMap = buildArtistMap(resolveArtists(recommendedArtists), "recommended");
+  const trendingArtistMap = buildArtistMap(resolveArtists(trendingArtists), "trending");
   const libraryShows = [];
   const recommendedShows = [];
   const seen = new Set();
@@ -484,11 +496,13 @@ export const getNearbyShows = async ({
   sortShows(groupedLibraryShows);
   sortShows(groupedRecommendedShows);
 
-  return {
+  const result = {
     location,
     shows: groupedShows.slice(0, resolvedLimit),
     libraryShows: groupedLibraryShows.slice(0, resolvedLimit),
     recommendedShows: groupedRecommendedShows.slice(0, resolvedLimit),
     total: groupedShows.length,
   };
+  if (resultCacheKey) nearbyShowsResponseCache.set(resultCacheKey, result);
+  return result;
 };

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -1,6 +1,6 @@
 import { buildImageProxyUrl } from "./imageProxyService.js";
 import { dbOps } from "../db/helpers/index.js";
-import { libraryManager } from "./libraryManager.js";
+import { iterateCanonicalArtistProjection } from "./libraryQueryService.js";
 import { getNewsSettings } from "./apiClients/config.js";
 import { fetchArticleImage, fetchRssFeed } from "./rssNews.js";
 import { mapWithConcurrency } from "./discovery/helpers.js";
@@ -210,7 +210,7 @@ export const disableNewsFeed = (sourceUrl, sourceName) => {
 
 export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "matched" } = {}) {
   const settings = getNewsSettings();
-  const libraryArtists = await libraryManager.getAllArtists();
+  const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   const recommendedArtists = userId
     ? ((await getUserDiscovery(userId, 50, 0))?.body?.recommendations || [])
     : [];

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -208,7 +208,13 @@ export const disableNewsFeed = (sourceUrl, sourceName) => {
   return nextNews;
 };
 
-export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "matched" } = {}) {
+export async function getNewsForUser({
+  limit = 60,
+  offset = 0,
+  userId,
+  mode = "matched",
+  refresh = false,
+} = {}) {
   const settings = getNewsSettings();
   const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   const recommendedArtists = userId
@@ -219,9 +225,11 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     ...recommendedArtists.map((artist) => ({ ...artist, newsType: "recommended" })),
   ]);
   const preferences = getNewsPreferences(userId);
-  const refresh = await refreshFeeds();
+  const refreshResult = refresh
+    ? await refreshFeeds()
+    : { state: getStoredState(), warning: null };
   const activeFeedUrls = new Set(getEnabledFeeds(settings).map((feed) => feed.url));
-  const activeArticles = refresh.state.articles.filter((article) => activeFeedUrls.has(article.sourceUrl));
+  const activeArticles = refreshResult.state.articles.filter((article) => activeFeedUrls.has(article.sourceUrl));
   const matchedArticles = matchNewsArticles(
     activeArticles,
     artists,
@@ -242,7 +250,9 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     : matchedArticles;
   if (mode === "top") {
     const page = articles.slice(safeOffset, safeOffset + safeLimit);
-    const enrichedPage = await enrichArticleImages(page, refresh.state);
+    const enrichedPage = refresh
+      ? await enrichArticleImages(page, refreshResult.state)
+      : page;
     const enrichedById = new Map(enrichedPage.map((article) => [article.id, article]));
     articles = articles.map((article) => enrichedById.get(article.id) || article);
   }
@@ -254,9 +264,9 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
     hasMore: safeOffset + safeLimit < articles.length,
     blockedPublishers: preferences.blockedPublishers,
     refresh: {
-      checkedAt: refresh.state.checkedAt || null,
-      failedFeeds: refresh.state.failedFeeds,
-      warning: refresh.warning || null,
+      checkedAt: refreshResult.state.checkedAt || null,
+      failedFeeds: refreshResult.state.failedFeeds,
+      warning: refreshResult.warning || null,
     },
   };
 }
@@ -264,7 +274,7 @@ export async function getNewsForUser({ limit = 60, offset = 0, userId, mode = "m
 export const getLibraryNews = getNewsForUser;
 
 export async function refreshLibraryNews() {
-  return getNewsForUser();
+  return getNewsForUser({ refresh: true });
 }
 
 export const getNewsFeedState = () => {

--- a/backend/services/newsService.js
+++ b/backend/services/newsService.js
@@ -5,6 +5,7 @@ import { getNewsSettings } from "./apiClients/config.js";
 import { fetchArticleImage, fetchRssFeed } from "./rssNews.js";
 import { mapWithConcurrency } from "./discovery/helpers.js";
 import { getUserDiscovery } from "./discovery/userDiscovery.js";
+import createCache from "./apiClients/simpleCache.js";
 
 const NEWS_PREFERENCES_KEY = (userId) => `user:${Number.parseInt(userId, 10)}:newsPreferences`;
 const NEWS_STATE_KEY = "news:rssState";
@@ -15,6 +16,7 @@ const MAX_ARTICLES = 1000;
 const MAX_BLOCKED_PUBLISHERS = 100;
 
 let refreshPromise = null;
+const newsResponseCache = createCache(5 * 60, 100);
 
 const normalizeBlockedPublishers = (publishers) => {
   const seen = new Set();
@@ -185,6 +187,7 @@ export const getNewsPreferences = (userId) => {
 export const updateNewsPreferences = (userId, preferences = {}) => {
   const next = { blockedPublishers: normalizeBlockedPublishers(preferences.blockedPublishers) };
   dbOps.setJSONSetting(NEWS_PREFERENCES_KEY(userId), next);
+  newsResponseCache.flushAll();
   return next;
 };
 
@@ -205,6 +208,7 @@ export const disableNewsFeed = (sourceUrl, sourceName) => {
   dbOps.updateSettings({
     integrations: { ...(settings.integrations || {}), news: nextNews },
   });
+  newsResponseCache.flushAll();
   return nextNews;
 };
 
@@ -215,6 +219,13 @@ export async function getNewsForUser({
   mode = "matched",
   refresh = false,
 } = {}) {
+  const safeLimit = Math.max(1, Math.min(100, Math.floor(Number(limit) || 60)));
+  const safeOffset = Math.max(0, Math.floor(Number(offset) || 0));
+  const responseCacheKey = JSON.stringify([userId || null, mode, safeLimit, safeOffset]);
+  if (!refresh) {
+    const cached = newsResponseCache.get(responseCacheKey);
+    if (cached) return cached;
+  }
   const settings = getNewsSettings();
   const libraryArtists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
   const recommendedArtists = userId
@@ -237,8 +248,6 @@ export async function getNewsForUser({
   );
   const matchedById = new Map(matchedArticles.map((article) => [article.id, article]));
   // Normalize pagination before enriching or slicing the current page.
-  const safeLimit = Math.max(1, Math.min(100, Math.floor(Number(limit) || 60)));
-  const safeOffset = Math.max(0, Math.floor(Number(offset) || 0));
   let articles = mode === "top"
     ? activeArticles
       .filter((article) => !isPublisherBlocked(article.source, preferences.blockedPublishers))
@@ -256,7 +265,7 @@ export async function getNewsForUser({
     const enrichedById = new Map(enrichedPage.map((article) => [article.id, article]));
     articles = articles.map((article) => enrichedById.get(article.id) || article);
   }
-  return {
+  const result = {
     configured: settings.enabled && getEnabledFeeds(settings).length > 0,
     artistCount: artists.length,
     feedCount: getEnabledFeeds(settings).length,
@@ -269,11 +278,14 @@ export async function getNewsForUser({
       warning: refreshResult.warning || null,
     },
   };
+  if (!refresh) newsResponseCache.set(responseCacheKey, result);
+  return result;
 }
 
 export const getLibraryNews = getNewsForUser;
 
 export async function refreshLibraryNews() {
+  newsResponseCache.flushAll();
   return getNewsForUser({ refresh: true });
 }
 

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -33,6 +33,7 @@ const STORAGE_HEALTH_CACHE_TTL_MS = Math.max(
   0,
   Math.floor(Number(process.env.AURRAL_STORAGE_HEALTH_CACHE_MS) || 60 * 1000),
 );
+const STORAGE_HEALTH_SNAPSHOT_KEY = "storageHealthSnapshot";
 const MEDIA_HEALTH_SAMPLE_LIMIT = Math.max(
   50,
   Math.floor(Number(process.env.AURRAL_MEDIA_HEALTH_SAMPLE_LIMIT) || 500),
@@ -996,6 +997,7 @@ export async function runStorageHealthCheck({ force = false } = {}) {
       storageHealthCache = result;
       storageHealthCacheKey = cacheKey;
       storageHealthCacheExpiresAt = Date.now() + STORAGE_HEALTH_CACHE_TTL_MS;
+      dbOps.setJSONSetting(STORAGE_HEALTH_SNAPSHOT_KEY, result);
       return result;
     })
     .finally(() => {
@@ -1004,4 +1006,8 @@ export async function runStorageHealthCheck({ force = false } = {}) {
     });
 
   return storageHealthInflight;
+}
+
+export function getStorageHealthSnapshot() {
+  return dbOps.getJSONSetting(STORAGE_HEALTH_SNAPSHOT_KEY);
 }

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -1,7 +1,19 @@
 import { randomUUID } from "node:crypto";
 import { dbOps } from "../db/helpers/index.js";
 import { db } from "../config/db-sqlite.js";
-import { getCanonicalLibrary } from "./libraryQueryService.js";
+import {
+  getCanonicalAlbumPage,
+  getCanonicalArtistPage,
+  getCanonicalFavoriteTargetKeys,
+  getCanonicalGenres,
+  getCanonicalLibrary,
+  getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
+  getCanonicalSearchPage,
+  getCanonicalTopTracks,
+  getCanonicalTrack,
+  getCanonicalTrackPage,
+} from "./libraryQueryService.js";
 import { fetchReleaseGroupCoverUrl } from "./releaseGroupCoverService.js";
 import { getArtistImage } from "./imageService.js";
 import { buildImageProxyUrl, warmPublicImageUrl } from "./imageProxyService.js";
@@ -212,14 +224,14 @@ const toArtistSummary = (artist) => {
     id: idFor("artist", artist.identityKey),
     name: artist.name,
     coverArt: idFor("artist", artist.identityKey),
-    albumCount: artist.albumIds.length,
+    albumCount: artist.albumCount ?? artist.albumIds.length,
     ...(genres.length
       ? { genre: genres[0], genres: genres.map((name) => ({ name })) }
       : {}),
   };
 };
 
-const indexLibrary = (library) => ({
+const indexFocusedLibrary = (library) => ({
   ...library,
   artistsById: new Map(library.artists.map((artist) => [artist.id, artist])),
   albumsById: new Map(library.albums.map((album) => [album.id, album])),
@@ -228,10 +240,6 @@ const indexLibrary = (library) => ({
   albumsByIdentity: new Map(library.albums.map((album) => [album.identityKey, album])),
   tracksByIdentity: new Map(library.tracks.map((track) => [track.identityKey, track])),
 });
-
-function readLibrary() {
-  return indexLibrary(getCanonicalLibrary({ availableOnly: false }));
-}
 
 function findCanonical(library, parsed) {
   if (!parsed) return null;
@@ -325,24 +333,30 @@ const flowJobs = (flow, { includePending = false } = {}) =>
 const playlistCoverArt = (kind, playlistId) => idFor(kind, playlistId);
 
 export function listArtists() {
-  const library = readLibrary();
-  const artists = [...library.artists].sort((left, right) =>
-    String(left.sortName || left.name).localeCompare(String(right.sortName || right.name)),
-  );
-  return artists.map(toArtistSummary);
+  return getCanonicalArtistPage({ source: "all", availableOnly: false }).artists.map(toArtistSummary);
 }
 
 export function getArtist(value) {
-  const library = readLibrary();
   const parsed = parseId(value);
-  const artist = parsed?.kind === "artist" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "artist") return null;
+  const library = indexFocusedLibrary(getCanonicalLibraryForArtistReferences({
+    source: "all",
+    availableOnly: false,
+    references: [parsed.key],
+  }));
+  const artist = findCanonical(library, parsed);
   return artist?.identityKey ? toArtist(library, artist) : null;
 }
 
 export function getAlbum(value) {
-  const library = readLibrary();
   const parsed = parseId(value);
-  const album = parsed?.kind === "album" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "album") return null;
+  const library = indexFocusedLibrary(getCanonicalLibraryForAlbumReferences({
+    source: "all",
+    availableOnly: false,
+    references: [parsed.key],
+  }));
+  const album = findCanonical(library, parsed);
   return album?.identityKey ? toAlbum(library, album) : null;
 }
 
@@ -350,9 +364,14 @@ export function getSong(value, user) {
   const playlistEntry = playlistJobFromId(user, value);
   if (playlistEntry) return toPlaylistSong(playlistEntry.playlist, playlistEntry.kind, playlistEntry.job);
 
-  const library = readLibrary();
   const parsed = parseId(value);
-  const track = parsed?.kind === "song" ? findCanonical(library, parsed) : null;
+  if (parsed?.kind !== "song") return null;
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
+  const track = findCanonical(library, parsed);
   return track?.identityKey ? toSong(library, track) : null;
 }
 
@@ -385,165 +404,58 @@ export function getMusicDirectory(value) {
 
 export function searchLibrary(query, options = {}) {
   const needle = String(query || "").trim().toLocaleLowerCase();
-  const library = readLibrary();
-  const artists = library.artists.filter((artist) =>
-    artist.name.toLocaleLowerCase().includes(needle),
-  );
-  const albums = library.albums
-    .filter((album) => {
-      const artist = findArtistForAlbum(library, album);
-      return [album.title, album.albumArtist, artist?.name].some((value) =>
-        String(value || "").toLocaleLowerCase().includes(needle),
-      );
-    });
-  const songs = library.tracks
-    .filter((track) => {
-      const album = findAlbumForTrack(library, track);
-      const artist = findArtistForAlbum(library, album);
-      return [track.title, track.artistName, album?.title, artist?.name].some((value) =>
-        String(value || "").toLocaleLowerCase().includes(needle),
-      );
-    });
-  const page = (items, count, offset) => items.slice(offset, offset + count);
+  const result = getCanonicalSearchPage({
+    source: "all",
+    availableOnly: false,
+    query: needle,
+    artistLimit: normalizeLimit(options.artistCount),
+    artistOffset: normalizeOffset(options.artistOffset),
+    albumLimit: normalizeLimit(options.albumCount),
+    albumOffset: normalizeOffset(options.albumOffset),
+    songLimit: normalizeLimit(options.songCount),
+    songOffset: normalizeOffset(options.songOffset),
+  });
+  const artistLibrary = indexFocusedLibrary({ artists: result.artists, albums: [], tracks: [] });
+  const albumLibrary = indexFocusedLibrary(result.albums);
+  const trackLibrary = indexFocusedLibrary(result.tracks);
   return {
-    artist: page(artists, normalizeLimit(options.artistCount), normalizeOffset(options.artistOffset)).map(
-      toArtistSummary,
-    ),
-    album: page(albums, normalizeLimit(options.albumCount), normalizeOffset(options.albumOffset)).map(
-      (album) => toAlbum(library, album),
-    ),
-    song: page(songs, normalizeLimit(options.songCount), normalizeOffset(options.songOffset)).map(
-      (track) => toSong(library, track),
-    ),
+    artist: artistLibrary.artists.map(toArtistSummary),
+    album: albumLibrary.albums.map((album) => toAlbum(albumLibrary, album)),
+    song: trackLibrary.tracks.map((track) => toSong(trackLibrary, track)),
   };
 }
 
 export function getAlbumList(options = {}) {
-  const library = readLibrary();
   const type = String(options.type || "alphabeticalByName");
-  let albums = [...library.albums];
-
   if (type === "starred") return [];
-  if (options.genre) {
-    const genre = String(options.genre).toLocaleLowerCase();
-    albums = albums.filter((album) =>
-      albumData(library, album).value.genres?.some((entry) =>
-        entry.name.toLocaleLowerCase() === genre,
-      ),
-    );
-  }
-  if (type === "byYear" || options.fromYear || options.toYear) {
-    const fromYear = Number.parseInt(options.fromYear, 10);
-    const toYear = Number.parseInt(options.toYear, 10);
-    const lowerYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
-      ? Math.min(fromYear, toYear)
-      : fromYear;
-    const upperYear = Number.isFinite(fromYear) && Number.isFinite(toYear)
-      ? Math.max(fromYear, toYear)
-      : toYear;
-    albums = albums.filter((album) => {
-      const releaseYear = year(album.releaseDate) || 0;
-      return (!Number.isFinite(lowerYear) || releaseYear >= lowerYear) &&
-        (!Number.isFinite(upperYear) || releaseYear <= upperYear);
-    });
-  }
-
-  const values = new Map(albums.map((album) => [album.id, albumData(library, album).value]));
-  const compareName = (left, right) =>
-    `${left.title}\u0000${left.albumArtist}`.localeCompare(
-      `${right.title}\u0000${right.albumArtist}`,
-    );
-  const compareArtist = (left, right) =>
-    `${left.albumArtist}\u0000${left.title}`.localeCompare(
-      `${right.albumArtist}\u0000${right.title}`,
-    );
-  const compareReleaseDate = (left, right) => {
-    const leftDate = Date.parse(String(left.releaseDate || ""));
-    const rightDate = Date.parse(String(right.releaseDate || ""));
-    if (!Number.isFinite(leftDate) && !Number.isFinite(rightDate)) return compareName(left, right);
-    if (!Number.isFinite(leftDate)) return 1;
-    if (!Number.isFinite(rightDate)) return -1;
-    return rightDate - leftDate || compareName(left, right);
-  };
-  const compareYear = (left, right) => {
-    const leftYear = year(left.releaseDate) || 0;
-    const rightYear = year(right.releaseDate) || 0;
-    return leftYear - rightYear || compareName(left, right);
-  };
-  const compareGenre = (left, right) =>
-    `${values.get(left.id)?.genre || ""}\u0000${left.title}`.localeCompare(
-      `${values.get(right.id)?.genre || ""}\u0000${right.title}`,
-    );
-
-  if (type === "random") {
-    for (let index = albums.length - 1; index > 0; index -= 1) {
-      const swapIndex = Math.floor(Math.random() * (index + 1));
-      [albums[index], albums[swapIndex]] = [albums[swapIndex], albums[index]];
-    }
-  } else if (type === "newest" || type === "recent") {
-    albums.sort(compareReleaseDate);
-  } else if (type === "alphabeticalByArtist") {
-    albums.sort(compareArtist);
-  } else if (type === "byYear") {
-    const fromYear = Number.parseInt(options.fromYear, 10);
-    const toYear = Number.parseInt(options.toYear, 10);
-    albums.sort((left, right) => {
-      const comparison = compareYear(left, right);
-      return Number.isFinite(fromYear) && Number.isFinite(toYear) && fromYear > toYear
-        ? -comparison
-        : comparison;
-    });
-  } else if (type === "byGenre") {
-    albums.sort(compareGenre);
-  } else {
-    albums.sort(compareName);
-  }
-  const offset = normalizeOffset(options.offset);
-  const size = normalizeLimit(options.size);
-  return albums.slice(offset, offset + size).map((album) => toAlbumSummary(library, album));
+  const library = indexFocusedLibrary(getCanonicalAlbumPage({
+    source: "all",
+    availableOnly: false,
+    type,
+    genre: options.genre,
+    fromYear: options.fromYear,
+    toYear: options.toYear,
+    offset: normalizeOffset(options.offset),
+    limit: normalizeLimit(options.size),
+  }));
+  return library.albums.map((album) => toAlbumSummary(library, album));
 }
 
 export function getSongsByGenre(genre, options = {}) {
   const target = String(genre || "").trim().toLocaleLowerCase();
   if (!target) return [];
-  const library = readLibrary();
-  const tracks = library.tracks.filter((track) => {
-    const album = findAlbumForTrack(library, track);
-    const artist = findArtistForAlbum(library, album);
-    return [
-      ...entityGenres(artist),
-      ...entityGenres(album),
-      ...entityGenres(track),
-    ].some((value) => value.toLocaleLowerCase() === target);
-  });
-  const offset = normalizeOffset(options.offset);
-  const size = normalizeLimit(options.count);
-  return tracks.slice(offset, offset + size).map((track) => toSong(library, track));
+  const library = indexFocusedLibrary(getCanonicalTrackPage({
+    source: "all",
+    availableOnly: false,
+    genre: target,
+    offset: normalizeOffset(options.offset),
+    limit: normalizeLimit(options.count),
+  }));
+  return library.tracks.map((track) => toSong(library, track));
 }
 
 export function getGenres() {
-  const library = readLibrary();
-  const genres = new Map();
-  for (const album of library.albums) {
-    const tracks = albumTracks(library, album);
-    const artistGenres = entityGenres(findArtistForAlbum(library, album));
-    const albumMetadataGenres = entityGenres(album);
-    const albumGenres = [
-      ...artistGenres,
-      ...entityGenres(album),
-      ...tracks.flatMap((track) => entityGenres(track)),
-    ];
-    for (const name of new Set(albumGenres)) {
-      const value = genres.get(name) || { albumCount: 0, songCount: 0, value: name };
-      value.albumCount += 1;
-      value.songCount +=
-        artistGenres.includes(name) || albumMetadataGenres.includes(name)
-          ? tracks.length
-          : tracks.filter((track) => entityGenres(track).includes(name)).length;
-      genres.set(name, value);
-    }
-  }
-  return [...genres.values()].sort((left, right) => left.value.localeCompare(right.value));
+  return getCanonicalGenres({ source: "all", availableOnly: false });
 }
 
 const getStarsStmt = db.prepare(
@@ -607,7 +519,11 @@ const resolveSubsonicTrack = (user, value) => {
   if (playlistSong) return playlistSong;
   const parsed = parseId(value);
   if (parsed?.kind !== "song") return null;
-  const library = readLibrary();
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
   const track = findCanonical(library, parsed);
   const normalized = trackFromCanonical(library, track);
   return normalized ? { kind: "song", track: normalized, canonical: track } : null;
@@ -628,7 +544,19 @@ const findLibraryJob = (track) => {
 };
 
 const findAvailableCanonicalFile = (track) => {
-  const library = readLibrary();
+  const library = indexFocusedLibrary(track?.trackMbid
+    ? getCanonicalTrack({
+        trackId: track.trackMbid,
+        source: "all",
+        availableOnly: true,
+      })
+    : getCanonicalTrackPage({
+        source: "all",
+        availableOnly: true,
+        query: track?.trackName,
+        artist: track?.artistName,
+        limit: 1,
+      }));
   const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   const file = firstFile(candidate);
   return file?.available && file.path ? { file, albumName: findAlbumForTrack(library, candidate)?.title } : null;
@@ -795,16 +723,20 @@ export function star(user, value) {
 export function starMany(user, values, { skipCanonicalValidation = false } = {}) {
   const parsed = values.map(starTarget);
   if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
-  const library = skipCanonicalValidation ? null : readLibrary();
+  const canonicalTargets = parsed
+    .filter((target) => ["artist", "album", "song"].includes(target.kind))
+    .map((target) => idFor(target.kind, target.key));
   const playlistSongs = parsed.map((target) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? resolvePlaylistSong(user, idFor(target.kind, target.key))
       : null,
   );
+  if (!skipCanonicalValidation &&
+    getCanonicalFavoriteTargetKeys(canonicalTargets).size !== canonicalTargets.length) return false;
   if (parsed.some((target, index) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? !playlistSongs[index]
-      : !skipCanonicalValidation && !findCanonical(library, target),
+      : false,
   )) return false;
   if (favoriteAutoKeepEnabled()) {
     const createdJobIds = [];
@@ -873,7 +805,7 @@ export function getStarredWithLibrary(user) {
   const library = getCanonicalLibrary({
     favoriteKeys: canonicalRows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),
   });
-  return { starred: buildStarred(indexLibrary(library), rows, user), library };
+  return { starred: buildStarred(indexFocusedLibrary(library), rows, user), library };
 }
 
 export function getStarred(user) {
@@ -887,22 +819,13 @@ export function getArtistInfo(value) {
 export function getTopSongs(artist, options = {}) {
   const target = String(artist || "").trim();
   if (!target) return [];
-  const library = readLibrary();
-  const normalizedTarget = target.toLocaleLowerCase();
-  const artistRecord = library.artists.find(
-    (entry) =>
-      entry.identityKey === target || entry.name.toLocaleLowerCase() === normalizedTarget,
-  );
-  if (!artistRecord) return [];
-  const tracks = library.tracks.filter((track) => {
-    const album = findAlbumForTrack(library, track);
-    const trackArtist = findArtistForAlbum(library, album);
-    return (
-      trackArtist?.id === artistRecord.id ||
-      String(track.artistName || "").trim().toLocaleLowerCase() === normalizedTarget
-    );
-  });
-  return tracks.slice(0, normalizeLimit(options.count)).map((track) => toSong(library, track));
+  const library = indexFocusedLibrary(getCanonicalTopTracks({
+    source: "all",
+    availableOnly: false,
+    artist: target,
+    limit: normalizeLimit(options.count),
+  }));
+  return library.tracks.map((track) => toSong(library, track));
 }
 
 export function getFlowPlaylists(user) {
@@ -967,8 +890,14 @@ export function resolveStreamPath(value, user) {
       : null;
   }
 
-  const library = readLibrary();
-  const track = findCanonical(library, parseId(value));
+  const parsed = parseId(value);
+  if (parsed?.kind !== "song") return null;
+  const library = indexFocusedLibrary(getCanonicalTrack({
+    trackId: parsed.key,
+    source: "all",
+    availableOnly: false,
+  }));
+  const track = findCanonical(library, parsed);
   const file = firstFile(track);
   return file?.available && file.path ? file.path : null;
 }
@@ -997,7 +926,23 @@ export async function resolveArtworkUrl(value) {
     return artwork;
   }
 
-  const library = readLibrary();
+  const library = indexFocusedLibrary(parsed.kind === "artist"
+    ? getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [parsed.key],
+      })
+    : parsed.kind === "album"
+      ? getCanonicalLibraryForAlbumReferences({
+          source: "all",
+          availableOnly: false,
+          references: [parsed.key],
+        })
+      : getCanonicalTrack({
+          trackId: parsed.key,
+          source: "all",
+          availableOnly: false,
+        }));
   const entity = findCanonical(library, parsed);
   if (!entity) return null;
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -731,8 +731,12 @@ export function starMany(user, values, { skipCanonicalValidation = false } = {})
       ? resolvePlaylistSong(user, idFor(target.kind, target.key))
       : null,
   );
-  if (!skipCanonicalValidation &&
-    getCanonicalFavoriteTargetKeys(canonicalTargets).size !== canonicalTargets.length) return false;
+  const canonicalTargetKeys = skipCanonicalValidation
+    ? null
+    : getCanonicalFavoriteTargetKeys(canonicalTargets);
+  if (canonicalTargetKeys && canonicalTargets.some((target) => !canonicalTargetKeys.has(target))) {
+    return false;
+  }
   if (parsed.some((target, index) =>
     ["flow-song", "shared-song"].includes(target.kind)
       ? !playlistSongs[index]

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -555,7 +555,7 @@ const findAvailableCanonicalFile = (track) => {
         availableOnly: true,
         query: track?.trackName,
         artist: track?.artistName,
-        limit: 1,
+        limit: 25,
       }));
   const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   const file = firstFile(candidate);

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -180,7 +180,7 @@ export async function processSystemTask(payload = {}) {
     }
     case "lidarr-retry": {
       const { libraryManager } = await import("./libraryManager.js");
-      await libraryManager.getAllArtists({ forceRefresh: true });
+      await libraryManager.syncLidarrArtists({ forceRefresh: true });
       return;
     }
     default:

--- a/backend/services/systemTaskWorker.js
+++ b/backend/services/systemTaskWorker.js
@@ -8,7 +8,7 @@ import { cleanExpiredSessions } from "../config/session-helpers.js";
 import { dbOps } from "../db/helpers/index.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 
-export async function processSystemTask(payload = {}) {
+export async function processSystemTask(payload = {}, job = null) {
   const kind = String(payload?.kind || "").trim();
   switch (kind) {
     case "weekly-flow-refresh": {
@@ -76,8 +76,24 @@ export async function processSystemTask(payload = {}) {
       return;
     }
     case "inbox-refresh": {
-      const { refreshInboxForAllUsers } = await import("./inboxService.js");
-      await refreshInboxForAllUsers();
+      const {
+        enqueueInboxRefreshForAllUsers,
+        refreshInboxForUser,
+      } = await import("./inboxService.js");
+      const userId = Number(payload.userId);
+      if (Number.isInteger(userId) && userId > 0) {
+        await refreshInboxForUser(userId, {
+          force: true,
+          throwOnFailure: true,
+          jobId: job?.id || payload.jobId || null,
+          zipCode: payload.zipCode || "",
+          ipAddress: payload.ipAddress || "",
+        });
+      } else {
+        await enqueueInboxRefreshForAllUsers({
+          reason: payload.reason || "scheduled",
+        });
+      }
       return;
     }
     case "news-refresh": {

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -5,7 +5,12 @@ import {
   flowPlaylistConfig,
   tracksShareMembership,
 } from "./weeklyFlowPlaylistConfig.js";
-import { libraryManager } from "../libraryManager.js";
+import {
+  buildCanonicalLibraryReadModel,
+  findCanonicalArtist,
+  findCanonicalTracksForAlbum,
+} from "../canonicalLibraryReadAdapter.js";
+import { getCanonicalLibraryForArtistReferences } from "../libraryQueryService.js";
 import { commitImportToPlaylistLibrary, sanitizePathPart } from "../playlistDownloadUtils.js";
 import {
   AURRAL_FLOWS_DIR,
@@ -393,14 +398,15 @@ function findMatchingTrack(tracks, track, strictAlbum = false) {
 
 async function findLidarrSource(track, options = {}) {
   const strictAlbum = options.targetPlaylistType === "library";
-  let artists = [];
-  try {
-    artists = await libraryManager.getAllArtists();
-  } catch (error) {
-    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr artists:", error.message);
-    return null;
-  }
-  const artist = findMatchingArtist(Array.isArray(artists) ? artists : [], track);
+  const { artists, albums, tracks } = buildCanonicalLibraryReadModel(
+    getCanonicalLibraryForArtistReferences({
+      source: "lidarr",
+      availableOnly: false,
+      references: [track?.artistMbid, track?.artistName],
+    }),
+  );
+  const artist = findCanonicalArtist(artists, track?.artistMbid) ||
+    findMatchingArtist(artists, track);
   if (!artist) {
     console.log(
       `[WeeklyFlowReuse] Lidarr: no artist match for "${track?.artistName}" (mbid ${track?.artistMbid || "none"}, ${artists.length} Lidarr artists checked)`,
@@ -410,14 +416,8 @@ async function findLidarrSource(track, options = {}) {
   const artistId = artist.id || artist.artistId;
   if (!artistId) return null;
 
-  let albums = [];
-  try {
-    albums = await libraryManager.getAlbums(artistId);
-  } catch (error) {
-    console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr albums:", error.message);
-    return null;
-  }
-  if (!albums.length) {
+  const artistAlbums = albums.filter((album) => String(album.artistId) === String(artist.id));
+  if (!artistAlbums.length) {
     console.log(
       `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" (id ${artistId}) matched but has 0 albums`,
     );
@@ -425,7 +425,7 @@ async function findLidarrSource(track, options = {}) {
   }
 
   let foundTitleOnAnyAlbum = false;
-  const rankedAlbums = rankAlbums(Array.isArray(albums) ? albums : [], track);
+  const rankedAlbums = rankAlbums(artistAlbums, track);
   const albumsToCheck = strictAlbum
     ? rankedAlbums.filter((album) => {
         const albumMbid = String(track?.albumMbid || "").trim();
@@ -440,15 +440,9 @@ async function findLidarrSource(track, options = {}) {
       })
     : rankedAlbums;
   for (const album of albumsToCheck) {
-    let tracks = [];
-    try {
-      tracks = await libraryManager.getTracks(album.id);
-    } catch (error) {
-      console.warn("[WeeklyFlowReuse] Failed to inspect Lidarr tracks:", error.message);
-      continue;
-    }
+    const albumTracks = findCanonicalTracksForAlbum(tracks, album.id);
     const matchedTrack = findMatchingTrack(
-      Array.isArray(tracks) ? tracks : [],
+      albumTracks,
       track,
       strictAlbum,
     );
@@ -477,7 +471,7 @@ async function findLidarrSource(track, options = {}) {
   }
   if (!foundTitleOnAnyAlbum) {
     console.log(
-      `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" matched (${albums.length} albums checked) but no album's tracklist contained "${track.trackName}"`,
+      `[WeeklyFlowReuse] Lidarr: artist "${artist.artistName}" matched (${artistAlbums.length} albums checked) but no album's tracklist contained "${track.trackName}"`,
     );
   }
   return null;

--- a/backend/services/weeklyFlow/weeklyFlowPlaylistSource.js
+++ b/backend/services/weeklyFlow/weeklyFlowPlaylistSource.js
@@ -5,6 +5,14 @@ import { getBlockedArtistKeys } from "../discovery/feedback.js";
 import { mapWithConcurrency } from "../discovery/helpers.js";
 import { getYear } from "../providers/brainzmashRanking.js";
 import { resolveWeeklyFlowTrackContext } from "./weeklyFlowTrackResolver.js";
+import {
+  buildCanonicalLibraryReadModel,
+} from "../canonicalLibraryReadAdapter.js";
+import {
+  getCanonicalLibraryPage,
+  getCanonicalLibraryForArtistReferences,
+  iterateCanonicalArtistProjection,
+} from "../libraryQueryService.js";
 import BoundedMap from "../boundedMap.js";
 const LASTFM_HARVEST_CONCURRENCY = 12;
 const ARTIST_TOP_TRACKS_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
@@ -467,8 +475,7 @@ export class WeeklyFlowPlaylistSource {
     }
 
     const promise = (async () => {
-      const { libraryManager } = await import("../libraryManager.js");
-      const artists = await libraryManager.getAllArtists();
+      const artists = [...iterateCanonicalArtistProjection({ pageSize: 100 })];
       return this._buildArtistKeySet(artists);
     })();
     this.libraryArtistKeysCache = { promise };
@@ -1964,7 +1971,7 @@ export class WeeklyFlowPlaylistSource {
     return tracks.slice(0, limit);
   }
 
-  async _getLibraryOwnership(libraryManager, artistId) {
+  async _getLibraryOwnership(_libraryManager, artistId) {
     const key = String(artistId ?? "");
     if (!key) {
       return { ownedTitles: new Set(), ownedAlbums: new Set() };
@@ -1973,11 +1980,25 @@ export class WeeklyFlowPlaylistSource {
     if (cached?.data && cached.expiresAt > Date.now()) {
       return cached.data;
     }
-    const albums = await libraryManager.getAlbums(artistId);
-    const [ownedTitles, ownedAlbums] = await Promise.all([
-      this.getLibraryTrackTitles(libraryManager, artistId, albums),
-      this.getLibraryAlbumNames(libraryManager, artistId, albums),
-    ]);
+    const { albums, tracks } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
+    );
+    const ownedTitles = new Set(
+      tracks
+        .filter((track) => track.available)
+        .map((track) => String(track.trackName || track.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const ownedAlbums = new Set(
+      albums
+        .filter((album) => album.available)
+        .map((album) => String(album.albumName || album.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
     const data = { ownedTitles, ownedAlbums };
     this.libraryOwnershipCache.set(key, {
       data,
@@ -1986,42 +2007,42 @@ export class WeeklyFlowPlaylistSource {
     return data;
   }
 
-  async getLibraryTrackTitles(libraryManager, artistId, knownAlbums = null) {
-    const albums = Array.isArray(knownAlbums)
-      ? knownAlbums
-      : await libraryManager.getAlbums(artistId);
-    const titles = new Set();
-    const maxAlbums = 30;
-    const trackLists = await Promise.all(
-      albums.slice(0, maxAlbums).map((album) => libraryManager.getTracks(album.id)),
+  async getLibraryTrackTitles(_libraryManager, artistId, _knownAlbums = null) {
+    const { tracks } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
     );
-    for (const tracks of trackLists) {
-      for (const t of tracks) {
-        const name = (t.trackName || t.title || "").trim().toLowerCase();
-        if (name) titles.add(name);
-      }
-    }
-    return titles;
+    return new Set(
+      tracks
+        .filter((track) => track.available)
+        .map((track) => String(track.trackName || track.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
   }
 
-  async getLibraryAlbumNames(libraryManager, artistId, knownAlbums = null) {
-    const albums = Array.isArray(knownAlbums)
-      ? knownAlbums
-      : await libraryManager.getAlbums(artistId);
-    const names = new Set();
-    const maxAlbums = 40;
-    for (const album of albums.slice(0, maxAlbums)) {
-      const name = (album.albumName || album.title || "").trim().toLowerCase();
-      if (name) names.add(name);
-    }
-    return names;
+  async getLibraryAlbumNames(_libraryManager, artistId, _knownAlbums = null) {
+    const { albums } = buildCanonicalLibraryReadModel(
+      getCanonicalLibraryForArtistReferences({
+        source: "all",
+        availableOnly: false,
+        references: [artistId],
+      }),
+    );
+    return new Set(
+      albums
+        .filter((album) => album.available)
+        .map((album) => String(album.albumName || album.title || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
   }
 
   async getMixTracks(limit, options = {}) {
-    const { libraryManager } = await import("../libraryManager.js");
     const artists = Array.isArray(options?.libraryArtists)
       ? options.libraryArtists
-      : await libraryManager.getAllArtists();
+      : [...iterateCanonicalArtistProjection({ pageSize: 100 })];
     if (artists.length === 0) {
       throw new Error("No artists in library. Add artists to enable Mix.");
     }
@@ -2050,7 +2071,7 @@ export class WeeklyFlowPlaylistSource {
           if (!artistKey || seenArtists.has(artistKey)) return null;
           try {
             const { ownedTitles, ownedAlbums } = await this._getLibraryOwnership(
-              libraryManager,
+              null,
               artist.id,
             );
             const trackList = await this._getArtistTopTrackList(artistName);
@@ -2104,15 +2125,21 @@ export class WeeklyFlowPlaylistSource {
     }
     const set = new Set();
     try {
-      const { lidarrClient } = await import("../lidarrClient.js");
-      if (lidarrClient.isConfigured()) {
-        const albums = await lidarrClient.getAllAlbums();
-        for (const album of Array.isArray(albums) ? albums : []) {
-          const mbid = String(album?.foreignAlbumId || "")
+      for (let page = 1; ; page += 1) {
+        const result = getCanonicalLibraryPage({
+          source: "all",
+          availableOnly: false,
+          kind: "albums",
+          page,
+          pageSize: 100,
+        });
+        for (const album of result.items) {
+          const mbid = String(album?.foreignAlbumId || album?.mbid || "")
             .trim()
             .toLowerCase();
           if (mbid) set.add(mbid);
         }
+        if (!result.hasMore) break;
       }
     } catch {}
     this.libraryAlbumMbidCache = {

--- a/frontend/src/hooks/useStorageHealth.js
+++ b/frontend/src/hooks/useStorageHealth.js
@@ -1,6 +1,9 @@
 import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getStorageHealth } from "../utils/api/endpoints/settings.js";
+import {
+  getStorageHealth,
+  runStorageHealthCheck,
+} from "../utils/api/endpoints/settings.js";
 import { queryClient, queryKeys } from "../queryClient.js";
 
 const toSnapshot = (result, dataUpdatedAt = 0) => ({
@@ -34,7 +37,8 @@ export function setStorageHealthResult(result) {
 export function refreshStorageHealth({ force = false } = {}) {
   return queryClient.fetchQuery({
     queryKey: queryKeys.storageHealth,
-    queryFn: ({ signal }) => getStorageHealth({ force, signal }),
+    queryFn: ({ signal }) =>
+      force ? runStorageHealthCheck({ signal }) : getStorageHealth({ signal }),
     staleTime: force ? 0 : 120_000,
   });
 }

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -1933,7 +1933,7 @@ function LibraryPage() {
             />
           </div>
           <span className="native-library-card__meta">
-            {artist.albumIds?.length || 0} album{artist.albumIds?.length === 1 ? "" : "s"}
+            {artist.albumCount ?? artist.albumIds?.length ?? 0} album{(artist.albumCount ?? artist.albumIds?.length ?? 0) === 1 ? "" : "s"}
           </span>
         </div>
       </article>

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -180,7 +180,16 @@ export const lookupArtistsInLibraryBatch = async (mbids) => {
   if (!ids.length) return {};
   const data = await queryClient.fetchQuery({
     queryKey: queryKeys.libraryLookupBatch(ids),
-    queryFn: ({ signal }) => postData("/library/lookup/batch", { mbids: ids }, { signal }),
+    queryFn: async ({ signal }) => {
+      const lookup = {};
+      for (let index = 0; index < ids.length; index += 100) {
+        Object.assign(
+          lookup,
+          await postData("/library/lookup/batch", { mbids: ids.slice(index, index + 100) }, { signal }),
+        );
+      }
+      return lookup;
+    },
     staleTime: 60_000,
   });
   writeLibraryLookupCache(data);

--- a/frontend/src/utils/api/endpoints/settings.js
+++ b/frontend/src/utils/api/endpoints/settings.js
@@ -100,11 +100,11 @@ export const testLidarrLibraryAccess = (url, apiKey) =>
     params: lidarrCredentialParams(url, apiKey),
   });
 
-export const getStorageHealth = ({ force = false, signal } = {}) =>
-  getData("/settings/storage-health", {
-    params: force ? { force: "1" } : undefined,
-    signal,
-  });
+export const getStorageHealth = ({ signal } = {}) =>
+  getData("/settings/storage-health", { signal });
+
+export const runStorageHealthCheck = ({ signal } = {}) =>
+  postData("/settings/storage-health/check", {}, { signal });
 
 export const getSettingsTasks = ({ signal } = {}) => getData("/settings/tasks", { signal });
 

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -506,6 +506,9 @@ async function main() {
         options.repeats,
       );
     }
+    const artistProjectionCold = measure(
+      () => queryService.getCanonicalArtistProjection({ page: 1, pageSize: 100 }),
+    );
     const artistProjectionSamples = [];
     for (let index = 0; index < options.repeats; index += 1) {
       artistProjectionSamples.push(
@@ -514,7 +517,8 @@ async function main() {
     }
     const stripProjection = ({ value: _value, ...sample }) => sample;
     pages["artist-projection"] = {
-      shape: artistProjectionSummary(artistProjectionSamples[0].value),
+      shape: artistProjectionSummary(artistProjectionCold.value),
+      cold: stripProjection(artistProjectionCold),
       warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
     };
     const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -111,10 +111,11 @@ function measure(operation) {
   const started = performance.now();
   const value = operation();
   const elapsedMs = performance.now() - started;
+  const serialized = JSON.stringify(value);
   const after = memoryStats();
   return {
     elapsedMs: Number(elapsedMs.toFixed(3)),
-    jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+    jsonBytes: Buffer.byteLength(serialized),
     memoryBefore: before,
     memoryAfter: after,
     rssDeltaBytes: after.rssBytes - before.rssBytes,
@@ -394,6 +395,7 @@ const before = process.memoryUsage();
 const started = performance.now();
 const value = read[operation]();
 const elapsedMs = performance.now() - started;
+const serialized = JSON.stringify(value);
 const after = process.memoryUsage();
 const counts = Array.isArray(value)
   ? { items: value.length }
@@ -404,7 +406,7 @@ const counts = Array.isArray(value)
     };
 console.log(JSON.stringify({
   elapsedMs: Number(elapsedMs.toFixed(3)),
-  jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+  jsonBytes: Buffer.byteLength(serialized),
   rssDeltaBytes: after.rss - before.rss,
   heapDeltaBytes: after.heapUsed - before.heapUsed,
   rssBytes: after.rss,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -518,7 +518,7 @@ async function main() {
     const stripProjection = ({ value: _value, ...sample }) => sample;
     pages["artist-projection"] = {
       shape: artistProjectionSummary(artistProjectionCold.value),
-      cold: stripProjection(artistProjectionCold),
+      cold: summarizeSamples([stripProjection(artistProjectionCold)]),
       warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
     };
     const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -132,6 +132,10 @@ function pageSummary(page) {
   };
 }
 
+function artistProjectionSummary(artists) {
+  return { itemCount: artists.length };
+}
+
 function seedDatabase(database, { tracks, tracksPerAlbum }) {
   const albumCount = Math.ceil(tracks / tracksPerAlbum);
   const artistCount = Math.ceil(albumCount / 10);
@@ -502,6 +506,22 @@ async function main() {
         options.repeats,
       );
     }
+    const artistProjectionSamples = [];
+    for (let index = 0; index < options.repeats; index += 1) {
+      artistProjectionSamples.push(
+        measure(() => queryService.getCanonicalArtistProjection({ page: 1, pageSize: 100 })),
+      );
+    }
+    const stripProjection = ({ value: _value, ...sample }) => sample;
+    pages["artist-projection"] = {
+      shape: artistProjectionSummary(artistProjectionSamples[0].value),
+      warm: summarizeSamples(artistProjectionSamples.map(stripProjection)),
+    };
+    const artistProjectionPlan = queryService.getCanonicalArtistProjectionQueryPlan({
+      page: 1,
+      pageSize: 100,
+    });
+    const artistProjectionPlanDetails = artistProjectionPlan.map((row) => String(row.detail || ""));
     database.close();
     database = null;
     const fullReads = {};
@@ -548,6 +568,12 @@ async function main() {
       fallbackIndexerStopsAtBulkFailure: indexerProbes.fallback.status === "completed"
         && indexerProbes.fallback.error === "bulk track-file read failed"
         && indexerProbes.fallback.maxActiveAlbums === 0,
+      artistProjectionPageBounded:
+        artistProjectionPlanDetails.some((detail) => detail.includes("MATERIALIZE artist_page"))
+        && artistProjectionPlanDetails.some((detail) =>
+          /SEARCH album USING (?:COVERING )?INDEX .*artist_id/.test(detail),
+        )
+        && !artistProjectionPlanDetails.some((detail) => detail === "SCAN album"),
       pageWarmP95Under750ms: Object.values(pageP95).every((value) => value < 750),
     };
     output = {
@@ -560,6 +586,7 @@ async function main() {
       elapsedMs: Number((performance.now() - started).toFixed(3)),
       seed: { ...seed, elapsedMs: seedElapsedMs },
       pages,
+      artistProjectionPlan,
       fullReads,
       indexer: {
         requestedAlbums: options.indexerAlbums,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -114,9 +114,11 @@ function measure(operation) {
   const after = memoryStats();
   return {
     elapsedMs: Number(elapsedMs.toFixed(3)),
+    jsonBytes: Buffer.byteLength(JSON.stringify(value)),
     memoryBefore: before,
     memoryAfter: after,
     rssDeltaBytes: after.rssBytes - before.rssBytes,
+    heapDeltaBytes: after.heapUsedBytes - before.heapUsedBytes,
     value,
   };
 }
@@ -244,6 +246,19 @@ function seedDatabase(database, { tracks, tracksPerAlbum }) {
   };
 }
 
+function seedSubsonicFavorite(database) {
+  const now = Date.now();
+  const userId = Number(database.prepare(
+    `INSERT INTO users (username, password_hash, role, permissions)
+     VALUES ('benchmark', 'benchmark', 'user', '{}')`,
+  ).run().lastInsertRowid);
+  database.prepare(
+    `INSERT INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
+     VALUES (?, 'song', 'benchmark:track:0', ?)`,
+  ).run(userId, now);
+  return { id: userId, username: "benchmark", permissions: {} };
+}
+
 function collectPageSamples(getPage, invalidate, repeats) {
   const coldSamples = [];
   const warmSamples = [];
@@ -338,53 +353,76 @@ function runChild({ dataDir, dbPath, code, timeoutMs, heapMb, env = {} }) {
   });
 }
 
-const fullReadCode = `
-import { performance } from "node:perf_hooks";
-import { getCanonicalLibrary } from "./backend/services/libraryQueryService.js";
-import { getCanonicalLibraryReadModel } from "./backend/services/canonicalLibraryReadAdapter.js";
+const boundedReadCode = `
+import { groupArtists } from "./backend/routes/subsonic.js";
 import {
-  buildPublicLibrary,
-  publicLibraryJsonReplacer,
-} from "./backend/routes/library/handlers/canonical.js";
+  getAlbum,
+  getFlowPlaylists,
+  getStarred,
+  getArtist,
+  listArtists,
+  searchLibrary,
+} from "./backend/services/subsonicLibraryService.js";
+import { getCanonicalTrackPage } from "./backend/services/libraryQueryService.js";
 
-const mode = process.env.AURRAL_BENCHMARK_MODE;
-let value;
-let rawReadMs = 0;
-let transformMs = 0;
-if (mode === "legacy-adapter") {
-  const started = performance.now();
-  value = getCanonicalLibraryReadModel({ source: "lidarr", availableOnly: true });
-  rawReadMs = performance.now() - started;
-} else {
-  const rawStarted = performance.now();
-  const raw = getCanonicalLibrary({ source: "lidarr", availableOnly: true });
-  rawReadMs = performance.now() - rawStarted;
-  const transformStarted = performance.now();
-  value = buildPublicLibrary(raw);
-  transformMs = performance.now() - transformStarted;
-}
-const readMs = rawReadMs + transformMs;
-const serializeStarted = performance.now();
-const jsonReplacer = mode === "full-endpoint" ? publicLibraryJsonReplacer : undefined;
-const jsonBytes = Buffer.byteLength(JSON.stringify(value, jsonReplacer));
-const serializeMs = performance.now() - serializeStarted;
-const memory = process.memoryUsage();
-const counts = {
-  artists: Array.isArray(value.artists) ? value.artists.length : 0,
-  albums: Array.isArray(value.albums) ? value.albums.length : 0,
-  tracks: Array.isArray(value.tracks) ? value.tracks.length : 0,
+const user = { id: 1, username: "benchmark", permissions: {} };
+const encodedId = (kind, key) => kind + ":" + encodeURIComponent(key);
+const operation = process.env.AURRAL_BENCHMARK_OPERATION;
+const read = {
+  getIndexes: () => ({ index: groupArtists(listArtists()) }),
+  getArtist: () => getArtist(encodedId("artist", "benchmark:artist:0")),
+  getAlbum: () => getAlbum(encodedId("album", "benchmark:album:0")),
+  search3: () => searchLibrary("Benchmark Track", {
+    artistCount: "20",
+    albumCount: "20",
+    songCount: "20",
+  }),
+  randomSongs: () => getCanonicalTrackPage({
+    source: "lidarr",
+    availableOnly: true,
+    random: true,
+    limit: 20,
+  }).tracks,
+  starred: () => getStarred(user),
+  playlists: () => getFlowPlaylists(user),
 };
+const before = process.memoryUsage();
+const started = performance.now();
+const value = read[operation]();
+const elapsedMs = performance.now() - started;
+const after = process.memoryUsage();
+const counts = Array.isArray(value)
+  ? { items: value.length }
+  : {
+      artists: Array.isArray(value?.artist) ? value.artist.length : undefined,
+      albums: Array.isArray(value?.album) ? value.album.length : undefined,
+      songs: Array.isArray(value?.song) ? value.song.length : undefined,
+    };
 console.log(JSON.stringify({
-  rawReadMs: Number(rawReadMs.toFixed(3)),
-  transformMs: Number(transformMs.toFixed(3)),
-  readMs: Number(readMs.toFixed(3)),
-  serializeMs: Number(serializeMs.toFixed(3)),
-  jsonBytes,
+  elapsedMs: Number(elapsedMs.toFixed(3)),
+  jsonBytes: Buffer.byteLength(JSON.stringify(value)),
+  rssDeltaBytes: after.rss - before.rss,
+  heapDeltaBytes: after.heapUsed - before.heapUsed,
+  rssBytes: after.rss,
+  heapUsedBytes: after.heapUsed,
   counts,
-  rssBytes: memory.rss,
-  heapUsedBytes: memory.heapUsed,
 }));
 `;
+
+function summarizeReadSamples(samples) {
+  const values = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
+  const completed = samples.filter((sample) => sample.status === "completed");
+  const strip = ({ status: _status, ...sample }) => sample;
+  return {
+    samples: samples.map(strip),
+    responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
+    medianMs: completed.length ? percentile(0.5) : null,
+    p95Ms: completed.length ? percentile(0.95) : null,
+    maxRssDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.rssDeltaBytes)) : null,
+    maxHeapDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.heapDeltaBytes)) : null,
+  };
+}
 
 const indexerProbeCode = `
 import { performance } from "node:perf_hooks";
@@ -486,6 +524,7 @@ async function main() {
     const queryService = await import("../backend/services/libraryQueryService.js");
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
+    const benchmarkUser = seedSubsonicFavorite(database);
     const seedElapsedMs = Number((performance.now() - seedStarted).toFixed(3));
     const pageCases = [
       ["artists", { kind: "artists", page: 1, pageSize: 100 }],
@@ -504,16 +543,31 @@ async function main() {
     }
     database.close();
     database = null;
-    const fullReads = {};
-    for (const mode of ["full-endpoint", "legacy-adapter"]) {
-      fullReads[mode] = await runChild({
-        dataDir,
-        dbPath,
-        timeoutMs: options.fullReadTimeoutMs,
-        heapMb: options.childHeapMb,
-        code: fullReadCode,
-        env: { AURRAL_BENCHMARK_MODE: mode },
-      });
+    const subsonicReads = {};
+    for (const operation of [
+      "getIndexes",
+      "getArtist",
+      "getAlbum",
+      "search3",
+      "randomSongs",
+      "starred",
+      "playlists",
+    ]) {
+      const samples = [];
+      for (let index = 0; index < options.repeats; index += 1) {
+        samples.push(await runChild({
+          dataDir,
+          dbPath,
+          timeoutMs: options.fullReadTimeoutMs,
+          heapMb: options.childHeapMb,
+          code: boundedReadCode,
+          env: {
+            AURRAL_BENCHMARK_OPERATION: operation,
+            AURRAL_BENCHMARK_USER_ID: String(benchmarkUser.id),
+          },
+        }));
+      }
+      subsonicReads[operation] = summarizeReadSamples(samples);
     }
     const indexerProbes = {};
     for (const [mode, probeDir] of [
@@ -534,13 +588,13 @@ async function main() {
     }
     const expectedBulkIndexerCalls = 5;
     const expectedFallbackIndexerCalls = 5;
-    const adapter = fullReads["legacy-adapter"];
     const pageP95 = Object.fromEntries(
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
     );
+    const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
+      read.samples.every((sample) => sample.error === undefined));
     const checks = {
-      fullEndpointReadCompleted: fullReads["full-endpoint"].status === "completed",
-      legacyReadCompleted: adapter.status === "completed",
+      boundedReadCompleted,
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
         && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
       fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
@@ -559,8 +613,8 @@ async function main() {
       options,
       elapsedMs: Number((performance.now() - started).toFixed(3)),
       seed: { ...seed, elapsedMs: seedElapsedMs },
+      subsonicReads,
       pages,
-      fullReads,
       indexer: {
         requestedAlbums: options.indexerAlbums,
         expectedBulkCalls: expectedBulkIndexerCalls,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -419,6 +419,11 @@ function summarizeReadSamples(samples) {
   const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   return {
     samples,
+    sampleCount: samples.length,
+    completedCount: completed.length,
+    nonVacuous: samples.length > 0
+      && completed.length === samples.length
+      && completed.every((sample) => Number(sample.jsonBytes) > 0),
     responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
     medianMs: completed.length ? percentile(0.5) : null,
     p95Ms: completed.length ? percentile(0.95) : null,
@@ -525,11 +530,14 @@ async function main() {
     const imported = await import("../backend/config/db-sqlite.js");
     database = imported.db;
     const queryService = await import("../backend/services/libraryQueryService.js");
+    const { rebuildLibrarySearchIndex } = await import("../backend/services/librarySearchIndex.js");
     const { flowPlaylistConfig } = await import(
       "../backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js"
     );
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
+    rebuildLibrarySearchIndex();
+    queryService.rebuildCanonicalGenreStats();
     const benchmarkUser = seedSubsonicFavorite(database);
     flowPlaylistConfig.createSharedPlaylist({
       name: "Benchmark Playlist",
@@ -548,7 +556,7 @@ async function main() {
     for (const [name, pageOptions] of pageCases) {
       pages[name] = collectPageSamples(
         () => queryService.getCanonicalLibraryPage(pageOptions),
-        queryService.invalidateCanonicalLibraryCache,
+        () => queryService.invalidateCanonicalLibraryCache({ persistedGenres: false }),
         options.repeats,
       );
     }
@@ -599,13 +607,41 @@ async function main() {
     }
     const expectedBulkIndexerCalls = 5;
     const expectedFallbackIndexerCalls = 5;
-    const pageP95 = Object.fromEntries(
-      Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
-    );
+    const measuredReadNames = ["search3", "randomSongs"];
+    const measuredReads = measuredReadNames.map((name) => subsonicReads[name]);
+    const measuredQueryChecks = {
+      nonVacuousCompletedSamples: measuredReads.every((read) => read.nonVacuous),
+      coldP95Under750ms: measuredReads.every((read) => read.p95Ms < 750),
+      responseUnder2MiB: measuredReads.every((read) =>
+        read.responseBytes.length > 0
+        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: measuredReads.every((read) =>
+        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+    };
+    const pageBudgetChecks = {
+      warmP95Under250ms: Object.values(pages).every((page) => page.warm.p95Ms < 250),
+      coldP95Under750ms: Object.values(pages).every((page) => page.cold.p95Ms < 750),
+      responseUnder2MiB: Object.values(pages).every((page) =>
+        [...page.cold.samples, ...page.warm.samples]
+          .every((sample) => sample.jsonBytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: Object.values(pages).every((page) =>
+        [...page.cold.samples, ...page.warm.samples]
+          .every((sample) => sample.rssDeltaBytes < 64 * 1024 * 1024)),
+    };
+    const compatibilityReadChecks = {
+      responseUnder2MiB: Object.values(subsonicReads).every((read) =>
+        read.responseBytes.length > 0
+        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+      maxRssDeltaUnder64MiB: Object.values(subsonicReads).every((read) =>
+        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+    };
     const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
-      read.samples.every((sample) => sample.status === "completed"));
+      read.nonVacuous);
     const checks = {
       boundedReadCompleted,
+      measuredQueryBudgets: Object.values(measuredQueryChecks).every(Boolean),
+      pageBudgets: Object.values(pageBudgetChecks).every(Boolean),
+      compatibilityReadBudgets: Object.values(compatibilityReadChecks).every(Boolean),
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"
         && indexerProbes.bulk.callCount === expectedBulkIndexerCalls,
       fallbackIndexerCallCount: indexerProbes.fallback.status === "completed"
@@ -613,7 +649,6 @@ async function main() {
       fallbackIndexerStopsAtBulkFailure: indexerProbes.fallback.status === "completed"
         && indexerProbes.fallback.error === "bulk track-file read failed"
         && indexerProbes.fallback.maxActiveAlbums === 0,
-      pageWarmP95Under750ms: Object.values(pageP95).every((value) => value < 750),
     };
     output = {
       benchmark: "aurral-library",
@@ -626,6 +661,22 @@ async function main() {
       seed: { ...seed, elapsedMs: seedElapsedMs },
       subsonicReads,
       pages,
+      budgets: {
+        targets: {
+          warmPageP95Ms: 250,
+          coldPageP95Ms: 750,
+          responseBytes: 2 * 1024 * 1024,
+          requestRssDeltaBytes: 64 * 1024 * 1024,
+        },
+        measuredQueryChecks,
+        pageBudgetChecks,
+        compatibilityReadChecks,
+        deferredIntegrationChecks: [
+          "stableReadProviderCalls",
+          "readStartedJobs",
+          "restartMigrationRepeats",
+        ],
+      },
       indexer: {
         requestedAlbums: options.indexerAlbums,
         expectedBulkCalls: expectedBulkIndexerCalls,

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -250,13 +250,13 @@ function seedSubsonicFavorite(database) {
   const now = Date.now();
   const userId = Number(database.prepare(
     `INSERT INTO users (username, password_hash, role, permissions)
-     VALUES ('benchmark', 'benchmark', 'user', '{}')`,
+     VALUES ('benchmark', 'benchmark', 'user', '{"accessFlow":true}')`,
   ).run().lastInsertRowid);
   database.prepare(
     `INSERT INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
      VALUES (?, 'song', 'benchmark:track:0', ?)`,
   ).run(userId, now);
-  return { id: userId, username: "benchmark", permissions: {} };
+  return { id: userId, username: "benchmark", permissions: { accessFlow: true } };
 }
 
 function collectPageSamples(getPage, invalidate, repeats) {
@@ -365,7 +365,11 @@ import {
 } from "./backend/services/subsonicLibraryService.js";
 import { getCanonicalTrackPage } from "./backend/services/libraryQueryService.js";
 
-const user = { id: 1, username: "benchmark", permissions: {} };
+const user = {
+  id: Number(process.env.AURRAL_BENCHMARK_USER_ID),
+  username: "benchmark",
+  permissions: { accessFlow: true },
+};
 const encodedId = (kind, key) => kind + ":" + encodeURIComponent(key);
 const operation = process.env.AURRAL_BENCHMARK_OPERATION;
 const read = {
@@ -410,12 +414,11 @@ console.log(JSON.stringify({
 `;
 
 function summarizeReadSamples(samples) {
-  const values = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
-  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   const completed = samples.filter((sample) => sample.status === "completed");
-  const strip = ({ status: _status, ...sample }) => sample;
+  const values = completed.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
   return {
-    samples: samples.map(strip),
+    samples,
     responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
     medianMs: completed.length ? percentile(0.5) : null,
     p95Ms: completed.length ? percentile(0.95) : null,
@@ -522,9 +525,17 @@ async function main() {
     const imported = await import("../backend/config/db-sqlite.js");
     database = imported.db;
     const queryService = await import("../backend/services/libraryQueryService.js");
+    const { flowPlaylistConfig } = await import(
+      "../backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js"
+    );
     const seedStarted = performance.now();
     const seed = seedDatabase(database, options);
     const benchmarkUser = seedSubsonicFavorite(database);
+    flowPlaylistConfig.createSharedPlaylist({
+      name: "Benchmark Playlist",
+      ownerUserId: benchmarkUser.id,
+      tracks: [],
+    });
     const seedElapsedMs = Number((performance.now() - seedStarted).toFixed(3));
     const pageCases = [
       ["artists", { kind: "artists", page: 1, pageSize: 100 }],
@@ -592,7 +603,7 @@ async function main() {
       Object.entries(pages).map(([name, value]) => [name, value.warm.p95Ms]),
     );
     const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
-      read.samples.every((sample) => sample.error === undefined));
+      read.samples.every((sample) => sample.status === "completed"));
     const checks = {
       boundedReadCompleted,
       bulkIndexerCallCount: indexerProbes.bulk.status === "completed"

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -45,7 +45,7 @@ Options:
   --tracks-per-album N        Synthetic tracks per album, default 10
   --repeats N                 Page samples per cold/warm group, default 3
   --indexer-albums N          Albums in the Lidarr call probe, default 1000
-  --full-read-timeout-ms N    Timeout for full-read child probes, default 30000
+  --child-probe-timeout-ms N  Timeout for child probes, default 30000
   --child-heap-mb N           Child heap cap in megabytes, default 2048
   --output PATH               JSON result path, default perf-results/library-<timestamp>.json
   --check                     Exit nonzero when the regression gate fails
@@ -62,9 +62,9 @@ Options:
     readOption(args, "indexer-albums", 1000),
     "indexer-albums",
   );
-  const fullReadTimeoutMs = positiveInteger(
-    readOption(args, "full-read-timeout-ms", 30000),
-    "full-read-timeout-ms",
+  const childProbeTimeoutMs = positiveInteger(
+    readOption(args, "child-probe-timeout-ms", 30000),
+    "child-probe-timeout-ms",
   );
   const childHeapMb = positiveInteger(readOption(args, "child-heap-mb", 2048), "child-heap-mb");
   const output = readOption(
@@ -77,7 +77,7 @@ Options:
     tracksPerAlbum,
     repeats,
     indexerAlbums,
-    fullReadTimeoutMs,
+    childProbeTimeoutMs,
     childHeapMb,
     output: path.isAbsolute(output) ? output : path.join(repoRoot, output),
     check: args.includes("--check"),
@@ -569,7 +569,7 @@ async function main() {
         samples.push(await runChild({
           dataDir,
           dbPath,
-          timeoutMs: options.fullReadTimeoutMs,
+          timeoutMs: options.childProbeTimeoutMs,
           heapMb: options.childHeapMb,
           code: boundedReadCode,
           env: {
@@ -588,7 +588,7 @@ async function main() {
       indexerProbes[mode] = await runChild({
         dataDir: probeDir,
         dbPath: path.join(probeDir, "aurral.db"),
-        timeoutMs: options.fullReadTimeoutMs,
+        timeoutMs: options.childProbeTimeoutMs,
         heapMb: options.childHeapMb,
         code: indexerProbeCode,
         env: {

--- a/scripts/benchmark-library.mjs
+++ b/scripts/benchmark-library.mjs
@@ -401,13 +401,27 @@ const value = read[operation]();
 const elapsedMs = performance.now() - started;
 const serialized = JSON.stringify(value);
 const after = process.memoryUsage();
-const counts = Array.isArray(value)
-  ? { items: value.length }
-  : {
-      artists: Array.isArray(value?.artist) ? value.artist.length : undefined,
-      albums: Array.isArray(value?.album) ? value.album.length : undefined,
-      songs: Array.isArray(value?.song) ? value.song.length : undefined,
-    };
+const arrayCount = (target, key) => Array.isArray(target?.[key]) ? target[key].length : 0;
+const indexArtistCount = Array.isArray(value?.index)
+  ? value.index.reduce((total, group) => total + arrayCount(group, "artist"), 0)
+  : 0;
+const counts = {
+  getIndexes: { artists: indexArtistCount },
+  getArtist: { albums: arrayCount(value, "album") },
+  getAlbum: { songs: arrayCount(value, "song") },
+  search3: {
+    artists: arrayCount(value, "artist"),
+    albums: arrayCount(value, "album"),
+    songs: arrayCount(value, "song"),
+  },
+  randomSongs: { items: Array.isArray(value) ? value.length : 0 },
+  starred: {
+    artists: arrayCount(value, "artist"),
+    albums: arrayCount(value, "album"),
+    songs: arrayCount(value, "song"),
+  },
+  playlists: { items: Array.isArray(value) ? value.length : 0 },
+}[operation] || {};
 console.log(JSON.stringify({
   elapsedMs: Number(elapsedMs.toFixed(3)),
   jsonBytes: Buffer.byteLength(serialized),
@@ -421,21 +435,42 @@ console.log(JSON.stringify({
 
 function summarizeReadSamples(samples) {
   const completed = samples.filter((sample) => sample.status === "completed");
-  const values = completed.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  const statisticsComplete = samples.length > 0
+    && completed.length === samples.length
+    && completed.every((sample) => [
+      sample.elapsedMs,
+      sample.jsonBytes,
+      sample.rssDeltaBytes,
+      sample.heapDeltaBytes,
+    ].every(Number.isFinite));
+  const values = statisticsComplete
+    ? completed.map((sample) => sample.elapsedMs).sort((a, b) => a - b)
+    : [];
   const percentile = (fraction) => values[Math.min(values.length - 1, Math.ceil(values.length * fraction) - 1)];
+  const itemTotal = (sample) => Object.values(sample.counts || {})
+    .reduce((total, count) => total + (Number.isFinite(Number(count)) ? Number(count) : 0), 0);
   return {
     samples,
     sampleCount: samples.length,
     completedCount: completed.length,
+    statisticsComplete,
     nonVacuous: samples.length > 0
       && completed.length === samples.length
-      && completed.every((sample) => Number(sample.jsonBytes) > 0),
-    responseBytes: [...new Set(completed.map((sample) => sample.jsonBytes))],
-    medianMs: completed.length ? percentile(0.5) : null,
-    p95Ms: completed.length ? percentile(0.95) : null,
-    maxRssDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.rssDeltaBytes)) : null,
-    maxHeapDeltaBytes: completed.length ? Math.max(...completed.map((sample) => sample.heapDeltaBytes)) : null,
+      && completed.every((sample) => itemTotal(sample) > 0),
+    responseBytes: statisticsComplete ? [...new Set(completed.map((sample) => sample.jsonBytes))] : [],
+    medianMs: statisticsComplete ? percentile(0.5) : null,
+    p95Ms: statisticsComplete ? percentile(0.95) : null,
+    maxRssDeltaBytes: statisticsComplete
+      ? Math.max(...completed.map((sample) => sample.rssDeltaBytes))
+      : null,
+    maxHeapDeltaBytes: statisticsComplete
+      ? Math.max(...completed.map((sample) => sample.heapDeltaBytes))
+      : null,
   };
+}
+
+function isFiniteBelow(value, limit) {
+  return Number.isFinite(value) && value < limit;
 }
 
 const indexerProbeCode = `
@@ -637,29 +672,31 @@ async function main() {
     const measuredReads = measuredReadNames.map((name) => subsonicReads[name]);
     const measuredQueryChecks = {
       nonVacuousCompletedSamples: measuredReads.every((read) => read.nonVacuous),
-      coldP95Under750ms: measuredReads.every((read) => read.p95Ms < 750),
+      coldP95Under750ms: measuredReads.every((read) => isFiniteBelow(read.p95Ms, 750)),
       responseUnder2MiB: measuredReads.every((read) =>
         read.responseBytes.length > 0
-        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+        && read.responseBytes.every((bytes) => isFiniteBelow(bytes, 2 * 1024 * 1024))),
       maxRssDeltaUnder64MiB: measuredReads.every((read) =>
-        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+        isFiniteBelow(read.maxRssDeltaBytes, 64 * 1024 * 1024)),
     };
     const pageBudgetChecks = {
-      warmP95Under250ms: Object.values(pages).every((page) => page.warm.p95Ms < 250),
-      coldP95Under750ms: Object.values(pages).every((page) => page.cold.p95Ms < 750),
+      warmP95Under250ms: Object.values(pages).every((page) =>
+        isFiniteBelow(page.warm.p95Ms, 250)),
+      coldP95Under750ms: Object.values(pages).every((page) =>
+        isFiniteBelow(page.cold.p95Ms, 750)),
       responseUnder2MiB: Object.values(pages).every((page) =>
         [...page.cold.samples, ...page.warm.samples]
-          .every((sample) => sample.jsonBytes < 2 * 1024 * 1024)),
+          .every((sample) => isFiniteBelow(sample.jsonBytes, 2 * 1024 * 1024))),
       maxRssDeltaUnder64MiB: Object.values(pages).every((page) =>
         [...page.cold.samples, ...page.warm.samples]
-          .every((sample) => sample.rssDeltaBytes < 64 * 1024 * 1024)),
+          .every((sample) => isFiniteBelow(sample.rssDeltaBytes, 64 * 1024 * 1024))),
     };
     const compatibilityReadChecks = {
       responseUnder2MiB: Object.values(subsonicReads).every((read) =>
         read.responseBytes.length > 0
-        && read.responseBytes.every((bytes) => bytes < 2 * 1024 * 1024)),
+        && read.responseBytes.every((bytes) => isFiniteBelow(bytes, 2 * 1024 * 1024))),
       maxRssDeltaUnder64MiB: Object.values(subsonicReads).every((read) =>
-        read.maxRssDeltaBytes < 64 * 1024 * 1024),
+        isFiniteBelow(read.maxRssDeltaBytes, 64 * 1024 * 1024)),
     };
     const boundedReadCompleted = Object.values(subsonicReads).every((read) =>
       read.nonVacuous);


### PR DESCRIPTION
Large libraries need one deployable build that exercises the five performance changes together before the source pull requests merge.

This draft combines #681, #682, #683, #684, and #685 for preview-image and end-to-end testing. It bounds canonical and Subsonic reads, moves stable data reads to the local cache, removes read-side background work, shares volatile Lidarr polling, and applies the measured SQLite query changes.

Preview testing also found and fixed two independent regressions:

- Discover sent more than the API limit of 100 artist IDs in one batch, which returned `400` and left ownership markers unresolved.
- Honker replayed every missed recurring schedule after downtime. Eleven hours offline produced 11 hourly jobs, 22 half-hour jobs, and 44 quarter-hour jobs at startup.

Do not merge this aggregation pull request. The five source pull requests remain the review and merge units.

## Verification

- Full unit suite passed.
- Frontend and backend lint passed.
- Frontend production build passed.
- Library performance budgets passed at 100,000 and 350,000 tracks.
- The 201-artist regression now sends batches of 100, 100, and 1.
- A Docker startup with all nine schedules forced 11 hours overdue queued no missed runs.
- Under 1 CPU and 512 MiB, fixed startup peaked at 67.5%, fell below 1% within three seconds, and remained responsive at 2–7 ms.
- The previous image reproduced a delayed 100.9% CPU burst and dozens of duplicate scheduled jobs.
- Integration tests passed 53 of 54 cases. The remaining Navidrome temporary playlist path mismatch also reproduces on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster library search with improved artist, album, and track lookups.
  * Inbox refreshes now run in the background with visible queued, running, completed, and failed statuses.
  * Added cached news and nearby-show results for quicker repeat visits.
  * Added persisted storage-health results with separate on-demand checks.

* **Improvements**
  * Library pages better support unavailable albums, album counts, stable pagination, and focused browsing.
  * Download and request statuses remain more consistent during service interruptions.
  * Discovery recommendations now use valid artist links.
  * Navidrome connection failures retry automatically.
  * Improved cache handling and recovery for discovery and background tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->