### PR TITLE
fix(weekly-flow): preserve playlist track counts

### DIFF
--- a/.tests/weekly-flow/status-snapshot.test.js
+++ b/.tests/weekly-flow/status-snapshot.test.js
@@ -7,6 +7,7 @@ import {
   importFromRepo,
   resetDatabase,
 } from "../helpers/backendTestHarness.js";
+import { getSharedPlaylistTrackCount } from "../../frontend/src/pages/flows/flowStats.js";
 
 const [isolatedState, { db }, { dbOps }, { flowPlaylistConfig }, snapshotModule] =
   await setupIsolatedBackend(
@@ -33,8 +34,8 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("status snapshot includes shared playlist summaries without embedding track arrays", () => {
-  const tracks = Array.from({ length: 250 }, (_, index) => ({
+test("status snapshot includes shared playlist summaries without embedding track arrays", async () => {
+  const tracks = Array.from({ length: 421 }, (_, index) => ({
     artistName: `Artist ${index}`,
     trackName: `Track ${index}`,
   }));
@@ -44,20 +45,28 @@ test("status snapshot includes shared playlist summaries without embedding track
     sourceName: "Exported JSON",
     tracks,
   });
+  const { downloadTracker } = await importFromRepo(
+    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  );
+  downloadTracker.addJob(tracks[0], playlist.id);
 
   const status = getWeeklyFlowStatusSnapshot();
   const shared = (status.sharedPlaylists || []).find((p) => p.id === playlist.id);
 
   assert.ok(shared);
-  assert.equal(shared.trackCount, 250);
+  assert.equal(shared.trackCount, 421);
+  assert.equal(
+    getSharedPlaylistTrackCount(shared, status.sharedPlaylistStats[playlist.id]),
+    421,
+  );
   assert.equal("tracks" in shared, false);
   assert.ok(Array.isArray(shared.trackIdentities));
-  assert.equal(shared.trackIdentities.length, 250);
+  assert.equal(shared.trackIdentities.length, 421);
   assert.equal(shared.sourceName, "Exported JSON");
 
   const serialized = JSON.stringify(status);
-  assert.equal(serialized.includes("Artist 249"), false);
-  assert.equal(serialized.includes("Track 249"), false);
+  assert.equal(serialized.includes("Artist 420"), false);
+  assert.equal(serialized.includes("Track 420"), false);
 });
 
 test("status snapshot includes empty manual playlists", () => {

--- a/.tests/weekly-flow/status-snapshot.test.js
+++ b/.tests/weekly-flow/status-snapshot.test.js
@@ -112,3 +112,24 @@ test("status snapshot trackIdentities includes pending download jobs", async () 
     "expected pending job identity in snapshot",
   );
 });
+
+test("status snapshot trackCount includes failed download jobs", async () => {
+  const { downloadTracker } = await importFromRepo(
+    "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  );
+  const playlist = flowPlaylistConfig.createSharedPlaylist({ name: "Failed Mix" });
+  const jobId = downloadTracker.addJob(
+    { artistName: "Radiohead", trackName: "Karma Police" },
+    playlist.id,
+  );
+  downloadTracker.setFailed(jobId, "Not found");
+
+  const status = getWeeklyFlowStatusSnapshot();
+  const shared = status.sharedPlaylists.find((entry) => entry.id === playlist.id);
+
+  assert.equal(shared.trackCount, 1);
+  assert.equal(
+    getSharedPlaylistTrackCount(shared, status.sharedPlaylistStats[playlist.id]),
+    1,
+  );
+});

--- a/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
@@ -140,7 +140,7 @@ export function getWeeklyFlowStatusSnapshot({
       sourceFlowId: playlist.sourceFlowId,
       importedAt: playlist.importedAt,
       createdAt: playlist.createdAt,
-      trackCount: jobTotal > 0 ? jobTotal : playlist.trackCount,
+      trackCount: Math.max(jobTotal, Number(playlist.trackCount || 0)),
       trackIdentities: collectPlaylistTrackIdentities(playlist),
       trackEntries: collectPlaylistTrackEntries(playlist),
       importSource: playlist.importSource

--- a/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
+++ b/backend/services/weeklyFlow/weeklyFlowStatusSnapshot.js
@@ -131,7 +131,8 @@ export function getWeeklyFlowStatusSnapshot({
       Number(playlistStats?.pending || 0) +
       Number(playlistStats?.downloading || 0) +
       Number(playlistStats?.blocked || 0) +
-      Number(playlistStats?.done || 0);
+      Number(playlistStats?.done || 0) +
+      Number(playlistStats?.failed || 0);
     return {
       id: playlist.id,
       name: playlist.name,

--- a/frontend/src/pages/flows/flowStats.js
+++ b/frontend/src/pages/flows/flowStats.js
@@ -19,9 +19,11 @@ export const getFlowDisplayTrackCount = (flow, stats, trackListLength = 0) => {
 };
 
 export const getSharedPlaylistTrackCount = (playlist, stats, trackListLength = 0) => {
-  const fromJobs = Math.max(flowNumber(trackListLength), flowNumber(stats?.total));
-  if (fromJobs > 0) return fromJobs;
-  return flowNumber(playlist?.trackCount);
+  return Math.max(
+    flowNumber(playlist?.trackCount),
+    flowNumber(trackListLength),
+    flowNumber(stats?.total),
+  );
 };
 
 export const EMPTY_FLOW_STATS = {


### PR DESCRIPTION
## What changed

Preserved the larger of the stored playlist track count and completed download job count in weekly flow status snapshots and frontend statistics. Added regression coverage for playlists with active download jobs.

## Why

Playlist track counts could be reduced to the number of tracked download jobs, causing inaccurate status summaries for partially processed playlists.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

No linked issue.

## UI changes

No visual UI changes. This updates the track-count data used by flow statistics.

## Testing

- Updated and ran the weekly flow status snapshot regression test.
- Verified stored playlist counts are preserved when download job counts are lower.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared playlist track counts to consistently reflect the highest available count.
  * Fixed totals when configured tracks, loaded tracks, and reported job counts differ.
  * Included failed download jobs in shared playlist totals.
  * Updated status snapshots to accurately represent pending downloads, large playlists, and serialized output without track metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->