### PR TITLE
fix(github-labels): preserve canonical label colors

### DIFF
--- a/.tests/github-labels.test.js
+++ b/.tests/github-labels.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = join(repoRoot, "scripts", "label-pr-from-title.sh");
+
+function runLabelScript(title) {
+  const tempDir = mkdtempSync(join(tmpdir(), "aurral-github-label-test-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "gh.log");
+  const ghPath = join(binDir, "gh");
+  mkdirSync(binDir);
+  writeFileSync(
+    ghPath,
+    "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$GH_LOG\"\n",
+    "utf8",
+  );
+  chmodSync(ghPath, 0o755);
+
+  execFileSync("bash", [scriptPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      GH_LOG: logPath,
+      GITHUB_REPOSITORY: "lklynet/aurral",
+      PATH: `${binDir}:${process.env.PATH}`,
+      PR_NUMBER: "1",
+      PR_TITLE: title,
+    },
+    stdio: "ignore",
+  });
+
+  return readFileSync(logPath, "utf8").split("\n").filter(Boolean);
+}
+
+test("PR label automation preserves canonical label colors", () => {
+  const expected = [
+    ["fix: preserve labels", "bug", "d73a4a"],
+    ["feat: improve labels", "enhancement", "a2eeef"],
+    ["docs: explain labels", "documentation", "0075ca"],
+  ];
+
+  for (const [title, label, color] of expected) {
+    const commands = runLabelScript(title);
+    assert.ok(
+      commands.includes(
+        `label create ${label} --repo lklynet/aurral --color ${color} --force`,
+      ),
+      commands.join("\n"),
+    );
+  }
+});

--- a/scripts/label-pr-from-title.sh
+++ b/scripts/label-pr-from-title.sh
@@ -15,15 +15,19 @@ if [ -z "${commit_type}" ]; then
 fi
 
 desired_label=""
+desired_color=""
 case "${commit_type}" in
   feat)
     desired_label=enhancement
+    desired_color=a2eeef
     ;;
   fix)
     desired_label=bug
+    desired_color=d73a4a
     ;;
   docs)
     desired_label=documentation
+    desired_color=0075ca
     ;;
 esac
 
@@ -52,6 +56,7 @@ remove_issue_label() {
 if [ -n "${desired_label}" ]; then
   gh label create "${desired_label}" \
     --repo "${repository}" \
+    --color "${desired_color}" \
     --force >/dev/null
   gh api \
     --method POST \


### PR DESCRIPTION
## What changed

Updated PR label automation to apply canonical colors when creating `bug`, `enhancement`, and `documentation` labels. Added automated coverage for the label commands.

## Why

GitHub label automation could overwrite canonical label colors when recreating labels. Preserving the expected colors keeps PR labels consistent and recognizable.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

No linked issue.

## Testing

- Added `.tests/github-labels.test.js` covering canonical colors for `fix`, `feat`, and `docs` titles.
- Automated tests were added; no manual UI validation applies.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Pull request labels created automatically from titles now use consistent colors for enhancements, bugs, and documentation.
* **Tests**
  * Added automated coverage to verify that mapped labels receive their canonical colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->