### PR TITLE
fix(yt-dlp): update yt-dlp to resolve 403 errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV LD_PRELOAD=libjemalloc.so.2
 
-ADD --chmod=755 --checksum=sha256:e5d57466682cfa9d61e9cf7c8a4f09b00f4a62af37d3bbdc4bcffdf63615feac \
-    https://github.com/yt-dlp/yt-dlp/releases/download/2026.06.09/yt-dlp \
+ADD --chmod=755 --checksum=sha256:1fa6733c37ea6fb51c99ad8fe785e7b7e5f3246c9b980230329d4fb72ed8d4d6 \
+    https://github.com/yt-dlp/yt-dlp/releases/download/2026.08.19/yt-dlp \
     /usr/local/bin/yt-dlp
 RUN yt-dlp --version
 


### PR DESCRIPTION
## What changed

Updated yt-dlp from 2026.06.09 to 2026.08.19 and refreshed its checksum in the Dockerfile.

## Why

The newer yt-dlp release resolves 403 errors during media downloads.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Verified the Dockerfile references yt-dlp 2026.08.19 with the updated SHA-256 checksum.
- Runtime download testing was not run because no live provider test was included in this change.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled yt-dlp release to version 2026.08.19.
  * Refreshed the integrity verification for the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->