### PR TITLE
fix(library): merge artists when MBIDs become known

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -10,6 +10,7 @@ import {
   getCanonicalLibraryPage,
 } from "../../backend/services/libraryQueryService.js";
 import {
+  buildFallbackIdentityKey,
   getLibrarySnapshot,
   linkLibraryAlbumTrack,
   upsertLibraryAlbum,
@@ -166,6 +167,86 @@ test("scanMusicRoot derives stable fallback records when tags are missing", asyn
   } finally {
     if (filePath) deleteIndexedFile(source, filePath);
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("upsertLibraryArtist promotes a name fallback when its MBID becomes known", () => {
+  const name = `Identity Promotion ${process.pid} ${Date.now()}`;
+  const mbid = "11111111-1111-4111-8111-111111111112";
+  const fallback = upsertLibraryArtist({
+    identityKey: buildFallbackIdentityKey("artist", name),
+    name,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: buildFallbackIdentityKey("album", fallback.identity_key, "Album"),
+    artistId: fallback.id,
+    title: "Album",
+  });
+
+  try {
+    const resolved = upsertLibraryArtist({
+      identityKey: `mbid:${mbid}`,
+      mbid,
+      name,
+    });
+    const fallbackAgain = upsertLibraryArtist({
+      identityKey: buildFallbackIdentityKey("artist", name),
+      name,
+    });
+    const artists = db.prepare("SELECT id, mbid FROM library_artists WHERE name = ?").all(name);
+    const linkedAlbum = db.prepare("SELECT artist_id FROM library_albums WHERE id = ?").get(album.id);
+
+    assert.deepEqual(artists, [{ id: resolved.id, mbid }]);
+    assert.equal(resolved.id, fallback.id);
+    assert.equal(fallbackAgain.id, resolved.id);
+    assert.equal(linkedAlbum.artist_id, resolved.id);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE name = ?").run(name);
+  }
+});
+
+test("upsertLibraryArtist repairs an existing fallback and MBID duplicate", () => {
+  const name = `Identity Repair ${process.pid} ${Date.now()}`;
+  const mbid = "11111111-1111-4111-8111-111111111113";
+  const fallbackKey = buildFallbackIdentityKey("artist", name);
+  const fallback = upsertLibraryArtist({
+    identityKey: fallbackKey,
+    name,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: buildFallbackIdentityKey("album", fallback.identity_key, "Album"),
+    artistId: fallback.id,
+    title: "Album",
+  });
+  const timestamp = Date.now();
+  const resolvedId = Number(db.prepare(
+    `INSERT INTO library_artists
+      (identity_key, mbid, name, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(`mbid:${mbid}`, mbid, name, timestamp, timestamp).lastInsertRowid);
+  const userId = Number(db.prepare(
+    "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+  ).run(`identity-repair-${process.pid}-${timestamp}`, "hash").lastInsertRowid);
+  db.prepare(
+    `INSERT INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
+     VALUES (?, 'artist', ?, ?)`,
+  ).run(userId, fallbackKey, timestamp);
+
+  try {
+    const resolved = upsertLibraryArtist({ identityKey: `mbid:${mbid}`, mbid, name });
+    const artists = db.prepare("SELECT id, mbid FROM library_artists WHERE name = ?").all(name);
+    const linkedAlbum = db.prepare("SELECT artist_id FROM library_albums WHERE id = ?").get(album.id);
+    const star = db.prepare(
+      "SELECT entity_key FROM subsonic_stars WHERE user_id = ? AND entity_kind = 'artist'",
+    ).get(userId);
+
+    assert.deepEqual(artists, [{ id: resolvedId, mbid }]);
+    assert.equal(resolved.id, resolvedId);
+    assert.equal(linkedAlbum.artist_id, resolvedId);
+    assert.equal(star.entity_key, `mbid:${mbid}`);
+  } finally {
+    db.prepare("DELETE FROM users WHERE id = ?").run(userId);
+    db.prepare("DELETE FROM library_artists WHERE name = ?").run(name);
   }
 });
 

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -101,6 +101,42 @@ export function upsertLibraryArtist({
   const artistName = normalizeText(name);
   if (!key || !artistName) throw new Error("Library artist identityKey and name are required");
   const artist = db.transaction(() => {
+    const fallbackKey = buildFallbackIdentityKey("artist", artistName);
+    if (mbid) {
+      const resolved = db.prepare("SELECT id FROM library_artists WHERE identity_key = ?").get(key);
+      const fallback = fallbackKey === key
+        ? null
+        : db.prepare("SELECT id FROM library_artists WHERE identity_key = ?").get(fallbackKey);
+      if (fallback) {
+        db.prepare(
+          `INSERT OR IGNORE INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
+           SELECT user_id, entity_kind, ?, created_at
+           FROM subsonic_stars
+           WHERE entity_kind = 'artist' AND entity_key = ?`,
+        ).run(key, fallbackKey);
+        db.prepare(
+          "DELETE FROM subsonic_stars WHERE entity_kind = 'artist' AND entity_key = ?",
+        ).run(fallbackKey);
+      }
+      if (fallback && !resolved) {
+        db.prepare("UPDATE library_artists SET identity_key = ? WHERE id = ?").run(key, fallback.id);
+      } else if (fallback && resolved && fallback.id !== resolved.id) {
+        db.prepare("UPDATE library_albums SET artist_id = ? WHERE artist_id = ?")
+          .run(resolved.id, fallback.id);
+        db.prepare("DELETE FROM library_artists WHERE id = ?").run(fallback.id);
+      }
+    } else if (key === fallbackKey) {
+      const resolved = db.prepare(
+        `SELECT * FROM library_artists
+         WHERE mbid IS NOT NULL AND name = ? COLLATE NOCASE
+         ORDER BY id
+         LIMIT 2`,
+      ).all(artistName);
+      if (resolved.length === 1) {
+        if (syncSearch) syncLibrarySearchArtist(resolved[0].id);
+        return resolved[0];
+      }
+    }
     db.prepare(
       `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
Library scans can index the same artist twice when a file first lacks an MBID and later gains one. The fallback record remains in the artist grid without artwork or an Explore in Discover link.

`upsertLibraryArtist` now promotes a name-based fallback when its MBID becomes known. It also repairs existing fallback and MBID twins, keeps album ownership and favorites attached, and reuses a single resolved exact-name artist for later untagged files.

Verification:

- `node --test --import ./.tests/setup-env.js .tests/library/media-index.test.js`
- `npm run lint:backend`

The repair does not guess MBIDs when no unique resolved exact-name artist exists.