### PR TITLE
fix(lidarr): preserve concurrent album searches

### DIFF
--- a/.tests/library/concurrent-album-requests.test.js
+++ b/.tests/library/concurrent-album-requests.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "test";
+
+import { libraryManager } from "../../backend/services/libraryManager.js";
+import { lidarrClient } from "../../backend/services/lidarrClient.js";
+
+const flushImmediate = () => new Promise((resolve) => setImmediate(resolve));
+
+test("concurrent new-artist album requests search every requested album", async () => {
+  const originalIsConfigured = lidarrClient.isConfigured;
+  const originalGetArtistByMbid = lidarrClient.getArtistByMbid;
+  const originalAddArtist = lidarrClient.addArtist;
+  const originalGetAlbumByMbid = lidarrClient.getAlbumByMbid;
+  const originalResolveArtistAddOptions = libraryManager.resolveArtistAddOptions;
+  const originalAddAlbum = libraryManager.addAlbum;
+
+  const artistMbid = "concurrent-artist-mbid";
+  const artist = {
+    id: 7,
+    artistName: "Concurrent Artist",
+    foreignArtistId: artistMbid,
+    monitored: true,
+    monitor: "none",
+  };
+  let releaseArtistAdds;
+  const artistAddGate = new Promise((resolve) => {
+    releaseArtistAdds = resolve;
+  });
+  let artistAddCalls = 0;
+  const albumSearches = [];
+
+  lidarrClient.isConfigured = () => true;
+  lidarrClient.getArtistByMbid = async (_mbid, { forceRefresh = false } = {}) =>
+    forceRefresh ? artist : null;
+  lidarrClient.addArtist = async () => {
+    const callNumber = ++artistAddCalls;
+    await artistAddGate;
+    if (callNumber === 1) {
+      await flushImmediate();
+      return artist;
+    }
+    throw new Error("ArtistExistsValidator: artist already exists");
+  };
+  lidarrClient.getAlbumByMbid = async () => null;
+  libraryManager.resolveArtistAddOptions = async () => ({
+    quality: "standard",
+    monitorOption: "none",
+    rootFolderPath: "/music",
+    qualityProfileId: 1,
+  });
+  libraryManager.addAlbum = async (_artistId, albumMbid, albumName, options) => {
+    albumSearches.push({ albumMbid, albumName, triggerSearch: options.triggerSearch });
+    return {
+      id: albumMbid,
+      artistId: 7,
+      mbid: albumMbid,
+      foreignAlbumId: albumMbid,
+      albumName,
+      monitored: true,
+      statistics: { percentOfTracks: 0, sizeOnDisk: 0 },
+    };
+  };
+
+  try {
+    const requests = ["album-a", "album-b", "album-c"].map((albumMbid) =>
+      libraryManager.requestAlbumFromSearch({
+        albumMbid,
+        albumName: albumMbid,
+        artistMbid,
+        artistName: artist.artistName,
+        triggerSearch: true,
+        user: {
+          role: "user",
+          permissions: { addAlbum: true, addArtist: true },
+        },
+      }),
+    );
+
+    while (artistAddCalls < 3) await flushImmediate();
+    releaseArtistAdds();
+
+    const results = await Promise.all(requests);
+    assert.equal(results.length, 3);
+    assert.deepEqual(
+      albumSearches.map(({ albumMbid, triggerSearch }) => [albumMbid, triggerSearch]).sort(),
+      [
+        ["album-a", true],
+        ["album-b", true],
+        ["album-c", true],
+      ],
+    );
+    assert.equal(results.every((result) => result.status === "searching"), true);
+  } finally {
+    lidarrClient.isConfigured = originalIsConfigured;
+    lidarrClient.getArtistByMbid = originalGetArtistByMbid;
+    lidarrClient.addArtist = originalAddArtist;
+    lidarrClient.getAlbumByMbid = originalGetAlbumByMbid;
+    libraryManager.resolveArtistAddOptions = originalResolveArtistAddOptions;
+    libraryManager.addAlbum = originalAddAlbum;
+  }
+});

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -373,7 +373,7 @@ export class LibraryManager {
     } catch (error) {
       if (isArtistAlreadyAddedError(error)) {
         try {
-          const existing = await this.getArtist(mbid);
+          const existing = await this.getArtist(mbid, { forceRefresh: true });
           if (existing) {
             return existing;
           }
@@ -771,17 +771,19 @@ export class LibraryManager {
       logger.error('library', `Failed to fetch tracks for album ${releaseGroupMbid}: ${error.message}`);    }
   }
 
-  async getArtist(mbid) {
+  async getArtist(mbid, { forceRefresh = false } = {}) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
       return null;
     }
-    const cachedArtist = findCachedArtistByMbid(mbid);
-    if (cachedArtist) {
-      return cachedArtist;
+    if (!forceRefresh) {
+      const cachedArtist = findCachedArtistByMbid(mbid);
+      if (cachedArtist) {
+        return cachedArtist;
+      }
     }
     try {
-      const lidarrArtist = await lidarr.getArtistByMbid(mbid);
+      const lidarrArtist = await lidarr.getArtistByMbid(mbid, { forceRefresh });
       if (!lidarrArtist) return null;
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);


### PR DESCRIPTION
Several albums added quickly for a new artist could leave all but the first marked wanted but never searched. When concurrent artist adds received Lidarr's duplicate-artist response, Aurral reused a cached negative artist lookup and aborted those album requests.

Duplicate-artist recovery now forces a fresh Lidarr artist lookup, allowing every request to continue to its album search.

Verification:
- `npm run lint:backend`
- `NODE_ENV=test npm test` (868 tests passed)
- Added a focused concurrent-request regression test

Fixes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of simultaneous album requests for new artists.
  * Ensured duplicate-artist recovery retrieves the latest artist information rather than stale cached data.
  * Album searches now consistently proceed and report a searching status when requests overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->