### PR TITLE
fix(navidrome): post playlist updates to avoid URL limits

### DIFF
--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -245,6 +245,57 @@ test("posts large playlist replacements without exceeding request URL limits", a
   assert.equal(requests[1].init.body.getAll("songIndexToRemove").length, 1_000);
 });
 
+test("preserves playlist update parameters across same-origin redirects", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, init = {}) => {
+    requests.push({ url: new URL(url), init });
+    if (requests.length === 1) {
+      return new Response(null, {
+        status: 302,
+        headers: { location: "/canonical/updatePlaylist" },
+      });
+    }
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .request("updatePlaylist", { playlistId: "playlist-1", songIdToAdd: ["song-1"] });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requests[1].url.pathname, "/canonical/updatePlaylist");
+  assert.equal(requests[1].init.method, "POST");
+  assert.equal(requests[1].init.body.get("playlistId"), "playlist-1");
+  assert.deepEqual(requests[1].init.body.getAll("songIdToAdd"), ["song-1"]);
+});
+
+test("rejects playlist update redirects across origins", async () => {
+  const originalFetch = globalThis.fetch;
+  let requests = 0;
+  globalThis.fetch = async () => {
+    requests += 1;
+    return new Response(null, {
+      status: 302,
+      headers: { location: "https://other.test/updatePlaylist" },
+    });
+  };
+
+  try {
+    await assert.rejects(
+      new NavidromeClient("http://navidrome.test", "user", "password")
+        .request("updatePlaylist", { playlistId: "playlist-1" }),
+      /redirect request body across origins/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requests, 1);
+});
+
 test("prefers the exact indexed path when duplicate songs match", async () => {
   const client = new NavidromeClient("http://navidrome.test", "user", "password");
   client._getIndexedSongs = async () => [

--- a/.tests/navidrome-client.test.js
+++ b/.tests/navidrome-client.test.js
@@ -106,13 +106,13 @@ test("uses the fallback delay for invalid rate limit headers", async () => {
 
 test("batches large playlist creation requests", async () => {
   const originalFetch = globalThis.fetch;
-  const urls = [];
-  globalThis.fetch = async (url) => {
-    urls.push(new URL(url));
+  const requests = [];
+  globalThis.fetch = async (url, init = {}) => {
+    requests.push({ url: new URL(url), init });
     return jsonResponse({
       "subsonic-response": {
         status: "ok",
-        playlist: urls.length === 1 ? { id: "new-id", name: "Large" } : undefined,
+        playlist: requests.length === 1 ? { id: "new-id", name: "Large" } : undefined,
       },
     });
   };
@@ -124,12 +124,12 @@ test("batches large playlist creation requests", async () => {
     globalThis.fetch = originalFetch;
   }
 
-  assert.equal(urls.length, 9);
-  assert.equal(urls[0].pathname, "/rest/createPlaylist");
-  assert.equal(urls[0].searchParams.getAll("songId").length, 50);
-  assert.equal(urls[1].pathname, "/rest/updatePlaylist");
-  assert.equal(urls[1].searchParams.getAll("songIdToAdd").length, 50);
-  assert.ok(urls.every((url) => url.toString().length < 8192));
+  assert.equal(requests.length, 9);
+  assert.equal(requests[0].url.pathname, "/rest/createPlaylist");
+  assert.equal(requests[0].url.searchParams.getAll("songId").length, 50);
+  assert.equal(requests[1].url.pathname, "/rest/updatePlaylist");
+  assert.equal(requests[1].init.body.getAll("songIdToAdd").length, 50);
+  assert.ok(requests.every(({ url }) => url.toString().length < 8192));
 });
 
 test("preserves Subsonic error codes for missing native IDs", async () => {
@@ -154,10 +154,10 @@ test("preserves Subsonic error codes for missing native IDs", async () => {
 
 test("replaces playlist entries with repeated Subsonic parameters", async () => {
   const originalFetch = globalThis.fetch;
-  const urls = [];
-  globalThis.fetch = async (url) => {
-    urls.push(new URL(url));
-    if (urls.length === 1) {
+  const requests = [];
+  globalThis.fetch = async (url, init = {}) => {
+    requests.push({ url: new URL(url), init });
+    if (requests.length === 1) {
       return jsonResponse({
         "subsonic-response": {
           status: "ok",
@@ -175,17 +175,17 @@ test("replaces playlist entries with repeated Subsonic parameters", async () => 
     globalThis.fetch = originalFetch;
   }
 
-  assert.deepEqual(urls[1].searchParams.getAll("songIndexToRemove"), ["0", "1"]);
-  assert.deepEqual(urls[1].searchParams.getAll("songIdToAdd"), ["song-1", "song-2"]);
-  assert.equal(urls[1].searchParams.get("name"), "Renamed");
+  assert.deepEqual(requests[1].init.body.getAll("songIndexToRemove"), ["0", "1"]);
+  assert.deepEqual(requests[1].init.body.getAll("songIdToAdd"), ["song-1", "song-2"]);
+  assert.equal(requests[1].init.body.get("name"), "Renamed");
 });
 
 test("batches large playlist replacement requests", async () => {
   const originalFetch = globalThis.fetch;
-  const urls = [];
-  globalThis.fetch = async (url) => {
-    urls.push(new URL(url));
-    if (urls.length === 1) {
+  const requests = [];
+  globalThis.fetch = async (url, init = {}) => {
+    requests.push({ url: new URL(url), init });
+    if (requests.length === 1) {
       return jsonResponse({
         "subsonic-response": {
           status: "ok",
@@ -206,11 +206,43 @@ test("batches large playlist replacement requests", async () => {
     globalThis.fetch = originalFetch;
   }
 
-  assert.equal(urls.length, 4);
-  assert.equal(urls[1].searchParams.getAll("songIdToAdd").length, 50);
-  assert.equal(urls[2].searchParams.getAll("songIdToAdd").length, 50);
-  assert.equal(urls[3].searchParams.getAll("songIdToAdd").length, 1);
-  assert.ok(urls.every((url) => url.toString().length < 8192));
+  assert.equal(requests.length, 4);
+  assert.equal(requests[1].init.body.getAll("songIdToAdd").length, 50);
+  assert.equal(requests[2].init.body.getAll("songIdToAdd").length, 50);
+  assert.equal(requests[3].init.body.getAll("songIdToAdd").length, 1);
+  assert.ok(requests.every(({ url }) => url.toString().length < 8192));
+});
+
+test("posts large playlist replacements without exceeding request URL limits", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, init = {}) => {
+    if (String(url).length >= 8192) throw new TypeError("fetch failed");
+    requests.push({ url: new URL(url), init });
+    if (requests.length === 1) {
+      return jsonResponse({
+        "subsonic-response": {
+          status: "ok",
+          playlist: {
+            entry: Array.from({ length: 1_000 }, (_, index) => ({ id: `old-${index}` })),
+          },
+        },
+      });
+    }
+    return jsonResponse({ "subsonic-response": { status: "ok" } });
+  };
+
+  try {
+    await new NavidromeClient("http://navidrome.test", "user", "password")
+      .updatePlaylist("playlist-1", { name: "Large", songIds: ["song-1"] });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requests[1].url.pathname, "/rest/updatePlaylist");
+  assert.equal(requests[1].init.method, "POST");
+  assert.equal(requests[1].url.search, "");
+  assert.equal(requests[1].init.body.getAll("songIndexToRemove").length, 1_000);
 });
 
 test("prefers the exact indexed path when duplicate songs match", async () => {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -76,7 +76,10 @@ export class NavidromeClient {
           }
         }
         try {
-          const response = await axios.get(`${this.url}/rest/${endpoint}?${query}`);
+          const endpointUrl = `${this.url}/rest/${endpoint}`;
+          const response = endpoint === "updatePlaylist"
+            ? await axios.post(endpointUrl, query)
+            : await axios.get(`${endpointUrl}?${query}`);
 
           if (response.data["subsonic-response"]?.status === "failed") {
             const responseError = response.data["subsonic-response"].error || {};

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -78,7 +78,7 @@ export class NavidromeClient {
         try {
           const endpointUrl = `${this.url}/rest/${endpoint}`;
           const response = endpoint === "updatePlaylist"
-            ? await axios.post(endpointUrl, query)
+            ? await axios.post(endpointUrl, query, { preserveMethodOnRedirect: true })
             : await axios.get(`${endpointUrl}?${query}`);
 
           if (response.data["subsonic-response"]?.status === "failed") {

--- a/lib/axiosFetch.js
+++ b/lib/axiosFetch.js
@@ -156,11 +156,16 @@ async function axiosRequest(inputConfig) {
       const location = response.headers.get("location");
       if (![301, 302, 303, 307, 308].includes(response.status) || !location) break;
       const nextUrl = new URL(location, url).href;
-      if (new URL(url).origin !== new URL(nextUrl).origin) {
+      const crossesOrigin = new URL(url).origin !== new URL(nextUrl).origin;
+      if (crossesOrigin) {
         removeHeaders(init.headers, SENSITIVE_REDIRECT_HEADERS);
+        if (config.preserveMethodOnRedirect && init.body != null) {
+          throw new Error("Refusing to redirect request body across origins");
+        }
       }
-      if (([301, 302].includes(response.status) && requestMethod === "POST")
-        || (response.status === 303 && !["GET", "HEAD"].includes(requestMethod))) {
+      if (!config.preserveMethodOnRedirect
+        && (([301, 302].includes(response.status) && requestMethod === "POST")
+          || (response.status === 303 && !["GET", "HEAD"].includes(requestMethod)))) {
         requestMethod = "GET";
         init.method = requestMethod;
         delete init.body;


### PR DESCRIPTION
## What changed

Changed Navidrome playlist update requests from GET to POST, keeping playlist parameters in the request body and preventing large playlist replacements from exceeding URL length limits. Updated client tests to verify POST behavior and batched request payloads.

## Why

Large playlist replacements could fail when repeated song parameters made the request URL exceed server or client limits. Posting update parameters removes that constraint while preserving existing batching behavior.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Updated `.tests/navidrome-client.test.js` coverage for POST request bodies and large playlist replacements.
- Manual validation is covered by the regression test, which rejects URLs at or above 8192 characters.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist updates for large batches by sending song parameters in the request body.
  * Prevented oversized playlist operations from exceeding URL length limits.
  * Enhanced reliability when removing up to 1,000 playlist entries.
  * Preserved playlist update operations across same-origin redirects.
  * Improved redirect safety by preventing request bodies from being sent to different origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->