### PR TITLE
fix(ui): add Flows to the mobile navigation menu

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -8,6 +8,7 @@ import {
   Ellipsis,
   Ticket,
   AudioWaveform,
+  Workflow,
   Settings,
   LogOut,
   User,
@@ -122,6 +123,9 @@ function Layout({ children, headerActions }) {
       if (path.startsWith("/shows")) {
         return location.pathname.startsWith("/shows");
       }
+      if (path.startsWith("/flows")) {
+        return location.pathname.startsWith("/flows");
+      }
       if (path.startsWith("/activity")) {
         return location.pathname.startsWith("/activity");
       }
@@ -153,6 +157,12 @@ function Layout({ children, headerActions }) {
   const mobileOverflowItems = useMemo(() => {
     const items = [
       { path: "/shows/all", label: "Shows", icon: Ticket },
+      {
+        path: "/flows",
+        label: "Flows",
+        icon: Workflow,
+        permission: "accessFlow",
+      },
       { path: "/activity/queue", label: "Activity", icon: Activity },
       { path: "/profile", label: "Profile", icon: User },
       {


### PR DESCRIPTION
Fixes #675

## Problem

Below the 768px breakpoint there is no way to reach Flows. The reporter's only workaround was "Request Desktop Website".

## Cause

The mobile navigation is built from `mobilePrimaryItems` and `mobileOverflowItems` in `frontend/src/components/Layout.jsx`. These are separate from the desktop sidebar's nav list, and neither contained a `/flows` entry. `Sidebar.jsx` has had one all along, so the route itself was fine — only the mobile nav was missing it.

## Change

Add Flows to the overflow ("More") sheet rather than the bottom bar. `.app-mobile-nav__grid` is a fixed `repeat(4, minmax(0, 1fr))` grid that already holds three primary items plus the More button, so a fifth primary entry would wrap to a second row and need a CSS change too. The overflow list is unbounded, already carries a permission-gated entry (Settings), and already feeds the More button's active state.

The existing `.filter()` applies the same `accessFlow` gate the sidebar uses, so users without the permission still don't see it. `isActive` also gains a `/flows` branch alongside the existing `/shows` and `/activity` ones, so flow sub-routes keep the entry highlighted.

The icon is `Workflow` rather than the sidebar's `AudioWaveform`, because `Layout.jsx` already uses `AudioWaveform` for mobile Playlists and reusing it would put two identical icons in the same nav.

Net change is 10 added lines in one file. No CSS, no backend, no new dependency.

## Testing

`npm run lint --workspace frontend` and `npm run build` both pass. Verified against a Docker build of this branch alongside one of `main`, in a 390x844 mobile viewport:

| | Overflow sheet contents |
|---|---|
| `main` | Shows, Activity, Profile, Settings, Log out |
| this branch | Shows, **Flows**, Activity, Profile, Settings, Log out |

The bottom bar is unchanged at four cells in both, with no wrap. Tapping Flows lands on `/flows`, and the More button stays highlighted on `/flows` and on flow sub-routes while staying inactive on `/discover`.

## Not included

Mobile Playlists links to `/playlists`, which redirects to `/library/playlists`, so that entry never satisfies `isActive`'s equality check and never highlights. Same function, but a separate problem — happy to open an issue or a follow-up PR if you'd like it fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a permission-gated “Flows” option to mobile navigation.
  * Added active-state highlighting for Flows pages.
  * Included a workflow icon for the new navigation item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->