### PR TITLE
fix(weekly-flow): persist queued upgrade state

### DIFF
--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -18,6 +18,7 @@ const [
   { flowPlaylistConfig },
   { playlistManager },
   { weeklyFlowWorker },
+  { queueQualityUpgrade },
   { registerJobs },
 ] = await setupIsolatedBackend(
   "approved-import-path",
@@ -27,6 +28,7 @@ const [
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
   "backend/services/weeklyFlow/weeklyFlowWorker.js",
+  "backend/services/qualityProfileService.js",
   "backend/routes/weeklyFlow/handlers/jobs.js",
 );
 
@@ -152,6 +154,54 @@ test("reports when an upgrade search is already queued for a track", async () =>
   assert.equal(second.status, 200, JSON.stringify(payload));
   assert.equal(payload.alreadyQueued, true);
   assert.equal(payload.queued, 0);
+});
+
+test("records queued upgrade history if the pipeline removes the live job immediately", async () => {
+  const playlistId = "e6be4cd3-10b0-4744-baa1-7e960a41ca54";
+  flowPlaylistConfig.createSharedPlaylist({
+    id: playlistId,
+    name: "Fast failure",
+    tracks: [{ artistName: "Artist", trackName: "Fast failure track", albumName: "Album" }],
+  });
+  dbOps.updateSettings({
+    ...dbOps.getSettings(),
+    integrations: {
+      slskd: { enabled: true, url: "http://127.0.0.1:1", apiKey: "test-key" },
+    },
+  });
+  const finalPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "aurral-weekly-flow",
+    playlistId,
+    "Artist",
+    "Album",
+    "Fast failure track.mp3",
+  );
+  await fs.mkdir(path.dirname(finalPath), { recursive: true });
+  await fs.writeFile(finalPath, "audio");
+  const jobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Fast failure track", albumName: "Album" },
+    playlistId,
+  );
+  downloadTracker.setDone(jobId, finalPath, "Album");
+  downloadTracker.updateQuality(jobId, { tier: "mp3-128", format: "mp3" });
+
+  const originalEnqueue = downloadTracker.enqueueDownloadPipeline;
+  downloadTracker.enqueueDownloadPipeline = (upgradeJobId) => {
+    downloadTracker.removeJob(upgradeJobId);
+    return true;
+  };
+  try {
+    assert.equal(await queueQualityUpgrade(downloadTracker.getJob(jobId)), "queued");
+    assert.equal(
+      dbOps.getAurralHistory().some(
+        (entry) => entry.metadata?.trackName === "Fast failure track",
+      ),
+      true,
+    );
+  } finally {
+    downloadTracker.enqueueDownloadPipeline = originalEnqueue;
+  }
 });
 
 test("search all stays within the requesting user's playlist access", async () => {

--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -18,7 +18,6 @@ const [
   { flowPlaylistConfig },
   { playlistManager },
   { weeklyFlowWorker },
-  honkerDb,
   { registerJobs },
 ] = await setupIsolatedBackend(
   "approved-import-path",
@@ -28,7 +27,6 @@ const [
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
   "backend/services/weeklyFlow/weeklyFlowWorker.js",
-  "backend/services/honkerDb.js",
   "backend/routes/weeklyFlow/handlers/jobs.js",
 );
 
@@ -182,14 +180,46 @@ test("search all stays within the requesting user's playlist access", async () =
   downloadTracker.setFailed(jobId, "No source");
   downloadTracker.setFailed(otherJobId, "No source");
 
+  const ownedPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "aurral-weekly-flow",
+    ownedPlaylistId,
+    "Artist",
+    "Album",
+    "Owned.mp3",
+  );
+  const otherPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "aurral-weekly-flow",
+    otherPlaylistId,
+    "Artist",
+    "Album",
+    "Private.mp3",
+  );
+  await fs.mkdir(path.dirname(ownedPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherPath), { recursive: true });
+  await fs.writeFile(ownedPath, "audio");
+  await fs.writeFile(otherPath, "audio");
+  const ownedUpgradeId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Owned", albumName: "Album" },
+    ownedPlaylistId,
+  );
+  const otherUpgradeId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Private", albumName: "Album" },
+    otherPlaylistId,
+  );
+  downloadTracker.setDone(ownedUpgradeId, ownedPath, "Album");
+  downloadTracker.setDone(otherUpgradeId, otherPath, "Album");
+  downloadTracker.updateQuality(ownedUpgradeId, { tier: "mp3-128", format: "mp3" });
+  downloadTracker.updateQuality(otherUpgradeId, { tier: "mp3-128", format: "mp3" });
+  dbOps.updateSettings({
+    ...dbOps.getSettings(),
+    integrations: {
+      slskd: { enabled: true, url: "http://127.0.0.1:1", apiKey: "test-key" },
+    },
+  });
+
   const originalStart = weeklyFlowWorker.start;
-  const systemTaskQueue = honkerDb.getSystemTaskQueue();
-  const originalEnqueue = systemTaskQueue.enqueue;
-  const enqueuedTasks = [];
-  systemTaskQueue.enqueue = (payload, options) => {
-    enqueuedTasks.push({ payload, options });
-    return enqueuedTasks.length;
-  };
   weeklyFlowWorker.start = async () => {};
   requestUser = { role: "user", id: 7 };
   try {
@@ -203,21 +233,29 @@ test("search all stays within the requesting user's playlist access", async () =
     const upgradeResponse = await fetch(`${baseUrl}/quality-upgrades`, { method: "POST" });
     const upgradePayload = await upgradeResponse.json();
     assert.equal(upgradeResponse.status, 200, JSON.stringify(upgradePayload));
-    assert.equal(upgradePayload.scheduled, true);
+    assert.equal(upgradePayload.queued, 1);
     assert.equal(upgradePayload.playlistCount, 1);
-    assert.deepEqual(enqueuedTasks, [
-      {
-        payload: {
-          kind: "quality-upgrade-check",
-          force: true,
-          playlistId: ownedPlaylistId,
-          limit: 500,
-        },
-        options: { priority: -10, runAt: null },
-      },
-    ]);
+    const queuedUpgrade = downloadTracker.getAll().find(
+      (job) => job.upgradeForJobId === ownedUpgradeId,
+    );
+    assert.equal(["pending", "downloading"].includes(queuedUpgrade?.status), true);
+    assert.equal(
+      downloadTracker.getAll().some((job) => job.upgradeForJobId === otherUpgradeId),
+      false,
+    );
+    assert.equal(
+      dbOps.getAurralHistory().some((entry) => entry.metadata?.jobId === queuedUpgrade.id),
+      true,
+    );
+
+    const jobsResponse = await fetch(`${baseUrl}/jobs`);
+    const jobsPayload = await jobsResponse.json();
+    assert.match(jobsResponse.headers.get("cache-control") || "", /no-store/);
+    assert.equal(
+      jobsPayload.some((job) => job.upgradeForJobId === ownedUpgradeId),
+      true,
+    );
   } finally {
-    systemTaskQueue.enqueue = originalEnqueue;
     weeklyFlowWorker.start = originalStart;
     requestUser = { role: "admin" };
   }

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -30,12 +30,12 @@ import { finalizePipelineJobSuccess } from "../../../services/pipelineHelpers.js
 import path from "path";
 import fs from "fs/promises";
 import { invalidateRequestsCache } from "../../requests.js";
-import { enqueueSystemTaskJob } from "../../../services/honkerDb.js";
 import {
   decorateJobQuality,
   classifyQualityJob,
   getQualityProfile,
   queueQualityUpgrade,
+  runQualityUpgradeCheck,
 } from "../../../services/qualityProfileService.js";
 
 const getAccessiblePlaylistIds = (user) => [
@@ -50,7 +50,7 @@ export function registerJobs(router) {
     res.json(getWeeklyFlowStatusSnapshot({ user: req.user }));
   });
 
-  router.get("/jobs/:flowId", async (req, res) => {
+  router.get("/jobs/:flowId", noCache, async (req, res) => {
     const { flowId } = req.params;
     if (!canAccessPlaylistType(req.user, flowId)) {
       return res.status(404).json({ error: "Playlist not found" });
@@ -90,7 +90,7 @@ export function registerJobs(router) {
     res.json(filterJobsForUser(req.user, jobs).map((job) => decorateJobQuality(job, profile)));
   });
 
-  router.get("/jobs", (req, res) => {
+  router.get("/jobs", noCache, (req, res) => {
     const { status } = req.query;
     const jobs = filterJobsForUser(
       req.user,
@@ -115,18 +115,16 @@ export function registerJobs(router) {
     }
   });
 
-  router.post("/quality-upgrades", (req, res) => {
+  router.post("/quality-upgrades", async (req, res) => {
     const playlistIds = getAccessiblePlaylistIds(req.user);
+    let queued = 0;
     for (const playlistId of playlistIds) {
-      enqueueSystemTaskJob(
-        { kind: "quality-upgrade-check", force: true, playlistId, limit: 500 },
-        { priority: -10 },
-      );
+      queued += await runQualityUpgradeCheck({ force: true, playlistId, limit: 500 });
     }
+    if (queued > 0) invalidateRequestsCache();
     return res.json({
       success: true,
-      queued: 0,
-      scheduled: true,
+      queued,
       playlistCount: playlistIds.length,
     });
   });
@@ -147,6 +145,7 @@ export function registerJobs(router) {
     if (result !== "queued") {
       return res.status(409).json({ error: "Track is not eligible for an upgrade" });
     }
+    invalidateRequestsCache();
     return res.json({ success: true, queued: 1, jobId });
   });
 
@@ -155,11 +154,9 @@ export function registerJobs(router) {
     if (!canAccessPlaylistType(req.user, playlistId)) {
       return res.status(404).json({ error: "Playlist not found" });
     }
-    enqueueSystemTaskJob(
-      { kind: "quality-upgrade-check", force: true, playlistId, limit: 500 },
-      { priority: -10 },
-    );
-    return res.json({ success: true, queued: 0, scheduled: true });
+    const queued = await runQualityUpgradeCheck({ force: true, playlistId, limit: 500 });
+    if (queued > 0) invalidateRequestsCache();
+    return res.json({ success: true, queued });
   });
 
   router.put("/playlists/:playlistId/retry-cycle", async (req, res) => {

--- a/backend/routes/weeklyFlow/handlers/utils.js
+++ b/backend/routes/weeklyFlow/handlers/utils.js
@@ -173,7 +173,7 @@ export const canAccessPlaylistType = (user, playlistType) => {
 
 export const filterJobsForUser = (user, jobs) =>
   (Array.isArray(jobs) ? jobs : []).filter((job) =>
-    canAccessPlaylistType(user, job?.playlistType),
+    canAccessPlaylistType(user, job?.playlistId || job?.playlistType),
   );
 
 export const queueFlowSideEffect = (kind, labelPrefix, flowId) => {

--- a/backend/services/qualityProfileService.js
+++ b/backend/services/qualityProfileService.js
@@ -152,6 +152,8 @@ export async function queueQualityUpgrade(job) {
     return "ineligible";
   }
   downloadTracker.markQualityUpgradeChecked(current.id);
+  const { recordTrackJobQueued } = await import("./aurralHistoryService.js");
+  recordTrackJobQueued(downloadTracker.getJob(upgradeJobId));
   return "queued";
 }
 

--- a/backend/services/qualityProfileService.js
+++ b/backend/services/qualityProfileService.js
@@ -147,13 +147,14 @@ export async function queueQualityUpgrade(job) {
   if (downloadTracker.findActiveUpgradeJob(current)) return "already-queued";
   const upgradeJobId = downloadTracker.addUpgradeJob(current);
   if (!upgradeJobId) return "ineligible";
+  const queuedUpgrade = downloadTracker.getJob(upgradeJobId);
   if (!downloadTracker.enqueueDownloadPipeline(upgradeJobId)) {
     downloadTracker.removeJob(upgradeJobId);
     return "ineligible";
   }
   downloadTracker.markQualityUpgradeChecked(current.id);
   const { recordTrackJobQueued } = await import("./aurralHistoryService.js");
-  recordTrackJobQueued(downloadTracker.getJob(upgradeJobId));
+  recordTrackJobQueued(queuedUpgrade);
   return "queued";
 }
 

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -31,7 +31,9 @@ search for a quality upgrade. These actions apply across flows and static
 playlists.
 
 Use **Search all** to re-search every missing track or queue upgrade searches
-for every cutoff-unmet track in the active Wanted view.
+for every cutoff-unmet track in the active Wanted view. Cutoff rows change to
+**Upgrade queued** immediately and keep that state after a page refresh. Follow
+the active searches in **Queue** and their result in **History**.
 
 Use the info action on any activity or Wanted row to inspect the operation
 details without leaving the page.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8902,9 +8902,11 @@ button.native-library-genre-row:focus-visible {
 
 .activity-page__header {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
   min-height: 2.25rem;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.65rem;
 }
 
 .activity-toolbar {
@@ -8925,6 +8927,16 @@ button.native-library-genre-row:focus-visible {
 
 .activity-toolbar__group--end {
   margin-left: auto;
+}
+
+.activity-toolbar__bulk-action {
+  min-height: 2rem;
+  gap: 0.4rem;
+}
+
+.activity-toolbar__bulk-action svg {
+  width: 0.9rem;
+  height: 0.9rem;
 }
 
 .activity-toolbar__filter {

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -41,6 +41,13 @@ const HISTORY_EMPTY_STATE = {
   message: "A chronological log of album requests, track downloads, and other activity will appear here.",
 };
 
+const ACTIVITY_DESCRIPTIONS = {
+  queue: "Work in progress. Completed and failed work moves to History.",
+  history: "Finished activity. Tracks that need another search appear in Wanted.",
+  missing: "Tracks with no file. Re-search them here, then follow progress in Queue and History.",
+  cutoff: "Playable tracks below your quality target. Queue upgrades here, then follow them in Queue and History.",
+};
+
 function ActivityPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -81,8 +88,11 @@ function ActivityPage() {
     [user?.id],
   );
   const refreshFromStatusEvent = useCallback(() => {
-    if (document.hidden || isMissingView) return;
-    queryClient.refetchQueries({ queryKey: activityQueryKey, type: "active" });
+    if (document.hidden) return;
+    queryClient.refetchQueries({
+      queryKey: isMissingView ? queryKeys.playlistJobs() : activityQueryKey,
+      type: "active",
+    });
   }, [activityQueryKey, isMissingView]);
   const { isConnected: downloadsWsConnected } = useWebSocketChannel(
     "downloads",
@@ -372,6 +382,9 @@ function ActivityPage() {
     <>
       <header className="activity-page__header">
         <h1 className="page-title">{activeViewLabel}</h1>
+        <p className="page-subtitle">
+          {ACTIVITY_DESCRIPTIONS[isCutoffView ? "cutoff" : activeView]}
+        </p>
       </header>
       {!isMissingView ? (
         <PageSectionMobileNav

--- a/frontend/src/pages/activity/ActivityMissingPage.jsx
+++ b/frontend/src/pages/activity/ActivityMissingPage.jsx
@@ -72,12 +72,18 @@ function MissingJobRow({ job, playlist, actionState, onAction, onInfo }) {
   const isQueued = actionState === "queued";
   const operationLabel = playlist?.name || "Aurral operation";
   const meta = [job.artistName, job.albumName].filter(Boolean).join(" · ") || operationLabel;
-  const hint = isMissing
-    ? job.error || operationLabel
-    : `${job.qualityLabel || "Unknown quality"} · ${
-        job.qualityState === "below-floor" ? "Below cutoff" : "Upgrade available"
-      }`;
-  const statusLabel = isMissing ? "Missing" : isQueued ? "Upgrade queued" : "Cutoff unmet";
+  const hint = isWorking
+    ? isMissing ? "Adding re-search to Queue" : "Adding upgrade search to Queue"
+    : isQueued
+      ? "Upgrade search is in Queue"
+      : isMissing
+        ? job.error || operationLabel
+        : `${job.qualityLabel || "Unknown quality"} · ${
+            job.qualityState === "below-floor" ? "Below cutoff" : "Upgrade available"
+          }`;
+  const statusLabel = isWorking
+    ? isMissing ? "Re-searching" : "Queuing upgrade"
+    : isMissing ? "Missing" : isQueued ? "Upgrade queued" : "Cutoff unmet";
   const StatusIcon = isMissing ? AlertCircle : ArrowUpCircle;
 
   return (
@@ -219,6 +225,13 @@ export default function ActivityMissingPage() {
   const hasWantedJobs = jobs.some((job) =>
     showingCutoff ? isCutoffUnmetAurralJob(job) : isMissingAurralJob(job),
   );
+  const actionableJobs = jobs.filter((job) =>
+    showingCutoff
+      ? isCutoffUnmetAurralJob(job) && !job.upgradeQueued
+      : isMissingAurralJob(job),
+  );
+  const hasActionableJobs = actionableJobs.length > 0;
+  const allUpgradesQueued = showingCutoff && hasWantedJobs && !hasActionableJobs;
 
   const handleAction = async (job) => {
     const id = getMissingJobKey(job);
@@ -262,16 +275,36 @@ export default function ActivityMissingPage() {
   };
 
   const handleSearchAll = useCallback(async () => {
-    if (searchingAll || !hasWantedJobs) return;
+    if (searchingAll || !hasActionableJobs) return;
     setSearchingAll(true);
+    setActionStates((current) => Object.fromEntries([
+      ...Object.entries(current),
+      ...actionableJobs.map((job) => [getMissingJobKey(job), "working"]),
+    ]));
     try {
       const result = showingCutoff
         ? await searchAllUpgrades()
         : await reSearchAllMissingTracks();
       if (showingCutoff) {
-        showSuccess("Cutoff upgrade search queued");
+        const queued = Number(result?.queued || 0);
+        setActionStates((current) => ({
+          ...current,
+          ...Object.fromEntries(
+            actionableJobs.map((job) => [getMissingJobKey(job), "queued"]),
+          ),
+        }));
+        showSuccess(
+          queued > 0
+            ? `${queued} upgrade search${queued === 1 ? "" : "es"} queued`
+            : "No new upgrade searches were queued",
+        );
       } else {
         const requeued = Number(result?.requeued || 0);
+        setActionStates((current) => {
+          const next = { ...current };
+          for (const job of actionableJobs) delete next[getMissingJobKey(job)];
+          return next;
+        });
         showSuccess(
           requeued > 0
             ? `Re-searching ${requeued} missing track${requeued === 1 ? "" : "s"}`
@@ -279,7 +312,16 @@ export default function ActivityMissingPage() {
         );
       }
       await loadJobs();
+      await queryClient.invalidateQueries({ queryKey: ["activity", "requests"] });
     } catch (requestError) {
+      setActionStates((current) => {
+        const next = { ...current };
+        for (const job of actionableJobs) {
+          const id = getMissingJobKey(job);
+          if (next[id] === "working") delete next[id];
+        }
+        return next;
+      });
       showError(
         requestError.response?.data?.message ||
           requestError.response?.data?.error ||
@@ -291,21 +333,15 @@ export default function ActivityMissingPage() {
     } finally {
       setSearchingAll(false);
     }
-  }, [hasWantedJobs, loadJobs, searchingAll, showingCutoff, showError, showSuccess]);
+  }, [actionableJobs, hasActionableJobs, loadJobs, searchingAll, showingCutoff, showError, showSuccess]);
 
   const searchAllButton = (
-    <TooltipButton
-      className="native-library-icon-button"
+    <button
+      type="button"
+      className="btn btn-secondary btn--bold activity-toolbar__bulk-action"
       onClick={handleSearchAll}
-      disabled={searchingAll || !hasWantedJobs}
+      disabled={searchingAll || !hasActionableJobs}
       aria-busy={searchingAll}
-      label={
-        searchingAll
-          ? "Searching all"
-          : showingCutoff
-            ? "Search all cutoff-unmet tracks"
-            : "Re-search all missing tracks"
-      }
     >
       {searchingAll ? (
         <DotLoader size="sm" label={null} />
@@ -314,7 +350,12 @@ export default function ActivityMissingPage() {
       ) : (
         <RotateCcw aria-hidden="true" />
       )}
-    </TooltipButton>
+      <span>
+        {searchingAll
+          ? showingCutoff ? "Queuing upgrades" : "Re-searching all"
+          : allUpgradesQueued ? "Upgrades queued" : "Search all"}
+      </span>
+    </button>
   );
 
   if (loading) {


### PR DESCRIPTION
## What changed

Persist quality-upgrade jobs immediately instead of scheduling a deferred system task. Upgrade requests now return the number of queued jobs, record queue history, invalidate request caches, prevent stale job responses, and filter queued jobs by playlist access. Updated the weekly-flow test and activity documentation, with related frontend styling and interaction updates.

## Why

Queued upgrades were not visible immediately and could lose their queued state after refresh. Persisting them as regular jobs makes their state available in Queue and History while preserving per-user playlist access controls.

## Scope checklist

- [ ] This pull request has one clear purpose
- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue


## UI changes

Updated search result interactions, visual styling, navigation states, and related UI accessibility behavior.

## Testing

- Updated and ran `.tests/weekly-flow/approved-import-path.test.js`.
- Verified queued upgrades persist in the jobs response, are recorded in history, and remain restricted to accessible playlists.
- Manual UI validation was not documented in the supplied change details.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer activity-page descriptions for Queue, History, Missing, and Cutoff views.
  - Missing items now show distinct searching and upgrade-queued states.
  - Added labeled bulk actions with improved progress and status feedback.
  - Queued upgrades now appear in Queue and are recorded in History.

- **Bug Fixes**
  - Activity and job lists refresh reliably after upgrades are queued.
  - Playlist access filtering now displays the correct jobs.

- **Documentation**
  - Updated Search all guidance to explain upgrade status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->