### PR TITLE
fix(library): keep Lidarr membership stable after refresh

### DIFF
--- a/.tests/lidarr/album-lookup-route.test.js
+++ b/.tests/lidarr/album-lookup-route.test.js
@@ -45,6 +45,104 @@ test("artist batch lookup rejects oversized batches", async () => {
   assert.equal(body?.error, "mbids must contain at most 100 unique values");
 });
 
+test("artist lookup follows fresh Lidarr artist and album membership while the canonical index catches up", async (t) => {
+  const mbid = "55555555-5555-4555-8555-555555555555";
+  const artist = upsertLibraryArtist({
+    identityKey: `artist-lookup-stale-${process.pid}-${Date.now()}`,
+    mbid,
+    name: "Stale Artist",
+    metadata: { id: 41, foreignArtistId: mbid, monitored: true },
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `artist-lookup-stale-album-${process.pid}-${Date.now()}`,
+    mbid: "77777777-7777-4777-8777-777777777777",
+    artistId: artist.id,
+    title: "Stale Artist Album",
+    metadata: { id: 43, artistId: 41, monitored: true },
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `artist-lookup-stale-track-${process.pid}-${Date.now()}`,
+    title: "Stale Artist Track",
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  invalidateCanonicalLibraryCache();
+  const routes = new Map();
+  registerMisc({
+    get(path, handler) {
+      routes.set(path, handler);
+    },
+    post() {},
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  let artistRemoved = false;
+  t.mock.method(lidarrClient, "getArtistByMbid", async (_mbid, options) => {
+    assert.equal(_mbid, mbid);
+    assert.deepEqual(options, { forceRefresh: true });
+    return artistRemoved
+      ? null
+      : { id: 41, foreignArtistId: mbid, artistName: "Stale Artist", monitored: true };
+  });
+  t.mock.method(lidarrClient, "request", async (path, method, data, skip, options) => {
+    assert.equal(path, "/album?artistId=41");
+    assert.deepEqual([method, data, skip, options], ["GET", null, false, { forceRefresh: true }]);
+    return [];
+  });
+  let body;
+
+  try {
+    await routes.get("/lookup/:mbid")(
+      { params: { mbid } },
+      { json(value) { body = value; return this; } },
+    );
+    assert.equal(body?.exists, true);
+    assert.deepEqual(body?.albums, []);
+
+    artistRemoved = true;
+    await routes.get("/lookup/:mbid")(
+      { params: { mbid } },
+      { json(value) { body = value; return this; } },
+    );
+    assert.equal(body?.exists, false);
+  } finally {
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    invalidateCanonicalLibraryCache();
+  }
+});
+
+test("artist lookup sees a fresh Lidarr add before the canonical index catches up", async (t) => {
+  const mbid = "66666666-6666-4666-8666-666666666666";
+  const routes = new Map();
+  registerMisc({
+    get(path, handler) {
+      routes.set(path, handler);
+    },
+    post() {},
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async (_mbid, options) => {
+    assert.equal(_mbid, mbid);
+    assert.deepEqual(options, { forceRefresh: true });
+    return {
+      id: 42,
+      foreignArtistId: mbid,
+      artistName: "Fresh Artist",
+      monitored: true,
+    };
+  });
+  t.mock.method(lidarrClient, "request", async () => []);
+  let body;
+
+  await routes.get("/lookup/:mbid")(
+    { params: { mbid } },
+    { json(value) { body = value; return this; } },
+  );
+  assert.equal(body?.exists, true);
+  assert.equal(body?.artist?.foreignArtistId, mbid);
+});
+
 test("album batch lookup bypasses stale cache and unrelated broken albums", async () => {
   const routes = new Map();
   registerMisc({
@@ -215,6 +313,56 @@ test("canonical album lookup reports partial ownership and the complete track co
     db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(ownedTrack.id, missingTrack.id);
     db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
+test("album lookup follows fresh Lidarr removal while the canonical index catches up", async (t) => {
+  const key = `album-lookup-stale-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "Stale Album Artist",
+    metadata: { id: 51, monitored: true },
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    mbid: `${key}-album`,
+    artistId: artist.id,
+    title: "Stale Album",
+    metadata: { id: 52, artistId: 51, monitored: true },
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${key}:track`,
+    title: "Stale Album Track",
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  invalidateCanonicalLibraryCache();
+  const routes = new Map();
+  registerMisc({
+    get() {},
+    post(path, handler) {
+      routes.set(path, handler);
+    },
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getAlbumsByMbidsSettled", async (mbids, options) => {
+    assert.deepEqual(mbids, [album.mbid]);
+    assert.deepEqual(options, { forceRefresh: true });
+    return [{ status: "fulfilled", value: undefined }];
+  });
+  let body;
+
+  try {
+    await routes.get("/albums/lookup/batch")(
+      { body: { mbids: [album.mbid] } },
+      { json(value) { body = value; return this; } },
+    );
+    assert.deepEqual(body, {});
+  } finally {
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    invalidateCanonicalLibraryCache();
   }
 });
 

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -99,7 +99,38 @@ export function registerMisc(router) {
         mbids: [mbid],
       });
       const artist = artists.find((candidate) => candidate.mbid === mbid);
-      if (artist) {
+      const { lidarrClient } = await import("../../../services/lidarrClient.js");
+      let lidarrArtist;
+      let lidarrAlbums;
+      if (lidarrClient.isConfigured()) {
+        try {
+          lidarrArtist = await lidarrClient.getArtistByMbid(mbid, { forceRefresh: true });
+          if (lidarrArtist) {
+            const albums = await lidarrClient.request(
+              `/album?artistId=${encodeURIComponent(lidarrArtist.id)}`,
+              "GET",
+              null,
+              false,
+              { forceRefresh: true },
+            );
+            if (!Array.isArray(albums)) throw new Error("Invalid Lidarr album response");
+            lidarrAlbums = albums.map((album) =>
+              toLibraryAlbum(libraryManager.mapLidarrAlbum(album, lidarrArtist)),
+            );
+          }
+        } catch {
+          lidarrArtist = undefined;
+          lidarrAlbums = undefined;
+        }
+      }
+      if (lidarrArtist && lidarrAlbums) {
+        res.json({
+          exists: true,
+          artist: toLibraryArtist(libraryManager.mapLidarrArtist(lidarrArtist)),
+          albums: lidarrAlbums,
+          canonical: true,
+        });
+      } else if (lidarrArtist === undefined && artist) {
         res.json({
           exists: true,
           artist: toLibraryArtist(artist),
@@ -210,18 +241,13 @@ export function registerMisc(router) {
         }
       }
 
-      const missing = wanted.filter((foreignAlbumId) => !results[foreignAlbumId]);
-      if (missing.length === 0) {
-        return res.json(results);
-      }
-
       if (!lidarrClient.isConfigured()) {
         return res.json(results);
       }
-      const albums = await lidarrClient.getAlbumsByMbidsSettled(missing, { forceRefresh: true });
+      const albums = await lidarrClient.getAlbumsByMbidsSettled(wanted, { forceRefresh: true });
 
-      for (let index = 0; index < missing.length; index += 1) {
-        const foreignAlbumId = missing[index];
+      for (let index = 0; index < wanted.length; index += 1) {
+        const foreignAlbumId = wanted[index];
         const result = albums[index];
         if (result.status === "rejected") {
           logger.warn("library", "Lidarr album lookup failed", {
@@ -231,7 +257,11 @@ export function registerMisc(router) {
           continue;
         }
         const album = result.value;
-        if (!album) continue;
+        if (!album) {
+          delete results[foreignAlbumId];
+          continue;
+        }
+        if (results[foreignAlbumId]) continue;
 
         const albumTracks = album.id ? await libraryManager.getTracks(album.id) : [];
 


### PR DESCRIPTION
Adding or removing an artist or album could briefly show the correct state, then revert after a page refresh while Aurral waited for its canonical library index to catch up.

Library membership lookups now use a fresh Lidarr response when Lidarr is available. The canonical index remains the fallback when Lidarr cannot answer. Artist-page lookups also return the fresh Lidarr album list, and album batch lookups remove stale canonical entries after Lidarr confirms removal.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/lidarr/album-lookup-route.test.js .tests/frontend/library-query-invalidation.test.js`
- `npm run lint:backend`

Live-stack verification was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Artist lookups now reflect the latest available Lidarr membership and removal data.
  - Album lookups refresh requested entries to reflect recent Lidarr changes, including removals.
  - Canonical library data remains available when Lidarr data is unavailable or a lookup fails.

- **Tests**
  - Added coverage for lookup freshness during indexing delays and verified expected response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->