### PR TITLE
fix(integrations): recover from stale provider failures

### DIFF
--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -188,6 +188,52 @@ test("testConnection preserves Lidarr HTTP diagnostics", async (t) => {
   client._httpsInsecureAgent.destroy();
 });
 
+test("missing Lidarr resources are absent records, not endpoint failures", async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push([request.method, request.url]);
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ message: "Artist with ID 2411485 does not exist" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+  const originalConsoleError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args);
+  t.after(() => {
+    console.error = originalConsoleError;
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  assert.equal(await client.getArtist(2411485), null);
+  assert.equal(await client.getAlbum(2411485), null);
+  await assert.rejects(
+    client.updateAlbum(2411485, { monitored: true }),
+    /Album with ID 2411485 not found in Lidarr/,
+  );
+  assert.deepEqual(requests, [
+    ["GET", "/api/v1/artist/2411485"],
+    ["GET", "/api/v1/album/2411485"],
+    ["GET", "/api/v1/album/2411485"],
+  ]);
+  assert.deepEqual(errors, []);
+});
+
 test("getAlbumByMbid avoids unrelated broken albums in Lidarr", async (t) => {
   const requests = [];
   const server = http.createServer((request, response) => {
@@ -495,7 +541,7 @@ test("artist add resolves a non-numeric Lidarr response ID before follow-up call
   client._httpsInsecureAgent.destroy();
 });
 
-test("artist add retries with the active metadata provider ID after a UUID format error", async (t) => {
+test("artist add resolves a numeric metadata-provider response ID", async (t) => {
   const artistMbid = "9c9f1380-2516-4fc9-a3e6-f9f61941d090";
   const requests = [];
   let providerPayload;
@@ -527,14 +573,14 @@ test("artist add retries with the active metadata provider ID after a UUID forma
       }
       providerPayload = payload;
       return {
-        id: 42,
+        id: 2411485,
         foreignArtistId: "705@deezer",
         artistName: "Muse",
         monitored: true,
       };
     }
     if (endpoint === "/artist" && method === "GET") {
-      return [{ id: 42, foreignArtistId: "705@deezer", artistName: "Muse" }];
+      return [{ id: 42, foreignArtistId: "705@deezer", artistName: "Muse", monitored: true }];
     }
     if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {
       return [
@@ -563,6 +609,7 @@ test("artist add retries with the active metadata provider ID after a UUID forma
     { endpoint: "/artist", method: "POST" },
     { endpoint: `/artist/lookup?term=${encodeURIComponent("Muse")}`, method: "GET" },
     { endpoint: "/artist", method: "POST" },
+    { endpoint: "/artist", method: "GET" },
     { endpoint: "/artist", method: "GET" },
   ]);
 });
@@ -643,7 +690,14 @@ test("artist add accepts a MusicBrainz alias when resolving a provider ID", asyn
       };
     }
     if (endpoint === "/artist" && method === "GET") {
-      return [{ id: 42, foreignArtistId: providerArtistId, artistName: "FromSoftware" }];
+      return [
+        {
+          id: 42,
+          foreignArtistId: providerArtistId,
+          artistName: "FromSoftware",
+          monitored: true,
+        },
+      ];
     }
     if (
       endpoint === `/artist/lookup?term=${encodeURIComponent("FromSoftware")}` &&
@@ -698,6 +752,11 @@ test("artist add succeeds when a provider mapping conflict follows a successful 
     }
     if (endpoint === `/artist/lookup?term=${encodeURIComponent("Muse")}` && method === "GET") {
       return [{ foreignArtistId: providerId, artistName: "Muse" }];
+    }
+    if (endpoint === "/artist" && method === "GET") {
+      return [
+        { id: 42, foreignArtistId: providerId, artistName: "Muse", monitored: true },
+      ];
     }
     throw new Error(`Unexpected Lidarr request: ${method} ${endpoint}`);
   };

--- a/.tests/playback/navidrome-playback-destination.test.js
+++ b/.tests/playback/navidrome-playback-destination.test.js
@@ -884,6 +884,10 @@ test("keeps the stored playlist ID when Navidrome is unavailable", async () => {
     throw new Error("offline");
   };
   const destination = new NavidromePlaybackDestination(weeklyFlowRoot, { client });
+  let catchupScheduled = false;
+  destination._scheduleCatchup = () => {
+    catchupScheduled = true;
+  };
   navidromePlaylistPointerStore.setPointer(playlist.id, "global", {
     playlistId: "saved-id",
     title: playlist.name,
@@ -898,6 +902,8 @@ test("keeps the stored playlist ID when Navidrome is unavailable", async () => {
   );
 
   assert.equal(result.ok, false);
+  assert.equal(catchupScheduled, true);
+  assert.equal(destination._pendingSnapshots.has(`${playlist.id}:global`), true);
   assert.equal(
     navidromePlaylistPointerStore.getPointer(playlist.id, "global").playlistId,
     "saved-id",

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -590,8 +590,11 @@ export class LidarrClient {
           const statusText = error.response.statusText;
           const responseData = error.response.data;
 
-          const isAlbum404 = status === 404 && endpoint.includes("/album/");
-          if (!isAlbum404) {
+          const isMissingResource =
+            status === 404 &&
+            method === "GET" &&
+            /^\/(?:artist|album)\/\d+$/.test(endpoint);
+          if (!isMissingResource) {
             console.error(`Lidarr API error (${status}):`, {
               url: `${this.config.url}${this.apiPath}${endpoint}`,
               method: method,
@@ -651,8 +654,7 @@ export class LidarrClient {
             throw userError;
           }
           if (status === 404) {
-            const isAlbumEndpoint = endpoint.includes("/album/");
-            if (isAlbumEndpoint) {
+            if (isMissingResource) {
               return null;
             }
             const userError = new Error(
@@ -1014,12 +1016,14 @@ export class LidarrClient {
     };
 
     const resolveAddedArtist = async (artist) => {
-      if (normalizeLidarrArtistId(artist?.id)) {
+      const foreignArtistId = String(artist?.foreignArtistId || "").trim();
+      if (normalizeLidarrArtistId(artist?.id) && foreignArtistId === mbid) {
         return artist;
       }
-      let resolvedArtist = await this.getArtistByMbid(mbid);
+      const lookupId = foreignArtistId || mbid;
+      let resolvedArtist = await this.getArtistByMbid(lookupId);
       if (!normalizeLidarrArtistId(resolvedArtist?.id)) {
-        resolvedArtist = await this.getArtistByMbid(mbid, { forceRefresh: true });
+        resolvedArtist = await this.getArtistByMbid(lookupId, { forceRefresh: true });
       }
       if (!normalizeLidarrArtistId(resolvedArtist?.id)) {
         throw new Error(`Lidarr add did not return a numeric artist ID for ${mbid}`);
@@ -1183,6 +1187,9 @@ export class LidarrClient {
       throw new Error(`Lidarr artist ID must be numeric: ${artistId}`);
     }
     const artist = await this.getArtist(normalizedArtistId);
+    if (!artist) {
+      throw new Error(`Artist with ID ${normalizedArtistId} not found in Lidarr`);
+    }
 
     const updated = {
       ...artist,
@@ -1198,6 +1205,9 @@ export class LidarrClient {
       throw new Error(`Lidarr artist ID must be numeric: ${artistId}`);
     }
     const artist = await this.getArtist(normalizedArtistId);
+    if (!artist) {
+      throw new Error(`Artist with ID ${normalizedArtistId} not found in Lidarr`);
+    }
     const monitoring = getArtistMonitoringPayload(monitorOption);
 
     const updated = {
@@ -1451,6 +1461,9 @@ export class LidarrClient {
 
   async updateAlbum(albumId, updates) {
     const album = await this.getAlbum(albumId);
+    if (!album) {
+      throw new Error(`Album with ID ${albumId} not found in Lidarr`);
+    }
 
     const updated = {
       ...album,

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -519,11 +519,17 @@ export class NavidromePlaybackDestination {
   }
 
   async publishPlaylist(value) {
+    let snapshot;
+    let key;
     try {
-      const snapshot = createPlaybackPlaylistSnapshot(value);
-      const key = `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`;
+      snapshot = createPlaybackPlaylistSnapshot(value);
+      key = `${snapshot.entityId}:${this._targetKey(snapshot.ownerUserId)}`;
       return await this._runPlaylistOperation(key, () => this._publishPlaylist(snapshot));
     } catch (error) {
+      if (snapshot) {
+        this._pendingSnapshots.set(key, snapshot);
+        this._scheduleCatchup();
+      }
       return playbackOperationFailure({
         code: "PLAYLIST_PUBLISH_FAILED",
         message: error?.message || "Could not publish the Navidrome playlist",

--- a/docs/src/content/docs/admin/troubleshooting.mdx
+++ b/docs/src/content/docs/admin/troubleshooting.mdx
@@ -125,6 +125,22 @@ Aurral fetches covers on demand without a background prefetch. It caches each co
 
 The image-proxy disk cache has a 256MB limit and uses least-recently-used removal. Restart Aurral if you need a clean memory baseline.
 
+## The container exits with code 137
+
+Exit code 137 means that the container received `SIGKILL`. Check whether Docker killed it for exceeding its memory limit:
+
+```bash
+docker inspect <container> --format 'oom={{.State.OOMKilled}} memory_limit={{.HostConfig.Memory}}'
+```
+
+If the container is still running, capture its current memory use:
+
+```bash
+docker stats --no-stream <container>
+```
+
+If the container has stopped, `docker stats` has no historical usage data. Use the `docker inspect` result and the host's out-of-memory logs instead. If `oom=true`, increase the container memory limit. If `oom=false`, check the container supervisor and Docker daemon logs for the process that sent `SIGKILL`.
+
 ## Permission errors
 
 - Make sure mounted folders are writable by the container user.

--- a/docs/src/content/docs/integrations/navidrome.mdx
+++ b/docs/src/content/docs/integrations/navidrome.mdx
@@ -93,6 +93,8 @@ Aurral stores the Navidrome playlist ID for each flow or shared playlist. Names 
 
 Aurral also uploads its generated playlist artwork to API playlists and updates it when you change or regenerate artwork in Aurral. Aurral revalidates its local artwork response after restart, so the image stays current in the Aurral UI. Navidrome uses that uploaded image instead of its automatic tiled artwork when custom playlist artwork is supported.
 
+If Navidrome is unavailable during a playlist update, Aurral keeps the stored playlist ID and queues the snapshot for its existing catch-up attempts.
+
 If a new track is not indexed, Aurral leaves it out until Navidrome scans it; it never substitutes a same-title track from another artist. Navidrome scans the **Aurral Playlists** library, not only your main Lidarr library. If the library appears but has no tracks:
 
 - confirm that a permanent track exists under the Downloads Folder or a flow track exists under `_flows`;


### PR DESCRIPTION
Provider-backed Lidarr adds can return a positive numeric provider ID instead of the stored Lidarr artist ID. Aurral then requests an artist record that does not exist and reports the resulting 404 as an API version failure. A transient Navidrome update failure can also leave a playlist stale until another refresh.

This change resolves provider-backed additions through Lidarr's artist list, treats exact missing artist and album reads as absent resources, and queues failed Navidrome snapshots for the existing catch-up attempts. It also documents how to distinguish out-of-memory kills from other code-137 restarts.

Verification:

- `npm run lint:backend`
- `node --test --import ./.tests/setup-env.js .tests/lidarr/lidarr-circuit.test.js .tests/navidrome-client.test.js .tests/playback/navidrome-playback-destination.test.js` (76 passed)
- `npm run docs:build`

Known limitation: An application log cannot identify which host process sent `SIGKILL` when Docker reports `OOMKilled=false`. The troubleshooting guide points maintainers to the supervisor and Docker daemon logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing Lidarr artists and albums, with clearer failures for unresolved artist updates.
  - Preserved playlist references and queued catch-up processing when Navidrome playlist updates fail.

- **Documentation**
  - Added troubleshooting guidance for containers terminated with exit code 137, including memory diagnostics.
  - Documented Navidrome playlist recovery behavior during service outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->