### PR TITLE
docs(release): add 2.6.0 release notes

### DIFF
--- a/release-notes/2.6.0.md
+++ b/release-notes/2.6.0.md
@@ -1,0 +1,31 @@
+2.6.0 makes large libraries easier to browse and keeps library and playlist state in step with the services behind them. Discover and artist pages also get a cleaner, more consistent layout.
+
+## What's new
+
+- Faster large-library browsing and indexing through bounded reads, bulk Lidarr requests, and lower-memory response handling.
+- More predictable startup and refresh work, with fewer duplicate requests and shorter waits when the application shuts down.
+- Refreshed Discover and artist pages with clearer spacing, typography, responsive layouts, and mobile-friendly release lists.
+- **View info** actions for artists, albums, and tracks in the Library, with indexed metadata in the information dialog.
+- A consistent loading indicator with reduced-motion support and clearer accessibility labels.
+
+## Fixes worth noticing
+
+- Library membership now reflects recent Lidarr additions and removals after refreshes, while the existing index remains available when Lidarr cannot respond.
+- Artists are merged when a file gains a MusicBrainz ID, so one artist does not appear twice in the Library.
+- Favorited tracks from synced playlists stay in the Library after the source playlist removes them.
+- Large Navidrome playlist updates no longer fail because request URLs are too long, and failed updates can catch up after a retry.
+- Weekly Flow keeps the stored playlist track count when download jobs are still in progress.
+- Provider failures, stale playlist references, migrated media paths, and missing Lidarr resources recover with clearer results.
+- Search, pagination, favorites, and background refreshes make fewer duplicate requests and show fewer stale results.
+
+## Things to try
+
+- Browse a large Library and open **View info** for an artist, album, or track.
+- Open Discover and an artist page on both desktop and mobile widths.
+- Add or remove an artist or album in Lidarr, then refresh the Library.
+- Favorite a track from a synced playlist, then remove it from the source playlist.
+- Replace a large Navidrome playlist and check that its track count and contents remain intact.
+
+## Full change list
+
+The [full change list from 2.5.1 to 2.6.0](https://github.com/lklynet/aurral/compare/v2.5.1...v2.6.0) includes every pull request and fix.


### PR DESCRIPTION
## What changed

Added release notes for version 2.6.0, covering new features, notable fixes, testing suggestions, and the full change list.

## Why

Provides users with a concise overview of the 2.6.0 release and links to the complete comparison of changes.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

Not run; documentation-only change.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change