### PR TITLE
feat(discover): refine discover page layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4931,12 +4931,12 @@ textarea {
 /* Discover Page Components */
 
 .artist-discover-page {
-  padding-bottom: 1.5rem;
+  padding-bottom: 2.5rem;
   animation: fade-in 0.2s ease-out;
 }
 
 .artist-discover-section {
-  margin-bottom: var(--aurral-space-section);
+  margin-bottom: 2rem;
 }
 
 .discover-recommended-status__title {
@@ -4946,42 +4946,37 @@ textarea {
 .discover-recommended-status {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 3rem 1.5rem 3.5rem;
-  text-align: center;
-  background: var(--aurral-surface);
-  border-radius: var(--aurral-radius);
+  padding: 1.5rem 0;
+  text-align: left;
 }
 
 .discover-recommended-status--loading {
-  padding: 4rem 1.5rem;
+  padding: 2.5rem 0;
 }
 
 .discover-recommended-status__icon {
   display: flex;
-  width: 4.5rem;
-  height: 4.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1rem;
   color: var(--aurral-text-muted);
-}
-
-.discover-recommended-status__icon {
   background: var(--aurral-surface-raised);
   border-radius: var(--aurral-radius-round);
 }
 
 .discover-recommended-status__loader {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .discover-recommended-status__heading {
-  margin: 0 0 0.625rem;
+  margin: 0 0 0.5rem;
   color: var(--aurral-text);
-  font-size: 1.25rem;
-  font-weight: 700;
+  font-size: 1.125rem;
+  font-weight: 600;
   line-height: 1.3;
 }
 
@@ -4997,68 +4992,67 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: center;
+  justify-content: flex-start;
   margin-top: 1.5rem;
 }
 
 .artist-discover-hero {
   position: relative;
-  overflow: hidden;
-  margin-bottom: 2rem;
-  display: none;
-}
-
-@media (min-width: 768px) {
-  .artist-discover-hero {
-    display: block;
-    margin-bottom: var(--aurral-space-section);
-  }
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid var(--aurral-border);
 }
 
 .artist-discover-hero__content {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 1rem;
 }
 
 .artist-discover-hero__header {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1rem;
   justify-content: space-between;
-}
-
-@media (min-width: 768px) {
-  .artist-discover-hero__header {
-    flex-direction: row;
-    align-items: flex-start;
-  }
 }
 
 .artist-discover-hero__title-wrap {
   display: flex;
-  max-width: 32rem;
+  max-width: 48rem;
+  min-width: 0;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
 .artist-discover-hero__title-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.625rem 0.75rem;
+}
+
+.artist-discover-hero .page-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
 }
 
 .artist-discover-hero__updated {
   display: flex;
+  min-width: 0;
+  max-width: 100%;
   align-items: center;
+  overflow: hidden;
   border-radius: var(--aurral-radius-round);
   background: color-mix(in srgb, var(--aurral-text) 5%, transparent);
   padding: 0.25rem 0.5rem;
   color: var(--aurral-text-subtle);
   font-size: 0.75rem;
   font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .artist-discover-hero__updated--refreshing {
@@ -5072,29 +5066,19 @@ textarea {
 }
 
 .artist-discover-hero__description {
+  max-width: 38rem;
   color: var(--aurral-text-muted);
-  font-size: 0.875rem;
-}
-
-@media (min-width: 768px) {
-  .artist-discover-hero__description {
-    font-size: 1rem;
-  }
+  font-size: 0.9375rem;
+  line-height: 1.5;
 }
 
 .artist-discover-hero__based-on {
   color: var(--aurral-text-subtle);
-  font-size: 0.75rem;
-}
-
-@media (min-width: 768px) {
-  .artist-discover-hero__based-on {
-    font-size: 0.875rem;
-  }
+  font-size: 0.8125rem;
 }
 
 .artist-discover-hero__based-on-intro {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.375rem;
   color: var(--aurral-text-subtle);
   font-weight: 500;
 }
@@ -5156,7 +5140,7 @@ textarea {
 }
 
 .discover-page__customize-btn {
-  margin-top: 0.25rem;
+  margin-top: 0;
   flex-shrink: 0;
   align-self: flex-start;
 }
@@ -5174,14 +5158,14 @@ textarea {
 .artist-discover-hero__tags-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding-top: 1rem;
+  gap: 0.625rem;
+  padding-top: 0.25rem;
   color: var(--aurral-text-subtle);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .artist-discover-hero__tags-section-title {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.375rem;
   color: var(--aurral-text-subtle);
   font-weight: 500;
 }
@@ -5189,7 +5173,7 @@ textarea {
 .artist-tag-list--discover {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: 0.375rem;
 }
 
 .artist-discover-card {
@@ -5199,8 +5183,8 @@ textarea {
   width: 100%;
   min-width: 0;
   cursor: pointer;
-  border-radius: var(--aurral-radius-sm);
-  padding: 0.375rem;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.25rem 0.5rem;
   transition: background-color 0.18s ease;
 }
 
@@ -5214,7 +5198,7 @@ textarea {
   display: block;
   width: 100%;
   aspect-ratio: 1;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.625rem;
   overflow: hidden;
   border: 0;
   background: var(--aurral-surface-raised);
@@ -5321,8 +5305,8 @@ textarea {
   color: var(--aurral-text);
   font-family: inherit;
   font-size: 0.875rem;
-  font-weight: 800;
-  line-height: 1.35;
+  font-weight: 700;
+  line-height: 1.3;
   text-align: left;
   cursor: pointer;
   transition: color 0.18s ease;
@@ -5366,6 +5350,7 @@ textarea {
   margin-top: 0.25rem;
   color: var(--aurral-text-muted);
   font-size: 0.75rem;
+  line-height: 1.35;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5639,8 +5624,9 @@ textarea {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  background: var(--aurral-surface);
-  border-radius: var(--aurral-radius-round);
+  border: 1px solid var(--aurral-border);
+  background: var(--aurral-surface-raised);
+  border-radius: var(--aurral-radius);
   transition: border-color 0.18s ease;
 }
 
@@ -5651,13 +5637,13 @@ textarea {
 .artist-view-all-card--discover .artist-card-title {
   padding: 1rem;
   color: var(--aurral-text);
-  font-size: 1.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
   text-align: center;
 }
 
 .artist-discover-rail {
-  margin-bottom: var(--aurral-space-section);
+  margin-bottom: 2.5rem;
 }
 
 .artist-discover-rail__header {
@@ -5665,7 +5651,7 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  margin-bottom: 0.625rem;
+  margin-bottom: 0.875rem;
 }
 
 .artist-discover-rail__title-group {
@@ -5679,7 +5665,7 @@ textarea {
   margin: 0;
   color: var(--aurral-text);
   font-size: 1.25rem;
-  font-weight: 800;
+  font-weight: 700;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5714,13 +5700,14 @@ textarea {
 .artist-discover-rail__actions .btn:disabled {
   color: var(--aurral-text-subtle);
   cursor: default;
+  visibility: hidden;
 }
 
 .artist-discover-rail__content {
   display: flex;
-  gap: 1rem;
+  gap: 1.25rem;
   overflow-x: auto;
-  padding-bottom: 0.5rem;
+  padding: 0.125rem 0.25rem 0.75rem;
   scrollbar-width: none;
 }
 
@@ -5746,7 +5733,7 @@ textarea {
 }
 
 .artist-discover-shelf-card {
-  width: clamp(148px, 12vw, 220px);
+  width: clamp(160px, 13vw, 216px);
   flex-shrink: 0;
 }
 
@@ -5770,6 +5757,41 @@ textarea {
   transition:
     border-color 0.18s ease,
     background-color 0.18s ease;
+}
+
+@media (max-width: 767px) {
+  .artist-discover-hero {
+    margin-bottom: 2rem;
+    padding-bottom: 1.25rem;
+  }
+
+  .artist-discover-hero__tags-section {
+    display: none;
+  }
+
+  .artist-discover-rail {
+    margin-bottom: 2.25rem;
+  }
+
+  .artist-discover-rail__content {
+    gap: 0.875rem;
+    padding-inline: 0.125rem;
+  }
+
+  .artist-discover-shelf-card {
+    width: clamp(156px, 43vw, 184px);
+  }
+
+  .artist-discover-shelf-card--news,
+  .discover-news-rail-status {
+    width: min(82vw, 320px);
+  }
+
+  .discover-recommended-status__actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: min(100%, 16rem);
+  }
 }
 
 .discover-news-card__link {

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -992,9 +992,6 @@ function DiscoverPage() {
                   playlistsUpdateMessage={playlistsUpdateMessage}
                 />
               </div>
-              <p className="artist-discover-hero__description">
-                Your daily mix, curated from your library.
-              </p>
               {heroBasedOn.length > 0 && (
                 <div className="artist-discover-hero__based-on">
                   <div className="artist-discover-hero__based-on-intro">Based on:</div>


### PR DESCRIPTION
## What changed

Refined the Discover page layout with clearer spacing, typography, responsive behavior, card styling, and mobile rail presentation. Removed redundant hero copy and the unused reusable-library-source path and its integration coverage.

## Why

The Discover page now has a cleaner hierarchy and more consistent responsive layout across desktop and mobile. Removing the unused source-reuse path keeps library job handling focused on canonical files and active downloads.

## Scope checklist

- [ ] This pull request has one clear purpose
- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

No linked issue.

## UI changes

Before-and-after screenshots should be included for the Discover page on desktop and mobile.

## Testing

Automated Subsonic canonical integration coverage was updated to remove the obsolete source-reuse scenario. Manual UI validation should cover desktop and mobile Discover layouts, loading and empty states, responsive rails, and navigation controls.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Discover page layout and responsiveness across desktop and mobile screen sizes.
  * Reduced spacing and refined sizing for status panels, cards, rails, shelves, tags, and view-all options.
  * Improved hero content alignment, typography, borders, and mobile visibility.
  * Removed the Discover page hero description text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->