### PR TITLE
fix(library): sync canonical artist metadata

### DIFF
--- a/.tests/import-lists/listenbrainz-tracks.test.js
+++ b/.tests/import-lists/listenbrainz-tracks.test.js
@@ -53,3 +53,24 @@ test("parseListenBrainzPlaylist maps JSPF tracks and reports skipped entries", (
   ]);
   assert.deepEqual(stats, { incomplete: 1, duplicate: 1 });
 });
+
+test("parseListenBrainzPlaylist uses the primary artist name for a multi-artist credit", () => {
+  const { tracks } = parseListenBrainzPlaylist({
+    playlist: {
+      track: [{
+        creator: "Marshmello;Lil Peep",
+        title: "Spotlight",
+        album: "Spotlight",
+        identifier: ["https://musicbrainz.org/recording/track-mbid"],
+        extension: {
+          "https://musicbrainz.org/doc/jspf#track": {
+            artist_identifiers: ["https://musicbrainz.org/artist/marshmello-mbid"],
+            release_identifier: "https://musicbrainz.org/release/album-mbid",
+          },
+        },
+      }],
+    },
+  });
+
+  assert.equal(tracks[0].artistName, "Marshmello");
+});

--- a/.tests/library/library-refresh.test.js
+++ b/.tests/library/library-refresh.test.js
@@ -76,6 +76,7 @@ test("library refresh queues a forced scan and exposes its queue status", async 
 
   let body;
   let statusCode = 200;
+  let refreshJobId;
   const response = {
     status(code) {
       statusCode = code;
@@ -97,6 +98,12 @@ test("library refresh queues a forced scan and exposes its queue status", async 
       includeLidarr: true,
     });
     const jobId = body.jobId;
+    refreshJobId = jobId;
+
+    body = undefined;
+    await routes.get("GET /refresh")({ user: { id: 1 } }, response);
+    assert.equal(body.jobId, jobId);
+    assert.equal(body.status.status, "queued");
 
     body = undefined;
     await routes.get("GET /refresh/:jobId")(
@@ -106,7 +113,7 @@ test("library refresh queues a forced scan and exposes its queue status", async 
     assert.equal(body.status, "queued");
     body.jobId = jobId;
   } finally {
-    if (body?.jobId) getLibraryScanQueue().cancel(body.jobId);
+    if (refreshJobId || body?.jobId) getLibraryScanQueue().cancel(refreshJobId || body.jobId);
     clearScheduledLibraryScan();
     await new Promise((resolve) => setImmediate(resolve));
     await stopLibraryScanWorker();

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -385,6 +385,46 @@ test("upsertLibraryArtist repairs an existing fallback and MBID duplicate", () =
   }
 });
 
+test("upsertLibraryArtist merges normalized name variants when the MBID row exists first", () => {
+  const suffix = `${process.pid} ${Date.now()}`;
+  const cases = [
+    {
+      canonicalName: `Volcano! ${suffix}`,
+      fallbackName: `Volcano ${suffix}`,
+      mbid: "11111111-1111-4111-8111-111111111114",
+    },
+    {
+      canonicalName: `Marshmello;Lil Peep ${suffix}`,
+      fallbackName: `Marshmello, Lil Peep ${suffix}`,
+      mbid: "11111111-1111-4111-8111-111111111115",
+    },
+  ];
+
+  try {
+    for (const entry of cases) {
+      const resolved = upsertLibraryArtist({
+        identityKey: `mbid:${entry.mbid}`,
+        mbid: entry.mbid,
+        name: entry.canonicalName,
+      });
+      const fallback = upsertLibraryArtist({
+        identityKey: buildFallbackIdentityKey("artist", entry.fallbackName),
+        name: entry.fallbackName,
+      });
+
+      assert.equal(fallback.id, resolved.id);
+    }
+
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS count FROM library_artists WHERE name LIKE ?").get(`%${suffix}`)
+        .count,
+      cases.length,
+    );
+  } finally {
+    db.prepare("DELETE FROM library_artists WHERE name LIKE ?").run(`%${suffix}`);
+  }
+});
+
 test("scanMusicRoot applies trusted job metadata when file tags omit identities", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-job-metadata-"));
   const source = `test-job-metadata-${process.pid}`;

--- a/.tests/weekly-flow/playlist-mbid-enrichment.test.js
+++ b/.tests/weekly-flow/playlist-mbid-enrichment.test.js
@@ -13,6 +13,7 @@ const [
   { dbOps },
   { flowPlaylistConfig },
   { downloadTracker },
+  { playlistManager },
   { getPlaylistMbidEnrichmentQueue },
   {
     enrichSharedPlaylistMbids,
@@ -24,6 +25,7 @@ const [
   "backend/db/helpers/index.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
   "backend/services/honkerDb.js",
   "backend/services/playlistMbidEnrichmentService.js",
 );
@@ -93,6 +95,34 @@ test("enrichSharedPlaylistMbids fills missing playlist and job MBIDs", async () 
   assert.equal(storedJob.trackMbid, "track-new-noise");
   assert.equal(storedJob.trackNumber, 1);
   assert.equal(storedJob.albumTrackCount, 12);
+});
+
+test("enrichSharedPlaylistMbids rescans the library after updating a downloaded job", async (t) => {
+  const playlist = flowPlaylistConfig.createSharedPlaylist({
+    name: "Downloaded",
+    tracks: [{ artistName: "Refused", trackName: "New Noise" }],
+  });
+  const jobId = downloadTracker.addJob(
+    { artistName: "Refused", trackName: "New Noise" },
+    playlist.id,
+  );
+  downloadTracker.setDone(jobId, "/library/Refused/New Noise.flac");
+  const scheduleScanLibrary = t.mock.method(
+    playlistManager,
+    "scheduleScanLibrary",
+    () => 1,
+  );
+
+  await enrichSharedPlaylistMbids(playlist.id, {
+    resolveTrackContext: (track) => ({
+      ...track,
+      artistMbid: "artist-refused",
+      albumMbid: "album-shape",
+      trackMbid: "track-new-noise",
+    }),
+  });
+
+  assert.equal(scheduleScanLibrary.mock.callCount(), 1);
 });
 
 test("enrichSharedPlaylistMbids returns missing when playlistId is empty", async () => {

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -13,6 +13,7 @@ import {
 } from "../../../services/subsonicLibraryService.js";
 import {
   getLibraryScanStatus,
+  getScheduledLibraryScanJobId,
   scheduleLibraryScan,
 } from "../../../services/libraryScanWorker.js";
 
@@ -86,6 +87,14 @@ export function registerCanonical(router) {
       queued: true,
       jobId,
       status: getLibraryScanStatus(jobId),
+    });
+  });
+
+  router.get("/refresh", requireAuth, noCache, (_req, res) => {
+    const jobId = getScheduledLibraryScanJobId();
+    return res.json({
+      jobId,
+      status: jobId == null ? null : getLibraryScanStatus(jobId),
     });
   });
 

--- a/backend/services/importLists/listenbrainzTracks.js
+++ b/backend/services/importLists/listenbrainzTracks.js
@@ -20,7 +20,9 @@ export function parseListenBrainzPlaylist(payload) {
 
   for (const track of tracks) {
     const extension = getExtension(track);
-    const artistName = String(track?.creator || "").trim();
+    const creator = String(track?.creator || "").trim();
+    const artistMbid = getIdentifier(extension.artist_identifiers, ARTIST_URI_PREFIX);
+    const artistName = artistMbid ? creator.split(";", 1)[0].trim() : creator;
     const trackName = String(track?.title || "").trim();
     if (!artistName || !trackName) {
       stats.incomplete += 1;
@@ -31,7 +33,7 @@ export function parseListenBrainzPlaylist(payload) {
       trackName,
       albumName: String(track?.album || "").trim() || null,
       trackMbid: getIdentifier(track?.identifier, TRACK_URI_PREFIX),
-      artistMbid: getIdentifier(extension.artist_identifiers, ARTIST_URI_PREFIX),
+      artistMbid,
       albumMbid: getIdentifier(extension.release_identifier, RELEASE_URI_PREFIX),
       durationMs: Number.isFinite(Number(track?.duration)) ? Number(track.duration) : null,
     });

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -2,9 +2,11 @@ import path from "node:path";
 import { db } from "../config/db-sqlite.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
 import { scanMusicRoot } from "./libraryFileScanner.js";
+import { upsertLibraryArtist } from "./libraryMediaStore.js";
 import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
 import { rebuildLibrarySearchIndex } from "./librarySearchIndex.js";
 import { rebuildCanonicalGenreStats } from "./libraryQueryService.js";
+import { musicbrainzGetArtistNameByMbid } from "./apiClients/index.js";
 
 function getAurralJobMetadataByPath() {
   const rows = db
@@ -34,6 +36,28 @@ function getAurralJobMetadataByPath() {
   return byPath;
 }
 
+async function canonicalizeAurralArtistNames(jobMetadataByPath) {
+  const candidates = new Map();
+  for (const metadata of jobMetadataByPath.values()) {
+    const artistMbid = String(metadata?.artistMbid || "").trim();
+    const artistName = String(metadata?.artistName || "").trim();
+    if (!artistMbid || !/[;,×!]/.test(artistName) || candidates.has(artistMbid)) continue;
+    candidates.set(artistMbid, artistName);
+  }
+
+  for (const artistMbid of candidates.keys()) {
+    const existing = db.prepare("SELECT id FROM library_artists WHERE mbid = ?").get(artistMbid);
+    if (!existing) continue;
+    const artistName = await musicbrainzGetArtistNameByMbid(artistMbid).catch(() => null);
+    if (!artistName) continue;
+    upsertLibraryArtist({
+      identityKey: `mbid:${artistMbid}`,
+      mbid: artistMbid,
+      name: artistName,
+    });
+  }
+}
+
 export async function scanConfiguredLibrary({
   musicRoot = resolvePlaylistRoot(),
   lidarrClient,
@@ -50,6 +74,7 @@ export async function scanConfiguredLibrary({
       metadataEnricher: (_metadata, filePath) => jobMetadataByPath.get(path.resolve(filePath)),
       syncSearch: false,
     });
+    await canonicalizeAurralArtistNames(jobMetadataByPath);
     if (includeLidarr) {
       try {
         lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -110,41 +110,72 @@ export function upsertLibraryArtist({
   let libraryChanged = false;
   const artist = db.transaction(() => {
     const fallbackKey = buildFallbackIdentityKey("artist", artistName);
+    const findFallbackArtist = () => {
+      return db
+        .prepare("SELECT id, identity_key FROM library_artists WHERE identity_key = ? AND mbid IS NULL")
+        .get(fallbackKey);
+    };
+    const findResolvedArtist = () => {
+      const exact = db
+        .prepare(
+          `SELECT * FROM library_artists
+           WHERE mbid IS NOT NULL AND name = ? COLLATE NOCASE
+           ORDER BY id
+           LIMIT 2`,
+        )
+        .all(artistName);
+      if (exact.length === 1) return exact[0];
+      // ponytail: normalized duplicate repair scans artist rows; add a persisted normalized name if this becomes hot.
+      const matches = db
+        .prepare("SELECT * FROM library_artists WHERE mbid IS NOT NULL")
+        .all()
+        .filter((row) => buildFallbackIdentityKey("artist", row.name) === fallbackKey);
+      return matches.length === 1 ? matches[0] : null;
+    };
+    const mergeFallbackArtist = (fallback, resolved) => {
+      if (!fallback || !resolved || fallback.id === resolved.id) return;
+      libraryChanged = db.prepare(
+        `INSERT OR IGNORE INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
+         SELECT user_id, entity_kind, ?, created_at
+         FROM subsonic_stars
+         WHERE entity_kind = 'artist' AND entity_key = ?`,
+      ).run(resolved.identity_key, fallback.identity_key).changes > 0 || libraryChanged;
+      libraryChanged = db.prepare(
+        "DELETE FROM subsonic_stars WHERE entity_kind = 'artist' AND entity_key = ?",
+      ).run(fallback.identity_key).changes > 0 || libraryChanged;
+      libraryChanged = db.prepare("UPDATE library_albums SET artist_id = ? WHERE artist_id = ?")
+        .run(resolved.id, fallback.id).changes > 0 || libraryChanged;
+      libraryChanged = db.prepare("DELETE FROM library_artists WHERE id = ?")
+        .run(fallback.id).changes > 0 || libraryChanged;
+    };
     if (mbid) {
-      const resolved = db.prepare("SELECT id FROM library_artists WHERE identity_key = ?").get(key);
+      const resolved = db.prepare("SELECT id, identity_key FROM library_artists WHERE identity_key = ?").get(key);
       const fallback = fallbackKey === key
         ? null
-        : db.prepare("SELECT id FROM library_artists WHERE identity_key = ?").get(fallbackKey);
-      if (fallback) {
+        : findFallbackArtist();
+      if (fallback && !resolved) {
         libraryChanged = db.prepare(
           `INSERT OR IGNORE INTO subsonic_stars (user_id, entity_kind, entity_key, created_at)
            SELECT user_id, entity_kind, ?, created_at
            FROM subsonic_stars
            WHERE entity_kind = 'artist' AND entity_key = ?`,
-        ).run(key, fallbackKey).changes > 0 || libraryChanged;
+        ).run(key, fallback.identity_key).changes > 0 || libraryChanged;
         libraryChanged = db.prepare(
           "DELETE FROM subsonic_stars WHERE entity_kind = 'artist' AND entity_key = ?",
-        ).run(fallbackKey).changes > 0 || libraryChanged;
+        ).run(fallback.identity_key).changes > 0 || libraryChanged;
       }
       if (fallback && !resolved) {
         libraryChanged = db.prepare("UPDATE library_artists SET identity_key = ? WHERE id = ?")
           .run(key, fallback.id).changes > 0 || libraryChanged;
       } else if (fallback && resolved && fallback.id !== resolved.id) {
-        libraryChanged = db.prepare("UPDATE library_albums SET artist_id = ? WHERE artist_id = ?")
-          .run(resolved.id, fallback.id).changes > 0 || libraryChanged;
-        libraryChanged = db.prepare("DELETE FROM library_artists WHERE id = ?")
-          .run(fallback.id).changes > 0 || libraryChanged;
+        mergeFallbackArtist(fallback, resolved);
       }
     } else if (key === fallbackKey) {
-      const resolved = db.prepare(
-        `SELECT * FROM library_artists
-         WHERE mbid IS NOT NULL AND name = ? COLLATE NOCASE
-         ORDER BY id
-         LIMIT 2`,
-      ).all(artistName);
-      if (resolved.length === 1) {
-        if (syncSearch) syncLibrarySearchArtist(resolved[0].id);
-        return resolved[0];
+      const resolved = findResolvedArtist();
+      if (resolved) {
+        mergeFallbackArtist(findFallbackArtist(), resolved);
+        if (syncSearch) syncLibrarySearchArtist(resolved.id);
+        return resolved;
       }
     }
     const existing = db.prepare("SELECT * FROM library_artists WHERE identity_key = ?").get(key);

--- a/backend/services/playlistMbidEnrichmentService.js
+++ b/backend/services/playlistMbidEnrichmentService.js
@@ -322,6 +322,7 @@ export async function enrichSharedPlaylistMbids(
 
       if (playlistTracksUpdated > 0 || jobsUpdated > 0) {
         playlistManager.updateConfig(false);
+        playlistManager.scheduleScanLibrary();
       }
 
       return {

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -44,6 +44,7 @@ import {
   deleteArtistFromLibrary,
   deleteTrackFromLibrary,
   fetchCanonicalLibraryPage,
+  getActiveLibraryRefresh,
   getCanonicalLibraryPage,
   getLibraryFavorites,
   getLibraryRefreshStatus,
@@ -457,6 +458,60 @@ function LibraryPage() {
     refreshAttemptRef.current += 1;
   }, []);
 
+  const completeLibraryRefresh = useCallback(() => {
+    clearCanonicalLibraryPageCache();
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.libraryAlbumTracksPrefix,
+      refetchType: "none",
+    });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
+  }, []);
+
+  const pollLibraryRefresh = useCallback(async (jobId, attempt, announceSuccess = false) => {
+    const deadline = Date.now() + LIBRARY_REFRESH_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const status = await getLibraryRefreshStatus(jobId);
+      if (refreshAttemptRef.current !== attempt) return;
+      if (status.status === "completed") {
+        completeLibraryRefresh();
+        if (announceSuccess) showSuccess("Library refreshed");
+        return;
+      }
+      if (status.status === "failed") {
+        throw new Error(status.error || "Library refresh failed");
+      }
+      await wait(750);
+    }
+    throw new Error("Library refresh timed out");
+  }, [completeLibraryRefresh, showSuccess]);
+
+  useEffect(() => {
+    let mounted = true;
+    const restoreLibraryRefresh = async () => {
+      try {
+        const active = await getActiveLibraryRefresh();
+        if (!mounted || !active?.jobId || !["queued", "running"].includes(active.status?.status)) return;
+        const attempt = refreshAttemptRef.current + 1;
+        refreshAttemptRef.current = attempt;
+        setRefreshing(true);
+        try {
+          await pollLibraryRefresh(active.jobId, attempt);
+        } catch (requestError) {
+          if (refreshAttemptRef.current === attempt) {
+            showError(requestError.response?.data?.message || requestError.message || "Library refresh failed");
+          }
+        } finally {
+          if (refreshAttemptRef.current === attempt) setRefreshing(false);
+        }
+      } catch {}
+    };
+    void restoreLibraryRefresh();
+    return () => {
+      mounted = false;
+    };
+  }, [pollLibraryRefresh, showError]);
+
   const refreshLibrary = useCallback(async () => {
     if (refreshing) return;
     const attempt = refreshAttemptRef.current + 1;
@@ -467,28 +522,7 @@ function LibraryPage() {
       const queued = await requestLibraryRefresh();
       const jobId = queued?.jobId;
       if (!jobId) throw new Error("Library refresh did not start");
-
-      const deadline = Date.now() + LIBRARY_REFRESH_TIMEOUT_MS;
-      while (Date.now() < deadline) {
-        const status = await getLibraryRefreshStatus(jobId);
-        if (refreshAttemptRef.current !== attempt) return;
-        if (status.status === "completed") {
-          clearCanonicalLibraryPageCache();
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.libraryAlbumTracksPrefix,
-            refetchType: "none",
-          });
-          void queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
-          void queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
-          showSuccess("Library refreshed");
-          return;
-        }
-        if (status.status === "failed") {
-          throw new Error(status.error || "Library refresh failed");
-        }
-        await wait(750);
-      }
-      throw new Error("Library refresh timed out");
+      await pollLibraryRefresh(jobId, attempt, true);
     } catch (requestError) {
       if (refreshAttemptRef.current === attempt) {
         showError(requestError.response?.data?.message || requestError.message || "Library refresh failed");
@@ -496,7 +530,7 @@ function LibraryPage() {
     } finally {
       if (refreshAttemptRef.current === attempt) setRefreshing(false);
     }
-  }, [refreshing, showError, showSuccess]);
+  }, [pollLibraryRefresh, refreshing, showError]);
 
   const section = LIBRARY_VIEW_IDS.has(routeSection) ? routeSection : DEFAULT_LIBRARY_VIEW;
   const isDetail = Boolean(routeAlbumId || routeArtistId);

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -63,6 +63,8 @@ export const clearCanonicalLibraryPageCache = () => {
 
 export const requestLibraryRefresh = () => postData("/library/refresh", {});
 
+export const getActiveLibraryRefresh = () => getData("/library/refresh");
+
 export const getLibraryRefreshStatus = (jobId) =>
   getData(`/library/refresh/${encodeURIComponent(jobId)}`);
 


### PR DESCRIPTION
## What changed

- Canonicalize multi-artist playlist metadata using the primary artist and MusicBrainz artist names.
- Merge normalized artist-name variants into existing MBID-backed library records while preserving stars and album links.
- Rescan the library after playlist MBID enrichment updates downloaded jobs.
- Restore and poll active library refresh jobs after navigating or reloading the Library page.
- Add coverage for canonicalization, merging, refresh recovery, and rescan scheduling.

## Why

Downloaded and imported tracks could create duplicate or inconsistent artist records when their credited names differed from canonical MusicBrainz metadata. Library refreshes could also lose progress when the page was reloaded. This keeps artist identity and library state synchronized across imports, scans, and the UI.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The Library page now resumes displaying an active refresh after navigation or reload. No before-and-after screenshots included.

## Testing

- Added and updated automated tests for ListenBrainz artist parsing, library artist merging, refresh status recovery, and playlist MBID enrichment rescans.
- Manual UI validation not run.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visibility into active library refresh jobs and their current status.
  - Library refresh monitoring now resumes automatically after navigating away or reloading the page.
  - Playlist metadata enrichment now schedules a library scan automatically.

- **Bug Fixes**
  - Improved handling of multi-artist ListenBrainz credits.
  - Prevented duplicate artist records when names differ only by punctuation.
  - Improved artist merging and canonical name resolution during library scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->