### PR TITLE
fix(library): remove deleted Aurral tracks permanently

### DIFF
--- a/.tests/library/track-deletion.test.js
+++ b/.tests/library/track-deletion.test.js
@@ -8,6 +8,7 @@ import path from "node:path";
 import { db } from "../../backend/config/db-sqlite.js";
 import { lidarrClient } from "../../backend/services/lidarrClient.js";
 import { libraryManager } from "../../backend/services/libraryManager.js";
+import { downloadTracker } from "../../backend/services/weeklyFlow/weeklyFlowDownloadTracker.js";
 import {
   linkLibraryAlbumTrack,
   upsertLibraryAlbum,
@@ -26,21 +27,19 @@ test("deletes Aurral-owned track files without Lidarr", async (t) => {
   const artist = upsertLibraryArtist({
     identityKey: `${identity}:artist`,
     name: "Artist",
-    syncSearch: false,
   });
   const album = upsertLibraryAlbum({
     identityKey: `${identity}:album`,
     artistId: artist.id,
     title: "Album",
-    syncSearch: false,
   });
   const track = upsertLibraryTrack({
     identityKey: `${identity}:track`,
+    mbid: `${identity}-mbid`,
     title: "Track",
     artistName: "Artist",
-    syncSearch: false,
   });
-  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, syncSearch: false });
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
   upsertLibraryMediaFile({
     trackId: track.id,
     albumId: album.id,
@@ -48,6 +47,16 @@ test("deletes Aurral-owned track files without Lidarr", async (t) => {
     path: filePath,
     available: true,
   });
+  const libraryJobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Track" },
+    "library",
+  );
+  downloadTracker.setDone(libraryJobId, filePath, "Album");
+  const upgradeJobId = downloadTracker.addUpgradeJob(downloadTracker.getJob(libraryJobId));
+  const differentTrackJobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Track", trackMbid: `${identity}-different-mbid` },
+    "library",
+  );
 
   t.mock.method(lidarrClient, "isConfigured", () => false);
 
@@ -56,17 +65,36 @@ test("deletes Aurral-owned track files without Lidarr", async (t) => {
     await assert.rejects(() => access(filePath));
     assert.equal(
       db.prepare(
-        "SELECT available FROM library_media_files WHERE source = ? AND path = ?",
-      ).get("aurral", filePath)?.available,
-      0,
+        "SELECT 1 FROM library_media_files WHERE source = ? AND path = ?",
+      ).get("aurral", filePath),
+      undefined,
     );
-    assert.deepEqual(await libraryManager.deleteTrack(track.id), { success: true });
+    assert.equal(db.prepare("SELECT 1 FROM library_tracks WHERE id = ?").get(track.id), undefined);
+    assert.equal(db.prepare("SELECT 1 FROM library_albums WHERE id = ?").get(album.id), undefined);
+    assert.equal(db.prepare("SELECT 1 FROM library_artists WHERE id = ?").get(artist.id), undefined);
+    for (const [entityKind, entityId] of [["artist", artist.id], ["album", album.id], ["track", track.id]]) {
+      assert.equal(
+        db.prepare(
+          "SELECT 1 FROM library_search_documents WHERE entity_kind = ? AND entity_id = ?",
+        ).get(entityKind, entityId),
+        undefined,
+      );
+    }
+    assert.equal(downloadTracker.getJob(libraryJobId), null);
+    assert.equal(downloadTracker.getJob(upgradeJobId), null);
+    assert.notEqual(downloadTracker.getJob(differentTrackJobId), null);
   } finally {
+    db.prepare(
+      "DELETE FROM library_search_documents WHERE (entity_kind, entity_id) IN ((?, ?), (?, ?), (?, ?))",
+    ).run("artist", artist.id, "album", album.id, "track", track.id);
     db.prepare("DELETE FROM library_media_files WHERE source = ? AND path = ?").run("aurral", filePath);
     db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? AND track_id = ?").run(album.id, track.id);
     db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
     db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    if (libraryJobId) downloadTracker.removeJob(libraryJobId);
+    if (upgradeJobId) downloadTracker.removeJob(upgradeJobId);
+    if (differentTrackJobId) downloadTracker.removeJob(differentTrackJobId);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -107,10 +135,15 @@ test("records successful Aurral deletions when another file fails", async (t) =>
       available: true,
     });
   }
+  const libraryJobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Track" },
+    "library",
+  );
 
+  let failDeletion = true;
   const originalUnlink = fsp.unlink;
   t.mock.method(fsp, "unlink", async (filePath) => {
-    if (filePath === failedPath) {
+    if (failDeletion && filePath === failedPath) {
       const error = new Error("permission denied");
       error.code = "EACCES";
       throw error;
@@ -131,6 +164,7 @@ test("records successful Aurral deletions when another file fails", async (t) =>
       ).get("aurral", deletedPath)?.available,
       0,
     );
+    assert.equal(downloadTracker.getJob(libraryJobId), null);
     assert.equal(
       db.prepare(
         "SELECT available FROM library_media_files WHERE source = ? AND path = ?",
@@ -139,6 +173,12 @@ test("records successful Aurral deletions when another file fails", async (t) =>
     );
     await assert.rejects(() => access(deletedPath));
     await access(failedPath);
+    failDeletion = false;
+    assert.deepEqual(await libraryManager.deleteTrack(track.id), { success: true });
+    await assert.rejects(() => access(failedPath));
+    assert.equal(db.prepare("SELECT 1 FROM library_tracks WHERE id = ?").get(track.id), undefined);
+    assert.equal(db.prepare("SELECT 1 FROM library_albums WHERE id = ?").get(album.id), undefined);
+    assert.equal(db.prepare("SELECT 1 FROM library_artists WHERE id = ?").get(artist.id), undefined);
   } finally {
     db.prepare("DELETE FROM library_media_files WHERE source = ? AND path IN (?, ?)").run(
       "aurral",
@@ -149,6 +189,7 @@ test("records successful Aurral deletions when another file fails", async (t) =>
     db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
     db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
     db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    if (libraryJobId) downloadTracker.removeJob(libraryJobId);
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -10,10 +10,12 @@ import {
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
 import { scheduleLibraryScan } from "./libraryScanWorker.js";
+import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import {
   clearCanonicalLidarrAlbum,
   clearCanonicalLidarrArtist,
   markLibraryMediaFilesUnavailable,
+  removeLibraryTrackIfNoAvailableMedia,
 } from "./libraryMediaStore.js";
 const normalizeTypeName = (value) =>
   String(value || "")
@@ -60,6 +62,33 @@ const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
 function scheduleCanonicalLibraryReconciliation() {
   invalidateCanonicalLibraryCache();
   return scheduleLibraryScan({ includeLidarr: true });
+}
+
+function removeLibraryDownloadJobs(track) {
+  const normalize = (value) => String(value || "").trim().toLocaleLowerCase();
+  const trackMbid = normalize(track?.mbid);
+  const artistName = normalize(track?.artistName);
+  const trackName = normalize(track?.title);
+  const jobs = downloadTracker.getAll();
+  const removedJobIds = new Set();
+  for (const job of jobs) {
+    if (job.playlistType !== "library") continue;
+    const jobTrackMbid = normalize(job.trackMbid);
+    const matchesName = normalize(job.artistName) === artistName
+      && normalize(job.trackName) === trackName;
+    const matchesTrack = trackMbid && jobTrackMbid
+      ? jobTrackMbid === trackMbid
+      : matchesName;
+    if (matchesTrack) {
+      removedJobIds.add(job.id);
+      downloadTracker.removeJob(job.id);
+    }
+  }
+  for (const job of jobs) {
+    if (job.upgradeForJobId && removedJobIds.has(job.upgradeForJobId)) {
+      downloadTracker.removeJob(job.id);
+    }
+  }
 }
 
 function buildTrackFileIndex(trackFiles) {
@@ -1590,6 +1619,7 @@ export class LibraryManager {
       const lidarrFiles = track.files.filter((file) => file.source === "lidarr" && file.available);
       if (aurralFiles.length > 0 && lidarrFiles.length === 0) {
         const paths = [...new Set(aurralFiles.map((file) => file.path))];
+        removeLibraryDownloadJobs(track);
         try {
           const deletionResults = await Promise.allSettled(paths.map(async (filePath) => {
             try {
@@ -1605,7 +1635,6 @@ export class LibraryManager {
             .map((result) => result.value);
           if (reconciledPaths.length > 0) {
             markLibraryMediaFilesUnavailable("aurral", reconciledPaths);
-            invalidateCanonicalLibraryCache();
           }
           const failure = deletionResults.find((result) => result.status === "rejected");
           if (failure) {
@@ -1613,6 +1642,7 @@ export class LibraryManager {
             logger.error("library", `[LibraryManager] Failed to delete Aurral track file: ${error.message}`);
             return { success: false, code: "failed", error: error.message };
           }
+          removeLibraryTrackIfNoAvailableMedia(id);
           return { success: true };
         } catch (error) {
           logger.error("library", `[LibraryManager] Failed to delete Aurral track file: ${error.message}`);

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { db, dbHelpers } from "../config/db-sqlite.js";
 import { invalidateCanonicalLibraryCache } from "./libraryQueryService.js";
 import {
+  removeLibrarySearchDocument,
   syncLibrarySearchAlbum,
   syncLibrarySearchArtist,
   syncLibrarySearchTrack,
@@ -400,6 +401,56 @@ export function linkLibraryAlbumTrack({
     return result.changes > 0;
   })();
   if (changed) invalidateLibraryCache();
+}
+
+export function removeLibraryTrackIfNoAvailableMedia(trackId) {
+  const normalizedTrackId = Number(trackId);
+  if (!Number.isSafeInteger(normalizedTrackId)) return false;
+  const removed = db.transaction(() => {
+    const mediaFiles = db.prepare(
+      "SELECT album_id, available FROM library_media_files WHERE track_id = ?",
+    ).all(normalizedTrackId);
+    if (!mediaFiles.length || mediaFiles.some((file) => file.available === 1)) return false;
+
+    const albumIds = new Set([
+      ...db.prepare(
+        "SELECT album_id FROM library_album_tracks WHERE track_id = ?",
+      ).all(normalizedTrackId).map((row) => row.album_id),
+      ...mediaFiles.map((file) => file.album_id).filter((albumId) => albumId != null),
+    ]);
+    const artistIds = new Set(
+      db.prepare(
+        `SELECT artist_id
+         FROM library_albums
+         WHERE id IN (${[...albumIds].map(() => "?").join(",") || "NULL"})`,
+      ).all(...albumIds).map((row) => row.artist_id),
+    );
+
+    removeLibrarySearchDocument("track", normalizedTrackId);
+    db.prepare("DELETE FROM library_media_files WHERE track_id = ?").run(normalizedTrackId);
+    db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(normalizedTrackId);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(normalizedTrackId);
+
+    for (const albumId of albumIds) {
+      const result = db.prepare(
+        `DELETE FROM library_albums
+         WHERE id = ?
+           AND NOT EXISTS (SELECT 1 FROM library_album_tracks WHERE album_id = ?)`,
+      ).run(albumId, albumId);
+      if (result.changes > 0) removeLibrarySearchDocument("album", albumId);
+    }
+    for (const artistId of artistIds) {
+      const result = db.prepare(
+        `DELETE FROM library_artists
+         WHERE id = ?
+           AND NOT EXISTS (SELECT 1 FROM library_albums WHERE artist_id = ?)`,
+      ).run(artistId, artistId);
+      if (result.changes > 0) removeLibrarySearchDocument("artist", artistId);
+    }
+    return true;
+  })();
+  if (removed) invalidateLibraryCache();
+  return removed;
 }
 
 export function removeLibraryAlbumTracksWithoutMedia(albumId, source, { syncSearch = true } = {}) {

--- a/backend/services/librarySearchIndex.js
+++ b/backend/services/librarySearchIndex.js
@@ -102,6 +102,13 @@ export function syncLibrarySearchTrack(trackId) {
   );
 }
 
+export function removeLibrarySearchDocument(entityKind, entityId) {
+  if (!indexAvailable) return false;
+  return db.prepare(
+    "DELETE FROM library_search_documents WHERE entity_kind = ? AND entity_id = ?",
+  ).run(String(entityKind || ""), Number(entityId)).changes > 0;
+}
+
 export function rebuildLibrarySearchIndex() {
   if (!indexAvailable) return false;
   db.transaction(() => {

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -81,7 +81,7 @@ instance API key for WebSocket connections.
 | `PUT` | `/api/library/albums/:id` | Update an album |
 | `DELETE` | `/api/library/albums/:id` | Delete an album |
 | `GET` | `/api/library/tracks` | List album tracks |
-| `DELETE` | `/api/library/tracks/:id` | Delete a library track file |
+| `DELETE` | `/api/library/tracks/:id` | Delete a library track file and prune canonical records when no media remains |
 | `POST` | `/api/library/refresh` | Queue a canonical library scan |
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
 | `GET` | `/api/library/canonical` | Read a bounded canonical page; provide a supported `kind` and `pageSize` (1-100) |

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -26,6 +26,11 @@ reports stale library data, partial or missing files, provider health problems,
 and empty results. Use **View info** in an artist, album, or track action menu
 to inspect the indexed metadata without leaving the Library.
 
+When you delete an Aurral-owned track, Aurral removes its file. If no other
+media for the track is available, it also removes the canonical track and any
+empty album or artist record. If one of several files cannot be deleted, Aurral
+keeps the track until a later deletion succeeds.
+
 Navidrome remains optional. Lidarr remains the library provider when it is
 configured.
 

--- a/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
+++ b/frontend/src/pages/ArtistDetails/components/DeleteTrackModal.jsx
@@ -2,7 +2,7 @@ import { useId } from "react";
 import { DotLoader } from "../../../components/DotLoader";
 import { useModalDialog } from "../../../hooks/useModalDialog.js";
 
-export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting }) {
+export function DeleteTrackModal({ show, title, hasFile = true, onCancel, onConfirm, deleting }) {
   const titleId = useId();
   const { dialogRef } = useModalDialog({
     open: show,
@@ -22,11 +22,14 @@ export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting })
         tabIndex={-1}
       >
         <h3 id={titleId} className="artist-modal__title">
-          Delete Track File
+          {hasFile ? "Delete track file" : "Remove track from library"}
         </h3>
         <p className="artist-modal__copy">
-          Delete <strong>{title || "this track"}</strong> from the library? This permanently
-          removes the audio file from disk.
+          {hasFile
+            ? <>Delete <strong>{title || "this track"}</strong> from the library? This permanently
+              removes the audio file from disk.</>
+            : <>Remove <strong>{title || "this track"}</strong> from the library? This clears the
+              unavailable track record and stops it from being queued again.</>}
         </p>
         <div className="artist-modal__actions">
           <button onClick={onCancel} disabled={deleting} className="btn btn-secondary">
@@ -36,10 +39,10 @@ export function DeleteTrackModal({ show, title, onCancel, onConfirm, deleting })
             {deleting ? (
               <>
                 <DotLoader size="sm" label={null} />
-                Deleting...
+                {hasFile ? "Deleting..." : "Removing..."}
               </>
             ) : (
-              "Delete Track"
+              hasFile ? "Delete track" : "Remove track"
             )}
           </button>
         </div>

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -116,6 +116,9 @@ const firstAvailableFile = (track, albumId = null) =>
   || (albumId == null ? (track?.files || []).find((file) => file.available) : null)
   || null;
 
+const hasAurralTrackFile = (track) =>
+  (track?.files || []).some((file) => file.source === "aurral");
+
 const EMPTY_LIBRARY = { artists: [], albums: [], tracks: [], genres: [] };
 
 const normalizeLibraryPages = (pages) => pages.reduce(
@@ -941,12 +944,15 @@ function LibraryPage() {
       queryKey: queryKeys.libraryAlbumTracksPrefix,
       refetchType: "none",
     });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
   }, [setLibrary]);
 
   const handleLibraryRemovalConfirm = useCallback(async () => {
     if (!libraryRemoval?.entity || deletingLibraryEntity) return;
     const removal = libraryRemoval;
     const entity = removal.entity;
+    const trackHasFile = removal.kind === "track" && Boolean(firstAvailableFile(entity));
     setDeletingLibraryEntity(true);
     try {
       if (!isPreviewLibrary) {
@@ -965,7 +971,9 @@ function LibraryPage() {
           ? "Artist removed from library"
           : removal.kind === "album"
             ? "Album removed from library"
-            : "Track deleted",
+            : trackHasFile
+              ? "Track deleted"
+              : "Track removed from library",
       );
       if (
         (removal.kind === "artist" && String(routeArtistId) === String(entity.id)) ||
@@ -1742,11 +1750,11 @@ function LibraryPage() {
                   },
                 ]
               : []),
-            ...(file && canDeleteTrack
+            ...(canDeleteTrack && (file || hasAurralTrackFile(track))
               ? [
                   {
                     id: "delete",
-                    label: "Delete track file",
+                    label: file ? "Delete track file" : "Remove track from library",
                     icon: Trash2,
                     danger: true,
                     separatorBefore: true,
@@ -2568,6 +2576,7 @@ function LibraryPage() {
       <DeleteTrackModal
         show={libraryRemoval?.kind === "track"}
         title={libraryRemoval?.entity?.title || libraryRemoval?.entity?.trackName}
+        hasFile={Boolean(firstAvailableFile(libraryRemoval?.entity))}
         onCancel={() => setLibraryRemoval(null)}
         onConfirm={handleLibraryRemovalConfirm}
         deleting={deletingLibraryEntity}


### PR DESCRIPTION
Aurral-owned tracks that users deleted could remain as unavailable canonical rows and keep library download jobs. A later repair pass could queue the track again.

This change treats missing Aurral files as already deleted, removes matching library and quality-upgrade jobs, prunes unavailable media and empty canonical track, album, artist, and search records, and exposes a removal action for stale 0/1 track rows. The Library view refreshes its canonical and view queries after removal.

Verification:
- node --test .tests/library/track-deletion.test.js
- npm test (860 passed)
- npm run lint:backend
- npm run lint --workspace frontend
- npm run build --workspace frontend
- npm run docs:build

Known limitation: provider-backed artist and album deletion still follows the existing Lidarr flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved track removal handling for Aurral-sourced files.
  - Tracks without available media can now be removed from the library.
  - Deleting the final available file automatically cleans up related track, album, artist, and search records.
  - Download and upgrade jobs associated with removed tracks are cleared appropriately.
  - Removal dialogs and confirmation buttons now clearly distinguish deleting files from removing library entries.

- **Bug Fixes**
  - Improved cleanup and retry behavior when file deletion encounters an access error.

- **Documentation**
  - Updated API and library documentation to describe track deletion and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->