### PR TITLE
refactor(ui): simplify interface copy

### DIFF
--- a/frontend/src/components/LastfmBanner.jsx
+++ b/frontend/src/components/LastfmBanner.jsx
@@ -45,11 +45,7 @@ const LastfmBanner = () => {
   return (
     <div className="app-banner">
       <div className="app-banner__content">
-        <p className="app-banner__title">Personalize your discovery</p>
-        <p className="app-banner__text">
-          Connect Last.fm for personalized recommendations, related artists, full tag search, and
-          flows.
-        </p>
+        <p className="app-banner__title">Last.fm</p>
       </div>
       <div className="app-banner__actions">
         <button

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -41,13 +41,6 @@ const HISTORY_EMPTY_STATE = {
   message: "A chronological log of album requests, track downloads, and other activity will appear here.",
 };
 
-const ACTIVITY_DESCRIPTIONS = {
-  queue: "Work in progress. Completed and failed work moves to History.",
-  history: "Finished activity. Tracks that need another search appear in Wanted.",
-  missing: "Tracks with no file. Re-search them here, then follow progress in Queue and History.",
-  cutoff: "Playable tracks below your quality target. Queue upgrades here, then follow them in Queue and History.",
-};
-
 function ActivityPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -382,9 +375,6 @@ function ActivityPage() {
     <>
       <header className="activity-page__header">
         <h1 className="page-title">{activeViewLabel}</h1>
-        <p className="page-subtitle">
-          {ACTIVITY_DESCRIPTIONS[isCutoffView ? "cutoff" : activeView]}
-        </p>
       </header>
       {!isMissingView ? (
         <PageSectionMobileNav

--- a/frontend/src/pages/DiscoverPage.jsx
+++ b/frontend/src/pages/DiscoverPage.jsx
@@ -623,7 +623,7 @@ function DiscoverPage() {
         return (
           <DiscoverRail
             key="recommended"
-            title="Recommended for You"
+            title="Recommended"
             onViewAll={() => navigate("/search?type=recommended")}
           >
             <>
@@ -652,7 +652,7 @@ function DiscoverPage() {
         <section key="recommended" className="artist-discover-section">
           <h2 className="artist-section-title--discover discover-recommended-status__title">
             <span className="artist-section-title--discover-mobile">Recommended</span>
-            <span className="artist-section-title--discover-desktop">Recommended for You</span>
+            <span className="artist-section-title--discover-desktop">Recommended</span>
           </h2>
           <div
             className={`discover-recommended-status${isUpdating ? " discover-recommended-status--loading" : ""}`}
@@ -671,14 +671,9 @@ function DiscoverPage() {
                   ? "Not enough listening data yet"
                   : "Connect Last.fm"}
             </h3>
-            <p className="discover-recommended-status__message">
-              {isUpdating
-                ? updateProgressMessage ||
-                  "Scanning your library and Last.fm history. The first setup can take up to 10 minutes."
-                : provider === "lastfm"
-                  ? "Add artists to your library or keep scrobbling on Last.fm. Recommendations improve as Aurral learns your taste."
-                  : "Connect a Last.fm API key for personalized recommendations, related artists, and flows."}
-            </p>
+            {isUpdating && updateProgressMessage ? (
+              <p className="discover-recommended-status__message">{updateProgressMessage}</p>
+            ) : null}
             {!isUpdating ? (
               <div className="discover-recommended-status__actions">
                 {provider !== "lastfm" ? (
@@ -912,7 +907,6 @@ function DiscoverPage() {
       <div className="artist-loading--discover">
         <DotLoader size="2xl" label={null} className="aurral-dot-loader--discover" />
         <h2 className="artist-error-title--discover">Loading recommendations...</h2>
-        <p className="artist-error-copy--discover">Recommendations will appear as they load.</p>
       </div>
     );
   }
@@ -926,11 +920,9 @@ function DiscoverPage() {
             ? "Loading ListenBrainz discovery..."
             : "Building your recommendations..."}
         </h2>
-        <p className="artist-error-copy--discover">
-          {isListenBrainzFallback
-            ? "The app is loading trending artists and default genre shelves."
-            : "The app is scanning your library and Last.fm data. Please wait. This can take up to 10 minutes when Last.fm is configured. The page will update when ready."}
-        </p>
+        {updateProgressMessage ? (
+          <p className="artist-error-copy--discover">{updateProgressMessage}</p>
+        ) : null}
       </div>
     );
   }

--- a/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistDetailPage.jsx
@@ -278,7 +278,6 @@ export default function DiscoverPlaylistDetailPage() {
         <section className="discover-playlist-detail__status" aria-live="polite">
           <DotLoader size="lg" label={null} />
           <h1>Loading playlist</h1>
-          <p>Checking your latest discovery playlists.</p>
         </section>
       </div>
     );

--- a/frontend/src/pages/DiscoverPlaylistSection.jsx
+++ b/frontend/src/pages/DiscoverPlaylistSection.jsx
@@ -153,7 +153,7 @@ export function DiscoverPlaylistSection({
 
   return (
     <DiscoverRail
-      title="Playlists for you"
+      title="Playlists"
       onViewAll={() => navigate("/discover/playlists")}
       afterTitle={
         <DiscoveryStatusPill

--- a/frontend/src/pages/DiscoverPlaylistsPage.jsx
+++ b/frontend/src/pages/DiscoverPlaylistsPage.jsx
@@ -148,7 +148,7 @@ export default function DiscoverPlaylistsPage() {
       <div className="discover-playlists-page">
         <header className="discover-playlists-page__header">
           <div className="discover-playlists-page__title-row">
-            <h1 className="page-title">Playlists for you</h1>
+            <h1 className="page-title">Playlists</h1>
             <DiscoveryStatusPill
               isUpdating={isUpdating}
               playlistsUpdating={playlistsUpdating}
@@ -162,7 +162,6 @@ export default function DiscoverPlaylistsPage() {
           <div className="search-empty-panel discover-playlists-page__status-panel">
             <DotLoader size="lg" label={null} />
             <h2 className="search-empty-panel__title">Loading your playlists</h2>
-            <p className="search-empty-panel__message">Checking your latest discovery playlists.</p>
           </div>
         ) : isUpdating || playlistsUpdating ? (
           <div className="search-empty-panel">
@@ -190,9 +189,6 @@ export default function DiscoverPlaylistsPage() {
               <Music className="artist-icon-lg" />
             </div>
             <h2 className="search-empty-panel__title">Connect Last.fm</h2>
-            <p className="search-empty-panel__message">
-              Connect a Last.fm API key in Settings → Connect to generate discover playlists.
-            </p>
             <Link to="/settings/connect" className="btn btn-secondary btn-sm">
               Open Last.fm settings
             </Link>
@@ -203,9 +199,6 @@ export default function DiscoverPlaylistsPage() {
               <Music className="artist-icon-lg" />
             </div>
             <h2 className="search-empty-panel__title">No playlists yet</h2>
-            <p className="search-empty-panel__message">
-              Run a discovery refresh to generate playlists.
-            </p>
             <Link to="/settings/discover" className="btn btn-secondary btn-sm">
               Open Discovery Settings
             </Link>
@@ -219,7 +212,7 @@ export default function DiscoverPlaylistsPage() {
     <div className="discover-playlists-page">
       <header className="discover-playlists-page__header">
         <div className="discover-playlists-page__title-row">
-          <h1 className="page-title">Playlists for you</h1>
+          <h1 className="page-title">Playlists</h1>
           <DiscoveryStatusPill
             isUpdating={isUpdating}
             playlistsUpdating={playlistsUpdating}

--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -47,9 +47,6 @@ export default function NewsPage() {
       <header className="discover-news-page__header">
         <div>
           <h1 className="page-title">Artist News</h1>
-          <p className="discover-news-page__subtitle">
-            Top stories from your enabled RSS feeds
-          </p>
         </div>
         {newsConfigured ? (
           <button
@@ -76,7 +73,6 @@ export default function NewsPage() {
         <section className="discover-news-page__status">
           <DotLoader size="2xl" label={null} />
           <h2>Loading artist news</h2>
-          <p>Checking recent stories for your library artists.</p>
         </section>
       ) : articles.length > 0 ? (
         <>

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -244,7 +244,6 @@ function Onboarding() {
                   <OnboardingStepHeader
                     title="Welcome to Aurral"
                     titleClassName="onboarding-title--hero"
-                    copy="Create your admin account. Connect Lidarr next, then finish the rest in Settings."
                   />
                   <div className="onboarding-fields">
                     <div className="onboarding-field">
@@ -295,7 +294,6 @@ function Onboarding() {
                         </p>
                       ) : null}
                     </div>
-                    <OnboardingHint>Password must be at least 8 characters long.</OnboardingHint>
                     <div className="onboarding-toggle-row">
                       <span>Auto-login on local network</span>
                       <PillToggle
@@ -316,7 +314,6 @@ function Onboarding() {
                 <OnboardingStep>
                   <OnboardingStepHeader
                     title="Connect Lidarr"
-                    copy="Aurral is a Lidarr companion. Connect Lidarr to manage your library."
                   />
                   <div className="onboarding-fields">
                     <div className="onboarding-field">
@@ -358,10 +355,7 @@ function Onboarding() {
                       />
                     </div>
                     <OnboardingHint>
-                      Find your API key in Lidarr under Settings → General → Security. The
-                      Downloads Folder and optional playback clients are configured in Settings
-                      after setup. Aurral can play indexed media directly when the canonical file
-                      is readable.
+                      Find your API key in Lidarr under Settings → General → Security.
                     </OnboardingHint>
                     {lidarrTestSuccess ? (
                       <p className="onboarding-status onboarding-status--success" role="status">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -29,7 +29,6 @@ function ProfilePage() {
       <div className="profile-page__header">
         <div className="profile-page__intro">
           <h1 className="page-title">Profile</h1>
-          <p className="page-subtitle">Personal listening history and library defaults</p>
         </div>
         <span
           className={`profile-page__save-state${account.saving ? " is-saving" : ""}`}

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -157,7 +157,7 @@ function SearchResultsPage() {
   const isAlbumSearch = normalizedType === "album";
   const isUnifiedSearch = normalizedType === "unified" && !!trimmedQuery;
   const pageTitle = useMemo(() => {
-    if (normalizedType === "recommended") return "Recommended for You";
+    if (normalizedType === "recommended") return "Recommended";
     if (normalizedType === "trending") return "Global Trending";
     if (isTagSearch && trimmedQuery) {
       return trimmedQuery.startsWith("#") ? trimmedQuery : `#${trimmedQuery.replace(/^#/, "")}`;
@@ -1265,7 +1265,7 @@ function SearchResultsPage() {
     : searchTotalCount || results.length;
   const pageSubtitle =
     normalizedType === "recommended"
-      ? `${discoveryCount} recommendations we think you'll like`
+      ? `${discoveryCount} recommendations`
       : normalizedType === "trending"
         ? "Trending right now"
         : isUnifiedSearch && trimmedQuery
@@ -1463,10 +1463,6 @@ function SearchResultsPage() {
 
         {isAlbumSearch && trimmedQuery && (
           <>
-            <p className="search-page__subtitle">
-              Search results include compilations, soundtracks, and releases from Various Artists.
-            </p>
-
             <div className="artist-heading-row">
               <div className="artist-min-0">
                 <div className="artist-tabs">

--- a/frontend/src/pages/ShowsPage.jsx
+++ b/frontend/src/pages/ShowsPage.jsx
@@ -52,9 +52,6 @@ function ShowsPage() {
   const showGroups = getShowGroups(showsData);
   const shows = showGroups[showFilter] || showGroups.all;
   const hasAnyShows = Object.values(showGroups).some((group) => group.length > 0);
-  const pageSubtitle = showsLoading
-    ? "Finding Ticketmaster events matched to your library and recommendations."
-    : `Upcoming concerts around ${locationLabel}.`;
   const emptyMessage =
     showFilter === "library"
       ? `We could not find local Ticketmaster shows for artists from your library around ${locationLabel}.`
@@ -76,7 +73,6 @@ function ShowsPage() {
         <div className="shows-page__title-row">
           <div className="shows-page__title-wrap">
             <h1 className="page-title">Shows Near You</h1>
-            <p className="page-subtitle">{pageSubtitle}</p>
           </div>
           <NearbyLocationControl
             locationMode={locationMode}

--- a/frontend/src/pages/discoverUtils.js
+++ b/frontend/src/pages/discoverUtils.js
@@ -31,11 +31,11 @@ const DISCOVER_RECENT_RELEASES_KEY = "discoverRecentReleases";
 
 export const DEFAULT_DISCOVER_SECTIONS = [
   { id: "recentlyAdded", label: "Recently Added", enabled: true },
-  { id: "playlists", label: "Playlists for you", enabled: true },
+  { id: "playlists", label: "Playlists", enabled: true },
   { id: "recommendedShows", label: "Shows Near You", enabled: true },
   { id: "recentReleases", label: "Recent Releases", enabled: true },
   { id: "news", label: "Artist News", enabled: true },
-  { id: "recommended", label: "Recommended for You", enabled: true },
+  { id: "recommended", label: "Recommended", enabled: true },
   { id: "globalTop", label: "Global Trending", enabled: true },
   { id: "genreSections", label: "Because You Like", enabled: true },
 ];

--- a/frontend/src/pages/flows/flowComponents/FlowEmptyState.jsx
+++ b/frontend/src/pages/flows/flowComponents/FlowEmptyState.jsx
@@ -6,8 +6,6 @@ function getFlowEmptyCopy(libraryFilter, canCreate) {
   if (libraryFilter === "playlists") {
     return {
       title: "No playlists yet",
-      message:
-        "Create a playlist to curate tracks, or import one from Aurral Convert or a JSON export.",
       showPlaylistAction: true,
       showFlowAction: false,
       showImportAction: true,
@@ -17,8 +15,6 @@ function getFlowEmptyCopy(libraryFilter, canCreate) {
     if (!canCreate) {
       return {
         title: "Flows need listening history",
-        message:
-          "Connect Last.fm in Settings to create flows that generate tracks from your taste.",
         showPlaylistAction: false,
         showFlowAction: false,
         showImportAction: false,
@@ -27,17 +23,13 @@ function getFlowEmptyCopy(libraryFilter, canCreate) {
     }
     return {
       title: "No flows yet",
-      message:
-        "Flows are auto-updating playlists built from recipes like Release Radar or your top artists.",
       showPlaylistAction: false,
       showFlowAction: true,
       showImportAction: false,
     };
   }
   return {
-    title: "Start your playlist library",
-    message:
-      "Import a playlist, build your own track list, or create a flow that updates automatically from your taste.",
+    title: "No playlists or flows yet",
     showPlaylistAction: true,
     showFlowAction: canCreate,
     showImportAction: true,
@@ -65,7 +57,6 @@ export function FlowEmptyState({
         <ListMusic className="artist-icon-lg" />
       </div>
       <h2 className="flow-page__collection-empty__title">{copy.title}</h2>
-      <p className="flow-page__collection-empty__message">{copy.message}</p>
       {!isCompact ? (
         <div className="flow-page__collection-empty__actions">
           {copy.showPlaylistAction ? (


### PR DESCRIPTION
## What changed

- Simplified interface copy across discovery, activity, onboarding, profile, search, shows, news, Last.fm, and playlist flows.
- Removed redundant explanatory subtitles and loading or empty-state messages.
- Shortened recommendation and playlist labels for a more concise UI.

## Why

Reduce repetitive and overly verbose interface copy so page titles, statuses, and actions are easier to scan while preserving the existing functionality.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

This pull request changes UI copy throughout the application. Before-and-after screenshots are not included because the changes are text-only.

## Testing

- Not run; this change only updates frontend copy and removes redundant text.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified page headers, banners, and section labels across the app.
  * Shortened recommendation and playlist wording for a cleaner interface.
  * Removed secondary explanatory text from loading, empty, onboarding, and status states.
  * Preserved existing actions, connection behavior, loaders, and navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->