### PR TITLE
perf(library): avoid rewriting unchanged scans

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -7,7 +7,9 @@ import path from "node:path";
 import { db } from "../../backend/config/db-sqlite.js";
 import {
   getCanonicalArtistProjection,
+  getCanonicalLibrary,
   getCanonicalLibraryPage,
+  invalidateCanonicalLibraryCache,
 } from "../../backend/services/libraryQueryService.js";
 import {
   buildFallbackIdentityKey,
@@ -66,6 +68,57 @@ test("overlapping scans keep change tracking isolated", async () => {
     releaseFirst?.();
     db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(identityKey);
     db.prepare("DELETE FROM library_scan_runs WHERE source LIKE 'test-overlap-%'").run();
+  }
+});
+
+test("a failed scan-run insert does not leak scan state", async () => {
+  const identityKey = `name:scan-insert-failure-${process.pid}`;
+  let artist;
+  try {
+    artist = upsertLibraryArtist({ identityKey, name: "Before Failure", syncSearch: false });
+    const album = upsertLibraryAlbum({
+      identityKey: `${identityKey}:album`,
+      artistId: artist.id,
+      title: "Scan Failure Album",
+      syncSearch: false,
+    });
+    const track = upsertLibraryTrack({
+      identityKey: `${identityKey}:track`,
+      title: "Scan Failure Track",
+      artistName: "Before Failure",
+      syncSearch: false,
+    });
+    linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, syncSearch: false });
+    upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "aurral",
+      path: `/tmp/scan-insert-failure-${process.pid}.flac`,
+      available: true,
+    });
+    assert.equal(getCanonicalLibrary().artists.find((item) => item.id === artist.id)?.name, "Before Failure");
+
+    db.exec(`CREATE TEMP TRIGGER fail_library_scan_insert
+      BEFORE INSERT ON library_scan_runs BEGIN
+        SELECT RAISE(FAIL, 'scan insert failed');
+      END`);
+    await assert.rejects(
+      () => withLibraryScan("test-insert-failure", null, async () => ({})),
+      /scan insert failed/,
+    );
+    db.exec("DROP TRIGGER fail_library_scan_insert");
+
+    await withLibraryScan("test-after-insert-failure", null, async () => {
+      upsertLibraryArtist({ identityKey, name: "After Failure", syncSearch: false });
+      return { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+    });
+
+    assert.equal(getCanonicalLibrary().artists.find((item) => item.id === artist.id)?.name, "After Failure");
+  } finally {
+    db.exec("DROP TRIGGER IF EXISTS fail_library_scan_insert");
+    if (artist) db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    db.prepare("DELETE FROM library_scan_runs WHERE source LIKE 'test-%insert-failure'").run();
+    invalidateCanonicalLibraryCache();
   }
 });
 
@@ -1071,6 +1124,35 @@ test("a partial Lidarr rescan preserves existing file availability", async () =>
       "lidarr",
       filePath,
     );
+  }
+});
+
+test("a Lidarr rescan preserves files for an album with a missing artist response", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-missing-artist-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Missing Artist/Album/01 Track.flac");
+    const artist = { id: 117, artistName: "Missing Artist", foreignArtistId: "17171717-1717-4717-8717-171717171717" };
+    const album = { id: 118, artistId: 117, title: "Album", foreignAlbumId: "18181818-1818-4818-8818-181818181818" };
+    const track = { id: 119, albumId: 118, title: "Track", foreignRecordingId: "19191919-1919-4919-8919-191919191919", trackFileId: 120 };
+    const client = {
+      isConfigured: () => true,
+      request: async () => [artist],
+      getAllAlbums: async () => [album],
+      getTracksByAlbumId: async () => [track],
+      getTrackFilesByAlbumId: async () => [{ id: 120, path: filePath, trackIds: [119] }],
+      getRootFolders: async () => [{ path: root }],
+    };
+    await indexLidarrLibrary({ client });
+    client.request = async () => [];
+    const result = await indexLidarrLibrary({ client });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.equal(result.filesFailed, 1);
+    assert.equal(file?.available, 1);
+  } finally {
+    if (filePath) deleteIndexedFile("lidarr", filePath);
+    await rm(root, { recursive: true, force: true });
   }
 });
 

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -17,10 +17,26 @@ import {
   upsertLibraryArtist,
   upsertLibraryMediaFile,
   upsertLibraryTrack,
+  withLibraryScan,
 } from "../../backend/services/libraryMediaStore.js";
 import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
 import { scanConfiguredLibrary } from "../../backend/services/libraryIndexService.js";
+
+test("scan change tracking ignores unrelated database writes", async () => {
+  const settingKey = `unrelated-scan-write-${process.pid}`;
+  try {
+    const result = await withLibraryScan("test-unrelated-write", null, async () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(settingKey, "value");
+      return { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+    });
+
+    assert.equal(result.changed, false);
+  } finally {
+    db.prepare("DELETE FROM settings WHERE key = ?").run(settingKey);
+    db.prepare("DELETE FROM library_scan_runs WHERE source = 'test-unrelated-write'").run();
+  }
+});
 
 test("a local-only configured scan does not contact Lidarr", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-local-only-scan-"));
@@ -40,6 +56,41 @@ test("a local-only configured scan does not contact Lidarr", async () => {
     assert.equal(lidarrCalls, 0);
     assert.equal(result.lidarr.skipped, true);
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed provider scan repairs derived library indexes", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-failed-index-repair-"));
+  const identityKey = `name:failed-index-repair-${process.pid}`;
+  const artist = upsertLibraryArtist({
+    identityKey,
+    name: "Failed Index Repair",
+    syncSearch: false,
+  });
+  db.prepare("DELETE FROM library_search_documents WHERE entity_kind = 'artist' AND entity_id = ?")
+    .run(artist.id);
+
+  try {
+    const result = await scanConfiguredLibrary({
+      musicRoot: root,
+      lidarrClient: {
+        isConfigured: () => true,
+        request: async () => {
+          throw new Error("Lidarr unavailable");
+        },
+        getAllAlbums: async () => [],
+        getRootFolders: async () => [],
+      },
+    });
+    const indexed = db.prepare(
+      "SELECT 1 FROM library_search_documents WHERE entity_kind = 'artist' AND entity_id = ?",
+    ).get(artist.id);
+
+    assert.equal(result.lidarr.error, "Lidarr unavailable");
+    assert.equal(Boolean(indexed), true);
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(identityKey);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -509,6 +560,50 @@ test("an unchanged Lidarr rescan does not rewrite library rows", async () => {
     db.prepare("DELETE FROM settings WHERE key = ?").run(genreStatsKey);
     deleteIndexedFile("lidarr", filePath);
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Lidarr persistence yields between album transactions", async () => {
+  const artistMbid = "40404040-4040-4040-8040-404040404040";
+  const firstAlbumMbid = "50505050-5050-4050-8050-505050505050";
+  const secondAlbumMbid = "60606060-6060-4060-8060-606060606060";
+  let scanning = true;
+  const yieldedBetweenAlbums = new Promise((resolve) => {
+    const inspect = () => {
+      const firstExists = Boolean(db.prepare(
+        "SELECT 1 FROM library_albums WHERE release_group_mbid = ?",
+      ).get(firstAlbumMbid));
+      const secondExists = Boolean(db.prepare(
+        "SELECT 1 FROM library_albums WHERE release_group_mbid = ?",
+      ).get(secondAlbumMbid));
+      if (firstExists && !secondExists) return resolve(true);
+      if (!scanning) return resolve(false);
+      setImmediate(inspect);
+    };
+    setImmediate(inspect);
+  });
+
+  try {
+    await indexLidarrLibrary({
+      syncSearch: false,
+      client: {
+        isConfigured: () => true,
+        request: async () => [{ id: 4040, artistName: "Yield Artist", foreignArtistId: artistMbid }],
+        getAllAlbums: async () => [
+          { id: 5050, artistId: 4040, title: "First Yield Album", foreignAlbumId: firstAlbumMbid },
+          { id: 6060, artistId: 4040, title: "Second Yield Album", foreignAlbumId: secondAlbumMbid },
+        ],
+        getTracksByAlbumId: async () => [],
+        getTrackFilesByAlbumId: async () => [],
+        getRootFolders: async () => [],
+      },
+    });
+    scanning = false;
+
+    assert.equal(await yieldedBetweenAlbums, true);
+  } finally {
+    scanning = false;
+    db.prepare("DELETE FROM library_artists WHERE mbid = ?").run(artistMbid);
   }
 });
 

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -442,6 +442,76 @@ test("indexLidarrLibrary imports logical media and readable track files", async 
   }
 });
 
+test("an unchanged Lidarr rescan does not rewrite library rows", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-unchanged-"));
+  const filePath = await createAudioFile(root, "Stable Artist/Stable Album/01 Stable Track.flac");
+  const artistMbid = "10101010-1010-4010-8010-101010101010";
+  const albumMbid = "20202020-2020-4020-8020-202020202020";
+  const trackMbid = "30303030-3030-4030-8030-303030303030";
+  const genreStatsKey = `libraryGenreStats:unchanged-${process.pid}`;
+  const client = {
+    isConfigured: () => true,
+    request: async () => [{ id: 1010, artistName: "Stable Artist", foreignArtistId: artistMbid }],
+    getAllAlbums: async () => [{
+      id: 2020,
+      artistId: 1010,
+      title: "Stable Album",
+      foreignAlbumId: albumMbid,
+      path: path.dirname(filePath),
+    }],
+    getTracksByAlbumId: async () => [{
+      id: 3030,
+      albumId: 2020,
+      title: "Stable Track",
+      trackNumber: 1,
+      foreignRecordingId: trackMbid,
+      trackFileId: 4040,
+    }],
+    getTrackFilesByAlbumId: async () => [{ id: 4040, path: filePath, trackIds: [3030] }],
+    getRootFolders: async () => [{ path: root }],
+  };
+
+  try {
+    await indexLidarrLibrary({ client, syncSearch: false });
+    db.prepare("UPDATE library_artists SET updated_at = 1 WHERE mbid = ?").run(artistMbid);
+    db.prepare("UPDATE library_albums SET updated_at = 1 WHERE release_group_mbid = ?").run(albumMbid);
+    db.prepare("UPDATE library_tracks SET updated_at = 1 WHERE mbid = ?").run(trackMbid);
+    db.prepare("UPDATE library_media_files SET updated_at = 1 WHERE source = 'lidarr' AND path = ?")
+      .run(filePath);
+
+    const changesBefore = db.prepare("SELECT total_changes() AS count").get().count;
+    const result = await indexLidarrLibrary({ client, syncSearch: false });
+    const changesAfter = db.prepare("SELECT total_changes() AS count").get().count;
+
+    assert.equal(result.changed, false);
+    assert.equal(changesAfter - changesBefore, 2);
+    assert.deepEqual({
+      artist: db.prepare("SELECT updated_at FROM library_artists WHERE mbid = ?").get(artistMbid)?.updated_at,
+      album: db.prepare("SELECT updated_at FROM library_albums WHERE release_group_mbid = ?").get(albumMbid)?.updated_at,
+      track: db.prepare("SELECT updated_at FROM library_tracks WHERE mbid = ?").get(trackMbid)?.updated_at,
+      media: db.prepare("SELECT updated_at FROM library_media_files WHERE source = 'lidarr' AND path = ?")
+        .get(filePath)?.updated_at,
+    }, { artist: 1, album: 1, track: 1, media: 1 });
+
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(genreStatsKey, "preserved");
+    const configuredChangesBefore = db.prepare("SELECT total_changes() AS count").get().count;
+    const configured = await scanConfiguredLibrary({
+      musicRoot: path.join(root, "empty-aurral-root"),
+      lidarrClient: client,
+    });
+    const configuredChangesAfter = db.prepare("SELECT total_changes() AS count").get().count;
+
+    assert.equal(configured.local.changed, false);
+    assert.equal(configured.lidarr.changed, false);
+    assert.equal(configuredChangesAfter - configuredChangesBefore, 4);
+    assert.equal(db.prepare("SELECT value FROM settings WHERE key = ?").get(genreStatsKey)?.value, "preserved");
+  } finally {
+    db.prepare("DELETE FROM settings WHERE key = ?").run(genreStatsKey);
+    deleteIndexedFile("lidarr", filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("indexLidarrLibrary keeps artists without albums and refreshes monitoring metadata", async () => {
   const providerArtistId = "1212@deezer";
   let monitored = false;

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -38,6 +38,37 @@ test("scan change tracking ignores unrelated database writes", async () => {
   }
 });
 
+test("overlapping scans keep change tracking isolated", async () => {
+  const identityKey = `name:overlapping-scan-${process.pid}`;
+  let releaseFirst;
+  const holdFirst = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  let firstChanged;
+
+  try {
+    const first = withLibraryScan("test-overlap-first", null, async () => {
+      upsertLibraryArtist({ identityKey, name: "Overlapping Scan", syncSearch: false });
+      firstChanged = true;
+      await holdFirst;
+      return { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+    });
+    while (!firstChanged) await new Promise((resolve) => setImmediate(resolve));
+
+    const second = await withLibraryScan("test-overlap-second", null, async () => (
+      { filesSeen: 0, filesIndexed: 0, filesFailed: 0 }
+    ));
+    releaseFirst();
+
+    assert.equal(second.changed, false);
+    assert.equal((await first).changed, true);
+  } finally {
+    releaseFirst?.();
+    db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(identityKey);
+    db.prepare("DELETE FROM library_scan_runs WHERE source LIKE 'test-overlap-%'").run();
+  }
+});
+
 test("a local-only configured scan does not contact Lidarr", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-local-only-scan-"));
   let lidarrCalls = 0;
@@ -1126,6 +1157,34 @@ test("an empty Lidarr response leaves the last indexed library available", async
 
     assert.equal(result.filesIndexed, 0);
     assert.equal(file?.available, 1);
+  } finally {
+    if (filePath) deleteIndexedFile("lidarr", filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a Lidarr rescan marks the final removed media file unavailable", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-final-removal-"));
+  let filePath;
+  const artist = { id: 47, artistName: "Removal Artist", foreignArtistId: "47474747-4747-4747-8747-474747474747" };
+  const album = { id: 48, artistId: 47, title: "Removal Album", foreignAlbumId: "48484848-4848-4848-8848-484848484848" };
+  const track = { id: 49, albumId: 48, title: "Removal Track", trackNumber: 1, foreignRecordingId: "49494949-4949-4949-8949-494949494949", trackFileId: 50 };
+  try {
+    filePath = await createAudioFile(root, "Removal Artist/Removal Album/01 Removal Track.flac");
+    const client = {
+      isConfigured: () => true,
+      request: async () => [artist],
+      getAllAlbums: async () => [album],
+      getTracksByAlbumId: async () => [track],
+      getTrackFilesByAlbumId: async () => [{ id: 50, path: filePath, trackIds: [49] }],
+      getRootFolders: async () => [{ path: root }],
+    };
+    await indexLidarrLibrary({ client });
+    client.getTrackFilesByAlbumId = async () => [];
+    await indexLidarrLibrary({ client });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.equal(file?.available, 0);
   } finally {
     if (filePath) deleteIndexedFile("lidarr", filePath);
     await rm(root, { recursive: true, force: true });

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -4,8 +4,9 @@ import { parseFile } from "music-metadata";
 import {
   buildFallbackIdentityKey,
   buildIdentityKey,
+  getAvailableLibraryMediaPaths,
   linkLibraryAlbumTrack,
-  markUnseenFilesUnavailable,
+  markLibraryMediaFilesUnavailable,
   upsertLibraryAlbum,
   upsertLibraryArtist,
   upsertLibraryMediaFile,
@@ -193,6 +194,7 @@ export async function scanMusicRoot({
       )
     : null;
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  const unseenPaths = requestedFiles ? null : getAvailableLibraryMediaPaths(source);
   const scanResult = await withLibraryScan(source, resolvedRoot, (scanId) => {
     const run = async () => {
       const files = requestedFiles || walkAudioFiles(resolvedRoot);
@@ -255,12 +257,15 @@ export async function scanMusicRoot({
             quality: record.quality,
             scanId,
           });
+          unseenPaths?.delete(filePath);
           result.filesIndexed += 1;
         } catch {
           result.filesFailed += 1;
         }
       }
-      if (!requestedFiles && result.filesFailed === 0) markUnseenFilesUnavailable(scanId, source);
+      if (unseenPaths && result.filesFailed === 0) {
+        markLibraryMediaFilesUnavailable(source, unseenPaths);
+      }
       return result;
     };
     return run();

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -42,6 +42,7 @@ export async function scanConfiguredLibrary({
   const jobMetadataByPath = getAurralJobMetadataByPath();
   let local;
   let lidarr = { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  let scanFailed = false;
   try {
     local = await scanMusicRoot({
       rootPath: musicRoot,
@@ -53,6 +54,7 @@ export async function scanConfiguredLibrary({
       try {
         lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });
       } catch (error) {
+        scanFailed = true;
         lidarr = {
           skipped: false,
           error: error.message,
@@ -62,8 +64,11 @@ export async function scanConfiguredLibrary({
         };
       }
     }
+  } catch (error) {
+    scanFailed = true;
+    throw error;
   } finally {
-    if (local?.changed || lidarr?.changed) {
+    if (scanFailed || local?.changed || lidarr?.changed) {
       rebuildLibrarySearchIndex();
       rebuildCanonicalGenreStats();
     }

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -63,8 +63,10 @@ export async function scanConfiguredLibrary({
       }
     }
   } finally {
-    rebuildLibrarySearchIndex();
-    rebuildCanonicalGenreStats();
+    if (local?.changed || lidarr?.changed) {
+      rebuildLibrarySearchIndex();
+      rebuildCanonicalGenreStats();
+    }
   }
   return { local, lidarr };
 }

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -184,6 +184,7 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
     .filter(Boolean)
     .join(";") || null;
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
+  const tracksEnumerated = albumTrackData.some((albumData) => albumData.tracks.length > 0);
 
   return withLibraryScan("lidarr", rootPath, async (scanId) => {
     const indexedFiles = new Map();
@@ -302,7 +303,7 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
       for (const filePath of batch.seenPaths) unseenPaths.delete(filePath);
       await new Promise((resolve) => setImmediate(resolve));
     }
-    if (result.filesFailed === 0 && result.filesIndexed > 0) {
+    if (result.filesFailed === 0 && (result.filesIndexed > 0 || tracksEnumerated)) {
       markLibraryMediaFilesUnavailable("lidarr", unseenPaths);
     }
     return result;

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -206,8 +206,8 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
       }
     }
 
-    return db.transaction(() => {
-      const artistRecordsById = new Map();
+    const artistRecordsById = db.transaction(() => {
+      const records = new Map();
       for (const artist of artistById.values()) {
         const artistProviderId = text(artist.foreignArtistId);
         const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
@@ -215,7 +215,7 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
           (artistProviderId &&
             buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
           buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
-        artistRecordsById.set(String(artist.id), upsertLibraryArtist({
+        records.set(String(artist.id), upsertLibraryArtist({
           identityKey: artistKey,
           mbid: isUuid(artistProviderId) ? artistProviderId : null,
           name: artistName,
@@ -224,9 +224,15 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
           syncSearch,
         }));
       }
-      for (const album of Array.isArray(albums) ? albums : []) {
-        const artist = artistById.get(String(album?.artistId));
-        if (!artist || !album?.id) continue;
+      return records;
+    })();
+
+    for (const album of Array.isArray(albums) ? albums : []) {
+      const artist = artistById.get(String(album?.artistId));
+      if (!artist || !album?.id) continue;
+      const batch = db.transaction(() => {
+        const seenPaths = [];
+        let filesIndexed = 0;
         const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
         const artistRecord = artistRecordsById.get(String(artist.id));
         const albumProviderId = text(album.foreignAlbumId);
@@ -287,15 +293,19 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
             available: true,
             scanId,
           });
-          unseenPaths.delete(resolvedFile.localPath);
-          result.filesIndexed += 1;
+          seenPaths.push(resolvedFile.localPath);
+          filesIndexed += 1;
         }
-      }
-      if (result.filesFailed === 0 && result.filesIndexed > 0) {
-        markLibraryMediaFilesUnavailable("lidarr", unseenPaths);
-      }
-      return result;
-    })();
+        return { filesIndexed, seenPaths };
+      })();
+      result.filesIndexed += batch.filesIndexed;
+      for (const filePath of batch.seenPaths) unseenPaths.delete(filePath);
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    if (result.filesFailed === 0 && result.filesIndexed > 0) {
+      markLibraryMediaFilesUnavailable("lidarr", unseenPaths);
+    }
+    return result;
   });
 }
 

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -1,10 +1,12 @@
 import fs from "fs/promises";
 import path from "path";
+import { db } from "../config/db-sqlite.js";
 import {
   buildFallbackIdentityKey,
   buildIdentityKey,
+  getAvailableLibraryMediaPaths,
   linkLibraryAlbumTrack,
-  markUnseenFilesUnavailable,
+  markLibraryMediaFilesUnavailable,
   upsertLibraryAlbum,
   upsertLibraryArtist,
   upsertLibraryMediaFile,
@@ -184,73 +186,13 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
 
   return withLibraryScan("lidarr", rootPath, async (scanId) => {
-    const artistRecordsById = new Map();
-    for (const artist of artistById.values()) {
-      const artistProviderId = text(artist.foreignArtistId);
-      const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
-      const artistKey =
-        (artistProviderId &&
-          buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
-        buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
-      artistRecordsById.set(String(artist.id), upsertLibraryArtist({
-        identityKey: artistKey,
-        mbid: isUuid(artistProviderId) ? artistProviderId : null,
-        name: artistName,
-        sortName: artist.sortName || null,
-        metadata: { ...artist, librarySource: "lidarr" },
-        syncSearch,
-      }));
-    }
+    const indexedFiles = new Map();
+    const unseenPaths = getAvailableLibraryMediaPaths("lidarr");
     for (const album of Array.isArray(albums) ? albums : []) {
-      const artist = artistById.get(String(album?.artistId));
-      if (!artist || !album?.id) continue;
-      const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
-      const artistRecord = artistRecordsById.get(String(artist.id));
-      const albumProviderId = text(album.foreignAlbumId);
-      const albumKey =
-        (albumProviderId &&
-          buildIdentityKey(
-            isUuid(albumProviderId) ? "release-group" : "lidarr-album",
-            albumProviderId,
-          )) ||
-        buildFallbackIdentityKey("lidarr-album", album.id, album.title);
-      const albumRecord = upsertLibraryAlbum({
-        identityKey: albumKey,
-        mbid: isUuid(albumProviderId) ? albumProviderId : null,
-        releaseGroupMbid: isUuid(albumProviderId) ? albumProviderId : null,
-        artistId: artistRecord.id,
-        title: text(album.title) || "Unknown Album",
-        albumArtist: artistName,
-        releaseDate: album.releaseDate || null,
-        metadata: { ...album, librarySource: "lidarr" },
-        syncSearch,
-      });
-      for (const track of tracksByAlbumId.get(String(album.id)) || []) {
-        const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);
-        const trackKey =
-          (trackProviderId &&
-            buildIdentityKey(isUuid(trackProviderId) ? "recording" : "lidarr-track", trackProviderId)) ||
-          buildFallbackIdentityKey("lidarr-track", albumRecord.id, track.id, track.title);
-        const trackRecord = upsertLibraryTrack({
-          identityKey: trackKey,
-          mbid: isUuid(trackProviderId) ? trackProviderId : null,
-          title: text(track.title || track.trackTitle) || "Unknown Track",
-          artistName,
-          metadata: track,
-          syncSearch,
-        });
-        const trackNumber = Number(track.trackNumber || track.absoluteTrackNumber) || 0;
-        linkLibraryAlbumTrack({
-          albumId: albumRecord.id,
-          trackId: trackRecord.id,
-          discNumber: Number(track.mediumNumber || track.discNumber) || 1,
-          trackNumber,
-          syncSearch,
-        });
-
+      for (const track of tracksByAlbumId.get(String(album?.id)) || []) {
         const resolvedFile = resolveTrackFile(
           track,
-          filesByAlbumId.get(String(album.id)) || new Map(),
+          filesByAlbumId.get(String(album?.id)) || new Map(),
           album,
         );
         if (!resolvedFile) continue;
@@ -260,26 +202,100 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
           result.filesFailed += 1;
           continue;
         }
-        upsertLibraryMediaFile({
-          trackId: trackRecord.id,
-          albumId: albumRecord.id,
-          source: "lidarr",
-          path: resolvedFile.localPath,
-          format: path.extname(resolvedFile.localPath).slice(1).toLowerCase(),
-          size: stat.size,
-          mtimeMs: stat.mtimeMs,
-          durationMs: track.duration || resolvedFile.file?.duration || null,
-          quality: resolvedFile.file?.mediaInfo || track.mediaInfo || null,
-          available: true,
-          scanId,
-        });
-        result.filesIndexed += 1;
+        indexedFiles.set(track, { resolvedFile, stat });
       }
     }
-    if (result.filesFailed === 0 && result.filesIndexed > 0) {
-      markUnseenFilesUnavailable(scanId, "lidarr");
-    }
-    return result;
+
+    return db.transaction(() => {
+      const artistRecordsById = new Map();
+      for (const artist of artistById.values()) {
+        const artistProviderId = text(artist.foreignArtistId);
+        const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
+        const artistKey =
+          (artistProviderId &&
+            buildIdentityKey(isUuid(artistProviderId) ? "mbid" : "lidarr-artist", artistProviderId)) ||
+          buildFallbackIdentityKey("lidarr-artist", artist.id, artistName);
+        artistRecordsById.set(String(artist.id), upsertLibraryArtist({
+          identityKey: artistKey,
+          mbid: isUuid(artistProviderId) ? artistProviderId : null,
+          name: artistName,
+          sortName: artist.sortName || null,
+          metadata: { ...artist, librarySource: "lidarr" },
+          syncSearch,
+        }));
+      }
+      for (const album of Array.isArray(albums) ? albums : []) {
+        const artist = artistById.get(String(album?.artistId));
+        if (!artist || !album?.id) continue;
+        const artistName = text(artist.artistName || artist.name) || "Unknown Artist";
+        const artistRecord = artistRecordsById.get(String(artist.id));
+        const albumProviderId = text(album.foreignAlbumId);
+        const albumKey =
+          (albumProviderId &&
+            buildIdentityKey(
+              isUuid(albumProviderId) ? "release-group" : "lidarr-album",
+              albumProviderId,
+            )) ||
+          buildFallbackIdentityKey("lidarr-album", album.id, album.title);
+        const albumRecord = upsertLibraryAlbum({
+          identityKey: albumKey,
+          mbid: isUuid(albumProviderId) ? albumProviderId : null,
+          releaseGroupMbid: isUuid(albumProviderId) ? albumProviderId : null,
+          artistId: artistRecord.id,
+          title: text(album.title) || "Unknown Album",
+          albumArtist: artistName,
+          releaseDate: album.releaseDate || null,
+          metadata: { ...album, librarySource: "lidarr" },
+          syncSearch,
+        });
+        for (const track of tracksByAlbumId.get(String(album.id)) || []) {
+          const trackProviderId = text(track.foreignRecordingId || track.foreignTrackId);
+          const trackKey =
+            (trackProviderId &&
+              buildIdentityKey(isUuid(trackProviderId) ? "recording" : "lidarr-track", trackProviderId)) ||
+            buildFallbackIdentityKey("lidarr-track", albumRecord.id, track.id, track.title);
+          const trackRecord = upsertLibraryTrack({
+            identityKey: trackKey,
+            mbid: isUuid(trackProviderId) ? trackProviderId : null,
+            title: text(track.title || track.trackTitle) || "Unknown Track",
+            artistName,
+            metadata: track,
+            syncSearch,
+          });
+          const trackNumber = Number(track.trackNumber || track.absoluteTrackNumber) || 0;
+          linkLibraryAlbumTrack({
+            albumId: albumRecord.id,
+            trackId: trackRecord.id,
+            discNumber: Number(track.mediumNumber || track.discNumber) || 1,
+            trackNumber,
+            syncSearch,
+          });
+
+          const indexedFile = indexedFiles.get(track);
+          if (!indexedFile) continue;
+          const { resolvedFile, stat } = indexedFile;
+          upsertLibraryMediaFile({
+            trackId: trackRecord.id,
+            albumId: albumRecord.id,
+            source: "lidarr",
+            path: resolvedFile.localPath,
+            format: path.extname(resolvedFile.localPath).slice(1).toLowerCase(),
+            size: stat.size,
+            mtimeMs: stat.mtimeMs,
+            durationMs: track.duration || resolvedFile.file?.duration || null,
+            quality: resolvedFile.file?.mediaInfo || track.mediaInfo || null,
+            available: true,
+            scanId,
+          });
+          unseenPaths.delete(resolvedFile.localPath);
+          result.filesIndexed += 1;
+        }
+      }
+      if (result.filesFailed === 0 && result.filesIndexed > 0) {
+        markLibraryMediaFilesUnavailable("lidarr", unseenPaths);
+      }
+      return result;
+    })();
   });
 }
 

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -230,7 +230,10 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
 
     for (const album of Array.isArray(albums) ? albums : []) {
       const artist = artistById.get(String(album?.artistId));
-      if (!artist || !album?.id) continue;
+      if (!artist || !album?.id) {
+        result.filesFailed += 1;
+        continue;
+      }
       const batch = db.transaction(() => {
         const seenPaths = [];
         let filesIndexed = 0;

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { db, dbHelpers } from "../config/db-sqlite.js";
 import { invalidateCanonicalLibraryCache } from "./libraryQueryService.js";
 import {
@@ -34,12 +35,13 @@ const LIDARR_METADATA_KEYS = [
 ];
 
 let libraryScanDepth = 0;
-let libraryScanChanged = false;
 let libraryCacheInvalidationPending = false;
+const libraryScanContext = new AsyncLocalStorage();
 
 const invalidateLibraryCache = () => {
-  if (libraryScanDepth > 0) {
-    libraryScanChanged = true;
+  const scan = libraryScanContext.getStore();
+  if (scan) {
+    scan.changed = true;
     libraryCacheInvalidationPending = true;
     return;
   }
@@ -509,23 +511,27 @@ export function markLibraryMediaFilesUnavailable(source, paths) {
 }
 
 export async function withLibraryScan(source, rootPath, run) {
-  if (libraryScanDepth === 0) libraryScanChanged = false;
-  libraryScanDepth += 1;
-  const scanId = beginLibraryScan({ source, rootPath });
-  try {
-    const result = await run(scanId);
-    finishLibraryScan(scanId, { ...result, status: "complete" });
-    return { scanId, ...result, changed: libraryScanChanged, status: "complete" };
-  } catch (error) {
-    finishLibraryScan(scanId, { status: "failed", error: error.message });
-    throw error;
-  } finally {
-    libraryScanDepth -= 1;
-    if (libraryScanDepth === 0 && libraryCacheInvalidationPending) {
-      libraryCacheInvalidationPending = false;
-      invalidateCanonicalLibraryCache();
+  const parentScan = libraryScanContext.getStore();
+  const scan = { changed: false };
+  return libraryScanContext.run(scan, async () => {
+    libraryScanDepth += 1;
+    const scanId = beginLibraryScan({ source, rootPath });
+    try {
+      const result = await run(scanId);
+      finishLibraryScan(scanId, { ...result, status: "complete" });
+      return { scanId, ...result, changed: scan.changed, status: "complete" };
+    } catch (error) {
+      finishLibraryScan(scanId, { status: "failed", error: error.message });
+      throw error;
+    } finally {
+      if (scan.changed && parentScan) parentScan.changed = true;
+      libraryScanDepth -= 1;
+      if (libraryScanDepth === 0 && libraryCacheInvalidationPending) {
+        libraryCacheInvalidationPending = false;
+        invalidateCanonicalLibraryCache();
+      }
     }
-  }
+  });
 }
 
 export function getLibrarySnapshot() {

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -34,10 +34,12 @@ const LIDARR_METADATA_KEYS = [
 ];
 
 let libraryScanDepth = 0;
+let libraryScanChanged = false;
 let libraryCacheInvalidationPending = false;
 
 const invalidateLibraryCache = () => {
   if (libraryScanDepth > 0) {
+    libraryScanChanged = true;
     libraryCacheInvalidationPending = true;
     return;
   }
@@ -507,14 +509,13 @@ export function markLibraryMediaFilesUnavailable(source, paths) {
 }
 
 export async function withLibraryScan(source, rootPath, run) {
+  if (libraryScanDepth === 0) libraryScanChanged = false;
   libraryScanDepth += 1;
   const scanId = beginLibraryScan({ source, rootPath });
-  const changesBefore = db.prepare("SELECT total_changes() AS count").get().count;
   try {
     const result = await run(scanId);
-    const changed = db.prepare("SELECT total_changes() AS count").get().count > changesBefore;
     finishLibraryScan(scanId, { ...result, status: "complete" });
-    return { scanId, ...result, changed, status: "complete" };
+    return { scanId, ...result, changed: libraryScanChanged, status: "complete" };
   } catch (error) {
     finishLibraryScan(scanId, { status: "failed", error: error.message });
     throw error;

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -515,13 +515,14 @@ export async function withLibraryScan(source, rootPath, run) {
   const scan = { changed: false };
   return libraryScanContext.run(scan, async () => {
     libraryScanDepth += 1;
-    const scanId = beginLibraryScan({ source, rootPath });
+    let scanId;
     try {
+      scanId = beginLibraryScan({ source, rootPath });
       const result = await run(scanId);
       finishLibraryScan(scanId, { ...result, status: "complete" });
       return { scanId, ...result, changed: scan.changed, status: "complete" };
     } catch (error) {
-      finishLibraryScan(scanId, { status: "failed", error: error.message });
+      if (scanId) finishLibraryScan(scanId, { status: "failed", error: error.message });
       throw error;
     } finally {
       if (scan.changed && parentScan) parentScan.changed = true;

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -99,7 +99,11 @@ export function upsertLibraryArtist({
   const timestamp = now();
   const key = normalizeText(identityKey);
   const artistName = normalizeText(name);
+  const artistMbid = mbid || null;
+  const artistSortName = sortName || null;
+  const metadataText = stringify(metadata);
   if (!key || !artistName) throw new Error("Library artist identityKey and name are required");
+  let libraryChanged = false;
   const artist = db.transaction(() => {
     const fallbackKey = buildFallbackIdentityKey("artist", artistName);
     if (mbid) {
@@ -108,22 +112,24 @@ export function upsertLibraryArtist({
         ? null
         : db.prepare("SELECT id FROM library_artists WHERE identity_key = ?").get(fallbackKey);
       if (fallback) {
-        db.prepare(
+        libraryChanged = db.prepare(
           `INSERT OR IGNORE INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
            SELECT user_id, entity_kind, ?, created_at
            FROM subsonic_stars
            WHERE entity_kind = 'artist' AND entity_key = ?`,
-        ).run(key, fallbackKey);
-        db.prepare(
+        ).run(key, fallbackKey).changes > 0 || libraryChanged;
+        libraryChanged = db.prepare(
           "DELETE FROM subsonic_stars WHERE entity_kind = 'artist' AND entity_key = ?",
-        ).run(fallbackKey);
+        ).run(fallbackKey).changes > 0 || libraryChanged;
       }
       if (fallback && !resolved) {
-        db.prepare("UPDATE library_artists SET identity_key = ? WHERE id = ?").run(key, fallback.id);
+        libraryChanged = db.prepare("UPDATE library_artists SET identity_key = ? WHERE id = ?")
+          .run(key, fallback.id).changes > 0 || libraryChanged;
       } else if (fallback && resolved && fallback.id !== resolved.id) {
-        db.prepare("UPDATE library_albums SET artist_id = ? WHERE artist_id = ?")
-          .run(resolved.id, fallback.id);
-        db.prepare("DELETE FROM library_artists WHERE id = ?").run(fallback.id);
+        libraryChanged = db.prepare("UPDATE library_albums SET artist_id = ? WHERE artist_id = ?")
+          .run(resolved.id, fallback.id).changes > 0 || libraryChanged;
+        libraryChanged = db.prepare("DELETE FROM library_artists WHERE id = ?")
+          .run(fallback.id).changes > 0 || libraryChanged;
       }
     } else if (key === fallbackKey) {
       const resolved = db.prepare(
@@ -137,6 +143,17 @@ export function upsertLibraryArtist({
         return resolved[0];
       }
     }
+    const existing = db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
+    if (
+      existing &&
+      (artistMbid == null || artistMbid === existing.mbid) &&
+      artistName === existing.name &&
+      (artistSortName == null || artistSortName === existing.sort_name) &&
+      (metadataText == null || metadataText === existing.metadata_json)
+    ) {
+      if (syncSearch) syncLibrarySearchArtist(existing.id);
+      return existing;
+    }
     db.prepare(
       `INSERT INTO library_artists (identity_key, mbid, name, sort_name, metadata_json, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -146,12 +163,13 @@ export function upsertLibraryArtist({
          sort_name = COALESCE(excluded.sort_name, library_artists.sort_name),
          metadata_json = COALESCE(excluded.metadata_json, library_artists.metadata_json),
          updated_at = excluded.updated_at`,
-    ).run(key, mbid || null, artistName, sortName || null, stringify(metadata), timestamp, timestamp);
+    ).run(key, artistMbid, artistName, artistSortName, metadataText, timestamp, timestamp);
+    libraryChanged = true;
     const row = db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);
     if (syncSearch) syncLibrarySearchArtist(row?.id);
     return row;
   })();
-  invalidateLibraryCache();
+  if (libraryChanged) invalidateLibraryCache();
   return artist;
 }
 
@@ -211,10 +229,37 @@ export function upsertLibraryAlbum({
   const timestamp = now();
   const key = normalizeText(identityKey);
   const albumTitle = normalizeText(title);
+  const albumMbid = mbid || null;
+  const albumReleaseGroupMbid = releaseGroupMbid || null;
+  const albumArtistName = albumArtist || null;
+  const albumReleaseDate = releaseDate || null;
+  const metadataText = stringify(metadata);
   if (!key || !Number.isSafeInteger(Number(artistId)) || !albumTitle) {
     throw new Error("Library album identityKey, artistId, and title are required");
   }
+  let libraryChanged = false;
   const album = db.transaction(() => {
+    const existing = db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
+    if (
+      existing &&
+      (albumMbid == null || albumMbid === existing.mbid) &&
+      (albumReleaseGroupMbid == null || albumReleaseGroupMbid === existing.release_group_mbid) &&
+      Number(artistId) === existing.artist_id &&
+      albumTitle === existing.title &&
+      (albumArtistName == null || albumArtistName === existing.album_artist) &&
+      (albumReleaseDate == null || albumReleaseDate === existing.release_date) &&
+      (metadataText == null || metadataText === existing.metadata_json)
+    ) {
+      const searchChanged = syncSearch && syncLibrarySearchAlbum(existing.id);
+      if (searchChanged) {
+        for (const track of db.prepare(
+          "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
+        ).all(existing.id)) {
+          syncLibrarySearchTrack(track.track_id);
+        }
+      }
+      return existing;
+    }
     db.prepare(
       `INSERT INTO library_albums
         (identity_key, mbid, release_group_mbid, artist_id, title, album_artist, release_date, metadata_json, created_at, updated_at)
@@ -230,16 +275,17 @@ export function upsertLibraryAlbum({
          updated_at = excluded.updated_at`,
     ).run(
       key,
-      mbid || null,
-      releaseGroupMbid || null,
+      albumMbid,
+      albumReleaseGroupMbid,
       Number(artistId),
       albumTitle,
-      albumArtist || null,
-      releaseDate || null,
-      stringify(metadata),
+      albumArtistName,
+      albumReleaseDate,
+      metadataText,
       timestamp,
       timestamp,
     );
+    libraryChanged = true;
     const row = db.prepare("SELECT * FROM library_albums WHERE identity_key = ?").get(key);
     const searchChanged = syncSearch && syncLibrarySearchAlbum(row?.id);
     if (row?.id && searchChanged) {
@@ -251,7 +297,7 @@ export function upsertLibraryAlbum({
     }
     return row;
   })();
-  invalidateLibraryCache();
+  if (libraryChanged) invalidateLibraryCache();
   return album;
 }
 
@@ -266,8 +312,23 @@ export function upsertLibraryTrack({
   const timestamp = now();
   const key = normalizeText(identityKey);
   const trackTitle = normalizeText(title);
+  const trackMbid = mbid || null;
+  const trackArtistName = artistName || null;
+  const metadataText = stringify(metadata);
   if (!key || !trackTitle) throw new Error("Library track identityKey and title are required");
+  let libraryChanged = false;
   const track = db.transaction(() => {
+    const existing = db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
+    if (
+      existing &&
+      (trackMbid == null || trackMbid === existing.mbid) &&
+      trackTitle === existing.title &&
+      (trackArtistName == null || trackArtistName === existing.artist_name) &&
+      (metadataText == null || metadataText === existing.metadata_json)
+    ) {
+      if (syncSearch) syncLibrarySearchTrack(existing.id);
+      return existing;
+    }
     db.prepare(
       `INSERT INTO library_tracks (identity_key, mbid, title, artist_name, metadata_json, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -277,12 +338,13 @@ export function upsertLibraryTrack({
          artist_name = COALESCE(excluded.artist_name, library_tracks.artist_name),
          metadata_json = COALESCE(excluded.metadata_json, library_tracks.metadata_json),
          updated_at = excluded.updated_at`,
-    ).run(key, mbid || null, trackTitle, artistName || null, stringify(metadata), timestamp, timestamp);
+    ).run(key, trackMbid, trackTitle, trackArtistName, metadataText, timestamp, timestamp);
+    libraryChanged = true;
     const row = db.prepare("SELECT * FROM library_tracks WHERE identity_key = ?").get(key);
     if (syncSearch) syncLibrarySearchTrack(row?.id);
     return row;
   })();
-  invalidateLibraryCache();
+  if (libraryChanged) invalidateLibraryCache();
   return track;
 }
 
@@ -293,24 +355,25 @@ export function linkLibraryAlbumTrack({
   trackNumber = 0,
   syncSearch = true,
 }) {
-  db.transaction(() => {
-    db.prepare(
+  const changed = db.transaction(() => {
+    const result = db.prepare(
       `INSERT OR IGNORE INTO library_album_tracks
         (album_id, track_id, disc_number, track_number, created_at)
        VALUES (?, ?, ?, ?, ?)`,
     ).run(Number(albumId), Number(trackId), Number(discNumber) || 1, Number(trackNumber) || 0, now());
     if (syncSearch) syncLibrarySearchTrack(trackId);
+    return result.changes > 0;
   })();
-  invalidateLibraryCache();
+  if (changed) invalidateLibraryCache();
 }
 
 export function removeLibraryAlbumTracksWithoutMedia(albumId, source, { syncSearch = true } = {}) {
   const mediaSource = normalizeText(source);
-  db.transaction(() => {
+  const changed = db.transaction(() => {
     const trackIds = db.prepare(
       "SELECT track_id FROM library_album_tracks WHERE album_id = ?",
     ).all(Number(albumId)).map((row) => row.track_id);
-    db.prepare(
+    const result = db.prepare(
       `DELETE FROM library_album_tracks
        WHERE album_id = ?
          AND NOT EXISTS (
@@ -333,8 +396,9 @@ export function removeLibraryAlbumTracksWithoutMedia(albumId, source, { syncSear
     if (syncSearch) {
       for (const trackId of trackIds) syncLibrarySearchTrack(trackId);
     }
+    return result.changes > 0;
   })();
-  invalidateLibraryCache();
+  if (changed) invalidateLibraryCache();
 }
 
 export function upsertLibraryMediaFile({
@@ -358,6 +422,28 @@ export function upsertLibraryMediaFile({
   const normalizedAlbumId = Number.isSafeInteger(Number(albumId)) && Number(albumId) > 0
     ? Number(albumId)
     : null;
+  const normalizedFormat = format || null;
+  const normalizedSize = Number(size) || 0;
+  const normalizedMtimeMs = Number.isFinite(Number(mtimeMs)) ? Number(mtimeMs) : null;
+  const normalizedDurationMs = Number.isFinite(Number(durationMs)) ? Number(durationMs) : null;
+  const qualityText = stringify(quality);
+  const normalizedAvailable = available === true ? 1 : 0;
+  const existing = db.prepare(
+    "SELECT * FROM library_media_files WHERE source = ? AND path = ?",
+  ).get(fileSource, filePath);
+  if (
+    existing &&
+    Number(trackId) === existing.track_id &&
+    (normalizedAlbumId == null || normalizedAlbumId === existing.album_id) &&
+    normalizedFormat === existing.format &&
+    normalizedSize === existing.size &&
+    normalizedMtimeMs === existing.mtime_ms &&
+    normalizedDurationMs === existing.duration_ms &&
+    (qualityText == null || qualityText === existing.quality_json) &&
+    normalizedAvailable === existing.available
+  ) {
+    return existing;
+  }
   const timestamp = now();
   db.prepare(
     `INSERT INTO library_media_files
@@ -380,35 +466,55 @@ export function upsertLibraryMediaFile({
     normalizedAlbumId,
     fileSource,
     filePath,
-    format || null,
-    Number(size) || 0,
-    Number.isFinite(Number(mtimeMs)) ? Number(mtimeMs) : null,
-    Number.isFinite(Number(durationMs)) ? Number(durationMs) : null,
-    stringify(quality),
-    available === true ? 1 : 0,
+    normalizedFormat,
+    normalizedSize,
+    normalizedMtimeMs,
+    normalizedDurationMs,
+    qualityText,
+    normalizedAvailable,
     Number(scanId),
     timestamp,
     timestamp,
   );
   invalidateLibraryCache();
+  return db.prepare("SELECT * FROM library_media_files WHERE source = ? AND path = ?")
+    .get(fileSource, filePath);
 }
 
-export function markUnseenFilesUnavailable(scanId, source) {
-  db.prepare(
+export function getAvailableLibraryMediaPaths(source) {
+  return new Set(
+    db.prepare(
+      "SELECT path FROM library_media_files WHERE source = ? AND available = 1",
+    ).all(normalizeText(source)).map((row) => row.path),
+  );
+}
+
+export function markLibraryMediaFilesUnavailable(source, paths) {
+  const mediaSource = normalizeText(source);
+  const missingPaths = [...new Set(paths)].map(normalizeText).filter(Boolean);
+  if (!mediaSource || missingPaths.length === 0) return 0;
+  const update = db.prepare(
     `UPDATE library_media_files
      SET available = 0, updated_at = ?
-     WHERE source = ? AND (last_seen_scan_id IS NULL OR last_seen_scan_id != ?)`,
-  ).run(now(), normalizeText(source), Number(scanId));
-  invalidateLibraryCache();
+     WHERE source = ? AND path = ? AND available = 1`,
+  );
+  const changed = db.transaction(() => missingPaths.reduce(
+    (count, filePath) => count + update.run(now(), mediaSource, filePath).changes,
+    0,
+  ))();
+  if (changed > 0) invalidateLibraryCache();
+  return changed;
 }
 
 export async function withLibraryScan(source, rootPath, run) {
   libraryScanDepth += 1;
   const scanId = beginLibraryScan({ source, rootPath });
+  const changesBefore = db.prepare("SELECT total_changes() AS count").get().count;
   try {
     const result = await run(scanId);
+    const changed = db.prepare("SELECT total_changes() AS count").get().count > changesBefore;
     finishLibraryScan(scanId, { ...result, status: "complete" });
-    return { scanId, ...result, status: "complete" };
+    return { scanId, ...result, changed, status: "complete" };
   } catch (error) {
     finishLibraryScan(scanId, { status: "failed", error: error.message });
     throw error;


### PR DESCRIPTION
Library refreshes rewrote every artist, album, track, and media row even when Lidarr and the files had not changed. Large libraries produced heavy SQLite WAL traffic and disk writes during each scan.

This change skips unchanged entity writes, reconciles removed files from the paths seen during the scan, and batches the Lidarr persistence phase in one transaction. A configured refresh now rebuilds search and genre data only when either library source changed.

Verification:

- The regression test failed before the fix because a second unchanged scan replaced all four updated timestamps.
- An unchanged direct Lidarr scan now makes only two scan-run bookkeeping changes.
- An unchanged configured refresh now makes only four bookkeeping changes across the local and Lidarr scans.
- Removed-file and partial-scan availability tests pass.
- Full automated suite: 840 passing.
- Focused post-change library suite: 41 passing.
- Backend lint passes.
- The 100,000-track performance gate passes.

The report also suggests that CIFS file watching may trigger scans unexpectedly. This PR reduces the cost of every scan but does not claim that trigger is confirmed.

Refs #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library scans to accurately mark unavailable media files, including overlapping scans.
  * Unchanged Lidarr rescans no longer modify records or timestamps unnecessarily.
  * Preserved configured genre statistics during rescans.
  * Prevented unnecessary search-index and genre-statistics rebuilds when no library changes occur.
  * Search indexes and genre statistics are now repaired after scan failures.
  * Improved scan reliability by validating media files before updating the library.
  * Reduced processing interruptions during large Lidarr album scans.
  * Ensured failed scans correctly report their status while preserving library consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->