### PR TITLE
docs(release): add 2.6.1 performance release notes

### DIFF
--- a/release-notes/2.6.1.md
+++ b/release-notes/2.6.1.md
@@ -1,0 +1,11 @@
+2.6.1 keeps routine library refreshes lighter, especially for larger collections.
+
+## Performance
+
+- Unchanged library scans now skip row updates, reducing SQLite writes and WAL growth.
+- Lidarr scans persist album batches and yield between albums, keeping large refreshes responsive.
+- Search and genre indexes rebuild only when a scan changes library data or needs repair after a failure.
+
+## Full change list
+
+The [full change list from 2.6.0 to 2.6.1](https://github.com/lklynet/aurral/compare/v2.6.0...v2.6.1) includes every pull request and fix.


### PR DESCRIPTION
## What changed

Added release notes for version 2.6.1, covering reduced SQLite writes, responsive Lidarr scans, and conditional search and genre index rebuilds.

## Why

Documents the performance improvements included in the 2.6.1 release and links to the complete change list.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

Not applicable.

## Testing

Not run; this change only adds release documentation.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 2.6.1.
  * Documented reduced database activity and WAL growth for unchanged scans.
  * Documented more responsive album-batch persistence and conditional search and genre index rebuilding.
  * Included a link to the complete change list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->