### PR TITLE
fix(library): delete Aurral-owned track files without Lidarr

### DIFF
--- a/.tests/library/track-deletion.test.js
+++ b/.tests/library/track-deletion.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { db } from "../../backend/config/db-sqlite.js";
+import { lidarrClient } from "../../backend/services/lidarrClient.js";
+import { libraryManager } from "../../backend/services/libraryManager.js";
+import {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} from "../../backend/services/libraryMediaStore.js";
+
+test("deletes Aurral-owned track files without Lidarr", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-track-delete-"));
+  const filePath = path.join(root, "Artist", "Album", "01 Track.flac");
+  const identity = `track-delete-${process.pid}-${Date.now()}`;
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, "fixture");
+
+  const artist = upsertLibraryArtist({
+    identityKey: `${identity}:artist`,
+    name: "Artist",
+    syncSearch: false,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${identity}:album`,
+    artistId: artist.id,
+    title: "Album",
+    syncSearch: false,
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${identity}:track`,
+    title: "Track",
+    artistName: "Artist",
+    syncSearch: false,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, syncSearch: false });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "aurral",
+    path: filePath,
+    available: true,
+  });
+
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+
+  try {
+    assert.deepEqual(await libraryManager.deleteTrack(track.id), { success: true });
+    await assert.rejects(() => access(filePath));
+    assert.equal(
+      db.prepare(
+        "SELECT available FROM library_media_files WHERE source = ? AND path = ?",
+      ).get("aurral", filePath)?.available,
+      0,
+    );
+    assert.deepEqual(await libraryManager.deleteTrack(track.id), { success: true });
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run("aurral", filePath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? AND track_id = ?").run(album.id, track.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/.tests/library/track-deletion.test.js
+++ b/.tests/library/track-deletion.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import fsp from "node:fs/promises";
 import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -62,6 +63,88 @@ test("deletes Aurral-owned track files without Lidarr", async (t) => {
     assert.deepEqual(await libraryManager.deleteTrack(track.id), { success: true });
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run("aurral", filePath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? AND track_id = ?").run(album.id, track.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("records successful Aurral deletions when another file fails", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-track-delete-partial-"));
+  const deletedPath = path.join(root, "Artist", "Album", "01 Track.flac");
+  const failedPath = path.join(root, "Artist", "Album", "02 Track.flac");
+  const identity = `track-delete-partial-${process.pid}-${Date.now()}`;
+  await mkdir(path.dirname(deletedPath), { recursive: true });
+  await writeFile(deletedPath, "fixture");
+  await writeFile(failedPath, "fixture");
+
+  const artist = upsertLibraryArtist({
+    identityKey: `${identity}:artist`,
+    name: "Artist",
+    syncSearch: false,
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${identity}:album`,
+    artistId: artist.id,
+    title: "Album",
+    syncSearch: false,
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${identity}:track`,
+    title: "Track",
+    artistName: "Artist",
+    syncSearch: false,
+  });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, syncSearch: false });
+  for (const filePath of [deletedPath, failedPath]) {
+    upsertLibraryMediaFile({
+      trackId: track.id,
+      albumId: album.id,
+      source: "aurral",
+      path: filePath,
+      available: true,
+    });
+  }
+
+  const originalUnlink = fsp.unlink;
+  t.mock.method(fsp, "unlink", async (filePath) => {
+    if (filePath === failedPath) {
+      const error = new Error("permission denied");
+      error.code = "EACCES";
+      throw error;
+    }
+    return originalUnlink(filePath);
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+
+  try {
+    assert.deepEqual(await libraryManager.deleteTrack(track.id), {
+      success: false,
+      code: "failed",
+      error: "permission denied",
+    });
+    assert.equal(
+      db.prepare(
+        "SELECT available FROM library_media_files WHERE source = ? AND path = ?",
+      ).get("aurral", deletedPath)?.available,
+      0,
+    );
+    assert.equal(
+      db.prepare(
+        "SELECT available FROM library_media_files WHERE source = ? AND path = ?",
+      ).get("aurral", failedPath)?.available,
+      1,
+    );
+    await assert.rejects(() => access(deletedPath));
+    await access(failedPath);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path IN (?, ?)").run(
+      "aurral",
+      deletedPath,
+      failedPath,
+    );
     db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? AND track_id = ?").run(album.id, track.id);
     db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
     db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1,3 +1,4 @@
+import fsp from "fs/promises";
 import path from "path";
 import { UUID_REGEX } from "../../lib/uuid.js";
 import { dbOps, userOps } from "../db/helpers/index.js";
@@ -12,6 +13,7 @@ import { scheduleLibraryScan } from "./libraryScanWorker.js";
 import {
   clearCanonicalLidarrAlbum,
   clearCanonicalLidarrArtist,
+  markLibraryMediaFilesUnavailable,
 } from "./libraryMediaStore.js";
 const normalizeTypeName = (value) =>
   String(value || "")
@@ -1576,26 +1578,54 @@ export class LibraryManager {
   }
 
   async deleteTrack(id) {
-    const lidarr = await getLidarrClient();
-    if (!lidarr || !lidarr.isConfigured()) {
-      return { success: false, code: "lidarr_unavailable", error: "Lidarr is not configured" };
-    }
     try {
       const library = getCanonicalTrack({
         trackId: id,
-        source: "lidarr",
         availableOnly: false,
       });
       const track = library.tracks.find((entry) => String(entry.id) === String(id));
       if (!track) return { success: false, code: "not_found", error: "Track not found" };
 
-      const metadata = track.metadata || {};
+      const aurralFiles = track.files.filter((file) => file.source === "aurral" && file.path);
+      const lidarrFiles = track.files.filter((file) => file.source === "lidarr" && file.available);
+      if (aurralFiles.length > 0 && lidarrFiles.length === 0) {
+        const paths = [...new Set(aurralFiles.map((file) => file.path))];
+        try {
+          await Promise.all(paths.map(async (filePath) => {
+            try {
+              await fsp.unlink(filePath);
+            } catch (error) {
+              if (error?.code !== "ENOENT") throw error;
+            }
+          }));
+          markLibraryMediaFilesUnavailable("aurral", paths);
+          invalidateCanonicalLibraryCache();
+          return { success: true };
+        } catch (error) {
+          logger.error("library", `[LibraryManager] Failed to delete Aurral track file: ${error.message}`);
+          return { success: false, code: "failed", error: error.message };
+        }
+      }
+
+      const lidarr = await getLidarrClient();
+      if (!lidarr || !lidarr.isConfigured()) {
+        return { success: false, code: "lidarr_unavailable", error: "Lidarr is not configured" };
+      }
+      const lidarrLibrary = getCanonicalTrack({
+        trackId: id,
+        source: "lidarr",
+        availableOnly: false,
+      });
+      const lidarrTrack = lidarrLibrary.tracks.find((entry) => String(entry.id) === String(id));
+      if (!lidarrTrack) return { success: false, code: "not_found", error: "Track not found" };
+
+      const metadata = lidarrTrack.metadata || {};
       let trackFileId = Number(
         metadata.trackFileId || metadata.trackFile?.id || metadata.file?.id,
       );
       if (!Number.isFinite(trackFileId)) {
-        const trackAlbums = Array.isArray(track.albums) ? track.albums : [];
-        const album = library.albums.find((entry) =>
+        const trackAlbums = Array.isArray(lidarrTrack.albums) ? lidarrTrack.albums : [];
+        const album = lidarrLibrary.albums.find((entry) =>
           trackAlbums.some((relation) => String(relation.albumId) === String(entry.id)),
         );
         const lidarrAlbumId = Number(album?.metadata?.id);

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -1591,15 +1591,28 @@ export class LibraryManager {
       if (aurralFiles.length > 0 && lidarrFiles.length === 0) {
         const paths = [...new Set(aurralFiles.map((file) => file.path))];
         try {
-          await Promise.all(paths.map(async (filePath) => {
+          const deletionResults = await Promise.allSettled(paths.map(async (filePath) => {
             try {
               await fsp.unlink(filePath);
+              return filePath;
             } catch (error) {
-              if (error?.code !== "ENOENT") throw error;
+              if (error?.code === "ENOENT") return filePath;
+              throw error;
             }
           }));
-          markLibraryMediaFilesUnavailable("aurral", paths);
-          invalidateCanonicalLibraryCache();
+          const reconciledPaths = deletionResults
+            .filter((result) => result.status === "fulfilled")
+            .map((result) => result.value);
+          if (reconciledPaths.length > 0) {
+            markLibraryMediaFilesUnavailable("aurral", reconciledPaths);
+            invalidateCanonicalLibraryCache();
+          }
+          const failure = deletionResults.find((result) => result.status === "rejected");
+          if (failure) {
+            const error = failure.reason;
+            logger.error("library", `[LibraryManager] Failed to delete Aurral track file: ${error.message}`);
+            return { success: false, code: "failed", error: error.message };
+          }
           return { success: true };
         } catch (error) {
           logger.error("library", `[LibraryManager] Failed to delete Aurral track file: ${error.message}`);

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -81,6 +81,7 @@ instance API key for WebSocket connections.
 | `PUT` | `/api/library/albums/:id` | Update an album |
 | `DELETE` | `/api/library/albums/:id` | Delete an album |
 | `GET` | `/api/library/tracks` | List album tracks |
+| `DELETE` | `/api/library/tracks/:id` | Delete a library track file |
 | `POST` | `/api/library/refresh` | Queue a canonical library scan |
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
 | `GET` | `/api/library/canonical` | Read a bounded canonical page; provide a supported `kind` and `pageSize` (1-100) |


### PR DESCRIPTION
## What changed

- Delete Aurral-owned track files directly when no available Lidarr file exists.
- Mark deleted Aurral media files unavailable and invalidate the library cache.
- Simplify library refresh handling and remove the obsolete active-refresh endpoint.
- Document the track deletion endpoint and add coverage for deletion without Lidarr.

## Why

Aurral-owned downloads could not be deleted unless Lidarr was configured. This allows users to remove those files directly while preserving the existing Lidarr deletion flow.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The library refresh UI was simplified to poll only the refresh job started by the current action. No screenshots are included because there is no material visual change.

## Testing

- Added an automated test covering deletion of an Aurral-owned track file when Lidarr is unavailable.
- Verified the file is removed and marked unavailable in the database.
- Other existing tests were updated for removed refresh and artist-canonicalization behavior.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deleting locally stored Aurral-owned track files.
  * Track records are marked unavailable after successful deletion.
  * Repeated deletion requests are handled successfully.
  * Partial deletion failures are reported while successfully removed files are reconciled.

* **Documentation**
  * Documented the library track deletion API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->