### PR TITLE
fix(library): sync playlist-backed favorites

### DIFF
--- a/.tests/frontend/library-playlist-favorites.test.js
+++ b/.tests/frontend/library-playlist-favorites.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "vite";
+
+test("library favorites include playlist-backed Subsonic songs", async (t) => {
+  const vite = await createServer({
+    root: "frontend",
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    optimizeDeps: { noDiscovery: true },
+  });
+  t.after(() => vite.close());
+
+  const { favoriteId, favoriteLibraryFromResponse } = await vite.ssrLoadModule(
+    "/src/pages/LibraryPage.jsx?playlist-favorites-test",
+  );
+  const playlistSong = {
+    id: "shared-song:playlist-id%3Ajob-id",
+    title: "Playlist Favorite",
+    artist: "Favorite Artist",
+    album: "Favorite Album",
+    duration: 223,
+    suffix: "flac",
+  };
+  const library = favoriteLibraryFromResponse({
+    library: {
+      artists: [],
+      albums: [],
+      tracks: [{ id: 1, identityKey: "canonical-song", title: "Canonical Favorite" }],
+    },
+    song: [
+      { id: "song:canonical-song", title: "Canonical Favorite" },
+      playlistSong,
+    ],
+  });
+
+  assert.deepEqual(library.tracks.map((track) => track.title), [
+    "Canonical Favorite",
+    "Playlist Favorite",
+  ]);
+  assert.equal(favoriteId("song", library.tracks[1]), playlistSong.id);
+  assert.match(library.tracks[1].files[0].previewUrl, /\/playlists\/stream\/job-id/);
+});

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -56,6 +56,7 @@ import {
   addSharedPlaylistTracks,
   createSharedPlaylist,
   deleteSharedPlaylistTrack,
+  getFlowTrackStreamUrl,
 } from "../utils/api/endpoints/playlists.js";
 import { buildAuthenticatedApiUrl } from "../utils/api/core.js";
 import { mergeAlbumMetadataTracks } from "../utils/libraryTrackHydration.js";
@@ -101,8 +102,11 @@ const yearOf = (value) => {
   return match ? match[1] : "";
 };
 
-const favoriteId = (kind, entity) =>
-  kind + ":" + encodeURIComponent(text(entity?.identityKey));
+export const favoriteId = (kind, entity) => {
+  const id = text(entity?.id);
+  if (kind === "song" && /^(flow|shared)-song:/.test(id)) return id;
+  return kind + ":" + encodeURIComponent(text(entity?.identityKey));
+};
 
 const firstAvailableFile = (track, albumId = null) =>
   (track?.files || []).find((file) => file.available && file.albumId === albumId)
@@ -128,6 +132,34 @@ const normalizeLibraryPages = (pages) => pages.reduce(
   },
   { artists: [], albums: [], tracks: [], genres: [] },
 );
+
+export const favoriteLibraryFromResponse = (favorites) => {
+  const library = normalizeLibraryPages([favorites?.library || EMPTY_LIBRARY]);
+  const playlistTracks = (Array.isArray(favorites?.song) ? favorites.song : [])
+    .filter((track) => /^(flow|shared)-song:/.test(text(track?.id)))
+    .map((track) => {
+      const jobId = decodeURIComponent(track.id.slice(track.id.indexOf(":") + 1)).split(":").at(-1);
+      const durationMs = Number(track.duration) > 0 ? Number(track.duration) * 1000 : null;
+      return {
+        id: track.id,
+        identityKey: track.id,
+        title: track.title,
+        artistName: track.artist,
+        albumName: track.album,
+        durationMs,
+        albums: [],
+        files: [{
+          available: true,
+          previewUrl: getFlowTrackStreamUrl(jobId),
+          format: track.suffix || null,
+          durationMs,
+        }],
+      };
+    });
+  return playlistTracks.length
+    ? { ...library, tracks: [...library.tracks, ...playlistTracks] }
+    : library;
+};
 
 const favoriteIdsFromPages = (pages) => new Set(
   ["artists", "albums", "tracks"].flatMap((kind) =>
@@ -570,7 +602,9 @@ function LibraryPage() {
       const pageResults = section === "favorites"
         ? [nextData?.library || EMPTY_LIBRARY]
         : Array.isArray(nextData) ? nextData : [nextData];
-      const normalizedLibrary = normalizeLibraryPages(pageResults);
+      const normalizedLibrary = section === "favorites"
+        ? favoriteLibraryFromResponse(nextData)
+        : normalizeLibraryPages(pageResults);
       const usePreview =
         import.meta.env.DEV &&
         pageResults.every((page) => Number(page?.total || 0) === 0) &&
@@ -1366,7 +1400,7 @@ function LibraryPage() {
         id: track.id,
         title: track.title,
         artist: artist?.name || track.artistName || "Unknown Artist",
-        album: album?.title || "Unknown Album",
+        album: album?.title || track.albumName || track.album || "Unknown Album",
         src:
           file?.previewUrl ||
           (file && album
@@ -1612,7 +1646,7 @@ function LibraryPage() {
             String(currentTrack?.id) === String(track.id) &&
             matchesSource(librarySource);
           const artistName = artist?.name || track.artistName || "Unknown Artist";
-          const albumName = album?.title || "Unknown Album";
+          const albumName = album?.title || track.albumName || track.album || "Unknown Album";
           const trackNumber = track.albums?.find(
             (entry) => String(entry.albumId) === String(album?.id),
           )?.trackNumber;


### PR DESCRIPTION
## What changed

Include playlist-backed Subsonic songs when hydrating library favorites, preserving their IDs and playlist stream URLs. Added a focused frontend regression test.

## Why

Playlist-backed favorites were omitted from the Library view because only canonical library tracks were normalized. This restores visibility and playback for those favorites.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The Library view now displays playlist-backed favorites and uses their playlist stream URLs for playback. Before-and-after screenshots were not included.

## Testing

- Added `.tests/frontend/library-playlist-favorites.test.js` covering playlist-backed favorite hydration, IDs, and preview URLs.
- Automated test execution was not reported in the supplied change details.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library favorites now include playable songs from playlists and shared sources.
  - Favorite tracks display streamable previews with normalized durations.
  - Track album labels fall back to available source album information when needed.

- **Bug Fixes**
  - Preserved song identifiers for favorite entries.
  - Improved playlist favorite handling and preview playback links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->