### PR TITLE
fix(library): refresh artist stream membership

### DIFF
--- a/.tests/lidarr/album-lookup-route.test.js
+++ b/.tests/lidarr/album-lookup-route.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { db } from "../../backend/config/db-sqlite.js";
+import { registerStream as registerArtistStream } from "../../backend/routes/artists/handlers/stream.js";
 import { registerMisc } from "../../backend/routes/library/handlers/misc.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
@@ -103,6 +104,43 @@ test("artist lookup follows fresh Lidarr artist and album membership while the c
       { json(value) { body = value; return this; } },
     );
     assert.equal(body?.exists, false);
+
+    const streamRoutes = new Map();
+    registerArtistStream({
+      get(path, ...handlers) {
+        streamRoutes.set(path, handlers.at(-1));
+      },
+    });
+    const writes = [];
+    let closeStream = () => {};
+    await streamRoutes.get("/:mbid/stream")(
+      {
+        params: { mbid },
+        query: { artistName: "Stale Artist" },
+        headers: {},
+        socket: { destroyed: false },
+        on(event, handler) {
+          if (event === "close") closeStream = handler;
+        },
+      },
+      {
+        setHeader() {},
+        status() { return this; },
+        json() { return this; },
+        write(value) { writes.push(value); },
+        flush() {},
+        end() {},
+      },
+    );
+    const deadline = Date.now() + 1000;
+    let libraryEventIndex = writes.indexOf("event: library\n");
+    while (libraryEventIndex === -1 && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+      libraryEventIndex = writes.indexOf("event: library\n");
+    }
+    assert.notEqual(libraryEventIndex, -1);
+    assert.equal(JSON.parse(writes[libraryEventIndex + 1].slice(6)).exists, false);
+    closeStream();
   } finally {
     db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
     db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);

--- a/backend/routes/artists/handlers/stream.js
+++ b/backend/routes/artists/handlers/stream.js
@@ -16,40 +16,13 @@ import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import {
   attachCachedCoverUrls,
 } from "../../../services/releaseGroupCoverService.js";
-import {
-  findCanonicalAlbumsForArtist,
-  findCanonicalArtist,
-  getCanonicalLibraryReadModelForArtists,
-} from "../../../services/canonicalLibraryReadAdapter.js";
+import { getArtistLibraryLookup } from "../../library/handlers/misc.js";
 import { getArtistByMbid } from "../../../services/providers/brainzmashProvider.js";
 import {
   getArtistTagPayload,
   buildArtistBase,
   extractLastfmImageUrl,
 } from "../shared/transform.js";
-
-const toLibraryArtist = (artist) => ({
-  ...artist,
-  id: artist.providerId ?? artist.id,
-  canonicalId: String(artist.canonicalId ?? artist.id),
-  foreignArtistId: artist.foreignArtistId || artist.mbid,
-  added: artist.addedAt,
-});
-
-const toLibraryAlbum = (album) => ({
-  ...album,
-  id: album.providerId ?? album.id,
-  artistId: album.providerArtistId ?? album.artistId,
-  canonicalId: String(album.canonicalId ?? album.id),
-  foreignAlbumId: album.foreignAlbumId || album.mbid,
-  title: album.albumName,
-  albumType: "Album",
-  statistics: album.statistics || {
-    trackCount: 0,
-    sizeOnDisk: 0,
-    percentOfTracks: 0,
-  },
-});
 
 export function registerStream(router) {
   router.get("/:mbid/stream", noCache, async (req, res) => {
@@ -141,36 +114,8 @@ export function registerStream(router) {
         );
 
         const libraryTask = (async () => {
-          const canonical = getCanonicalLibraryReadModelForArtists({
-            source: "all",
-            availableOnly: false,
-            mbids: [resolvedMbid, mbid],
-          });
-          const canonicalArtist =
-            findCanonicalArtist(canonical.artists, resolvedMbid) ||
-            findCanonicalArtist(canonical.artists, mbid);
-          if (canonicalArtist) {
-            if (isClientConnected()) {
-              sendSSE(res, "library", {
-                exists: true,
-                canonical: true,
-                artist: toLibraryArtist(canonicalArtist),
-                albums: findCanonicalAlbumsForArtist(canonical.albums, canonicalArtist.id).map(
-                  toLibraryAlbum,
-                ),
-              });
-            }
-            return;
-          }
-
-          if (isClientConnected()) {
-            sendSSE(res, "library", {
-              exists: false,
-              canonical: true,
-              artist: null,
-              albums: [],
-            });
-          }
+          const lookup = await getArtistLibraryLookup(mbid);
+          if (isClientConnected()) sendSSE(res, "library", lookup);
         })();
         tasks.push(libraryTask);
 

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -68,6 +68,61 @@ const toLibraryAlbum = (album) => ({
   albumType: "Album",
 });
 
+export async function getArtistLibraryLookup(mbid) {
+  const { artists, albums } = getCanonicalLibraryReadModelForArtists({
+    source: "all",
+    availableOnly: false,
+    mbids: [mbid],
+  });
+  const artist = artists.find((candidate) => candidate.mbid === mbid);
+  const { lidarrClient } = await import("../../../services/lidarrClient.js");
+  let lidarrArtist;
+  let lidarrAlbums;
+  if (lidarrClient.isConfigured()) {
+    try {
+      lidarrArtist = await lidarrClient.getArtistByMbid(mbid, { forceRefresh: true });
+      if (lidarrArtist) {
+        const albums = await lidarrClient.request(
+          `/album?artistId=${encodeURIComponent(lidarrArtist.id)}`,
+          "GET",
+          null,
+          false,
+          { forceRefresh: true },
+        );
+        if (!Array.isArray(albums)) throw new Error("Invalid Lidarr album response");
+        lidarrAlbums = albums.map((album) =>
+          toLibraryAlbum(libraryManager.mapLidarrAlbum(album, lidarrArtist)),
+        );
+      }
+    } catch {
+      lidarrArtist = undefined;
+      lidarrAlbums = undefined;
+    }
+  }
+  if (lidarrArtist && lidarrAlbums) {
+    return {
+      exists: true,
+      artist: toLibraryArtist(libraryManager.mapLidarrArtist(lidarrArtist)),
+      albums: lidarrAlbums,
+      canonical: true,
+    };
+  }
+  if (lidarrArtist === undefined && artist) {
+    return {
+      exists: true,
+      artist: toLibraryArtist(artist),
+      albums: albums.filter((album) => album.artistMbid === mbid).map(toLibraryAlbum),
+      canonical: true,
+    };
+  }
+  return {
+    exists: false,
+    artist: null,
+    albums: [],
+    canonical: true,
+  };
+}
+
 export function registerMisc(router) {
   router.get("/rootfolder", async (req, res) => {
     try {
@@ -93,58 +148,7 @@ export function registerMisc(router) {
         return res.status(400).json({ error: "Invalid MBID format" });
       }
 
-      const { artists, albums } = getCanonicalLibraryReadModelForArtists({
-        source: "all",
-        availableOnly: false,
-        mbids: [mbid],
-      });
-      const artist = artists.find((candidate) => candidate.mbid === mbid);
-      const { lidarrClient } = await import("../../../services/lidarrClient.js");
-      let lidarrArtist;
-      let lidarrAlbums;
-      if (lidarrClient.isConfigured()) {
-        try {
-          lidarrArtist = await lidarrClient.getArtistByMbid(mbid, { forceRefresh: true });
-          if (lidarrArtist) {
-            const albums = await lidarrClient.request(
-              `/album?artistId=${encodeURIComponent(lidarrArtist.id)}`,
-              "GET",
-              null,
-              false,
-              { forceRefresh: true },
-            );
-            if (!Array.isArray(albums)) throw new Error("Invalid Lidarr album response");
-            lidarrAlbums = albums.map((album) =>
-              toLibraryAlbum(libraryManager.mapLidarrAlbum(album, lidarrArtist)),
-            );
-          }
-        } catch {
-          lidarrArtist = undefined;
-          lidarrAlbums = undefined;
-        }
-      }
-      if (lidarrArtist && lidarrAlbums) {
-        res.json({
-          exists: true,
-          artist: toLibraryArtist(libraryManager.mapLidarrArtist(lidarrArtist)),
-          albums: lidarrAlbums,
-          canonical: true,
-        });
-      } else if (lidarrArtist === undefined && artist) {
-        res.json({
-          exists: true,
-          artist: toLibraryArtist(artist),
-          albums: albums.filter((album) => album.artistMbid === mbid).map(toLibraryAlbum),
-          canonical: true,
-        });
-      } else {
-        res.json({
-          exists: false,
-          artist: null,
-          albums: [],
-          canonical: true,
-        });
-      }
+      res.json(await getArtistLibraryLookup(mbid));
     } catch (error) {
       res.status(500).json({
         error: "Failed to lookup artist",


### PR DESCRIPTION
An artist page can show stale library membership after Lidarr removes the artist because the page stream reads the delayed canonical index. Retrying removal then fails because Lidarr no longer has the artist.

Use the same forced Lidarr lookup for both the artist stream and the library lookup route. Keep the canonical index as the fallback when Lidarr is unavailable.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/frontend/library-query-invalidation.test.js .tests/lidarr/album-lookup-route.test.js`
- `npm run lint:backend`
- `git diff --check`