### PR TITLE
fix(search): recover transient metadata failures

### DIFF
--- a/.tests/helpers/api-client-utils.test.js
+++ b/.tests/helpers/api-client-utils.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import http from "node:http";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 import createCache from "../../backend/services/apiClients/simpleCache.js";
@@ -43,6 +44,23 @@ test("fetch transport failures expose axios-compatible request metadata", async 
     );
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetch timeouts expose an axios-compatible timeout code", async () => {
+  const server = http.createServer((_request, response) => {
+    setTimeout(() => response.end("ok"), 100);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  try {
+    await assert.rejects(
+      axios.get(`http://127.0.0.1:${port}`, { timeout: 10 }),
+      (error) => error.code === "ECONNABORTED",
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
   }
 });
 

--- a/.tests/search/search-service.test.js
+++ b/.tests/search/search-service.test.js
@@ -1,9 +1,72 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeAlbumReleaseTypesFilter } from "../../backend/services/searchService.js";
+import { createMockHttpServer } from "../helpers/backendTestHarness.js";
+import { dbOps } from "../../backend/db/helpers/index.js";
+import { clearMetadataProviderCaches } from "../../backend/services/providers/brainzmashProvider.js";
+import {
+  normalizeAlbumReleaseTypesFilter,
+  searchArtists,
+} from "../../backend/services/searchService.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
+
+test("searchArtists normalizes BrainzMash artists", async () => {
+  let requests = 0;
+  const server = await createMockHttpServer((request, response) => {
+    if (!request.url?.startsWith("/search/artist")) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+    requests += 1;
+    if (requests === 1) {
+      response.writeHead(503);
+      response.end();
+      return;
+    }
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify([
+        {
+          id: "artist-mbid",
+          artistname: "Adele",
+          sortname: "Adele",
+          type: "Person",
+          genres: ["pop"],
+          images: [{ Url: "https://images.example/adele.jpg", CoverType: "poster" }],
+        },
+      ]),
+    );
+  });
+  const originalSettings = dbOps.getSettings();
+  dbOps.updateSettings({
+    ...originalSettings,
+    integrations: {
+      ...originalSettings.integrations,
+      metadata: {
+        ...originalSettings.integrations.metadata,
+        baseUrl: server.url,
+        enableNarrowFallbacks: false,
+      },
+    },
+  });
+  clearMetadataProviderCaches();
+
+  try {
+    const result = await searchArtists("Adele", 5, 0);
+    assert.equal(result.items[0].id, "artist-mbid");
+    assert.equal(result.items[0].name, "Adele");
+    assert.equal(result.items[0].artistType, "Person");
+    assert.deepEqual(result.items[0].genres, ["pop"]);
+    assert.equal(result.items[0].imageUrl, "https://images.example/adele.jpg");
+    assert.equal(requests, 2);
+  } finally {
+    clearMetadataProviderCaches();
+    dbOps.updateSettings(originalSettings);
+    await server.close();
+  }
+});
 
 test("normalizeAlbumReleaseTypesFilter removes invalid and duplicate release types", () => {
   assert.deepEqual(

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -24,6 +24,8 @@ import { runSharedInflight } from "../sharedInflight.js";
 const providerCache = createCache(300);
 const releaseCache = createCache(300);
 const providerInflightRequests = new Map();
+const METADATA_REQUEST_TIMEOUT_MS = 8000;
+const METADATA_MAX_RETRIES = 1;
 
 export function clearMetadataProviderCaches() {
   providerCache.flushAll();
@@ -75,6 +77,13 @@ function getUserAgent() {
   return `${APP_NAME}/${APP_VERSION}`;
 }
 
+function isRetryable(error) {
+  return (
+    ["ECONNABORTED", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "EAI_AGAIN"].includes(error?.code) ||
+    [408, 425, 429, 500, 502, 503, 504].includes(error?.response?.status)
+  );
+}
+
 async function request(path, params = {}, { signal } = {}) {
   const baseUrl = getMetadataBaseUrl();
   const cacheKey = `${baseUrl}${path}:${JSON.stringify(params)}`;
@@ -84,27 +93,33 @@ async function request(path, params = {}, { signal } = {}) {
   healthState.lastCheckedAt = nowIso();
 
   return runSharedInflight(providerInflightRequests, cacheKey, async (sharedSignal) => {
-    try {
-      const response = await axios.get(`${baseUrl}${path}`, {
-        params,
-        timeout: 8000,
-        headers: {
-          "User-Agent": getUserAgent(),
-        },
-        signal: sharedSignal,
-      });
-      providerCache.set(cacheKey, response.data);
-      healthState.lastSuccessAt = healthState.lastCheckedAt;
-      healthState.lastFailureReason = "";
-      return response.data;
-    } catch (error) {
-      healthState.lastFailureAt = healthState.lastCheckedAt;
-      healthState.lastFailureReason =
-        error?.response?.status != null
-          ? `HTTP ${error.response.status}`
-          : error?.code || error?.message || "Unknown error";
-      throw error;
+    for (let attempt = 0; attempt <= METADATA_MAX_RETRIES; attempt += 1) {
+      if (sharedSignal.aborted) throw sharedSignal.reason || new Error("The operation was aborted");
+      try {
+        const response = await axios.get(`${baseUrl}${path}`, {
+          params,
+          timeout: METADATA_REQUEST_TIMEOUT_MS,
+          headers: {
+            "User-Agent": getUserAgent(),
+          },
+          signal: sharedSignal,
+        });
+        providerCache.set(cacheKey, response.data);
+        healthState.lastSuccessAt = healthState.lastCheckedAt;
+        healthState.lastFailureReason = "";
+        return response.data;
+      } catch (error) {
+        if (sharedSignal.aborted) throw sharedSignal.reason || error;
+        healthState.lastFailureAt = healthState.lastCheckedAt;
+        healthState.lastFailureReason =
+          error?.response?.status != null
+            ? `HTTP ${error.response.status}`
+            : error?.code || error?.message || "Unknown error";
+        if (attempt === METADATA_MAX_RETRIES || !isRetryable(error)) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
     }
+    throw new Error("Metadata provider request failed");
   }, { signal });
 }
 

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -116,7 +116,18 @@ async function request(path, params = {}, { signal } = {}) {
             ? `HTTP ${error.response.status}`
             : error?.code || error?.message || "Unknown error";
         if (attempt === METADATA_MAX_RETRIES || !isRetryable(error)) throw error;
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve, reject) => {
+          const onAbort = () => {
+            clearTimeout(timer);
+            reject(sharedSignal.reason || new Error("The operation was aborted"));
+          };
+          const timer = setTimeout(() => {
+            sharedSignal.removeEventListener("abort", onAbort);
+            resolve();
+          }, 250);
+          if (sharedSignal.aborted) onAbort();
+          else sharedSignal.addEventListener("abort", onAbort, { once: true });
+        });
       }
     }
     throw new Error("Metadata provider request failed");

--- a/backend/services/searchService.js
+++ b/backend/services/searchService.js
@@ -1,6 +1,7 @@
 import { getDiscoveryCache } from "./discovery/index.js";
 import { getLastfmApiKey, lastfmRequest } from "./apiClients/index.js";
 import { buildImageProxyUrl } from "./imageProxyService.js";
+import { selectBestArtistImage } from "./imageService.js";
 import { LIDARR_ALBUM_LOOKUP_BATCH_MAX, lidarrClient } from "./lidarrClient.js";
 import {
   searchAlbums as providerSearchAlbums,
@@ -83,6 +84,28 @@ export function normalizeAlbumSearchSort(value) {
   return ["relevance", "dateDesc", "artistAsc", "titleAsc"].includes(normalized)
     ? normalized
     : "relevance";
+}
+
+function normalizeArtistItem(item) {
+  const image = selectBestArtistImage(item.images);
+  return {
+    type: "artist",
+    id: item.id,
+    name: item.name,
+    sortName: item.sortName || item.name,
+    image: image?.url || null,
+    imageUrl: image?.url || null,
+    artistType: item.type || null,
+    country: null,
+    area: null,
+    begin: null,
+    end: null,
+    disambiguation: item.disambiguation || null,
+    tags: Array.isArray(item.genres) ? item.genres : [],
+    genres: Array.isArray(item.genres) ? item.genres : [],
+    inLibrary: false,
+    score: item.score || 0,
+  };
 }
 
 function normalizeAlbumItem(item, lookup = null) {

--- a/lib/axiosFetch.js
+++ b/lib/axiosFetch.js
@@ -119,8 +119,12 @@ async function axiosRequest(inputConfig) {
   }
   const timeoutMs = Number(config.timeout || 0);
   let timer = null;
+  let timeoutTriggered = false;
   if (timeoutMs > 0) {
-    timer = setTimeout(() => controller.abort(), timeoutMs);
+    timer = setTimeout(() => {
+      timeoutTriggered = true;
+      controller.abort();
+    }, timeoutMs);
   }
 
   const publicDispatchers = [];
@@ -196,7 +200,14 @@ async function axiosRequest(inputConfig) {
     }
     return axiosResponse;
   } catch (error) {
-    if (controller.signal.aborted && !error.code) {
+    if (timeoutTriggered) {
+      Object.defineProperty(error, "code", {
+        configurable: true,
+        enumerable: true,
+        value: "ECONNABORTED",
+        writable: true,
+      });
+    } else if (controller.signal.aborted && !error.code) {
       error.code = "ECONNABORTED";
     }
     if (!error.response && !error.request) {


### PR DESCRIPTION
External metadata failures could leave search empty or crash the legacy artist search route. Undici timeout errors were also reported with a numeric code that bypassed the existing retry logic.

This change:
- restores the existing BrainzMash artist result normalization;
- retries one transient BrainzMash timeout or upstream 5xx response;
- maps transport timeouts to Axios-compatible ECONNABORTED errors.

Verification:
- npm test — 857 passed
- npm run lint:backend
- focused timeout, search, and shared-inflight tests

Fixes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata provider reliability by retrying eligible failed requests automatically.
  * Standardized artist search results, including names, genres, scores, descriptions, and preferred images.
  * Improved timeout handling so timed-out requests consistently report a clear timeout error.
  * Prevented unnecessary retry delays when requests are cancelled.
* **Tests**
  * Added coverage for request timeouts, provider retries, cancellation behavior, and normalized artist search responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->