### PR TITLE
fix(subsonic): fall back to canonical track search

### DIFF
--- a/.tests/subsonic/subsonic-canonical.int.test.js
+++ b/.tests/subsonic/subsonic-canonical.int.test.js
@@ -182,7 +182,7 @@ test.before(async () => {
     albumName: "Canonical Album",
     albumMbid: "22222222-2222-4222-8222-222222222222",
     trackName: "Canonical Song",
-    trackMbid: "33333333-3333-4333-8333-333333333333",
+    trackMbid: "55555555-5555-4555-8555-555555555555",
     durationMs: 10_000,
   }, canonicalFavoritePlaylist.id);
   downloadTracker.setDone(canonicalFavoriteJobId, fixturePath, "Canonical Album");

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -555,7 +555,7 @@ const findReusableLibrarySource = (track) =>
   );
 
 const findAvailableCanonicalFile = (track) => {
-  const library = indexFocusedLibrary(track?.trackMbid
+  let library = indexFocusedLibrary(track?.trackMbid
     ? getCanonicalTrack({
         trackId: track.trackMbid,
         source: "all",
@@ -568,7 +568,17 @@ const findAvailableCanonicalFile = (track) => {
         artist: track?.artistName,
         limit: 25,
       }));
-  const candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
+  let candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
+  if (!candidate && track?.trackMbid) {
+    library = indexFocusedLibrary(getCanonicalTrackPage({
+      source: "all",
+      availableOnly: true,
+      query: track.trackName,
+      artist: track.artistName,
+      limit: 25,
+    }));
+    candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
+  }
   const file = firstFile(candidate);
   return file?.available && file.path
     ? { file, track: candidate, albumName: findAlbumForTrack(library, candidate)?.title }


### PR DESCRIPTION
## What changed

Add a fallback search by canonical track name and artist when the MBID-focused lookup cannot find an available file.

## Why

Some canonical tracks have mismatched or unavailable MBIDs, preventing reusable library files from being found. The fallback allows matching tracks to resolve through the canonical search path.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Updated the Subsonic canonical integration fixture.
- Ran the applicable Subsonic canonical integration test.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved canonical playlist track matching by first using the track’s unique identifier and then falling back to title and artist details when needed.
  - Canonical playlist items now resolve to available library files more reliably, including cases where track identifiers differ from the library copy.
- **Tests**
  - Updated coverage to validate matching canonical playlist tracks with distinct identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->