### PR TITLE
feat(activity): show queued playlist imports and downloads

### DIFF
--- a/.tests/history/aurral-history.test.js
+++ b/.tests/history/aurral-history.test.js
@@ -23,9 +23,13 @@ const {
 const { downloadTracker } = await importFromRepo(
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
 );
+const { getHonkerDb } = await importFromRepo("backend/services/honkerDb.js");
 
 test.beforeEach(() => {
   resetDatabase(db);
+  const transaction = getHonkerDb().transaction();
+  transaction.execute("DELETE FROM _honker_live WHERE queue = ?", ["weekly-flow-operation"]);
+  transaction.commit();
   downloadTracker.clearAll();
 });
 
@@ -187,10 +191,46 @@ test("queued library track jobs appear in activity immediately", async () => {
   recordTrackJobQueued(downloadTracker.getJob(jobId));
 
   const entry = (await getAurralHistoryRequests()).find((item) => item.jobId === jobId);
-  assert.equal(entry?.status, "processing");
-  assert.equal(entry?.statusLabel, "Searching");
+  assert.equal(entry?.status, "pending");
+  assert.equal(entry?.statusLabel, "Queued");
   assert.equal(entry?.inQueue, true);
   assert.equal(entry?.trackName, "Queued Song");
+});
+
+test("pending tracker jobs without history appear in activity immediately", async () => {
+  const jobId = downloadTracker.addJob(
+    {
+      artistName: "Artist",
+      trackName: "Unrecorded Song",
+    },
+    "playlist-1",
+  );
+
+  const entry = (await getAurralHistoryRequests()).find((item) => item.jobId === jobId);
+  assert.equal(entry?.status, "pending");
+  assert.equal(entry?.statusLabel, "Queued");
+  assert.equal(entry?.inQueue, true);
+  assert.equal(entry?.trackName, "Unrecorded Song");
+});
+
+test("pending playlist imports appear in activity before the worker starts", async () => {
+  const operationId = getHonkerDb().queue("weekly-flow-operation").enqueue({
+    kind: "shared-playlist-create",
+    playlistId: "pending-playlist",
+    name: "Pending Playlist",
+    sourceName: "ListenBrainz",
+    ownerUserId: 42,
+    tracks: [{ artistName: "Artist", trackName: "Song" }],
+  });
+
+  const entry = (await getAurralHistoryRequests()).find(
+    (item) => item.id === `aurral-playlist_import-${operationId}`,
+  );
+  assert.equal(entry?.kind, "playlist_import");
+  assert.equal(entry?.status, "pending");
+  assert.equal(entry?.statusLabel, "Queued");
+  assert.equal(entry?.playlistName, "Pending Playlist");
+  assert.equal(entry?.subtitle, "ListenBrainz · 1 track waiting for download");
 });
 
 test("getAurralHistoryRequests fails stale active download history", async () => {
@@ -217,8 +257,10 @@ test("getAurralHistoryRequests fails stale active download history", async () =>
     },
     createdAt: Date.now() - 20 * 60 * 1000,
   });
+  downloadTracker.setDownloading(jobId);
   const job = downloadTracker.getJob(jobId);
   job.createdAt = Date.now() - 20 * 60 * 1000;
+  job.startedAt = job.createdAt;
 
   const entries = await getAurralHistoryRequests();
   const entry = entries.find((item) => item.jobId === jobId);

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -13,9 +13,7 @@ const router = express.Router();
 const dismissedAlbumIds = new Map();
 const DISMISSED_ALBUM_TTL_MS = 24 * 60 * 60 * 1000;
 const REQUESTS_CACHE_MS = 15000;
-let lastRequestsResponse = null;
-let lastRequestsAt = 0;
-let lastRequestsUserId = null;
+const requestsCache = new Map();
 const pendingRequestsRefreshes = new Map();
 
 const getRequestsUserId = (user) => (user?.id == null ? null : String(user.id));
@@ -35,19 +33,20 @@ const filterDismissedRequests = (requests) =>
     : [];
 
 const updateRequestsCache = (requests, user) => {
-  lastRequestsResponse = filterDismissedRequests(requests);
-  lastRequestsAt = Date.now();
-  lastRequestsUserId = getRequestsUserId(user);
-  return lastRequestsResponse;
+  const response = filterDismissedRequests(requests);
+  requestsCache.set(getRequestsUserId(user), { response, at: Date.now() });
+  return response;
 };
 
 const removeAlbumFromRequestsCache = (albumId) => {
-  if (!lastRequestsResponse) return;
   const normalizedAlbumId = String(albumId);
-  lastRequestsResponse = lastRequestsResponse.filter(
-    (request) => String(request?.albumId) !== normalizedAlbumId,
-  );
-  lastRequestsAt = Date.now();
+  for (const cache of requestsCache.values()) {
+    if (!cache?.response) continue;
+    cache.response = cache.response.filter(
+      (request) => String(request?.albumId) !== normalizedAlbumId,
+    );
+    cache.at = Date.now();
+  }
 };
 
 const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
@@ -117,23 +116,24 @@ router.get("/", requireAuth, noCache, async (req, res) => {
   try {
     pruneDismissedAlbumIds();
     const { lidarrClient } = await import("../services/lidarrClient.js");
-
-    if (!lidarrClient?.isConfigured()) {
-      const aurralOnly = await getAurralHistoryRequests(null, req.user);
-      lastRequestsResponse = filterDismissedRequests(aurralOnly);
-      lastRequestsAt = Date.now();
-      lastRequestsUserId = getRequestsUserId(req.user);
-      return res.json(aurralOnly);
-    }
-
     const forceRefresh = req.query.refresh === "1" || req.query.refresh === "true";
+    const userId = getRequestsUserId(req.user);
+    const cached = requestsCache.get(userId);
+
     if (
       !forceRefresh &&
-      lastRequestsResponse &&
-      lastRequestsUserId === getRequestsUserId(req.user) &&
-      Date.now() - lastRequestsAt < REQUESTS_CACHE_MS
+      cached &&
+      Date.now() - cached.at < REQUESTS_CACHE_MS
     ) {
-      return res.json(filterDismissedRequests(lastRequestsResponse));
+      return res.json(filterDismissedRequests(cached.response));
+    }
+
+    if (!lidarrClient?.isConfigured()) {
+      const requests = await refreshRequestsCache(lidarrClient, {
+        force: forceRefresh,
+        user: req.user,
+      });
+      return res.json(requests);
     }
 
     const requests = await refreshRequestsCache(lidarrClient, {
@@ -142,8 +142,9 @@ router.get("/", requireAuth, noCache, async (req, res) => {
     });
     res.json(requests);
   } catch (error) {
-    if (lastRequestsResponse && lastRequestsUserId === getRequestsUserId(req.user)) {
-      return res.json(filterDismissedRequests(lastRequestsResponse));
+    const cached = requestsCache.get(getRequestsUserId(req.user));
+    if (cached?.response) {
+      return res.json(filterDismissedRequests(cached.response));
     }
     res.status(500).json({ error: "Failed to fetch requests" });
   }
@@ -209,9 +210,7 @@ router.delete("/:mbid", requireAuth, requirePermission("deleteArtist"), async (r
 });
 
 export const invalidateRequestsCache = () => {
-  lastRequestsResponse = null;
-  lastRequestsAt = 0;
-  lastRequestsUserId = null;
+  requestsCache.clear();
 };
 
 export default router;

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -15,7 +15,10 @@ const DISMISSED_ALBUM_TTL_MS = 24 * 60 * 60 * 1000;
 const REQUESTS_CACHE_MS = 15000;
 let lastRequestsResponse = null;
 let lastRequestsAt = 0;
-let pendingRequestsRefresh = null;
+let lastRequestsUserId = null;
+const pendingRequestsRefreshes = new Map();
+
+const getRequestsUserId = (user) => (user?.id == null ? null : String(user.id));
 
 const pruneDismissedAlbumIds = () => {
   const now = Date.now();
@@ -31,9 +34,10 @@ const filterDismissedRequests = (requests) =>
     ? requests.filter((r) => !r.albumId || !dismissedAlbumIds.has(String(r.albumId)))
     : [];
 
-const updateRequestsCache = (requests) => {
+const updateRequestsCache = (requests, user) => {
   lastRequestsResponse = filterDismissedRequests(requests);
   lastRequestsAt = Date.now();
+  lastRequestsUserId = getRequestsUserId(user);
   return lastRequestsResponse;
 };
 
@@ -73,13 +77,13 @@ const filterRedundantAurralRequests = (aurralRequests, lidarrRequests) => {
   });
 };
 
-const buildRequestsResponse = async (lidarrClient, { force = false } = {}) => {
+const buildRequestsResponse = async (lidarrClient, { force = false, user = null } = {}) => {
   const snapshot = lidarrClient?.isConfigured()
     ? await getLidarrStatusSnapshot({ force })
     : null;
   const [lidarrRequests, aurralRequests] = await Promise.all([
     snapshot ? buildLidarrRequests(lidarrClient, snapshot.provider) : Promise.resolve([]),
-    getAurralHistoryRequests(lidarrClient),
+    getAurralHistoryRequests(lidarrClient, user),
   ]);
   const filteredAurral = filterRedundantAurralRequests(aurralRequests, lidarrRequests);
   return [...lidarrRequests, ...filteredAurral].sort(
@@ -88,13 +92,15 @@ const buildRequestsResponse = async (lidarrClient, { force = false } = {}) => {
 };
 
 const refreshRequestsCache = async (lidarrClient, options) => {
-  if (pendingRequestsRefresh) return pendingRequestsRefresh;
-  pendingRequestsRefresh = buildRequestsResponse(lidarrClient, options)
-    .then(updateRequestsCache)
+  const userId = getRequestsUserId(options?.user);
+  if (pendingRequestsRefreshes.has(userId)) return pendingRequestsRefreshes.get(userId);
+  const refresh = buildRequestsResponse(lidarrClient, options)
+    .then((requests) => updateRequestsCache(requests, options?.user))
     .finally(() => {
-      pendingRequestsRefresh = null;
+      pendingRequestsRefreshes.delete(userId);
     });
-  return pendingRequestsRefresh;
+  pendingRequestsRefreshes.set(userId, refresh);
+  return refresh;
 };
 
 const removeMatchingQueueItems = async (lidarrClient, matches) => {
@@ -113,21 +119,30 @@ router.get("/", requireAuth, noCache, async (req, res) => {
     const { lidarrClient } = await import("../services/lidarrClient.js");
 
     if (!lidarrClient?.isConfigured()) {
-      const aurralOnly = await getAurralHistoryRequests();
-      lastRequestsResponse = aurralOnly;
+      const aurralOnly = await getAurralHistoryRequests(null, req.user);
+      lastRequestsResponse = filterDismissedRequests(aurralOnly);
       lastRequestsAt = Date.now();
+      lastRequestsUserId = getRequestsUserId(req.user);
       return res.json(aurralOnly);
     }
 
     const forceRefresh = req.query.refresh === "1" || req.query.refresh === "true";
-    if (!forceRefresh && lastRequestsResponse && Date.now() - lastRequestsAt < REQUESTS_CACHE_MS) {
+    if (
+      !forceRefresh &&
+      lastRequestsResponse &&
+      lastRequestsUserId === getRequestsUserId(req.user) &&
+      Date.now() - lastRequestsAt < REQUESTS_CACHE_MS
+    ) {
       return res.json(filterDismissedRequests(lastRequestsResponse));
     }
 
-    const requests = await refreshRequestsCache(lidarrClient, { force: forceRefresh });
+    const requests = await refreshRequestsCache(lidarrClient, {
+      force: forceRefresh,
+      user: req.user,
+    });
     res.json(requests);
   } catch (error) {
-    if (lastRequestsResponse) {
+    if (lastRequestsResponse && lastRequestsUserId === getRequestsUserId(req.user)) {
       return res.json(filterDismissedRequests(lastRequestsResponse));
     }
     res.status(500).json({ error: "Failed to fetch requests" });
@@ -196,6 +211,7 @@ router.delete("/:mbid", requireAuth, requirePermission("deleteArtist"), async (r
 export const invalidateRequestsCache = () => {
   lastRequestsResponse = null;
   lastRequestsAt = 0;
+  lastRequestsUserId = null;
 };
 
 export default router;

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -461,6 +461,81 @@ const isHonkerQueueActive = async (queueName, predicate) => {
   }
 };
 
+const canViewPlaylistActivity = (user, playlistId, ownerUserId = undefined) => {
+  if (!user || user.role === "admin") return true;
+  if (ownerUserId !== undefined) {
+    return ownerUserId != null && Number(ownerUserId) === Number(user.id);
+  }
+  const id = String(playlistId || "").trim();
+  if (!id || id === "library") return true;
+  const flow = flowPlaylistConfig.getFlow(id);
+  if (flow) return flowPlaylistConfig.canUserAccessFlow(user, flow);
+  const playlist = flowPlaylistConfig.getSharedPlaylist(id);
+  return playlist ? flowPlaylistConfig.canUserAccessSharedPlaylist(user, playlist) : false;
+};
+
+const loadPendingPlaylistImportHistory = async (user) => {
+  try {
+    const { getHonkerDb } = await import("./honkerDb.js");
+    const rows = getHonkerDb().query(
+      `
+        SELECT id, payload, state, created_at
+        FROM _honker_live
+        WHERE queue = ?
+          AND state IN ('pending', 'processing')
+        ORDER BY created_at ASC, id ASC
+      `,
+      ["weekly-flow-operation"],
+    );
+    return rows.flatMap((row) => {
+      const payload = parseHonkerPayload(row?.payload);
+      if (payload?.kind !== "shared-playlist-create") return [];
+      if (
+        user &&
+        user.role !== "admin" &&
+        (payload.ownerUserId == null || Number(payload.ownerUserId) !== Number(user.id))
+      ) {
+        return [];
+      }
+      const playlistId = String(payload.playlistId || "").trim();
+      const playlistName = String(payload.name || "Playlist").trim() || "Playlist";
+      const sourceName = String(payload.sourceName || "Playlist import").trim();
+      const trackCount = Array.isArray(payload.tracks) ? payload.tracks.length : 0;
+      const state = row.state === "processing" ? "processing" : "pending";
+      const countLabel = `${trackCount} track${trackCount === 1 ? "" : "s"}`;
+      const createdAt = Number(row.created_at);
+      return [
+        {
+          id: stableId("playlist_import", row.id),
+          kind: "playlist_import",
+          title: state === "processing" ? `Preparing ${playlistName}` : `Queued ${playlistName}`,
+          subtitle: `${sourceName} · ${countLabel} waiting for download`,
+          status: state,
+          statusLabel: state === "processing" ? "Preparing" : "Queued",
+          href: flowPlaylistConfig.getSharedPlaylist(playlistId)
+            ? buildPlaylistHref(playlistId)
+            : null,
+          metadata: {
+            operationId: row.id,
+            playlistId,
+            playlistName,
+            ownerUserId: payload.ownerUserId ?? null,
+            trackCount,
+          },
+          createdAt:
+            Number.isFinite(createdAt) && createdAt > 0
+              ? createdAt > 1e12
+                ? createdAt
+                : createdAt * 1000
+              : Date.now(),
+        },
+      ];
+    });
+  } catch {
+    return [];
+  }
+};
+
 const isPipelineActiveForJob = async (jobId) =>
   isHonkerQueueActive("slskd-pipeline", (payload) => payload?.jobId === jobId);
 
@@ -530,6 +605,7 @@ export const syncTrackDownloadHistory = async (historyEntries = null) => {
       continue;
     }
     if (isBlocked) continue;
+    if (job.status === "pending") continue;
 
     const anchorTime = Math.max(
       Number(job.startedAt || 0),
@@ -837,7 +913,11 @@ export const recordTrackJobSearching = (job) =>
 export const recordTrackJobQueued = (job) => {
   const jobId = String(job?.id || "").trim();
   if (!jobId || dbOps.getAurralHistoryById(stableId("track_download", jobId))) return null;
-  return recordTrackJobSearching(job);
+  return recordTrackJob(job, {
+    status: "pending",
+    statusLabel: "Queued",
+    title: `Queued ${job?.trackName || "track"}`,
+  });
 };
 
 export const recordTrackJobDownloading = (job) =>
@@ -901,6 +981,7 @@ export const toHistoryRequestItem = (entry, options = {}) => {
     href: entry.href || null,
     kind,
     playlistId: entry.metadata?.playlistId || null,
+    playlistName: entry.metadata?.playlistName || null,
     jobId: entry.metadata?.jobId || null,
     trackName,
     artistName: entry.metadata?.artistName || null,
@@ -923,9 +1004,42 @@ export const toHistoryRequestItem = (entry, options = {}) => {
 
 const FAILED_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
-export const getAurralHistoryRequests = async (lidarrClient = null) => {
+const buildActiveTrackHistory = (job) => {
+  const playlistId = job?.playlistId || job?.playlistType;
+  const status =
+    job?.status === "blocked" ? "blocked" : job?.status === "downloading" ? "processing" : "pending";
+  const statusLabel =
+    status === "blocked" ? "Review" : status === "processing" ? "Downloading" : "Queued";
+  const title =
+    status === "blocked"
+      ? `Review needed for ${job?.trackName || "track"}`
+      : status === "processing"
+        ? `Downloading ${job?.trackName || "track"} via ${resolveDownloadClientLabel(job?.downloadSource, job?.downloadClient)}`
+        : `Queued ${job?.trackName || "track"}`;
+  return {
+    id: stableId("track_download", job?.id),
+    kind: "track_download",
+    title,
+    subtitle: `${job?.artistName || "Artist"} · ${resolvePlaylistName(playlistId)}`,
+    status,
+    statusLabel,
+    href: buildPlaylistHref(playlistId),
+    metadata: {
+      jobId: job?.id,
+      trackName: job?.trackName,
+      artistName: job?.artistName,
+      ...(job?.albumName ? { albumName: job.albumName } : {}),
+      playlistId,
+      downloadSource: job?.downloadSource || "slskd",
+      downloadClient: job?.downloadClient || null,
+    },
+    createdAt: Number(job?.createdAt) || Date.now(),
+  };
+};
+
+export const getAurralHistoryRequests = async (lidarrClient = null, user = null) => {
   await syncActivityFeedHistory(lidarrClient);
-  const entries = loadRecentHistory();
+  const entries = [...(await loadPendingPlaylistImportHistory(user)), ...loadRecentHistory()];
   const entryIds = new Set(entries.map((e) => e.id));
 
   const { downloadTracker } = await import("./weeklyFlow/weeklyFlowDownloadTracker.js");
@@ -936,10 +1050,12 @@ export const getAurralHistoryRequests = async (lidarrClient = null) => {
     const historyId = stableId("track_download", job.id);
     if (entryIds.has(historyId)) continue;
     const row = dbOps.getAurralHistoryById(historyId);
-    if (row) {
-      entries.push(row);
-      entryIds.add(historyId);
+    const entry = row || buildActiveTrackHistory(job);
+    if (!canViewPlaylistActivity(user, entry.metadata?.playlistId || entry.metadata?.playlistType)) {
+      continue;
     }
+    entries.push(entry);
+    entryIds.add(historyId);
   }
 
   const now = Date.now();
@@ -948,6 +1064,11 @@ export const getAurralHistoryRequests = async (lidarrClient = null) => {
     .filter(
       (e) =>
         !ACTIVITY_HIDDEN_KINDS.has(e.kind) &&
+        canViewPlaylistActivity(
+          user,
+          e.metadata?.playlistId || e.metadata?.playlistType,
+          e.metadata?.ownerUserId,
+        ) &&
         (e.status !== "failed" || now - e.createdAt < FAILED_RETENTION_MS),
     )
     .map((entry) => {

--- a/backend/services/importLists/importPlaylist.js
+++ b/backend/services/importLists/importPlaylist.js
@@ -57,7 +57,7 @@ export async function enqueueImportedPlaylist({
     lastSyncAt: Date.now(),
     lastSyncTrackCount: tracks.length,
   });
-  return weeklyFlowOperationQueue.enqueuePayload({
+  const result = await weeklyFlowOperationQueue.enqueuePayload({
     kind: "shared-playlist-create",
     label: "shared-playlist:create",
     playlistId: safePlaylistId,
@@ -67,4 +67,5 @@ export async function enqueueImportedPlaylist({
     ownerUserId,
     importSource,
   });
+  return { ...result, tracksQueued: tracks.length };
 }

--- a/backend/services/weeklyFlow/weeklyFlowOperations.js
+++ b/backend/services/weeklyFlow/weeklyFlowOperations.js
@@ -4,6 +4,7 @@ import {
   recordFlowGenerationStarted,
   recordFlowTracksGenerated,
   recordPlaylistTracksAdded,
+  recordTrackJobQueued,
 } from "../aurralHistoryService.js";
 import {
   buildSharedTrackIdentity,
@@ -156,6 +157,7 @@ const queueTracksForPlaylist = async (tracks, playlistId) => {
       );
     }
     jobIds.push(jobId);
+    recordTrackJobQueued(downloadTracker.getJob(jobId));
   }
   return { reusedJobIds, jobIds, createdJobIds };
 };

--- a/docs/src/content/docs/using/activity.mdx
+++ b/docs/src/content/docs/using/activity.mdx
@@ -5,7 +5,7 @@ description: Track active downloads, Lidarr requests, and Aurral playlist jobs.
 
 Activity replaces the older Requests and Downloads views. It has two views:
 
-- **Queue**: album requests, downloads in progress, and tracks waiting for review
+- **Queue**: album requests, queued or active downloads, playlist imports, and tracks waiting for review
 - **History**: completed, denied, and failed events
 
 The **Wanted** section combines Aurral-owned tracks that need another search with
@@ -16,7 +16,7 @@ those two filters.
 
 ![Aurral activity timeline](../../../assets/screenshots/history.webp)
 
-Use **Queue** to see active downloads and processes. Review items stay in this list because they are queued for your decision. A duration or identity mismatch can remain here for preview, approval, or denial.
+Use **Queue** to see queued and active downloads and processes, including playlist imports that have not started yet. Review items stay in this list because they are queued for your decision. A duration or identity mismatch can remain here for preview, approval, or denial.
 
 Use the review controls in **Queue** when you must listen to a track before import. Use **History** to see completed and failed events.
 

--- a/docs/src/content/docs/using/playlist-imports.mdx
+++ b/docs/src/content/docs/using/playlist-imports.mdx
@@ -196,6 +196,7 @@ Aurral treats a top-level array of track objects as one playlist.
 - Aurral treats a top-level array of playlist objects as multiple playlists.
 - If an imported playlist name conflicts with an existing playlist, Aurral renames it automatically.
 - Imported playlists queue their own downloads and do not affect any flow configuration.
+- Activity > Queue shows the playlist import and its queued tracks immediately, before a worker starts them.
 - When existing file reuse succeeds, Aurral immediately marks the imported track as complete.
 - Aurral keeps the imported track order in the playlist view and in the Navidrome playlist after reuse and downloads finish.
 

--- a/frontend/src/pages/activity/ActivityInfoModal.jsx
+++ b/frontend/src/pages/activity/ActivityInfoModal.jsx
@@ -30,6 +30,7 @@ const formatKind = (kind) => {
   const labels = {
     album_requested: "Album request",
     track_download: "Track download",
+    playlist_import: "Playlist import",
     track_reused_aurral: "Reused track",
     track_reused_lidarr: "Reused track",
   };


### PR DESCRIPTION
## What changed

- Show playlist imports in Activity > Queue while they are pending or processing.
- Show queued track downloads immediately, including jobs without persisted history.
- Filter playlist activity by user access and preserve per-user request caching.
- Add playlist import labels and document the updated queue behavior.

## Why

Users could not see playlist imports or newly queued downloads until processing began or history was written. This makes Activity reflect pending work immediately while keeping activity visibility scoped to the appropriate user.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

No linked issue.

## UI changes

The Activity information modal now identifies playlist imports. Queue entries now include pending playlist imports and queued downloads.

## Testing

- Added and updated automated history tests covering queued downloads, pending playlist imports, stale active downloads, and queue isolation.
- Documentation updated for Activity and playlist imports.
- Full test suite and manual screenshot validation were not run.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activity now shows queued and active downloads immediately, including tracks and playlist imports before processing begins.
  - Playlist activity is filtered according to access permissions.
  - Activity details now identify playlist imports clearly.
  - Playlist import results include the number of tracks queued.

- **Bug Fixes**
  - Request caching and fallback responses are now isolated per signed-in user.
  - Queued jobs display the correct “Queued” status instead of appearing to be processing.

- **Documentation**
  - Updated Activity and playlist import guidance to explain queue visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->