### PR TITLE
fix(library): recover from stale Lidarr track file IDs

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -886,6 +886,72 @@ test("indexLidarrLibrary uses bulk track reads when Lidarr provides them", async
   }
 });
 
+test("indexLidarrLibrary refreshes track files when an ID batch is stale", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-stale-track-file-"));
+  let filePath;
+  try {
+    filePath = await createAudioFile(root, "Stale Artist/Stale Album/01 Stale Track.flac");
+    const calls = [];
+    const client = {
+      isConfigured: () => true,
+      request: async () => [{
+        id: 717,
+        artistName: "Stale Artist",
+        foreignArtistId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }],
+      getAllAlbums: async () => [{
+        id: 818,
+        artistId: 717,
+        title: "Stale Album",
+        foreignAlbumId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        path: path.join(root, "Stale Artist", "Stale Album"),
+      }],
+      getAllTracks: async ({ artistIds }) => {
+        assert.deepEqual(artistIds, [717]);
+        calls.push("tracks");
+        return [{
+          id: 819,
+          albumId: 818,
+          title: "Stale Track",
+          trackNumber: 1,
+          foreignRecordingId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          trackFileId: 820,
+        }];
+      },
+      getTrackFilesByIds: async (trackFileIds) => {
+        assert.deepEqual(trackFileIds, [820]);
+        calls.push("id-files");
+        throw new Error("Lidarr API error: 500 - Expected query to return 1 rows but returned 0");
+      },
+      getAllTrackFiles: async ({ artistIds }) => {
+        assert.deepEqual(artistIds, [717]);
+        calls.push("artist-files");
+        return [{ id: 821, path: filePath, trackIds: [819] }];
+      },
+      getTracksByAlbumId: async () => {
+        throw new Error("per-album track read should not run after stale ID recovery");
+      },
+      getTrackFilesByAlbumId: async () => {
+        throw new Error("per-album file read should not run after stale ID recovery");
+      },
+      getRootFolders: async () => [{ path: root }],
+    };
+
+    const result = await indexLidarrLibrary({ client });
+    const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
+
+    assert.deepEqual(calls, ["tracks", "id-files", "artist-files"]);
+    assert.equal(result.filesIndexed, 1);
+    assert.equal(file?.source, "lidarr");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run(
+      "lidarr",
+      filePath,
+    );
+  }
+});
+
 test("indexLidarrLibrary does not fan out per album when a bulk track read fails", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-lidarr-bulk-fallback-"));
   let filePath;

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -106,7 +106,14 @@ async function loadAlbumTrackData(client, albums, artistIds) {
       files = await client.getTrackFilesByIds(
         tracks.map((track) => track?.trackFileId),
         { forceRefresh: true, throwOnError: true },
-      );
+      ).catch((error) => {
+        if (typeof client.getAllTrackFiles !== "function") throw error;
+        return client.getAllTrackFiles({
+          artistIds,
+          forceRefresh: true,
+          throwOnError: true,
+        });
+      });
     } else {
       [tracks, files] = await Promise.all([
         client.getAllTracks({ artistIds, forceRefresh: true, throwOnError: true }),


### PR DESCRIPTION
## What changed

When a bulk Lidarr track-file lookup fails because cached track file IDs are stale, the library indexer now refreshes track files by artist instead. Added regression coverage for this recovery path.

## Why

Lidarr can retain track records that reference deleted or stale track file IDs. Previously, this caused library indexing to fail instead of recovering with current track file data.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #718

## Testing

- Added and ran the regression test for stale Lidarr track file ID recovery.
- Verified that the refreshed file is indexed as a Lidarr library file.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Lidarr library indexing resilience when bulk track-file lookups fail.
  - Indexing now retries with an artist-level lookup when available, helping ensure track files are still discovered without making individual album requests.
  - Added regression coverage to verify successful fallback indexing and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->