### PR TITLE
fix(weekly-flow): review upgrade duration mismatches

### DIFF
--- a/.tests/weekly-flow/approved-import-path.test.js
+++ b/.tests/weekly-flow/approved-import-path.test.js
@@ -112,6 +112,55 @@ test("approving a reviewed download commits it inside the managed playlist libra
   await assert.rejects(fs.access(path.join(playlistManager.libraryRoot, "Reviewed.m3u")));
 });
 
+test("approving a reviewed upgrade replaces the source playlist file", async () => {
+  const flow = flowPlaylistConfig.createFlow({
+    name: "Reviewed upgrade flow",
+    size: 10,
+    mix: { discover: 100 },
+    scheduleDays: [1],
+  });
+  const originalPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "_flows",
+    flow.id,
+    "Artist",
+    "Album",
+    "Track.mp3",
+  );
+  const candidatePath = path.join(isolatedState.baseDir, "review", "Track.flac");
+  await fs.mkdir(path.dirname(originalPath), { recursive: true });
+  await fs.mkdir(path.dirname(candidatePath), { recursive: true });
+  await fs.writeFile(originalPath, "original audio");
+  await fs.writeFile(candidatePath, "upgrade audio");
+
+  const sourceJobId = downloadTracker.addJob(
+    { artistName: "Artist", trackName: "Track", albumName: "Album" },
+    flow.id,
+  );
+  downloadTracker.setDone(sourceJobId, originalPath, "Album");
+  downloadTracker.updateQuality(sourceJobId, { tier: "mp3-128", format: "mp3" });
+  const upgradeJobId = downloadTracker.addUpgradeJob(downloadTracker.getJob(sourceJobId));
+  downloadTracker.setBlocked(upgradeJobId, "blocked-duration-mismatch", candidatePath);
+
+  const response = await fetch(`${baseUrl}/jobs/${upgradeJobId}/approve`, { method: "POST" });
+  const payload = await response.json();
+  const expectedPath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "_flows",
+    flow.id,
+    "Artist",
+    "Album",
+    "Track.flac",
+  );
+
+  assert.equal(response.status, 200, JSON.stringify(payload));
+  assert.equal(payload.path, expectedPath);
+  assert.equal(downloadTracker.getJob(upgradeJobId), null);
+  assert.equal(downloadTracker.getJob(sourceJobId)?.finalPath, expectedPath);
+  assert.equal(await fs.readFile(expectedPath, "utf8"), "upgrade audio");
+  await assert.rejects(fs.access(originalPath));
+});
+
 test("reports when an upgrade search is already queued for a track", async () => {
   const playlistId = "c79c1598-699a-4ab3-b8cd-4e570f001f18";
   flowPlaylistConfig.createSharedPlaylist({

--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -18,6 +18,7 @@ const [
   { processUsenetPipelinePayload },
   { dbOps },
   { db },
+  { blockPipelineJobForReview },
 ] = await setupIsolatedBackend(
   "download-review-routing",
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
@@ -25,6 +26,7 @@ const [
   "backend/services/usenetOrchestrator.js",
   "backend/db/helpers/index.js",
   "backend/config/db-sqlite.js",
+  "backend/services/pipelineHelpers.js",
 );
 
 test.beforeEach(() => {
@@ -232,4 +234,39 @@ test("Usenet sends its best plausible duration mismatch to review", async () => 
   } finally {
     await server.close();
   }
+});
+
+test("upgrade duration mismatches remain available for review", async () => {
+  const originalPath = path.join(process.env.DOWNLOAD_FOLDER, "original.mp3");
+  const candidatePath = path.join(process.env.DOWNLOAD_FOLDER, "candidate.mp3");
+  await writeOneSecondMp3(originalPath);
+  await writeOneSecondMp3(candidatePath);
+
+  const sourceJobId = downloadTracker.addJob(
+    {
+      artistName: "Artist Name",
+      trackName: "Correct Track",
+      albumName: "Album Name",
+      durationMs: 100000,
+    },
+    "upgrade-review",
+  );
+  downloadTracker.setDone(sourceJobId, originalPath, "Album Name");
+  const upgradeJobId = downloadTracker.addUpgradeJob(downloadTracker.getJob(sourceJobId));
+  downloadTracker.setDownloading(upgradeJobId);
+
+  const result = blockPipelineJobForReview({
+    downloadTracker,
+    job: downloadTracker.getJob(upgradeJobId),
+    validation: {
+      blocked: true,
+      reason: "blocked-duration-mismatch: candidate duration differs",
+    },
+    sourcePath: candidatePath,
+  });
+
+  assert.equal(result, true);
+  assert.equal(downloadTracker.getJob(upgradeJobId)?.status, "blocked");
+  assert.equal(downloadTracker.getJob(upgradeJobId)?.stagingPath, candidatePath);
+  await access(candidatePath);
 });

--- a/.tests/weekly-flow/weekly-flow-track-resolver.test.js
+++ b/.tests/weekly-flow/weekly-flow-track-resolver.test.js
@@ -1,7 +1,24 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import axios from "../../lib/axiosFetch.js";
 
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+} from "../helpers/backendTestHarness.js";
+import { clearMetadataProviderCaches } from "../../backend/services/providers/brainzmashProvider.js";
 import { pickResolvedDurationMs } from "../../backend/services/providers/brainzmashRanking.js";
+
+const [isolatedState, { dbOps }, { resolveWeeklyFlowTrackContext }] =
+  await setupIsolatedBackend(
+    "weekly-flow-track-resolver",
+    "backend/db/helpers/index.js",
+    "backend/services/weeklyFlow/weeklyFlowTrackResolver.js",
+  );
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
 
 test("pickResolvedDurationMs prefers Last.fm only when albums agree", () => {
   assert.equal(
@@ -36,4 +53,127 @@ test("pickResolvedDurationMs prefers Last.fm only when albums agree", () => {
     pickResolvedDurationMs({ lastfmDurationMs: null, matchedTrackDurationMs: 207000 }),
     207000,
   );
+});
+
+test("pickResolvedDurationMs replaces a stale playlist duration with the matched release duration", () => {
+  assert.equal(
+    pickResolvedDurationMs({
+      playlistDurationMs: 524773,
+      albumName: "Jet Set Radio Future SEGA Original Tracks",
+      matchedTrackDurationMs: 222813,
+    }),
+    222813,
+  );
+});
+
+test("resolveWeeklyFlowTrackContext replaces a stale album MBID before resolving duration", async (t) => {
+  const originalSettings = dbOps.getSettings();
+  dbOps.updateSettings({
+    ...originalSettings,
+    integrations: {
+      ...originalSettings.integrations,
+      metadata: {
+        ...originalSettings.integrations.metadata,
+        baseUrl: "https://brainzmash.example.test",
+        enableNarrowFallbacks: false,
+      },
+    },
+  });
+  clearMetadataProviderCaches();
+  t.after(() => {
+    clearMetadataProviderCaches();
+    dbOps.updateSettings(originalSettings);
+  });
+
+  t.mock.method(axios, "get", async (url, options) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/album") {
+      return {
+        data: options?.params?.artist
+          ? [
+              {
+                id: "wrong-album",
+                title: "Jet Set Radio",
+                artistid: "wrong-artist",
+                artists: [{ id: "wrong-artist", artistname: "Vulgar Unicorn" }],
+              },
+            ]
+          : [
+              {
+                id: "correct-album",
+                title: "Jet Set Radio Future Original Sound Tracks",
+                artistid: "correct-artist",
+                artists: [{ id: "correct-artist", artistname: "長沼英樹" }],
+                releasedate: "2002-03-20",
+              },
+            ],
+      };
+    }
+    if (path === "/album/wrong-album") {
+      return {
+        data: {
+          id: "wrong-album",
+          title: "Jet Set Radio",
+          artistid: "wrong-artist",
+          artists: [{ id: "wrong-artist", artistname: "Vulgar Unicorn" }],
+          releases: [
+            {
+              id: "wrong-release",
+              status: "Official",
+              tracks: [
+                {
+                  trackname: "I Saw the Messenger of the New God There",
+                  trackposition: 4,
+                  durationms: 524773,
+                  recordingid: "wrong-track",
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+    if (path === "/album/correct-album") {
+      return {
+        data: {
+          id: "correct-album",
+          title: "Jet Set Radio Future Original Sound Tracks",
+          artistid: "correct-artist",
+          artists: [{ id: "correct-artist", artistname: "長沼英樹" }],
+          releasedate: "2002-03-20",
+          releases: [
+            {
+              id: "correct-release",
+              status: "Official",
+              releasedate: "2002-03-20",
+              tracks: [
+                {
+                  trackname: "The Concept of Love",
+                  trackposition: 1,
+                  durationms: 222813,
+                  recordingid: "correct-track",
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+    return { data: {} };
+  });
+
+  const resolved = await resolveWeeklyFlowTrackContext({
+    artistName: "Hideki Naganuma",
+    trackName: "The Concept of Love",
+    albumName: "Jet Set Radio Future SEGA Original Tracks",
+    artistMbid: "wrong-artist",
+    albumMbid: "wrong-album",
+    durationMs: 524773,
+    trackNumber: 4,
+  });
+
+  assert.equal(resolved.albumMbid, "correct-album");
+  assert.equal(resolved.durationMs, 222813);
+  assert.equal(resolved.trackNumber, 1);
+  assert.deepEqual(resolved.albumTrackTitles, ["The Concept of Love"]);
 });

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -270,8 +270,9 @@ export function registerJobs(router) {
     const ext = path.extname(sourcePath).toLowerCase();
     const albumDir = sanitizePathPart(job.albumName, "Unknown Album");
     const artistDir = sanitizePathPart(job.artistName, "Unknown Artist");
-    const destination = buildAurralTrackDestination(job.playlistType, artistDir, albumDir, {
-      ephemeral: Boolean(flowPlaylistConfig.getFlow(job.playlistType)),
+    const playlistId = job.playlistId || job.playlistType;
+    const destination = buildAurralTrackDestination(playlistId, artistDir, albumDir, {
+      ephemeral: Boolean(flowPlaylistConfig.getFlow(playlistId)),
     });
     const finalDir = joinUnderRoot(playlistRoot, destination);
     const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".mp3"}`;

--- a/backend/services/pipelineHelpers.js
+++ b/backend/services/pipelineHelpers.js
@@ -42,7 +42,7 @@ export function blockPipelineJobForReview({
   sourcePath,
 }) {
   const stagingPath = String(sourcePath || "").trim();
-  if (job?.upgradeForJobId || !validation?.blocked || !stagingPath) return false;
+  if (!validation?.blocked || !stagingPath) return false;
   const reason = validation.reason || "Blocked for review";
   if (!downloadTracker.setBlocked(job.id, reason, stagingPath)) return false;
   import("./aurralHistoryService.js")

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -7,7 +7,11 @@ import {
   DEFAULT_METADATA_BASE_URL,
   MUSICBRAINZ_API,
 } from "../../config/constants.js";
-import { rankAlbumCandidates, rankArtistCandidates } from "./brainzmashRanking.js";
+import {
+  rankAlbumCandidates,
+  rankArtistCandidates,
+  scoreTextMatch,
+} from "./brainzmashRanking.js";
 import {
   toLegacyArtist,
   toLegacyRelease,
@@ -329,6 +333,10 @@ export async function resolveAlbumByArtistAndTitle({
   albumTitle = "",
   releaseYear = null,
 }) {
+  const pickStrongMatch = (candidates) =>
+    candidates.find(
+      (candidate) => candidate?.id && scoreTextMatch(candidate.title, albumTitle) >= 85,
+    );
   const firstPass = await searchAlbums(albumTitle, {
     artistName,
     limit: 10,
@@ -338,7 +346,8 @@ export async function resolveAlbumByArtistAndTitle({
     artistName,
     releaseYear,
   });
-  if (ranked[0]?.id) return ranked[0].id;
+  const firstMatch = pickStrongMatch(ranked);
+  if (firstMatch?.id) return firstMatch.id;
 
   const secondPass = await searchAlbums(albumTitle, {
     artistName: "",
@@ -349,7 +358,7 @@ export async function resolveAlbumByArtistAndTitle({
     artistName,
     releaseYear,
   });
-  return ranked[0]?.id || null;
+  return pickStrongMatch(ranked)?.id || null;
 }
 
 export async function listArtistAlbums(

--- a/backend/services/providers/brainzmashRanking.js
+++ b/backend/services/providers/brainzmashRanking.js
@@ -151,18 +151,19 @@ export function pickResolvedDurationMs({
 } = {}) {
   let duration = positiveMs(playlistDurationMs);
   const lastfm = positiveMs(lastfmDurationMs);
+  const matched = positiveMs(matchedTrackDurationMs);
+  const lastfmAlbumMatches =
+    Boolean(albumName) &&
+    Boolean(lastfmAlbumName) &&
+    scoreTextMatch(lastfmAlbumName, albumName, { extended: true }) >= 85;
   if (lastfm) {
     if (!duration) {
       duration = lastfm;
-    } else if (
-      albumName &&
-      lastfmAlbumName &&
-      scoreTextMatch(lastfmAlbumName, albumName, { extended: true }) >= 85
-    ) {
+    } else if (lastfmAlbumMatches) {
       duration = lastfm;
     }
   }
-  return duration || positiveMs(matchedTrackDurationMs);
+  return matched && !lastfmAlbumMatches ? matched : duration || matched;
 }
 
 export function getYear(value) {

--- a/backend/services/weeklyFlow/weeklyFlowTrackResolver.js
+++ b/backend/services/weeklyFlow/weeklyFlowTrackResolver.js
@@ -53,6 +53,14 @@ function pickBestCandidate(candidates, expectedTitle, expectedYear = null) {
     .sort((left, right) => right.score - left.score)[0]?.candidate;
 }
 
+function matchesAlbumTitle(actualTitle, expectedTitle) {
+  return (
+    !actualTitle ||
+    !expectedTitle ||
+    scoreTextMatchBase(actualTitle, expectedTitle, MATCHER_OPTIONS) >= 85
+  );
+}
+
 async function fetchArtistAliases(artistMbid) {
   const key = String(artistMbid || "").trim();
   if (!key) return [];
@@ -105,7 +113,8 @@ async function resolveReleaseGroup(artistName, artistMbid, albumName, releaseYea
     try {
       const candidates = safeMbid ? await listArtistAlbums(safeMbid) : [];
       const best = pickBestCandidate(candidates, safeAlbum, releaseYear);
-      if (best?.Id || best?.id) {
+      const bestTitle = best?.Title || best?.title;
+      if ((best?.Id || best?.id) && matchesAlbumTitle(bestTitle, safeAlbum)) {
         return {
           id: String(best?.Id || best?.id),
           title: String(best?.Title || best?.title || safeAlbum).trim() || safeAlbum,
@@ -185,6 +194,7 @@ async function fetchReleaseContext(albumMbid) {
         null;
       if (!pickedRelease) {
         return {
+          albumName: String(album?.title || "").trim() || null,
           artistId,
           artistName,
           releaseYear: getYear(album?.releaseDate),
@@ -202,6 +212,7 @@ async function fetchReleaseContext(albumMbid) {
           }))
         : [];
       return {
+        albumName: String(album?.title || "").trim() || null,
         artistId,
         artistName,
         releaseYear: getYear(pickedRelease?.releaseDate) || getYear(album?.releaseDate),
@@ -284,6 +295,18 @@ export async function resolveWeeklyFlowTrackContext(track) {
   }
 
   let releaseContext = null;
+  if (base.albumMbid) {
+    releaseContext = await fetchReleaseContext(base.albumMbid);
+    if (
+      releaseContext?.albumName &&
+      base.albumName &&
+      !matchesAlbumTitle(releaseContext.albumName, base.albumName)
+    ) {
+      base.albumMbid = null;
+      base.trackMbid = null;
+      releaseContext = null;
+    }
+  }
   if (!base.albumMbid && base.albumName) {
     const releaseGroup = await resolveReleaseGroup(
       base.artistName,
@@ -307,7 +330,7 @@ export async function resolveWeeklyFlowTrackContext(track) {
 
   let matchedTrackDurationMs = null;
   if (base.albumMbid) {
-    releaseContext = await fetchReleaseContext(base.albumMbid);
+    releaseContext ||= await fetchReleaseContext(base.albumMbid);
     if (
       releaseContext?.artistId &&
       artistNamesMatch(base.artistName, releaseContext.artistName)

--- a/docs/src/content/docs/using/playlists.mdx
+++ b/docs/src/content/docs/using/playlists.mdx
@@ -71,7 +71,7 @@ The default profile accepts all tiers and uses **FLAC standard** as the cutoff.
 
 Aurral can use search-result names and bitrate data to order candidates. Aurral does not trust that data for final admission. It reads the downloaded file and rejects it when the format, bitrate, sample rate, or bit depth does not match an enabled tier.
 
-An unknown final quality is not valid. A quality rejection does not go to **Activity > Queue**. Queue review stays for track identity and duration decisions.
+An unknown final quality is not valid. A quality rejection does not go to **Activity > Queue**. Queue review stays for track identity and duration decisions, including upgrade downloads.
 
 The **Quality** column on the Playlists page shows the measured tier and its profile state. It labels a file reused from Lidarr as **Lidarr**.
 
@@ -93,6 +93,8 @@ A user who can open the playlist can start these searches. Manual searches work 
 To schedule upgrades, enable **Automatic upgrades** in the quality profile. The default is off. Set the interval from 1 to 365 days. The default is 2 days for each track.
 
 Upgrade jobs have a lower priority than missing-track downloads. Aurral uses slskd and Usenet for upgrades, in the configured source-priority order. It stops after the first source provides a valid, strictly better file. It waits for the next interval before it tries another automatic improvement for that track.
+
+If an upgrade download matches the requested track but has a significant duration mismatch, Aurral retains it under **Activity > Queue** for preview, approval, or denial. Approving it replaces the existing Aurral file.
 
 yt-dlp can supply an acceptable first file. Aurral does not use yt-dlp for upgrades.
 


### PR DESCRIPTION
## What changed

- Keep upgrade downloads with duration mismatches available for review.
- Approving a reviewed upgrade replaces the existing source file and updates its playlist path.
- Reject stale album metadata before resolving track duration and prefer matched release durations when appropriate.
- Add regression coverage for review routing, approval replacement, and metadata resolution.
- Document upgrade duration-mismatch review behavior.

## Why

Upgrade downloads with duration mismatches were not routed to review, and approved upgrades could use incorrect playlist routing or leave the original file in place. Stale album metadata could also produce incorrect duration and track resolution.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

None.

## Testing

- Added and ran weekly-flow regression tests covering upgrade review routing, approval replacement, duration selection, and stale metadata recovery.
- Manual validation: not run; automated coverage exercises the affected state transitions.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade downloads with significant duration mismatches can now be reviewed before approval.
  * Approved upgrades replace the existing playlist file while preserving the upgraded content.
* **Bug Fixes**
  * Improved album and release matching to avoid incorrect metadata associations.
  * Improved duration selection when playlist, album, and track metadata differ.
  * Corrected destination handling for playlist upgrades.
* **Documentation**
  * Updated playlist guidance for reviewing, approving, or denying quality-rejected upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->