### PR TITLE
feat: deemix download client

### DIFF
--- a/.tests/download/download-client.test.js
+++ b/.tests/download/download-client.test.js
@@ -11,6 +11,7 @@ import {
   describeBitrateSupport,
 } from "../../backend/services/deemixClient.js";
 import { registerDownloadClients } from "../../backend/routes/settings/handlers/downloadClients.js";
+import { QUALITY_TIERS } from "../../backend/services/qualityProfileModel.js";
 
 function client(key, configured) {
   const updates = [];
@@ -81,6 +82,17 @@ test("deemix needs an enabled adapter with a server URL", () => {
   client.updateConfig({ enabled: true, url: "http://deemix.local", bitrate: 7 });
   assert.equal(client.getBitrate(), 9);
   assert.equal(buildQueueUuid("3135556", 9), "track_3135556_9");
+});
+
+test("deemix maps each bitrate to a real quality tier", () => {
+  const client = new DeemixClient({ enabled: true, url: "http://deemix.local" });
+  const tierIds = new Set(QUALITY_TIERS.map((tier) => tier.id));
+
+  for (const [bitrate, expected] of [[9, "flac-standard"], [3, "mp3-320"], [1, "mp3-128"]]) {
+    client.updateConfig({ enabled: true, url: "http://deemix.local", bitrate });
+    assert.equal(client.getQualityTierId(), expected);
+    assert.equal(tierIds.has(expected), true);
+  }
 });
 
 test("deemix reports a bitrate the Deezer plan cannot stream", () => {

--- a/.tests/download/download-client.test.js
+++ b/.tests/download/download-client.test.js
@@ -5,6 +5,7 @@ import { DownloadClientRegistry } from "../../backend/services/download/download
 import { getDownloadClientSettings } from "../../backend/services/download/downloadClientSettings.js";
 import { NzbgetClient } from "../../backend/services/nzbgetClient.js";
 import { SlskdClient } from "../../backend/services/slskdClient.js";
+import { DeemixClient, buildQueueUuid } from "../../backend/services/deemixClient.js";
 import { registerDownloadClients } from "../../backend/routes/settings/handlers/downloadClients.js";
 
 function client(key, configured) {
@@ -41,10 +42,12 @@ test("download client registry validates, updates, and selects adapters", () => 
 test("download adapters expose settings metadata without field values", () => {
   const settings = getDownloadClientSettings();
 
-  assert.deepEqual(Object.keys(settings), ["slskd", "ytdlp", "nzbget", "sabnzbd"]);
+  assert.deepEqual(Object.keys(settings), ["slskd", "ytdlp", "nzbget", "sabnzbd", "deemix"]);
   assert.deepEqual(settings.nzbget.validation.required, ["url"]);
   assert.equal(settings.sabnzbd.fields.find((field) => field.key === "apiKey").secret, true);
   assert.equal(settings.ytdlp.fields.find((field) => field.key === "stagingPath").type, "path");
+  assert.deepEqual(settings.deemix.validation.required, ["url"]);
+  assert.equal(settings.deemix.fields.find((field) => field.key === "bitrate").type, "select");
   for (const definition of Object.values(settings)) {
     for (const field of definition.fields) {
       assert.equal("value" in field, false);
@@ -60,6 +63,20 @@ test("download client instances can receive adapter configuration", () => {
   assert.equal(client.isConfigured(), true);
   client.updateConfig({ enabled: false, url: "http://nzbget.local" });
   assert.equal(client.isConfigured(), false);
+});
+
+test("deemix needs an enabled adapter with a server URL", () => {
+  const client = new DeemixClient({ enabled: false, url: "http://deemix.local" });
+
+  assert.equal(client.isConfigured(), false);
+  client.updateConfig({ enabled: true, url: "http://deemix.local" });
+  assert.equal(client.isConfigured(), true);
+  assert.equal(client.getBitrate(), 9);
+  client.updateConfig({ enabled: true, url: "http://deemix.local", bitrate: "3" });
+  assert.equal(client.getBitrate(), 3);
+  client.updateConfig({ enabled: true, url: "http://deemix.local", bitrate: 7 });
+  assert.equal(client.getBitrate(), 9);
+  assert.equal(buildQueueUuid("3135556", 9), "track_3135556_9");
 });
 
 test("slskd treats an explicitly disabled adapter as unconfigured", () => {

--- a/.tests/download/download-client.test.js
+++ b/.tests/download/download-client.test.js
@@ -5,7 +5,11 @@ import { DownloadClientRegistry } from "../../backend/services/download/download
 import { getDownloadClientSettings } from "../../backend/services/download/downloadClientSettings.js";
 import { NzbgetClient } from "../../backend/services/nzbgetClient.js";
 import { SlskdClient } from "../../backend/services/slskdClient.js";
-import { DeemixClient, buildQueueUuid } from "../../backend/services/deemixClient.js";
+import {
+  DeemixClient,
+  buildQueueUuid,
+  describeBitrateSupport,
+} from "../../backend/services/deemixClient.js";
 import { registerDownloadClients } from "../../backend/routes/settings/handlers/downloadClients.js";
 
 function client(key, configured) {
@@ -77,6 +81,17 @@ test("deemix needs an enabled adapter with a server URL", () => {
   client.updateConfig({ enabled: true, url: "http://deemix.local", bitrate: 7 });
   assert.equal(client.getBitrate(), 9);
   assert.equal(buildQueueUuid("3135556", 9), "track_3135556_9");
+});
+
+test("deemix reports a bitrate the Deezer plan cannot stream", () => {
+  const free = { can_stream_lossless: false, can_stream_hq: false };
+  const hifi = { can_stream_lossless: true, can_stream_hq: true };
+
+  assert.match(describeBitrateSupport(free, 9), /cannot stream FLAC/);
+  assert.match(describeBitrateSupport(free, 3), /cannot stream MP3 320/);
+  assert.equal(describeBitrateSupport(free, 1), null);
+  assert.equal(describeBitrateSupport(hifi, 9), null);
+  assert.equal(describeBitrateSupport(undefined, 9), null);
 });
 
 test("slskd treats an explicitly disabled adapter as unconfigured", () => {

--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -16,6 +16,7 @@ const [
   { downloadTracker },
   { processYtdlpPipelinePayload },
   { processUsenetPipelinePayload },
+  { processDeemixPipelinePayload },
   { dbOps },
   { db },
   { blockPipelineJobForReview },
@@ -24,6 +25,7 @@ const [
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
   "backend/services/ytdlpOrchestrator.js",
   "backend/services/usenetOrchestrator.js",
+  "backend/services/deemixOrchestrator.js",
   "backend/db/helpers/index.js",
   "backend/config/db-sqlite.js",
   "backend/services/pipelineHelpers.js",
@@ -269,4 +271,75 @@ test("upgrade duration mismatches remain available for review", async () => {
   assert.equal(downloadTracker.getJob(upgradeJobId)?.status, "blocked");
   assert.equal(downloadTracker.getJob(upgradeJobId)?.stagingPath, candidatePath);
   await access(candidatePath);
+});
+
+test("deemix drops its queue entry before a track goes to review", async () => {
+  const removed = [];
+  const filePath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "deemix-complete",
+    "Artist Name - Correct Track.mp3",
+  );
+  await writeOneSecondMp3(filePath);
+  const server = await createMockHttpServer((req, res) => {
+    req.resume();
+    const url = new URL(req.url, "http://deemix.test");
+    if (url.pathname === "/api/removeFromQueue") removed.push(url.searchParams.get("uuid"));
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify(
+        url.pathname === "/api/getQueue"
+          ? { queue: { track_1_1: { status: "completed", files: [{ path: filePath }] } } }
+          : { result: true },
+      ),
+    );
+  });
+
+  try {
+    dbOps.updateSettings({
+      integrations: { deemix: { enabled: true, url: server.url, bitrate: 1 } },
+    });
+    const jobId = addDurationMismatchJob("deemix-review");
+    downloadTracker.updateDownloadMetadata(jobId, {
+      downloadSource: "deemix",
+      downloadClient: "deemix",
+      downloadClientId: "track_1_1",
+      releaseGuid: "1",
+      remoteFilename: "Correct Track",
+    });
+
+    const polled = await processDeemixPipelinePayload(
+      {
+        phase: "poll",
+        source: "deemix",
+        jobId,
+        queueUuid: "track_1_1",
+        destination: "deemix-review/Artist Name/Album Name",
+        candidate: {
+          raw: {
+            id: "1",
+            title: "Correct Track",
+            artist: "Artist Name",
+            album: "Album Name",
+            file: "Artist Name - Correct Track",
+          },
+        },
+        candidateIndex: 0,
+      },
+      { failOrTryNextSource: failIfPipelineFallsThrough },
+    );
+
+    assert.equal(polled.phase, "finalize");
+    assert.deepEqual(removed, []);
+
+    const result = await processDeemixPipelinePayload(polled, {
+      failOrTryNextSource: failIfPipelineFallsThrough,
+    });
+
+    assert.equal(result, null);
+    await assertReviewable(jobId, filePath, "deemix");
+    assert.deepEqual(removed, ["track_1_1"]);
+  } finally {
+    await server.close();
+  }
 });

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -95,6 +95,12 @@ export const defaultData = {
         priority: 50,
         stagingPath: "",
       },
+      deemix: {
+        enabled: false,
+        url: "",
+        bitrate: 9,
+        priority: 15,
+      },
       ticketmaster: {
         apiKey: "",
         searchRadiusMiles: 250,

--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -284,6 +284,7 @@ function buildBootstrapPayload(req) {
     payload.sabnzbdConfigured = downloadSources.usenet.sabnzbdConfigured;
     payload.usenetConfigured = downloadSources.usenet.configured;
     payload.ytdlpConfigured = downloadSources.ytdlp.configured;
+    payload.deemixConfigured = downloadSources.deemix.configured;
     payload.downloadSources = downloadSources;
     payload.metadataProviders = getMetadataProviderHealthSnapshot();
     payload.localNetworkBypass = getLocalNetworkBypassStatus(req);

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -306,6 +306,32 @@ export function registerGeneral(router) {
         nextSabnzbd.addPaused = nextSabnzbd.addPaused === true;
         integrations.sabnzbd = nextSabnzbd;
       }
+      if (integrations?.deemix) {
+        const nextDeemix = {
+          ...(currentSettings.integrations?.deemix || {}),
+          ...integrations.deemix,
+        };
+        const trimmedUrl = String(nextDeemix.url || "").trim();
+        if (trimmedUrl) {
+          const urlValidation = validateExternalUrl(trimmedUrl);
+          if (!urlValidation.valid) {
+            return res.status(400).json({
+              error: `Invalid deemix URL: ${urlValidation.error}`,
+            });
+          }
+          nextDeemix.url = urlValidation.url.replace(/\/+$/, "");
+        } else {
+          nextDeemix.url = "";
+        }
+        nextDeemix.enabled = nextDeemix.enabled === true;
+        const bitrate = Number.parseInt(nextDeemix.bitrate, 10);
+        nextDeemix.bitrate = [1, 3, 9].includes(bitrate) ? bitrate : 9;
+        const priority = Number.parseInt(nextDeemix.priority, 10);
+        nextDeemix.priority = Number.isFinite(priority)
+          ? Math.min(1000, Math.max(1, priority))
+          : 15;
+        integrations.deemix = nextDeemix;
+      }
       if (integrations?.ytdlp) {
         const nextYtdlp = {
           ...(currentSettings.integrations?.ytdlp || {}),
@@ -341,7 +367,7 @@ export function registerGeneral(router) {
         integrations.news = nextNews;
       }
 
-      const INTEGRATION_KEYS = ["lidarr", "navidrome", "jellyfin", "slskd", "prowlarr", "nzbget", "sabnzbd", "ytdlp", "lastfm", "ticketmaster", "news", "metadata", "general", "gotify", "webhookEvents"];
+      const INTEGRATION_KEYS = ["lidarr", "navidrome", "jellyfin", "slskd", "prowlarr", "nzbget", "sabnzbd", "ytdlp", "deemix", "lastfm", "ticketmaster", "news", "metadata", "general", "gotify", "webhookEvents"];
       let mergedIntegrations =
         currentSettings.integrations || defaultData.settings.integrations || {};
       if (integrations) {

--- a/backend/routes/weeklyFlow/handlers/jobs.js
+++ b/backend/routes/weeklyFlow/handlers/jobs.js
@@ -302,12 +302,9 @@ export function registerJobs(router) {
     if (sourcePath) {
       await fs.rm(sourcePath, { force: true }).catch(() => {});
     }
-    const deniedSourceKey =
-      job.downloadSource === "usenet"
-        ? String(job.releaseGuid || "").trim()
-        : job.downloadSource === "ytdlp"
-          ? String(job.releaseGuid || "").trim()
-          : `${String(job.remoteUsername || "").trim()}\0${String(job.remoteFilename || "").trim()}`;
+    const deniedSourceKey = ["usenet", "ytdlp", "deemix"].includes(job.downloadSource)
+      ? String(job.releaseGuid || "").trim()
+      : `${String(job.remoteUsername || "").trim()}\0${String(job.remoteFilename || "").trim()}`;
     if (job.downloadSource && deniedSourceKey) {
       downloadTracker.recordDeniedSource(job.id, job.downloadSource, deniedSourceKey);
     }

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -69,6 +69,7 @@ const resolveTrackDownloadHistorySource = (downloadSource, downloadClient) => {
     return "nzbget";
   }
   if (normalized === "ytdlp") return "ytdlp";
+  if (normalized === "deemix") return "deemix";
   return "slskd";
 };
 
@@ -77,6 +78,7 @@ const CLIENT_LABELS = {
   nzbget: "NZBGet",
   slskd: "slskd",
   ytdlp: "yt-dlp",
+  deemix: "deemix",
 };
 const resolveDownloadClientLabel = (downloadSource, downloadClient) =>
   CLIENT_LABELS[resolveTrackDownloadHistorySource(downloadSource, downloadClient)] || "slskd";

--- a/backend/services/deemixClient.js
+++ b/backend/services/deemixClient.js
@@ -65,6 +65,11 @@ export function buildQueueUuid(trackId, bitrate) {
   return `track_${String(trackId || "").trim()}_${normalizeInteger(bitrate, FLAC_BITRATE)}`;
 }
 
+// deemix downloads exactly the configured bitrate, so unlike a Soulseek or
+// Usenet release its quality tier is known before anything is downloaded.
+// Deezer serves 16-bit FLAC, which classifies as flac-standard.
+const BITRATE_TIERS = Object.freeze({ 9: "flac-standard", 3: "mp3-320", 1: "mp3-128" });
+
 function bitrateLabel(bitrate) {
   const rate = normalizeInteger(bitrate, FLAC_BITRATE);
   return BITRATE_OPTIONS.find((option) => Number(option.value) === rate)?.label || String(rate);
@@ -189,6 +194,10 @@ export class DeemixClient {
 
   getBitrate() {
     return this._getSettings().bitrate;
+  }
+
+  getQualityTierId() {
+    return BITRATE_TIERS[this._getSettings().bitrate] || null;
   }
 
   async testConnection({ force = false } = {}) {

--- a/backend/services/deemixClient.js
+++ b/backend/services/deemixClient.js
@@ -65,6 +65,38 @@ export function buildQueueUuid(trackId, bitrate) {
   return `track_${String(trackId || "").trim()}_${normalizeInteger(bitrate, FLAC_BITRATE)}`;
 }
 
+function bitrateLabel(bitrate) {
+  const rate = normalizeInteger(bitrate, FLAC_BITRATE);
+  return BITRATE_OPTIONS.find((option) => Number(option.value) === rate)?.label || String(rate);
+}
+
+// Deezer plans gate the higher bitrates, and deemix refuses the queue instead of
+// downgrading. Name the setting to change rather than echoing its error id.
+export function describeBitrateSupport(currentUser, bitrate) {
+  const rate = normalizeInteger(bitrate, FLAC_BITRATE);
+  if (rate === FLAC_BITRATE && currentUser?.can_stream_lossless === false) {
+    return "This Deezer account cannot stream FLAC. Set Bitrate to MP3 320 or MP3 128.";
+  }
+  if (rate === 3 && currentUser?.can_stream_hq === false) {
+    return "This Deezer account cannot stream MP3 320. Set Bitrate to MP3 128.";
+  }
+  return null;
+}
+
+function describeAddToQueueError(errid, currentUser, bitrate) {
+  const id = String(errid || "").trim();
+  if (id === "CantStream") {
+    return (
+      describeBitrateSupport(currentUser, bitrate) ||
+      `This Deezer account cannot stream at ${bitrateLabel(bitrate)}. Lower the deemix bitrate.`
+    );
+  }
+  if (id === "NotLoggedIn") {
+    return "deemix is not logged in. Sign in with your ARL in the deemix web UI.";
+  }
+  return `deemix rejected the download: ${id || "unknown error"}`;
+}
+
 // deemix authenticates per express-session, so every call has to reuse the
 // cookie that /api/connect issues.
 // ponytail: one shared session, deemix runs single-user by default.
@@ -198,12 +230,20 @@ export class DeemixClient {
         };
       } else {
         const user = String(connected?.currentUser?.name || "").trim();
+        const unsupportedBitrate = describeBitrateSupport(
+          connected?.currentUser,
+          settings.bitrate,
+        );
+        const connectedMessage = `deemix is connected${user ? ` as ${user}` : ""}${suffix}`;
         result = {
           ok: true,
+          warning: !!unsupportedBitrate,
           configured: true,
           connected: true,
           version,
-          message: `deemix is connected${user ? ` as ${user}` : ""}${suffix}`,
+          message: unsupportedBitrate
+            ? `${connectedMessage}. ${unsupportedBitrate}`
+            : connectedMessage,
         };
       }
     } catch (error) {
@@ -235,13 +275,15 @@ export class DeemixClient {
     const url = String(trackUrl || "").trim();
     if (!url) throw new Error("deemix download requires a Deezer track URL");
     const settings = this._getSettings();
-    await requireSession(settings);
+    const connected = await requireSession(settings);
     const data = await request(settings, "POST", "/api/addToQueue", {
       data: { url, bitrate: settings.bitrate },
       timeout: 60000,
     });
     if (data?.result !== true) {
-      throw new Error(`deemix rejected the download: ${data?.errid || "unknown error"}`);
+      throw new Error(
+        describeAddToQueueError(data?.errid, connected?.currentUser, settings.bitrate),
+      );
     }
     const queued = Array.isArray(data?.data?.obj) ? data.data.obj[0] : data?.data?.obj;
     // A track already in the queue comes back without an object, so fall back to

--- a/backend/services/deemixClient.js
+++ b/backend/services/deemixClient.js
@@ -1,0 +1,269 @@
+import { dbOps } from "../db/helpers/index.js";
+import { normalizeBaseUrl, normalizeInteger } from "./usenetClientCommon.js";
+import axios from "../../lib/axiosFetch.js";
+
+const FLAC_BITRATE = 9;
+const BITRATE_OPTIONS = Object.freeze([
+  Object.freeze({ value: "9", label: "FLAC" }),
+  Object.freeze({ value: "3", label: "MP3 320" }),
+  Object.freeze({ value: "1", label: "MP3 128" }),
+]);
+
+export const deemixSettings = Object.freeze({
+  key: "deemix",
+  label: "deemix",
+  subtitle: "Deezer",
+  enabledDefault: false,
+  healthKey: "deemixConfigured",
+  testRequiresEnabled: true,
+  fields: Object.freeze([
+    Object.freeze({ key: "enabled", label: "Enable deemix", type: "toggle" }),
+    Object.freeze({
+      key: "url",
+      label: "Server URL",
+      type: "url",
+      required: true,
+      section: "Connection",
+      placeholder: "http://localhost:6595",
+      hint: "Sign in with your ARL in the deemix web UI first.",
+    }),
+    Object.freeze({
+      key: "bitrate",
+      label: "Bitrate",
+      type: "select",
+      section: "Downloads",
+      options: BITRATE_OPTIONS,
+    }),
+    Object.freeze({
+      key: "priority",
+      label: "Source priority",
+      type: "number",
+      min: 1,
+      max: 1000,
+      section: "Downloads",
+    }),
+  ]),
+  defaults: Object.freeze({ enabled: false, url: "", bitrate: FLAC_BITRATE, priority: 15 }),
+  validation: Object.freeze({ required: ["url"], url: ["url"] }),
+  testConnection: true,
+});
+
+function getSettings(config = null) {
+  const deemix = config || dbOps.getSettings()?.integrations?.deemix || {};
+  const bitrate = normalizeInteger(deemix.bitrate, FLAC_BITRATE);
+  return {
+    enabled: deemix.enabled === true,
+    url: normalizeBaseUrl(deemix.url),
+    bitrate: BITRATE_OPTIONS.some((option) => Number(option.value) === bitrate)
+      ? bitrate
+      : FLAC_BITRATE,
+    priority: normalizeInteger(deemix.priority, 15),
+  };
+}
+
+export function buildQueueUuid(trackId, bitrate) {
+  return `track_${String(trackId || "").trim()}_${normalizeInteger(bitrate, FLAC_BITRATE)}`;
+}
+
+// deemix authenticates per express-session, so every call has to reuse the
+// cookie that /api/connect issues.
+// ponytail: one shared session, deemix runs single-user by default.
+let session = { url: "", cookie: "" };
+let connectionCache = { checkedAt: 0, result: null, url: null };
+
+async function request(settings, method, path, { params, data, timeout = 30000 } = {}) {
+  if (!settings.url) throw new Error("deemix URL is required");
+  const response = await axios({
+    method,
+    url: `${settings.url}${path}`,
+    params,
+    data,
+    timeout,
+    headers: session.cookie ? { Cookie: session.cookie } : {},
+  });
+  const setCookie = response.headers?.["set-cookie"];
+  if (setCookie) session.cookie = String(setCookie).split(";")[0];
+  return response.data;
+}
+
+function isLoggedIn(connected) {
+  return connected?.autologin === false;
+}
+
+async function connect(settings) {
+  if (session.url !== settings.url) session = { url: settings.url, cookie: "" };
+  const first = await request(settings, "GET", "/api/connect");
+  const arl = String(first?.singleUser?.arl || "").trim();
+  if (isLoggedIn(first) || !arl) return first;
+  await request(settings, "POST", "/api/loginArl", { data: { arl }, timeout: 45000 });
+  return request(settings, "GET", "/api/connect");
+}
+
+async function requireSession(settings) {
+  const connected = await connect(settings);
+  if (!isLoggedIn(connected)) {
+    throw new Error("deemix is not logged in. Sign in with your ARL in the deemix web UI.");
+  }
+  return connected;
+}
+
+function normalizeTrack(entry) {
+  const id = String(entry?.id || "").trim();
+  if (!id) return null;
+  return {
+    id,
+    title: String(entry?.title || "").trim(),
+    artist: String(entry?.artist?.name || "").trim(),
+    album: String(entry?.album?.title || "").trim(),
+    durationSec: normalizeInteger(entry?.duration, 0),
+    url: String(entry?.link || "").trim() || `https://www.deezer.com/track/${id}`,
+    readable: entry?.readable !== false,
+  };
+}
+
+export class DeemixClient {
+  constructor(config = null) {
+    this.key = "deemix";
+    this.name = "deemix";
+    this._config = config;
+  }
+
+  updateConfig(config = null) {
+    this._config = config;
+  }
+
+  _getSettings() {
+    return getSettings(this._config);
+  }
+
+  isEnabled() {
+    return this._getSettings().enabled;
+  }
+
+  isConfigured() {
+    const { enabled, url } = this._getSettings();
+    return enabled && !!url;
+  }
+
+  getStatus() {
+    const settings = this._getSettings();
+    const cached = connectionCache.url === settings.url ? connectionCache.result : null;
+    return {
+      enabled: settings.enabled,
+      configured: this.isConfigured(),
+      connected: cached?.connected === true,
+    };
+  }
+
+  getBitrate() {
+    return this._getSettings().bitrate;
+  }
+
+  async testConnection({ force = false } = {}) {
+    const settings = this._getSettings();
+    if (!settings.enabled) {
+      return { ok: false, configured: false, connected: false, message: "deemix is disabled" };
+    }
+    if (!settings.url) {
+      return { ok: false, configured: false, connected: false, message: "deemix URL is required" };
+    }
+    if (
+      !force &&
+      connectionCache.url === settings.url &&
+      connectionCache.result &&
+      Date.now() - connectionCache.checkedAt < 30000
+    ) {
+      return connectionCache.result;
+    }
+    let result;
+    try {
+      const connected = await connect(settings);
+      const version = String(connected?.update?.deemixVersion || "").trim();
+      const suffix = version ? ` (v${version})` : "";
+      if (connected?.deezerAvailable === false) {
+        result = {
+          ok: false,
+          configured: true,
+          connected: true,
+          version,
+          message: `deemix cannot reach Deezer${suffix}`,
+        };
+      } else if (!isLoggedIn(connected)) {
+        result = {
+          ok: false,
+          configured: true,
+          connected: true,
+          version,
+          message: `deemix is reachable${suffix} but not logged in. Sign in with your ARL in the deemix web UI.`,
+        };
+      } else {
+        const user = String(connected?.currentUser?.name || "").trim();
+        result = {
+          ok: true,
+          configured: true,
+          connected: true,
+          version,
+          message: `deemix is connected${user ? ` as ${user}` : ""}${suffix}`,
+        };
+      }
+    } catch (error) {
+      result = {
+        ok: false,
+        configured: true,
+        connected: false,
+        message: error?.message || "Failed to reach deemix",
+      };
+    }
+    connectionCache = { checkedAt: Date.now(), result, url: settings.url };
+    return result;
+  }
+
+  async search(query, { limit = 10 } = {}) {
+    const term = String(query || "").trim();
+    if (!term) return [];
+    const settings = this._getSettings();
+    await requireSession(settings);
+    const data = await request(settings, "GET", "/api/search", {
+      params: { term, type: "track", start: 0, nb: Math.min(Math.max(limit, 1), 50) },
+      timeout: 45000,
+    });
+    if (data?.error) throw new Error(`deemix search failed: ${data.error}`);
+    return (Array.isArray(data?.data) ? data.data : []).map(normalizeTrack).filter(Boolean);
+  }
+
+  async addToQueue(trackUrl, trackId) {
+    const url = String(trackUrl || "").trim();
+    if (!url) throw new Error("deemix download requires a Deezer track URL");
+    const settings = this._getSettings();
+    await requireSession(settings);
+    const data = await request(settings, "POST", "/api/addToQueue", {
+      data: { url, bitrate: settings.bitrate },
+      timeout: 60000,
+    });
+    if (data?.result !== true) {
+      throw new Error(`deemix rejected the download: ${data?.errid || "unknown error"}`);
+    }
+    const queued = Array.isArray(data?.data?.obj) ? data.data.obj[0] : data?.data?.obj;
+    // A track already in the queue comes back without an object, so fall back to
+    // the uuid deemix derives from the track and bitrate.
+    return String(queued?.uuid || "").trim() || buildQueueUuid(trackId, settings.bitrate);
+  }
+
+  async getQueueItem(uuid) {
+    const id = String(uuid || "").trim();
+    if (!id) return null;
+    const settings = this._getSettings();
+    const data = await request(settings, "GET", "/api/getQueue");
+    return data?.queue?.[id] || null;
+  }
+
+  async removeFromQueue(uuid) {
+    const id = String(uuid || "").trim();
+    if (!id) return false;
+    const settings = this._getSettings();
+    await request(settings, "POST", "/api/removeFromQueue", { params: { uuid: id } });
+    return true;
+  }
+}
+
+export const deemixClient = new DeemixClient();

--- a/backend/services/deemixOrchestrator.js
+++ b/backend/services/deemixOrchestrator.js
@@ -242,10 +242,15 @@ async function handleDeemixPoll(payload, helpers) {
 }
 
 async function handleDeemixFinalize(payload, helpers) {
+  // deemix derives the queue uuid from the track and bitrate, so a finished entry
+  // left behind makes the next request match it instead of downloading again.
+  // Dropping it once here covers every exit below, a job held for review included.
+  await getDeemixClient()
+    .removeFromQueue(payload.queueUuid)
+    .catch(() => {});
   const job = downloadTracker.getJob(payload.jobId);
   if (!job) return null;
   if (job.status === "failed" || job.status === "done") return null;
-  const client = getDeemixClient();
   const candidate = getPayloadCandidate(payload);
   const resolvedTrack = {
     ...buildResolvedTrack(job, payload.track),
@@ -254,7 +259,6 @@ async function handleDeemixFinalize(payload, helpers) {
   const filePath = String(payload.downloadedPath || "").trim();
   const exists = filePath ? await fs.stat(filePath).catch(() => null) : null;
   if (!exists?.isFile()) {
-    await client.removeFromQueue(payload.queueUuid).catch(() => {});
     const reason = filePath
       ? `deemix download is not readable at ${filePath}. Add a path mapping for deemix in Settings.`
       : "deemix finished without an audio file";
@@ -283,7 +287,6 @@ async function handleDeemixFinalize(payload, helpers) {
     ) {
       return null;
     }
-    await client.removeFromQueue(payload.queueUuid).catch(() => {});
     const reason = validation.reason || "deemix download failed track validation";
     if (hasNextCandidate(payload)) {
       return buildNextCandidatePayload(payload, { queueUuid: null, downloadedPath: null });
@@ -304,7 +307,6 @@ async function handleDeemixFinalize(payload, helpers) {
   const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".flac"}`;
   const finalPath = path.join(finalDir, finalName);
   const committedFinalPath = await commitImportToPlaylistLibrary(filePath, finalPath);
-  await client.removeFromQueue(payload.queueUuid).catch(() => {});
   return finalizePipelineJobSuccess({
     downloadTracker,
     job,

--- a/backend/services/deemixOrchestrator.js
+++ b/backend/services/deemixOrchestrator.js
@@ -1,0 +1,317 @@
+import path from "path";
+import fs from "fs/promises";
+import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
+import { getDownloadClient } from "./download/downloadClientSettings.js";
+import { logger } from "./logger.js";
+import { validateDownloadedTrack } from "./weeklyFlow/weeklyFlowSoulseekMatcher.js";
+import {
+  buildDeemixSearchQueries,
+  rankDeemixResults,
+} from "./weeklyFlow/weeklyFlowDeemixMatcher.js";
+import { resolvePlaylistRoot } from "./playlistPaths.js";
+import { getPathMappings, resolveLocalPath } from "./pathMappings.js";
+import {
+  buildResolvedPlaylistTrack as buildResolvedTrack,
+  commitImportToPlaylistLibrary,
+  joinUnderRoot,
+  sanitizePathPart,
+  writeAudioMetadata,
+} from "./playlistDownloadUtils.js";
+import {
+  getPayloadCandidate,
+  hasNextCandidate,
+  buildNextCandidatePayload,
+  mergeSearchResults,
+  blockPipelineJobForReview,
+  finalizePipelineJobSuccess,
+} from "./pipelineHelpers.js";
+
+const SEARCH_LIMIT = 10;
+const POLL_DELAY_SECONDS = 3;
+const MAX_POLL_ATTEMPTS = 200;
+
+function getDeemixClient() {
+  return getDownloadClient("deemix");
+}
+
+function hasEnoughCandidates(aggregated, resolvedTrack) {
+  return rankDeemixResults(aggregated, resolvedTrack).some((entry) => entry.preDownloadValid);
+}
+
+function readQueuedFilePath(queueItem) {
+  const files = Array.isArray(queueItem?.files) ? queueItem.files : [];
+  for (const file of files) {
+    const remotePath = String(file?.path || "").trim();
+    if (remotePath) return resolveLocalPath(remotePath, getPathMappings("deemix"));
+  }
+  return "";
+}
+
+function readQueueError(queueItem) {
+  const errors = Array.isArray(queueItem?.errors) ? queueItem.errors : [];
+  for (const error of errors) {
+    const message = String(error?.error || error?.message || error || "").trim();
+    if (message) return message;
+  }
+  return "";
+}
+
+async function handleDeemixSearch(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  downloadTracker.setDownloading(job.id);
+  downloadTracker.updateDownloadMetadata(job.id, {
+    downloadSource: "deemix",
+    downloadClient: "deemix",
+  });
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobSearching }) => recordTrackJobSearching(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+
+  const resolvedTrack = {
+    ...buildResolvedTrack(job, payload.track),
+    upgradeForJobId: payload.upgradeForJobId || null,
+  };
+  const client = getDeemixClient();
+  const queries = buildDeemixSearchQueries(resolvedTrack);
+  const aggregated = [];
+  const seen = new Set();
+  let lastError = "";
+  for (const query of queries) {
+    if (hasEnoughCandidates(aggregated, resolvedTrack)) break;
+    try {
+      const results = await client.search(query, { limit: SEARCH_LIMIT });
+      mergeSearchResults(aggregated, seen, results, (entry) => String(entry.id || "").trim());
+    } catch (error) {
+      lastError = error?.message || String(error);
+      logger.warn("deemix", "deemix search failed", {
+        jobId: job.id,
+        query,
+        error: lastError,
+      });
+    }
+  }
+
+  const ranked = rankDeemixResults(aggregated, resolvedTrack);
+  const deniedIds = new Set(
+    (Array.isArray(job.deniedRemoteSources) ? job.deniedRemoteSources : [])
+      .filter((entry) => Array.isArray(entry) && entry[0] === "deemix")
+      .map((entry) => String(entry[1] || "").trim()),
+  );
+  const candidates =
+    deniedIds.size > 0
+      ? ranked.filter((entry) => !deniedIds.has(String(entry?.raw?.id || "").trim()))
+      : ranked;
+  if (candidates.length === 0) {
+    const message =
+      lastError && aggregated.length === 0
+        ? `deemix search failed: ${lastError}`
+        : "No suitable deemix search results";
+    return helpers.failOrTryNextSource(payload, job, message, {
+      queryCount: queries.length,
+      rawResultCount: aggregated.length,
+      rankedCount: ranked.length,
+    });
+  }
+  return {
+    ...payload,
+    phase: "download",
+    source: "deemix",
+    candidates,
+    candidateIndex: 0,
+    resolvedTrack,
+  };
+}
+
+async function handleDeemixDownload(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+  const index = Number(payload.candidateIndex || 0);
+  const candidate = candidates[index];
+  const url = candidate?.raw?.url;
+  if (!url) {
+    return helpers.failOrTryNextSource(payload, job, "No deemix track URL available");
+  }
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobDownloading }) => recordTrackJobDownloading(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+
+  const client = getDeemixClient();
+  let queueUuid;
+  try {
+    queueUuid = await client.addToQueue(url, candidate.raw.id);
+  } catch (error) {
+    const message = error?.message || String(error);
+    logger.warn("deemix", "deemix queue submission failed", {
+      jobId: job.id,
+      url,
+      error: message,
+    });
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { queueUuid: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, message);
+  }
+
+  downloadTracker.updateDownloadMetadata(job.id, {
+    downloadSource: "deemix",
+    downloadClient: "deemix",
+    downloadClientId: queueUuid,
+    releaseGuid: candidate.raw.id,
+    releaseTitle: candidate.raw.title,
+    remoteUsername: candidate.raw.artist,
+    remoteFilename: candidate.raw.file,
+  });
+
+  return {
+    ...payload,
+    phase: "poll",
+    source: "deemix",
+    candidate,
+    candidateIndex: index,
+    queueUuid,
+    pollAttempts: 0,
+  };
+}
+
+async function handleDeemixPoll(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  const client = getDeemixClient();
+  const pollAttempts = Number(payload.pollAttempts || 0) + 1;
+  if (pollAttempts > MAX_POLL_ATTEMPTS) {
+    await client.removeFromQueue(payload.queueUuid).catch(() => {});
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { queueUuid: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, "deemix polling timed out");
+  }
+
+  let queueItem;
+  try {
+    queueItem = await client.getQueueItem(payload.queueUuid);
+  } catch (error) {
+    logger.warn("deemix", "deemix queue poll failed", {
+      jobId: job.id,
+      uuid: payload.queueUuid,
+      error: error?.message || String(error),
+    });
+    return { ...payload, phase: "poll", delaySeconds: POLL_DELAY_SECONDS, pollAttempts };
+  }
+
+  const status = String(queueItem?.status || "").trim();
+  if (!queueItem || status === "inQueue" || status === "downloading") {
+    return { ...payload, phase: "poll", delaySeconds: POLL_DELAY_SECONDS, pollAttempts };
+  }
+  const downloadedPath = readQueuedFilePath(queueItem);
+  if (!downloadedPath) {
+    await client.removeFromQueue(payload.queueUuid).catch(() => {});
+    const reason = readQueueError(queueItem) || `deemix download ${status || "failed"}`;
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { queueUuid: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, reason);
+  }
+  return { ...payload, phase: "finalize", downloadedPath, pollAttempts };
+}
+
+async function handleDeemixFinalize(payload, helpers) {
+  const job = downloadTracker.getJob(payload.jobId);
+  if (!job) return null;
+  if (job.status === "failed" || job.status === "done") return null;
+  const client = getDeemixClient();
+  const candidate = getPayloadCandidate(payload);
+  const resolvedTrack = {
+    ...buildResolvedTrack(job, payload.track),
+    upgradeForJobId: payload.upgradeForJobId || null,
+  };
+  const filePath = String(payload.downloadedPath || "").trim();
+  const exists = filePath ? await fs.stat(filePath).catch(() => null) : null;
+  if (!exists?.isFile()) {
+    await client.removeFromQueue(payload.queueUuid).catch(() => {});
+    const reason = filePath
+      ? `deemix download is not readable at ${filePath}. Add a path mapping for deemix in Settings.`
+      : "deemix finished without an audio file";
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { queueUuid: null, downloadedPath: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, reason);
+  }
+
+  const validation = await validateDownloadedTrack(
+    filePath,
+    {
+      ...candidate,
+      raw: { ...(candidate?.raw || {}), file: candidate?.raw?.file || filePath },
+    },
+    resolvedTrack,
+  );
+  if (!validation.valid) {
+    if (
+      blockPipelineJobForReview({
+        downloadTracker,
+        job,
+        validation,
+        sourcePath: filePath,
+      })
+    ) {
+      return null;
+    }
+    await client.removeFromQueue(payload.queueUuid).catch(() => {});
+    const reason = validation.reason || "deemix download failed track validation";
+    if (hasNextCandidate(payload)) {
+      return buildNextCandidatePayload(payload, { queueUuid: null, downloadedPath: null });
+    }
+    return helpers.failOrTryNextSource(payload, job, reason);
+  }
+
+  await writeAudioMetadata(filePath, resolvedTrack);
+  import("./aurralHistoryService.js")
+    .then(({ recordTrackJobMoving }) => recordTrackJobMoving(job))
+    .catch((err) => {
+      console.warn(err);
+    });
+  const playlistRoot = resolvePlaylistRoot();
+  const destination = String(payload.destination || "").trim();
+  const ext = path.extname(filePath).toLowerCase();
+  const finalDir = joinUnderRoot(playlistRoot, destination);
+  const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".flac"}`;
+  const finalPath = path.join(finalDir, finalName);
+  const committedFinalPath = await commitImportToPlaylistLibrary(filePath, finalPath);
+  await client.removeFromQueue(payload.queueUuid).catch(() => {});
+  return finalizePipelineJobSuccess({
+    downloadTracker,
+    job,
+    committedFinalPath,
+    album: candidate?.resolvedAlbumName || job.albumName,
+    quality: validation.quality,
+  });
+}
+
+export async function processDeemixPipelinePayload(payload, helpers = {}) {
+  logger.debug("deemix", "deemix pipeline phase", {
+    phase: payload.phase,
+    jobId: payload.jobId,
+    source: payload.source,
+  });
+  switch (payload.phase) {
+    case "search":
+      return handleDeemixSearch(payload, helpers);
+    case "download":
+      return handleDeemixDownload(payload, helpers);
+    case "poll":
+      return handleDeemixPoll(payload, helpers);
+    case "finalize":
+      return handleDeemixFinalize(payload, helpers);
+    default:
+      throw new Error(`Unknown deemix pipeline phase: ${payload.phase}`);
+  }
+}

--- a/backend/services/deemixOrchestrator.js
+++ b/backend/services/deemixOrchestrator.js
@@ -17,6 +17,8 @@ import {
   sanitizePathPart,
   writeAudioMetadata,
 } from "./playlistDownloadUtils.js";
+import { getQualityProfile } from "./qualityProfileService.js";
+import { isQualityUpgrade } from "./qualityProfileModel.js";
 import {
   getPayloadCandidate,
   hasNextCandidate,
@@ -36,6 +38,18 @@ function getDeemixClient() {
 
 function hasEnoughCandidates(aggregated, resolvedTrack) {
   return rankDeemixResults(aggregated, resolvedTrack).some((entry) => entry.preDownloadValid);
+}
+
+// The configured bitrate fixes the tier, so an upgrade that deemix cannot
+// improve on is refused before the download rather than after validation.
+function readUnusableUpgradeTier(upgradeForJobId) {
+  if (!upgradeForJobId) return null;
+  const tier = getDeemixClient().getQualityTierId();
+  const currentTier = downloadTracker.getJob(upgradeForJobId)?.qualityTier || null;
+  if (isQualityUpgrade({ tier }, currentTier, getQualityProfile())) return null;
+  return `deemix downloads ${tier || "an unknown tier"}, which is not an upgrade over ${
+    currentTier || "the current file"
+  }`;
 }
 
 function readQueuedFilePath(queueItem) {
@@ -60,6 +74,10 @@ async function handleDeemixSearch(payload, helpers) {
   const job = downloadTracker.getJob(payload.jobId);
   if (!job) return null;
   if (job.status === "failed" || job.status === "done") return null;
+  const unusableUpgrade = readUnusableUpgradeTier(payload.upgradeForJobId);
+  if (unusableUpgrade) {
+    return helpers.failOrTryNextSource(payload, job, unusableUpgrade);
+  }
   downloadTracker.setDownloading(job.id);
   downloadTracker.updateDownloadMetadata(job.id, {
     downloadSource: "deemix",

--- a/backend/services/download/downloadClientSettings.js
+++ b/backend/services/download/downloadClientSettings.js
@@ -4,12 +4,14 @@ import { SlskdClient, slskdClient, slskdSettings } from "../slskdClient.js";
 import { NzbgetClient, nzbgetClient, nzbgetSettings } from "../nzbgetClient.js";
 import { SabnzbdClient, sabnzbdClient, sabnzbdSettings } from "../sabnzbdClient.js";
 import { YtdlpClient, ytdlpClient, ytdlpSettings } from "../ytdlpClient.js";
+import { DeemixClient, deemixClient, deemixSettings } from "../deemixClient.js";
 
 const definitions = Object.freeze({
   slskd: slskdSettings,
   ytdlp: ytdlpSettings,
   nzbget: nzbgetSettings,
   sabnzbd: sabnzbdSettings,
+  deemix: deemixSettings,
 });
 
 const factories = {
@@ -17,6 +19,7 @@ const factories = {
   ytdlp: () => new YtdlpClient(),
   nzbget: () => new NzbgetClient(),
   sabnzbd: () => new SabnzbdClient(),
+  deemix: () => new DeemixClient(),
 };
 
 export const downloadClientRegistry = new DownloadClientRegistry([
@@ -24,6 +27,7 @@ export const downloadClientRegistry = new DownloadClientRegistry([
   ytdlpClient,
   nzbgetClient,
   sabnzbdClient,
+  deemixClient,
 ]);
 
 export function getDownloadClientSettings() {

--- a/backend/services/downloadSourceService.js
+++ b/backend/services/downloadSourceService.js
@@ -5,6 +5,7 @@ import { getDownloadClient } from "./download/downloadClientSettings.js";
 const SOURCE_LABELS = {
   slskd: "Soulseek",
   usenet: "Usenet",
+  deemix: "deemix",
   ytdlp: "yt-dlp",
 };
 
@@ -36,6 +37,11 @@ function getUsenetPriority() {
   return normalizePriority(integrations.nzbget?.priority, 20);
 }
 
+function getDeemixPriority() {
+  const deemix = getIntegrations().deemix || {};
+  return normalizePriority(deemix.priority, 15);
+}
+
 function getYtdlpPriority() {
   const ytdlp = getIntegrations().ytdlp || {};
   return normalizePriority(ytdlp.priority, 50);
@@ -46,12 +52,14 @@ export function getDownloadSourceStatus() {
   const nzbgetClient = getDownloadClient("nzbget");
   const sabnzbdClient = getDownloadClient("sabnzbd");
   const ytdlpClient = getDownloadClient("ytdlp");
+  const deemixClient = getDownloadClient("deemix");
   const slskdConfigured = isSlskdEnabled() && slskdClient.isConfigured();
   const prowlarrConfigured = prowlarrClient.isConfigured();
   const nzbgetConfigured = nzbgetClient.isConfigured();
   const sabnzbdConfigured = sabnzbdClient.isConfigured();
   const usenetConfigured = prowlarrConfigured && (nzbgetConfigured || sabnzbdConfigured);
   const ytdlpConfigured = ytdlpClient.isConfigured();
+  const deemixConfigured = deemixClient.isConfigured();
   return {
     slskd: {
       id: "slskd",
@@ -70,6 +78,13 @@ export function getDownloadSourceStatus() {
       nzbgetConfigured,
       sabnzbdConfigured,
     },
+    deemix: {
+      id: "deemix",
+      label: SOURCE_LABELS.deemix,
+      enabled: deemixClient.isEnabled(),
+      configured: deemixConfigured,
+      priority: getDeemixPriority(),
+    },
     ytdlp: {
       id: "ytdlp",
       label: SOURCE_LABELS.ytdlp,
@@ -85,6 +100,7 @@ export function getEnabledDownloadSources() {
   const sources = [];
   if (status.slskd.configured) sources.push(status.slskd);
   if (status.usenet.configured) sources.push(status.usenet);
+  if (status.deemix.configured) sources.push(status.deemix);
   if (status.ytdlp.configured) sources.push(status.ytdlp);
   return sources.sort((left, right) => {
     if (left.priority !== right.priority) return left.priority - right.priority;
@@ -101,6 +117,7 @@ export function getDownloadSourceNotConfiguredMessage() {
   const pieces = [];
   if (!status.slskd.configured) pieces.push("slskd");
   if (!status.usenet.configured) pieces.push("Prowlarr + NZBGet or SABnzbd");
+  if (!status.deemix.configured) pieces.push("deemix");
   if (!status.ytdlp.configured) pieces.push("yt-dlp");
   return `No download source is configured. Configure ${pieces.join(" or ")} in Settings > Integrations to enable downloads for flows and playlists.`;
 }

--- a/backend/services/pathMappings.js
+++ b/backend/services/pathMappings.js
@@ -8,6 +8,7 @@ const PATH_MAPPING_SOURCES = new Set([
   "slskd",
   "nzbget",
   "sabnzbd",
+  "deemix",
   "plex",
   "jellyfin",
 ]);

--- a/backend/services/qualityProfileService.js
+++ b/backend/services/qualityProfileService.js
@@ -128,10 +128,10 @@ export async function reclassifyQualityJobs({ enqueue = false } = {}) {
   return { classified, queued };
 }
 
+const UPGRADE_SOURCE_IDS = new Set(["slskd", "usenet", "deemix"]);
+
 function hasUpgradeSource() {
-  return getEnabledDownloadSources().some(
-    (source) => source.id === "slskd" || source.id === "usenet",
-  );
+  return getEnabledDownloadSources().some((source) => UPGRADE_SOURCE_IDS.has(source.id));
 }
 
 export async function queueQualityUpgrade(job) {

--- a/backend/services/slskdOrchestrator.js
+++ b/backend/services/slskdOrchestrator.js
@@ -19,6 +19,7 @@ import {
 } from "./slskdTransferHistory.js";
 import { processUsenetPipelinePayload } from "./usenetOrchestrator.js";
 import { processYtdlpPipelinePayload } from "./ytdlpOrchestrator.js";
+import { processDeemixPipelinePayload } from "./deemixOrchestrator.js";
 import {
   getDownloadSourceNotConfiguredMessage,
   getEnabledDownloadSources,
@@ -1137,6 +1138,13 @@ export async function processPipelinePayload(payload) {
       return job ? failOrTryNextSource(payload, job, "Usenet is not configured") : null;
     }
     return processUsenetPipelinePayload(payload, { failOrTryNextSource });
+  }
+  if (payload.source === "deemix") {
+    if (!isSourceConfigured("deemix")) {
+      const job = downloadTracker.getJob(payload.jobId);
+      return job ? failOrTryNextSource(payload, job, "deemix is not configured") : null;
+    }
+    return processDeemixPipelinePayload(payload, { failOrTryNextSource });
   }
   if (payload.source === "ytdlp") {
     if (!isSourceConfigured("ytdlp")) {

--- a/backend/services/weeklyFlow/weeklyFlowDeemixMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowDeemixMatcher.js
@@ -1,0 +1,116 @@
+import {
+  normalizeReleaseText as normalizeText,
+  scoreTextMatch,
+} from "../providers/brainzmashRanking.js";
+
+const MAX_CANDIDATES = 5;
+
+function readContext(context) {
+  return {
+    trackName: String(context?.trackName || context?.title || "").trim(),
+    artistName: String(context?.artistName || context?.artist || "").trim(),
+    albumName: String(context?.albumName || context?.album || "").trim(),
+    durationMs: Number(context?.durationMs || 0),
+  };
+}
+
+// Deezer reports the real track length, so a wide window only lets edits and
+// extended versions through.
+function scoreDuration(durationSec, expectedMs) {
+  if (!Number.isFinite(expectedMs) || expectedMs <= 0) return { ok: true, score: 0 };
+  if (!Number.isFinite(durationSec) || durationSec <= 0) return { ok: true, score: -8 };
+  const diff = Math.abs(durationSec * 1000 - expectedMs);
+  if (diff > Math.max(10000, expectedMs * 0.08)) return { ok: false, score: -40 };
+  if (diff <= 2000) return { ok: true, score: 25 };
+  if (diff <= 5000) return { ok: true, score: 18 };
+  return { ok: true, score: 10 };
+}
+
+function quote(value) {
+  return String(value || "").replace(/"/g, " ").trim();
+}
+
+export function buildDeemixSearchQueries(context) {
+  const ctx = readContext(context);
+  if (!ctx.trackName) return [];
+  const queries = [];
+  if (ctx.artistName) {
+    // Deezer's advanced search syntax keeps the first pass tight.
+    queries.push(`artist:"${quote(ctx.artistName)}" track:"${quote(ctx.trackName)}"`);
+    queries.push(`${ctx.artistName} ${ctx.trackName}`);
+  } else {
+    queries.push(ctx.trackName);
+  }
+  const seen = new Set();
+  return queries.filter((query) => {
+    const key = normalizeText(query);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function rankDeemixResults(results, context) {
+  const ctx = readContext(context);
+  const ranked = [];
+  for (const result of Array.isArray(results) ? results : []) {
+    const id = String(result?.id || "").trim();
+    const title = String(result?.title || "").trim();
+    const artist = String(result?.artist || "").trim();
+    const album = String(result?.album || "").trim();
+    if (!id || !title) continue;
+    if (result?.readable === false) continue;
+    const duration = scoreDuration(result.durationSec, ctx.durationMs);
+    if (!duration.ok) continue;
+
+    const titleScore = scoreTextMatch(title, ctx.trackName);
+    const artistScore = ctx.artistName ? scoreTextMatch(artist, ctx.artistName) : 0;
+    const albumScore =
+      ctx.albumName && album ? Math.round(scoreTextMatch(album, ctx.albumName) / 4) : 0;
+    if (titleScore < 55 || (ctx.artistName && artistScore < 40)) continue;
+    ranked.push({
+      raw: {
+        id,
+        title,
+        artist,
+        album,
+        url: result.url,
+        durationSec: result.durationSec,
+        file: artist ? `${artist} - ${title}` : title,
+      },
+      score: titleScore + artistScore + albumScore + duration.score,
+      scores: {
+        title: titleScore,
+        artist: artistScore,
+        album: albumScore,
+        duration: duration.score,
+      },
+      resolvedAlbumName: album || ctx.albumName || null,
+      preDownloadValid: titleScore >= 70 && (!ctx.artistName || artistScore >= 55),
+    });
+  }
+  ranked.sort((left, right) => right.score - left.score);
+  return ranked.slice(0, MAX_CANDIDATES);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("weeklyFlowDeemixMatcher.js")) {
+  const context = { artistName: "Daft Punk", trackName: "Get Lucky", durationMs: 248000 };
+  const ranked = rankDeemixResults(
+    [
+      { id: "good", title: "Get Lucky", artist: "Daft Punk", album: "Random Access Memories", durationSec: 248 },
+      { id: "wrong-artist", title: "Get Lucky", artist: "Lounge Covers", durationSec: 248 },
+      { id: "extended", title: "Get Lucky", artist: "Daft Punk", durationSec: 620 },
+      { id: "blocked", title: "Get Lucky", artist: "Daft Punk", durationSec: 248, readable: false },
+    ],
+    context,
+  );
+  console.assert(ranked[0]?.raw?.id === "good", "prefer the exact artist and duration match");
+  console.assert(!ranked.some((entry) => entry.raw.id === "wrong-artist"), "reject other artists");
+  console.assert(!ranked.some((entry) => entry.raw.id === "extended"), "reject long edits");
+  console.assert(!ranked.some((entry) => entry.raw.id === "blocked"), "reject unplayable tracks");
+  console.assert(
+    buildDeemixSearchQueries(context)[0] === 'artist:"Daft Punk" track:"Get Lucky"',
+    "build the advanced Deezer query first",
+  );
+  console.log("weeklyFlowDeemixMatcher self-check ok");
+}

--- a/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
@@ -235,7 +235,7 @@ function buildPipelinePayload(job) {
     destination: buildAurralTrackDestination(playlistId, artistDir, albumDir, { ephemeral }),
     upgrade: Boolean(job.upgradeForJobId),
     upgradeForJobId: job.upgradeForJobId || null,
-    allowedSources: job.upgradeForJobId ? ["slskd", "usenet"] : null,
+    allowedSources: job.upgradeForJobId ? ["slskd", "usenet", "deemix"] : null,
   };
 }
 

--- a/docs/architecture/0002-download-client.md
+++ b/docs/architecture/0002-download-client.md
@@ -24,7 +24,7 @@ The built-in adapters keep their settings metadata beside their client code. `GE
 
 ## Built-in clients
 
-The registry currently contains slskd, yt-dlp, NZBGet, and SABnzbd. Prowlarr remains an indexer service because it searches for Usenet releases and does not receive downloads.
+The registry currently contains slskd, yt-dlp, NZBGet, SABnzbd, and deemix. Prowlarr remains an indexer service because it searches for Usenet releases and does not receive downloads.
 
 The orchestration code selects clients through the registry. Provider-specific methods continue to run on the selected adapter, so each client can keep its own protocol and download state.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -69,6 +69,7 @@ export default defineConfig({
             { slug: "integrations/koito" },
             { slug: "integrations/slskd" },
             { slug: "integrations/ytdlp" },
+            { slug: "integrations/deemix" },
             { slug: "integrations/usenet" },
             { slug: "integrations/navidrome" },
             { slug: "integrations/plex" },

--- a/docs/src/content/docs/integrations/deemix.mdx
+++ b/docs/src/content/docs/integrations/deemix.mdx
@@ -40,7 +40,7 @@ When a downloaded file matches the requested track but its duration differs sign
 
 Aurral removes its own queue entry from deemix after each track, so a repeated request downloads again instead of matching a finished queue item.
 
-Automatic and manual upgrade searches use slskd or Usenet, not deemix.
+deemix can also serve quality upgrades. Its bitrate setting fixes the tier it delivers, so Aurral compares that tier against the tier of the file you already have and skips deemix when it cannot improve on it. A deemix set to FLAC upgrades an MP3, and a deemix set to MP3 128 is not asked to upgrade anything better. Downloaded files are checked against the quality profile as well, so a track is never replaced by a worse one.
 
 ## Download source priority
 

--- a/docs/src/content/docs/integrations/deemix.mdx
+++ b/docs/src/content/docs/integrations/deemix.mdx
@@ -1,0 +1,47 @@
+---
+title: deemix
+description: Tagged Deezer downloads for flows and playlists.
+---
+
+[deemix](https://github.com/bambanah/deemix) is a self-hosted Deezer downloader. It returns tagged files with cover art, so Aurral can use it as a download source for flows and playlists.
+
+Aurral talks to the deemix web server. It searches Deezer for the track, adds the best match to the deemix queue, waits for the queue item to finish, and then imports the file that deemix wrote.
+
+Aurral does not store your ARL. Sign in once in the deemix web UI. Aurral reuses that login through the deemix API.
+
+## Setup
+
+1. Run deemix and open its web UI. Sign in with your ARL.
+2. Open **Settings > Download clients > deemix**.
+3. Turn on **Enable deemix**.
+4. Set **Server URL** to your deemix address, for example `http://localhost:6595`.
+5. Choose a **Bitrate**. FLAC is the default. Your Deezer account must allow the bitrate that you select.
+6. If necessary, set **Source priority**.
+7. Select **Test connection**.
+8. Settings save automatically after each change.
+
+The deemix default priority is `15`. The slskd default is `10`. The Usenet default is `20`. The yt-dlp default is `50`.
+
+## Path mapping
+
+deemix writes files into its own download folder. Aurral has to read that same file.
+
+Mount the deemix download folder into the Aurral container at the same path, or add a remote path mapping under **Settings > Download clients > Remote path mappings** with **Applies to** set to `deemix`. Use the path that deemix reports as the remote path and the path that Aurral sees as the local path.
+
+Aurral moves the imported file into your Downloads Folder, so the track does not stay in the deemix download folder.
+
+## Behavior
+
+Aurral tries download sources in priority order. It ranks Deezer results by title, artist, album, and duration, and it skips tracks that your account cannot stream.
+
+Aurral validates the downloaded audio with the same track validation that it uses for other sources, then writes the playlist's title, artist, album, album artist, year, and track number into the file.
+
+When a downloaded file matches the requested track but its duration differs significantly, Aurral retains it under **Activity > Queue** for preview, approval, or denial.
+
+Aurral removes its own queue entry from deemix after each track, so a repeated request downloads again instead of matching a finished queue item.
+
+Automatic and manual upgrade searches use slskd or Usenet, not deemix.
+
+## Download source priority
+
+See [Usenet](/integrations/usenet/#download-source-priority-and-fallback) for how priority and fallback work across sources.

--- a/docs/src/content/docs/integrations/deemix.mdx
+++ b/docs/src/content/docs/integrations/deemix.mdx
@@ -9,6 +9,8 @@ Aurral talks to the deemix web server. It searches Deezer for the track, adds th
 
 Aurral does not store your ARL. Sign in once in the deemix web UI. Aurral reuses that login through the deemix API.
 
+deemix hands that login back over the address you configure, and that address is usually plain HTTP on your own network. Keep deemix on a network you trust, or put it behind HTTPS if the connection leaves one.
+
 ## Setup
 
 1. Run deemix and open its web UI. Sign in with your ARL.
@@ -38,7 +40,7 @@ Aurral validates the downloaded audio with the same track validation that it use
 
 When a downloaded file matches the requested track but its duration differs significantly, Aurral retains it under **Activity > Queue** for preview, approval, or denial.
 
-Aurral removes its own queue entry from deemix after each track, so a repeated request downloads again instead of matching a finished queue item.
+Aurral removes its own queue entry from deemix before it imports the file, including for a track it retains for review, so a repeated request downloads again instead of matching a finished queue item.
 
 deemix can also serve quality upgrades. Its bitrate setting fixes the tier it delivers, so Aurral compares that tier against the tier of the file you already have and skips deemix when it cannot improve on it. A deemix set to FLAC upgrades an MP3, and a deemix set to MP3 128 is not asked to upgrade anything better. Downloaded files are checked against the quality profile as well, so a track is never replaced by a worse one.
 

--- a/docs/src/content/docs/integrations/deemix.mdx
+++ b/docs/src/content/docs/integrations/deemix.mdx
@@ -15,7 +15,7 @@ Aurral does not store your ARL. Sign in once in the deemix web UI. Aurral reuses
 2. Open **Settings > Download clients > deemix**.
 3. Turn on **Enable deemix**.
 4. Set **Server URL** to your deemix address, for example `http://localhost:6595`.
-5. Choose a **Bitrate**. FLAC is the default. Your Deezer account must allow the bitrate that you select.
+5. Choose a **Bitrate**. FLAC is the default. Your Deezer plan has to allow it: FLAC needs a lossless plan, and MP3 320 needs a high quality plan. **Test connection** warns you when the selected bitrate is above your plan, and deemix refuses those downloads rather than lowering the quality.
 6. If necessary, set **Source priority**.
 7. Select **Test connection**.
 8. Settings save automatically after each change.

--- a/frontend/src/pages/Settings/components/PathMappingModal.jsx
+++ b/frontend/src/pages/Settings/components/PathMappingModal.jsx
@@ -12,6 +12,7 @@ const PATH_MAPPING_SOURCE_OPTIONS = [
   { value: "slskd", label: "slskd" },
   { value: "nzbget", label: "NZBGet" },
   { value: "sabnzbd", label: "SABnzbd" },
+  { value: "deemix", label: "deemix" },
   { value: "plex", label: "Plex" },
   { value: "jellyfin", label: "Jellyfin" },
 ];

--- a/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
+++ b/frontend/src/pages/Settings/components/SettingsDownloadClientsSection.jsx
@@ -173,25 +173,27 @@ export function SettingsDownloadClientsSection({
       const result = await testDownloadClientConnection(definition.key, config);
       if (result.success || result.ok) {
         if (result.warning || result.soulseekConnected === false) {
-          setTestStatus({ tone: "warning", message: "API reachable, but Soulseek is not connected." });
-          showInfo(result.message || `${definition.label} is reachable, but its service is not connected`);
+          const warning =
+            result.message || `${definition.label} is reachable, but its service is not connected`;
+          setTestStatus({ tone: "warning", message: warning });
+          showInfo(warning);
         } else {
           setTestStatus({ tone: "success", message: "Connected." });
           showSuccess(result.message || `${definition.label} connection OK`);
         }
       } else {
         const message = result.message || `${definition.label} connection failed`;
-        setTestStatus({ tone: "error", message: "Connection failed. Check the settings and retry." });
+        setTestStatus({ tone: "error", message });
         showError(message);
       }
     } catch (error) {
-      setTestStatus({ tone: "error", message: "Connection failed. Check the settings and retry." });
-      showError(
+      const message =
         error.response?.data?.message ||
-          error.response?.data?.error ||
-          error.message ||
-          `${definition.label} connection failed`,
-      );
+        error.response?.data?.error ||
+        error.message ||
+        `${definition.label} connection failed`;
+      setTestStatus({ tone: "error", message });
+      showError(message);
     } finally {
       setTestingClient(null);
     }

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -117,6 +117,12 @@ const defaultSettings = {
       priority: 50,
       stagingPath: "",
     },
+    deemix: {
+      enabled: false,
+      url: "",
+      bitrate: 9,
+      priority: 15,
+    },
     ticketmaster: {
       apiKey: "",
       searchRadiusMiles: 250,

--- a/frontend/src/pages/Settings/settingsTabsConfig.js
+++ b/frontend/src/pages/Settings/settingsTabsConfig.js
@@ -122,6 +122,7 @@ const SETTINGS_SEARCH_METADATA = {
       "yt-dlp": "YouTube web download client",
       NZBGet: "Usenet download client",
       SABnzbd: "Usenet download client",
+      deemix: "Deezer download client",
     },
     fields: {
       "Quality profile": "default acceptable allowed formats rank preference cutoff upgrades",
@@ -136,6 +137,8 @@ const SETTINGS_SEARCH_METADATA = {
       "Enable yt-dlp": "YouTube web on off",
       "Enable NZBGet": "Usenet on off",
       "Enable SABnzbd": "Usenet on off",
+      "Enable deemix": "Deezer on off",
+      Bitrate: "deemix FLAC MP3 quality",
       "Server URL": "client address host connection",
       "API key": "client credentials authentication",
       Username: "NZBGet credentials",

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -174,6 +174,13 @@ export const normalizeSettings = (savedSettings) => {
         stagingPath: "",
         ...(savedSettings.integrations?.ytdlp || {}),
       },
+      deemix: {
+        enabled: false,
+        url: "",
+        bitrate: 9,
+        priority: 15,
+        ...(savedSettings.integrations?.deemix || {}),
+      },
       ticketmaster: {
         apiKey: "",
         searchRadiusMiles: 250,

--- a/frontend/src/pages/activity/ActivityRequestRow.jsx
+++ b/frontend/src/pages/activity/ActivityRequestRow.jsx
@@ -69,8 +69,9 @@ export default function ActivityRequestRow({
   const isSlskd = request.source === "slskd";
   const isUsenet = request.source === "nzbget" || request.source === "sabnzbd";
   const isYtdlp = request.source === "ytdlp";
+  const isDeemix = request.source === "deemix";
   const isTrackDownload =
-    isSlskd || isUsenet || isYtdlp || request.kind === "track_download";
+    isSlskd || isUsenet || isYtdlp || isDeemix || request.kind === "track_download";
   const isAurral = request.source === "aurral" && !isTrackDownload;
   const isActivity = request.type === "activity";
   const isAlbum = request.type === "album";
@@ -84,7 +85,7 @@ export default function ActivityRequestRow({
   const displayMeta = getRequestMeta(request, displayTitle);
   const artistMbid = isAlbum ? request.artistMbid : request.mbid;
   const canNavigate =
-    ((isSlskd || isUsenet || isYtdlp) && request.playlistId) ||
+    ((isSlskd || isUsenet || isYtdlp || isDeemix) && request.playlistId) ||
     ((isAurral || isActivity) && request.href) ||
     (artistMbid && artistMbid !== "null" && artistMbid !== "undefined");
   const status = getStatusMeta(request);


### PR DESCRIPTION
## What changed

Adds deemix as a download client adapter on the seam from #734.

- `backend/services/deemixClient.js` — the adapter and its settings metadata. It talks to the deemix web API (`/api/connect`, `/api/search`, `/api/addToQueue`, `/api/getQueue`, `/api/removeFromQueue`) and holds the express-session cookie that deemix issues.
- `backend/services/weeklyFlow/weeklyFlowDeemixMatcher.js` — ranks Deezer results by title, artist, album, and duration, and skips tracks the account cannot stream.
- `backend/services/deemixOrchestrator.js` — the search, download, poll, and finalize phases, following the Usenet orchestrator.

The rest is registration: the client registry, download source priority and fallback, path mapping source, health, settings validation, the deny key, the Activity row, and a documentation page.

deemix also serves quality upgrades. Its bitrate setting fixes the tier it delivers, so unlike a Soulseek or Usenet release the tier is known before anything is downloaded, and the orchestrator falls through to the next source when deemix cannot improve on the current file. `validateParsedQuality` still has the final say after the file is measured, so a track cannot be replaced by a worse one.

Aurral does not store an ARL. deemix keeps its own login in single-user mode, and the adapter reuses it through `/api/connect`.

Aurral removes its own queue entry from deemix after each track, because deemix derives a queue uuid from the track and bitrate and would otherwise report a repeated request as already queued.

One judgment call worth your review: the download client card in `SettingsDownloadClientsSection.jsx` replaced every adapter's test message with `Connection failed. Check the settings and retry.`, or with slskd's `API reachable, but Soulseek is not connected.` no matter which client was tested. deemix needs that message to reach the person testing, because "not logged in" and "your plan cannot stream FLAC" are the two things they have to act on. The card now shows the adapter's own message, which also affects slskd, NZBGet, SABnzbd, and yt-dlp. Happy to split it into its own pull request if you would rather keep this one to the adapter.

## Why

Requested in #456: deemix returns tagged FLAC or MP3 with cover art and lyrics from Deezer, and #734 made a new adapter a registration rather than new plumbing.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Closes #456

## UI changes

<!-- Paste before-and-after screenshots of Settings > Download clients here:
     1. The client card grid, before and after, showing the new deemix card.
     2. The deemix settings modal, showing the Enable, Server URL, Bitrate, and Source priority fields.
     3. A Test connection result, showing the adapter's own message on the card. -->

## Testing

- `npm test` — 876 of 876 pass, including three new deemix cases in `.tests/download/download-client.test.js` covering adapter configuration, bitrate normalization, the queue uuid, the bitrate to quality tier mapping, and the plan capability check.
- `npm run lint` and `npm run build` — both clean.
- `node backend/services/weeklyFlow/weeklyFlowDeemixMatcher.js` — the matcher self-check passes.
- Manual, against deemix v3.14.0 in Docker beside Aurral: connection test, Deezer search, queueing, polling, and import into the library, with the shared `/downloads` mount and with a remote path mapping.
- Not covered: the FLAC path end to end. The Deezer account I tested with is free, so deemix answers `CantStream` for FLAC and MP3 320. Only MP3 128 completed a real download. The bitrate is passed straight through to `addToQueue`, so the difference is the value alone, but I could not prove the lossless path myself.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change
<img width="1163" height="289" alt="Screenshot 2026-08-27 131316" src="https://github.com/user-attachments/assets/f75abf92-4e24-4509-84ee-4f3e1c31acb0" />
<img width="570" height="568" alt="Screenshot 2026-08-27 131323" src="https://github.com/user-attachments/assets/dae34e0f-45df-48c5-87e9-d615ec030a2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Deemix as a Deezer download client for tracks and playlists.
  * Added configuration for connection URL, bitrate, priority, and enablement.
  * Added support for queues, quality upgrades, path mappings, activity requests, and fallback downloads.
  * Added bitrate and Deezer plan warnings during connection testing.
* **Documentation**
  * Added setup, configuration, security, and queue-handling guidance.
* **Bug Fixes**
  * Improved display of connection-test warnings and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->