### PR TITLE
fix(server): bind http server on the default host

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -412,7 +412,7 @@ process.once("SIGINT", () => {
   void gracefulShutdown("SIGINT");
 });
 
-httpServer.listen(PORT, "::", async () => {
+httpServer.listen(PORT, async () => {
   logger.info("system", `Server running on port ${PORT}`);
   bootstrapHonkerSchedules();
   initializeAppRuntime({ logger });


### PR DESCRIPTION
## What changed

Changed the HTTP server to listen on the default host instead of explicitly binding to IPv6.

## Why

This restores compatibility with environments where binding to `::` is unavailable or does not provide the expected network access.

## Scope checklist

- [ ] This pull request has one clear purpose
- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #686

## Testing

- Not run; the change only adjusts the HTTP server bind call.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup compatibility by allowing the application to listen on the configured port without forcing a specific network address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->