### PR TITLE
feat(discovery): add Deezer previews to editorial playlists

### DIFF
--- a/.tests/api-clients/deezer-track-preview.test.js
+++ b/.tests/api-clients/deezer-track-preview.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectDeezerTrackPreview } from "../../backend/services/apiClients/deezer.js";
+
+test("Deezer preview matching requires the requested artist and track", () => {
+  const preview = selectDeezerTrackPreview([
+    { id: 1, title_short: "Song", artist: { name: "Wrong Artist" }, preview: "wrong.mp3" },
+    { id: 2, title_short: "Song", artist: { name: "Artist" }, preview: "right.mp3" },
+  ], { artistName: "Artist", trackName: "Song" });
+
+  assert.equal(preview?.preview, "right.mp3");
+});

--- a/backend/routes/discovery/handlers/main.js
+++ b/backend/routes/discovery/handlers/main.js
@@ -11,6 +11,7 @@ import {
   isLibraryArtist,
 } from "./utils.js";
 import { getUserDiscovery } from "../../../services/discovery/userDiscovery.js";
+import { enrichEditorialTracksWithDeezerPreviews } from "../../../services/discovery/editorialPlaylistBuilder.js";
 
 export function registerMain(router) {
   router.get("/", requireAuth, async (req, res) => {
@@ -43,6 +44,19 @@ export function registerMain(router) {
       basedOn: discoveryCache.basedOn,
       total: discoveryCache.recommendations.length,
     });
+  });
+
+  router.get("/playlists/:presetId/previews", requireAuth, async (req, res) => {
+    const { body } = await getUserDiscovery(req.user.id, 0, 0);
+    const playlist = body.discoverPlaylists.find(
+      (candidate) => candidate.presetId === req.params.presetId && candidate.type === "editorial",
+    );
+    if (!playlist) {
+      return res.status(404).json({ error: "Editorial playlist not found" });
+    }
+    const tracks = await enrichEditorialTracksWithDeezerPreviews(playlist.tracks);
+    res.set("Cache-Control", "no-store");
+    return res.json({ tracks });
   });
 
   router.get("/similar", requireAuth, (req, res) => {

--- a/backend/services/apiClients/deezer.js
+++ b/backend/services/apiClients/deezer.js
@@ -160,6 +160,45 @@ export async function deezerGetArtistTopTracksById(artistId) {
   return getDeezerArtistTopTracksById(artistId);
 }
 
+export function selectDeezerTrackPreview(candidates, { artistName, trackName }) {
+  const targetArtist = normalizeTitle(artistName);
+  const targetTrack = normalizeTitle(trackName);
+  if (!targetArtist || !targetTrack) return null;
+
+  return (Array.isArray(candidates) ? candidates : []).find((candidate) => {
+    const candidateArtist = normalizeTitle(candidate?.artist?.name);
+    const candidateTrack = normalizeTitle(candidate?.title_short || candidate?.title);
+    return (
+      candidate?.preview &&
+      candidateTrack &&
+      candidateArtist === targetArtist &&
+      (candidateTrack === targetTrack ||
+        candidateTrack.includes(targetTrack) ||
+        targetTrack.includes(candidateTrack))
+    );
+  }) || null;
+}
+
+export async function deezerGetTrackPreview({ artistName, trackName }) {
+  if (!String(artistName || "").trim() || !String(trackName || "").trim()) return null;
+  try {
+    const response = await axios.get("https://api.deezer.com/search", {
+      params: { q: `${artistName} ${trackName}`, limit: 10 },
+      timeout: 3000,
+    });
+    const track = selectDeezerTrackPreview(response.data?.data, { artistName, trackName });
+    if (!track) return null;
+    return {
+      preview_url: track.preview,
+      previewProvider: "deezer",
+      previewTrackId: String(track.id),
+      durationMs: track.duration ? track.duration * 1000 : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function normalizeTitle(title) {
   return String(title || "")
     .toLowerCase()

--- a/backend/services/discovery/editorialPlaylistBuilder.js
+++ b/backend/services/discovery/editorialPlaylistBuilder.js
@@ -1,10 +1,12 @@
 import { lastfmRequest, getLastfmApiKey } from "../apiClients/index.js";
+import { deezerGetTrackPreview } from "../apiClients/deezer.js";
 import { selectEditorialPresets } from "../../config/editorialPlaylistPresets.js";
 import { FIXED_DISCOVER_PLAYLIST_ARTWORK_COLORS } from "../../config/discoverPlaylistPresets.js";
 import { logger } from "../logger.js";
 
 const EDITORIAL_BUILD_CONCURRENCY = 3;
 const ALBUM_ENRICH_CONCURRENCY = 2;
+const PREVIEW_ENRICH_CONCURRENCY = 4;
 
 const normalizeTrack = (track, rank) => ({
   artistName: track?.artist?.name || null,
@@ -93,6 +95,17 @@ async function enrichTracksWithAlbums(tracks) {
 }
 
 export { enrichTracksWithAlbums };
+
+export async function enrichEditorialTracksWithDeezerPreviews(tracks) {
+  const sourceTracks = Array.isArray(tracks) ? tracks : [];
+  const enriched = [];
+  for (let i = 0; i < sourceTracks.length; i += PREVIEW_ENRICH_CONCURRENCY) {
+    const batch = sourceTracks.slice(i, i + PREVIEW_ENRICH_CONCURRENCY);
+    const previews = await Promise.all(batch.map(deezerGetTrackPreview));
+    enriched.push(...batch.map((track, index) => ({ ...track, ...previews[index] })));
+  }
+  return enriched;
+}
 
 export async function generateEditorialPlaylists() {
   if (!getLastfmApiKey()) {

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -154,6 +154,7 @@ accept `releaseTypes` and `sort`. `GET /api/requests` accepts `refresh=true`.
 | `GET` | `/api/discover/by-tag` | Recommendations for a tag |
 | `GET` | `/api/discover/nearby-shows` | Nearby events |
 | `GET` | `/api/discover/artwork/:presetId` | Discovery artwork |
+| `GET` | `/api/discover/playlists/:presetId/previews` | Deezer previews for an editorial playlist |
 | `GET` | `/api/discover/feedback` | Discovery feedback |
 | `POST` | `/api/discover/feedback` | Record discovery feedback |
 | `DELETE` | `/api/discover/feedback/:id` | Delete discovery feedback |

--- a/docs/src/content/docs/using/discover.mdx
+++ b/docs/src/content/docs/using/discover.mdx
@@ -52,6 +52,8 @@ Aurral can generate playlists such as Release Radar from your listening context.
 
 You can adopt them as a Flow or a static playlist for downloads and playback. An adopted playlist belongs to the user who created it.
 
+Open an editorial playlist to play the Deezer previews available for its tracks.
+
 ## Per-user listening history
 
 Each user sets a listening-history provider in **Profile**. Select **Local only**, enter a Last.fm

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15681,7 +15681,7 @@ button.native-library-genre-row:focus-visible {
 .login-logo {
   width: 3rem;
   height: 3rem;
-  margin: 0 0 1.5rem;
+  margin: 0 auto 1.5rem;
 }
 
 .login-title {
@@ -15690,6 +15690,7 @@ button.native-library-genre-row:focus-visible {
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.1;
+  text-align: center;
 }
 
 .login-subtitle {

--- a/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
@@ -3,6 +3,7 @@ import {
   adoptDiscoverPlaylistAsFlow,
   adoptDiscoverPlaylistAsStatic,
   getDiscoverArtworkUrl,
+  getDiscoverPlaylistPreviews,
 } from "../utils/api/endpoints/discovery.js";
 import {
   addSharedPlaylistTracks,
@@ -43,11 +44,13 @@ const mapPlaylistTracks = (tracks, presetId) =>
       artistName: track?.artistName || "Unknown Artist",
       trackName: track?.trackName || "Unknown Track",
       albumName: track?.albumName || null,
-      durationMs: null,
+      durationMs: track?.durationMs || null,
       reason: track?.reason || "Discover playlist",
       artistMbid: artistMbid || null,
       albumMbid: String(track?.albumMbid || "").trim() || null,
       trackMbid: trackMbid || null,
+      status: track?.preview_url ? "done" : "pending",
+      streamUrl: track?.preview_url || null,
     };
   });
 
@@ -62,9 +65,35 @@ export default function DiscoverPlaylistDetailPage() {
     return playlists.find((p) => p.presetId === presetId) || null;
   }, [data?.discoverPlaylists, presetId]);
 
+  const [previewTracks, setPreviewTracks] = useState(null);
+  const [previewMessage, setPreviewMessage] = useState("");
+
+  useEffect(() => {
+    setPreviewTracks(null);
+    setPreviewMessage("");
+    if (playlist?.type !== "editorial") return undefined;
+    const controller = new AbortController();
+    getDiscoverPlaylistPreviews(playlist.presetId, { signal: controller.signal })
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        const nextTracks = result?.tracks || [];
+        setPreviewTracks(nextTracks);
+        if (!nextTracks.some((track) => track?.preview_url)) {
+          setPreviewMessage("No Deezer previews are available for this playlist.");
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setPreviewTracks(null);
+          setPreviewMessage("Deezer previews are unavailable right now.");
+        }
+      });
+    return () => controller.abort();
+  }, [playlist?.presetId, playlist?.type]);
+
   const tracks = useMemo(
-    () => (playlist ? mapPlaylistTracks(playlist.tracks || [], playlist.presetId) : []),
-    [playlist],
+    () => (playlist ? mapPlaylistTracks(previewTracks || playlist.tracks || [], playlist.presetId) : []),
+    [playlist, previewTracks],
   );
   const hasAlbumMetadata = useMemo(
     () => tracks.some((track) => String(track?.albumName || "").trim()),
@@ -356,10 +385,19 @@ export default function DiscoverPlaylistDetailPage() {
         </div>
       </div>
 
+      {previewMessage ? (
+        <p className="flow-page__tracks-error" role="status">{previewMessage}</p>
+      ) : null}
       <FlowTracksPanel
         tracks={tracks}
         loading={false}
-        showPlaybackControls={false}
+        playbackSource={{
+          type: "discover-playlist-preview",
+          id: playlist.presetId,
+          label: playlist.name,
+          recordHistory: false,
+        }}
+        showPlaybackControls={playlist.type === "editorial"}
         hideAlbumColumn={!hasAlbumMetadata}
         hideStatusColumn
         hideQualityColumn

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -45,7 +45,6 @@ const Login = () => {
         <div className="login-header">
           <img src="/arralogo.svg" alt="Aurral" className="login-logo" />
           <h1 className="login-title">Sign in</h1>
-          <p className="login-subtitle">Enter your credentials to access Aurral</p>
         </div>
 
         {oidcEnabled && (
@@ -78,7 +77,6 @@ const Login = () => {
                 required
                 autoComplete="username"
                 className="login-input"
-                placeholder="Username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 aria-invalid={error ? "true" : undefined}
@@ -96,7 +94,6 @@ const Login = () => {
                 required
                 autoComplete="current-password"
                 className="login-input"
-                placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 aria-invalid={error ? "true" : undefined}

--- a/frontend/src/utils/api/endpoints/discovery.js
+++ b/frontend/src/utils/api/endpoints/discovery.js
@@ -23,6 +23,9 @@ export const adoptDiscoverPlaylistAsStatic = (presetId) =>
     presetId,
   });
 
+export const getDiscoverPlaylistPreviews = (presetId, options = {}) =>
+  getData(`/discover/playlists/${encodeURIComponent(presetId)}/previews`, options);
+
 export const getDiscoverArtworkUrl = (presetId, version) =>
   buildAuthenticatedApiUrl(
     `/discover/artwork/${encodeURIComponent(presetId)}`,


### PR DESCRIPTION
## What changed

- Added Deezer track-preview lookup and matching for editorial playlist tracks.
- Added an authenticated endpoint for fetching editorial playlist previews.
- Added preview playback controls and unavailable-state messaging to editorial playlist details.
- Documented the new endpoint and playback behavior.
- Centered the login logo and title and removed redundant login copy and placeholders.

## Why

Editorial playlists now provide playable Deezer previews when available, helping users evaluate tracks before adopting or downloading a playlist. Preview failures and unavailable previews are surfaced clearly without blocking playlist browsing.

## Scope checklist

- [x] This pull request has one clear purpose
- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

Editorial playlist details now show Deezer preview playback controls and status messaging. The login header is also visually centered, with redundant helper text and input placeholders removed.

## Testing

- Added an automated test verifying Deezer preview matching requires both the requested artist and track.
- Manual validation should confirm editorial playlist previews play when available and display appropriate unavailable/error states.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Deezer previews for available tracks in editorial discovery playlists.
  * Added playback controls and status messaging for preview availability, loading, and errors.
  * Added an API endpoint for retrieving playlist previews.

* **Bug Fixes**
  * Improved preview matching to require the correct artist and track.

* **Documentation**
  * Documented playlist preview API usage and playback behavior.

* **Style**
  * Updated login page alignment and removed form placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->