### PR TITLE
fix(library): resolve playlist favorites to canonical tracks

### DIFF
--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -35,6 +35,8 @@ let sharedPlaylist;
 let syncedFavoritePlaylist;
 let syncedFavoriteSourcePath;
 let syncedFavoriteSourceJobId;
+let canonicalFavoritePlaylist;
+let canonicalFavoriteJobId;
 
 function subsonicUrl(method, params = {}) {
   const query = new URLSearchParams({
@@ -164,6 +166,26 @@ test.before(async () => {
     durationMs: 1000,
   }, sharedPlaylist.id);
   downloadTracker.setDone(sharedJobId, fixturePath);
+  canonicalFavoritePlaylist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Canonical Favorite Playlist",
+    ownerUserId: alice.id,
+    tracks: [{
+      artistName: "Canonical Artist",
+      albumName: "Canonical Album",
+      trackName: "Canonical Song",
+      durationMs: 10_000,
+    }],
+  });
+  canonicalFavoriteJobId = downloadTracker.addJob({
+    artistName: "Canonical Artist",
+    artistMbid: "11111111-1111-4111-8111-111111111111",
+    albumName: "Canonical Album",
+    albumMbid: "22222222-2222-4222-8222-222222222222",
+    trackName: "Canonical Song",
+    trackMbid: "33333333-3333-4333-8333-333333333333",
+    durationMs: 10_000,
+  }, canonicalFavoritePlaylist.id);
+  downloadTracker.setDone(canonicalFavoriteJobId, fixturePath, "Canonical Album");
   const syncedFavoriteTrack = {
     artistName: "Synced Favorite Artist",
     albumName: "Synced Favorite Album",
@@ -642,6 +664,37 @@ test("favoriting a synced playlist track keeps it when the source removes it", a
     if (libraryJobId) downloadTracker.removeJob(libraryJobId);
     await rm(path.join(weeklyFlowRoot, track.artistName), { recursive: true, force: true });
     flowPlaylistConfig.deleteSharedPlaylist(playlist.id);
+  }
+});
+
+test("playlist favorites resolve to the owned canonical track", async () => {
+  const playlistSongId = `shared-song:${encodeURIComponent(`${canonicalFavoritePlaylist.id}:${canonicalFavoriteJobId}`)}`;
+  let canonicalSongId;
+  try {
+    assert.equal(responseJson(await request("star", { id: playlistSongId })).status, "ok");
+
+    const favorites = await (await apiFetch("/api/library/favorites")).json();
+    assert.deepEqual(favorites.library.tracks.map((track) => track.title), ["Canonical Song"]);
+    assert.equal(favorites.song.some((song) => /^song:/.test(song.id)), true);
+
+    const album = responseJson(await request("getArtist", {
+      id: responseJson(await request("getArtists")).artists.index[0].artist[0].id,
+    })).artist.album[0];
+    canonicalSongId = responseJson(await request("getAlbum", { id: album.id })).album.song[0].id;
+    const page = await (await apiFetch(
+      "/api/library/canonical?kind=tracks&page=1&pageSize=100&availableOnly=true",
+    )).json();
+    assert.equal(page.items.find((track) => track.title === "Canonical Song").userFavorite, true);
+
+    assert.equal(responseJson(await request("unstar", { id: canonicalSongId })).status, "ok");
+    assert.equal(
+      responseJson(await request("getStarred")).starred.song.some(
+        (song) => song.id === canonicalSongId,
+      ),
+      false,
+    );
+  } finally {
+    await request("unstar", { id: [playlistSongId, canonicalSongId].filter(Boolean) });
   }
 });
 

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -570,7 +570,18 @@ const findAvailableCanonicalFile = (track) => {
       }));
   const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   const file = firstFile(candidate);
-  return file?.available && file.path ? { file, albumName: findAlbumForTrack(library, candidate)?.title } : null;
+  return file?.available && file.path
+    ? { file, track: candidate, albumName: findAlbumForTrack(library, candidate)?.title }
+    : null;
+};
+
+const canonicalStarRow = (user, row) => {
+  if (!["flow-song", "shared-song"].includes(row?.entity_kind)) return row;
+  const playlistSong = resolvePlaylistSong(user, idFor(row.entity_kind, row.entity_key));
+  const canonical = playlistSong ? findAvailableCanonicalFile(playlistSong.track)?.track : null;
+  return canonical
+    ? { ...row, entity_kind: "song", entity_key: canonical.identityKey }
+    : row;
 };
 
 const ensureLibraryJob = (track, createdJobIds = null) => {
@@ -786,8 +797,21 @@ export function unstar(user, value) {
 export function unstarMany(user, values) {
   const parsed = values.map(starTarget);
   if (!parsed.length || parsed.some((target) => !target) || !user?.id) return false;
+  const targetKeys = new Set(parsed.flatMap((target) => {
+    const row = { entity_kind: target.kind, entity_key: target.key };
+    const canonical = canonicalStarRow(user, row);
+    return [row, canonical].map((entry) => `${entry.entity_kind}:${entry.entity_key}`);
+  }));
   const removeStars = db.transaction(() => {
-    for (const target of parsed) removeStarStmt.run(user.id, target.kind, target.key);
+    for (const row of starredRows(user)) {
+      const canonical = canonicalStarRow(user, row);
+      if (
+        targetKeys.has(`${row.entity_kind}:${row.entity_key}`) ||
+        targetKeys.has(`${canonical.entity_kind}:${canonical.entity_key}`)
+      ) {
+        removeStarStmt.run(user.id, row.entity_kind, row.entity_key);
+      }
+    }
   });
   removeStars();
   return true;
@@ -796,7 +820,10 @@ export function unstarMany(user, values) {
 const starredRows = (user) => (user?.id ? getStarsStmt.all(user.id) : []);
 
 export function getStarredIdentityKeys(user) {
-  return new Set(starredRows(user).map((row) => `${row.entity_kind}:${row.entity_key}`));
+  return new Set(starredRows(user).map((row) => {
+    const canonical = canonicalStarRow(user, row);
+    return `${canonical.entity_kind}:${canonical.entity_key}`;
+  }));
 }
 
 const buildStarred = (library, rows, user) => {
@@ -825,7 +852,7 @@ const buildStarred = (library, rows, user) => {
 };
 
 export function getStarredWithLibrary(user) {
-  const rows = starredRows(user);
+  const rows = starredRows(user).map((row) => canonicalStarRow(user, row));
   const canonicalRows = rows.filter((row) => ["artist", "album", "song"].includes(row.entity_kind));
   const library = getCanonicalLibrary({
     favoriteKeys: canonicalRows.map((row) => ({ kind: row.entity_kind, key: row.entity_key })),

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -43,9 +43,10 @@ import {
   deleteAlbumFromLibrary,
   deleteArtistFromLibrary,
   deleteTrackFromLibrary,
+  fetchCanonicalLibraryPage,
   getCanonicalLibraryPage,
-  getLibraryRefreshStatus,
   getLibraryFavorites,
+  getLibraryRefreshStatus,
   getRequests,
   downloadTrackToLibrary,
   requestLibraryRefresh,
@@ -550,20 +551,21 @@ function LibraryPage() {
     queryFn: async ({ signal }) => {
       const nextData = isDetail
         ? routeAlbumId
-          ? await getCanonicalLibraryPage({
+          ? await fetchCanonicalLibraryPage({
               kind: "tracks",
               albumId: routeAlbumId,
               page: 1,
               pageSize,
             }, { signal })
           : await Promise.all([
-              getCanonicalLibraryPage({
+              fetchCanonicalLibraryPage({
                 kind: "albums",
                 artistId: routeArtistId,
                 page: 1,
                 pageSize,
+                availableOnly: true,
               }, { signal }),
-              getCanonicalLibraryPage({
+              fetchCanonicalLibraryPage({
                 kind: "tracks",
                 artistId: routeArtistId,
                 page: 1,
@@ -575,13 +577,13 @@ function LibraryPage() {
           ? await getLibraryFavorites({ signal })
           : section === "home"
             ? await Promise.all([
-                getCanonicalLibraryPage({
+                fetchCanonicalLibraryPage({
                   kind: "albums",
                   page: 1,
                   pageSize,
                   sort: "newest",
                 }, { signal }),
-                getCanonicalLibraryPage({
+                fetchCanonicalLibraryPage({
                   kind: "tracks",
                   page: 1,
                   pageSize: 12,
@@ -589,7 +591,7 @@ function LibraryPage() {
                   availableOnly: true,
                 }, { signal }),
               ])
-            : await getCanonicalLibraryPage({
+            : await fetchCanonicalLibraryPage({
                 kind: tab,
                 page: pageIndex,
                 pageSize,

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -22,28 +22,33 @@ const mergeSignals = (callerSignal, querySignal) => {
 export const getLibraryArtists = (options = {}) =>
   getData("/library/artists", options);
 
+const canonicalLibraryPageParams = (options = {}) => Object.fromEntries(
+  Object.entries({
+    kind: options.kind,
+    page: options.page,
+    pageSize: options.pageSize,
+    query: options.query,
+    genre: options.genre,
+    sort: options.sort,
+    direction: options.direction,
+    artistId: options.artistId,
+    albumId: options.albumId,
+    source: options.source || "all",
+    availableOnly: options.availableOnly === true ? "true" : "false",
+  }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
+);
+
+export const fetchCanonicalLibraryPage = (options = {}, { signal } = {}) =>
+  getData("/library/canonical", { params: canonicalLibraryPageParams(options), signal });
+
 export const getCanonicalLibraryPage = (options = {}, { signal } = {}) => {
-  const params = Object.fromEntries(
-    Object.entries({
-      kind: options.kind,
-      page: options.page,
-      pageSize: options.pageSize,
-      query: options.query,
-      genre: options.genre,
-      sort: options.sort,
-      direction: options.direction,
-      artistId: options.artistId,
-      albumId: options.albumId,
-      source: options.source || "all",
-      availableOnly: options.availableOnly === true ? "true" : "false",
-    }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
-  );
+  const params = canonicalLibraryPageParams(options);
   return queryClient.fetchQuery({
     queryKey: queryKeys.libraryCanonical(params),
-    queryFn: ({ signal: querySignal }) => getData("/library/canonical", {
-      params,
-      signal: mergeSignals(signal, querySignal),
-    }),
+    queryFn: ({ signal: querySignal }) => fetchCanonicalLibraryPage(
+      options,
+      { signal: mergeSignals(signal, querySignal) },
+    ),
     staleTime: 15_000,
   });
 };


### PR DESCRIPTION
## What changed

Playlist favorites now resolve to their owned canonical tracks across Subsonic responses, library favorites, and unstar operations. Library page requests also use the shared canonical-page fetcher with cancellation support.

## Why

Favoriting a playlist track could leave the favorite tied to a playlist-specific identity instead of the canonical library track. This caused inconsistent favorites, duplicate identity handling, and incorrect removal behavior.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The Library page now loads canonical library data through the shared request path. No intentional visual changes.

## Testing

- Added an integration test covering playlist favorites resolving to the owned canonical track.
- Verified favorite listing, canonical library favorite state, and unstar behavior.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change