### PR TITLE
fix(brainzmash): throttle metadata requests and extend cache

### DIFF
--- a/.tests/helpers/api-client-utils.test.js
+++ b/.tests/helpers/api-client-utils.test.js
@@ -20,6 +20,56 @@ test("rate limiter spaces concurrent request starts", async () => {
   assert.ok(starts[2] - starts[1] >= 20);
 });
 
+test("rate limiter rejects excess queued reservations from a burst", async () => {
+  const limiter = createRateLimiter(20, { maxQueue: 1 });
+  const first = limiter.schedule(() => {});
+  const queued = limiter.schedule(() => {});
+
+  await assert.rejects(
+    limiter.schedule(() => {}),
+    (error) => error.code === "EQUEUEFULL",
+  );
+  await Promise.all([first, queued]);
+});
+
+test("rate limiter expires queued work before invoking its callback", async () => {
+  const limiter = createRateLimiter(30);
+  const first = limiter.schedule(() => {});
+  let invoked = false;
+
+  await assert.rejects(
+    limiter.schedule(
+      () => {
+        invoked = true;
+      },
+      { timeoutMs: 5 },
+    ),
+    (error) => error.code === "ETIMEDOUT",
+  );
+  await first;
+  assert.equal(invoked, false);
+});
+
+test("rate limiter removes aborted queued work", async () => {
+  const limiter = createRateLimiter(30);
+  const first = limiter.schedule(() => {});
+  const controller = new AbortController();
+  let invoked = false;
+
+  const cancelled = limiter.schedule(
+    () => {
+      invoked = true;
+    },
+    { signal: controller.signal },
+  );
+  controller.abort();
+
+  await assert.rejects(cancelled, { name: "AbortError" });
+  await first;
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(invoked, false);
+});
+
 test("TTL cache evicts its oldest entry at the size limit", () => {
   const cache = createCache(300, 2);
   cache.set("first", 1);

--- a/.tests/metadata-providers.test.js
+++ b/.tests/metadata-providers.test.js
@@ -3,22 +3,25 @@ import assert from "node:assert/strict";
 import {
   setupIsolatedBackend,
   cleanupIsolatedState,
+  createMockHttpServer,
 } from "./helpers/backendTestHarness.js";
 import {
   defaultData,
   DEFAULT_METADATA_BASE_URL,
 } from "../backend/config/constants.js";
 
-const [isolatedState, { dbOps }, apiClients] = await setupIsolatedBackend(
+const [isolatedState, { dbOps }, apiClients, brainzmashProvider] = await setupIsolatedBackend(
   "metadata-providers",
   "backend/db/helpers/index.js",
   "backend/services/apiClients/index.js",
+  "backend/services/providers/brainzmashProvider.js",
 );
 
 const {
   getMetadataProviderHealthSnapshot,
   getMusicbrainzApiBaseUrl,
 } = apiClients;
+const { clearMetadataProviderCaches, getArtistByMbid } = brainzmashProvider;
 
 test.after(async () => {
   await cleanupIsolatedState(isolatedState);
@@ -74,4 +77,50 @@ test("provider health snapshot reports BrainzMash state", () => {
   assert.equal(snapshot.brainzmash.configuredProvider, "brainzmash");
   assert.equal(snapshot.brainzmash.activeBaseUrl, getMusicbrainzApiBaseUrl());
   assert.equal(snapshot.brainzmash.failoverActive, false);
+});
+
+test("BrainzMash rejects the saturation boundary before its deadline", async () => {
+  const previousSettings = dbOps.getSettings();
+  const server = await createMockHttpServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ Name: "Saturation" }));
+  });
+  const controller = new AbortController();
+  let requests = [];
+  let timeout = null;
+
+  try {
+    dbOps.updateSettings({
+      ...previousSettings,
+      integrations: {
+        ...(previousSettings.integrations || {}),
+        metadata: {
+          ...(previousSettings.integrations?.metadata || {}),
+          provider: "brainzmash",
+          baseUrl: server.url,
+        },
+      },
+    });
+    clearMetadataProviderCaches();
+    requests = Array.from({ length: 81 }, (_, index) =>
+      getArtistByMbid(`saturation-${index}`, { signal: controller.signal }),
+    );
+    const boundary = await Promise.race([
+      requests[80].then(
+        () => "resolved",
+        (error) => error.code || error.name,
+      ),
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve("late"), 50);
+      }),
+    ]);
+    assert.equal(boundary, "EQUEUEFULL");
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    controller.abort();
+    await Promise.allSettled(requests);
+    clearMetadataProviderCaches();
+    dbOps.updateSettings(previousSettings);
+    await server.close();
+  }
 });

--- a/backend/services/apiClients/rateLimiter.js
+++ b/backend/services/apiClients/rateLimiter.js
@@ -1,16 +1,132 @@
-export default function createRateLimiter(minTime) {
-  let lastCall = 0;
-  let reservationTail = Promise.resolve();
+const createAbortError = () => {
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+};
 
-  const schedule = async (fn) => {
-    const reservation = reservationTail.then(async () => {
-      const wait = Math.max(0, minTime - (Date.now() - lastCall));
-      if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+const getAbortReason = (signal) => signal?.reason || createAbortError();
+
+const createTimeoutError = () => {
+  const error = new Error("Rate limiter request deadline exceeded");
+  error.code = "ETIMEDOUT";
+  return error;
+};
+
+const createQueueFullError = () => {
+  const error = new Error("Rate limiter queue is full");
+  error.code = "EQUEUEFULL";
+  return error;
+};
+
+export default function createRateLimiter(minTime, { maxQueue = Infinity } = {}) {
+  const intervalMs = Math.max(0, Number(minTime) || 0);
+  const queueLimit = Number.isFinite(maxQueue)
+    ? Math.max(0, Math.floor(maxQueue))
+    : Infinity;
+  const queue = [];
+  let lastCall = 0;
+  let draining = false;
+  let pendingReservations = 0;
+
+  const drain = async () => {
+    if (draining) return;
+    draining = true;
+    while (queue.length > 0) {
+      const entry = queue.shift();
+      if (entry.settled) continue;
+
+      const wait = Math.max(0, intervalMs - (Date.now() - lastCall));
+      if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+      if (entry.settled) continue;
+
+      const remainingMs = entry.deadline == null ? undefined : entry.deadline - Date.now();
+      if (remainingMs != null && remainingMs <= 0) {
+        entry.cancel(createTimeoutError());
+        continue;
+      }
+
+      entry.started = true;
+      pendingReservations -= 1;
       lastCall = Date.now();
+      entry.cleanup();
+      let result;
+      try {
+        result = entry.fn(remainingMs);
+      } catch (error) {
+        entry.reject(error);
+        continue;
+      }
+      Promise.resolve(result).then(entry.resolve, entry.reject);
+    }
+    draining = false;
+    if (queue.length > 0) void drain();
+  };
+
+  const schedule = (fn, { signal, timeoutMs } = {}) => {
+    if (typeof fn !== "function") {
+      return Promise.reject(new TypeError("Rate limiter callback must be a function"));
+    }
+    if (signal?.aborted) return Promise.reject(getAbortReason(signal));
+    if (pendingReservations >= queueLimit) return Promise.reject(createQueueFullError());
+
+    pendingReservations += 1;
+
+    const parsedTimeoutMs = Number(timeoutMs);
+    const deadline = Number.isFinite(parsedTimeoutMs)
+      ? Date.now() + Math.max(0, parsedTimeoutMs)
+      : null;
+    let entry;
+
+    const promise = new Promise((resolve, reject) => {
+      entry = {
+        deadline,
+        started: false,
+        settled: false,
+        timeout: null,
+        onAbort: null,
+        cleanup() {
+          if (entry.timeout) clearTimeout(entry.timeout);
+          if (entry.onAbort) signal?.removeEventListener("abort", entry.onAbort);
+          entry.timeout = null;
+          entry.onAbort = null;
+        },
+        resolve: (value) => {
+          if (entry.settled) return;
+          entry.settled = true;
+          entry.cleanup();
+          resolve(value);
+        },
+        reject: (error) => {
+          if (entry.settled) return;
+          entry.settled = true;
+          entry.cleanup();
+          reject(error);
+        },
+        cancel: (error) => {
+          if (entry.settled) return;
+          if (!entry.started) pendingReservations -= 1;
+          const index = queue.indexOf(entry);
+          if (index >= 0) queue.splice(index, 1);
+          entry.reject(error);
+        },
+        fn,
+      };
+
+      if (signal) {
+        entry.onAbort = () => entry.cancel(getAbortReason(signal));
+        signal.addEventListener("abort", entry.onAbort, { once: true });
+      }
+      if (deadline != null) {
+        entry.timeout = setTimeout(
+          () => entry.cancel(createTimeoutError()),
+          Math.max(0, deadline - Date.now()),
+        );
+      }
+      queue.push(entry);
+      void drain();
     });
-    reservationTail = reservation.catch(() => {});
-    await reservation;
-    return fn();
+
+    return promise;
   };
 
   return {

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -32,7 +32,7 @@ const METADATA_REQUEST_MIN_INTERVAL_MS = 100;
 const METADATA_REQUEST_TIMEOUT_MS = 8000;
 const METADATA_MAX_QUEUED_REQUESTS = Math.floor(
   METADATA_REQUEST_TIMEOUT_MS / METADATA_REQUEST_MIN_INTERVAL_MS,
-);
+) - 1;
 const providerCache = createCache(METADATA_CACHE_TTL_SECONDS, METADATA_CACHE_MAX_ENTRIES);
 const releaseCache = createCache(300);
 const providerInflightRequests = new Map();

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -29,11 +29,16 @@ import { runSharedInflight } from "../sharedInflight.js";
 const METADATA_CACHE_TTL_SECONDS = 24 * 60 * 60;
 const METADATA_CACHE_MAX_ENTRIES = 20_000;
 const METADATA_REQUEST_MIN_INTERVAL_MS = 100;
+const METADATA_REQUEST_TIMEOUT_MS = 8000;
+const METADATA_MAX_QUEUED_REQUESTS = Math.floor(
+  METADATA_REQUEST_TIMEOUT_MS / METADATA_REQUEST_MIN_INTERVAL_MS,
+);
 const providerCache = createCache(METADATA_CACHE_TTL_SECONDS, METADATA_CACHE_MAX_ENTRIES);
 const releaseCache = createCache(300);
 const providerInflightRequests = new Map();
-const providerRequestLimiter = createRateLimiter(METADATA_REQUEST_MIN_INTERVAL_MS);
-const METADATA_REQUEST_TIMEOUT_MS = 8000;
+const providerRequestLimiter = createRateLimiter(METADATA_REQUEST_MIN_INTERVAL_MS, {
+  maxQueue: METADATA_MAX_QUEUED_REQUESTS,
+});
 const METADATA_MAX_RETRIES = 1;
 
 export function clearMetadataProviderCaches() {
@@ -105,15 +110,19 @@ async function request(path, params = {}, { signal } = {}) {
     for (let attempt = 0; attempt <= METADATA_MAX_RETRIES; attempt += 1) {
       if (sharedSignal.aborted) throw sharedSignal.reason || new Error("The operation was aborted");
       try {
-        const response = await providerRequestLimiter.schedule(() =>
-          axios.get(`${baseUrl}${path}`, {
-            params,
-            timeout: METADATA_REQUEST_TIMEOUT_MS,
-            headers: {
-              "User-Agent": getUserAgent(),
-            },
-            signal: sharedSignal,
-          }),
+        const response = await providerRequestLimiter.schedule(
+          (remainingMs) =>
+            axios.get(`${baseUrl}${path}`, {
+              params,
+              timeout: Number.isFinite(remainingMs)
+                ? Math.max(1, Math.floor(remainingMs))
+                : METADATA_REQUEST_TIMEOUT_MS,
+              headers: {
+                "User-Agent": getUserAgent(),
+              },
+              signal: sharedSignal,
+            }),
+          { signal: sharedSignal, timeoutMs: METADATA_REQUEST_TIMEOUT_MS },
         );
         providerCache.set(cacheKey, response.data);
         healthState.lastSuccessAt = healthState.lastCheckedAt;

--- a/backend/services/providers/brainzmashProvider.js
+++ b/backend/services/providers/brainzmashProvider.js
@@ -23,11 +23,16 @@ import {
   toNormalizedArtistAlbum,
 } from "./brainzmashMappers.js";
 import { selectBestAlbumImage } from "../imageService.js";
+import createRateLimiter from "../apiClients/rateLimiter.js";
 import { runSharedInflight } from "../sharedInflight.js";
 
-const providerCache = createCache(300);
+const METADATA_CACHE_TTL_SECONDS = 24 * 60 * 60;
+const METADATA_CACHE_MAX_ENTRIES = 20_000;
+const METADATA_REQUEST_MIN_INTERVAL_MS = 100;
+const providerCache = createCache(METADATA_CACHE_TTL_SECONDS, METADATA_CACHE_MAX_ENTRIES);
 const releaseCache = createCache(300);
 const providerInflightRequests = new Map();
+const providerRequestLimiter = createRateLimiter(METADATA_REQUEST_MIN_INTERVAL_MS);
 const METADATA_REQUEST_TIMEOUT_MS = 8000;
 const METADATA_MAX_RETRIES = 1;
 
@@ -100,14 +105,16 @@ async function request(path, params = {}, { signal } = {}) {
     for (let attempt = 0; attempt <= METADATA_MAX_RETRIES; attempt += 1) {
       if (sharedSignal.aborted) throw sharedSignal.reason || new Error("The operation was aborted");
       try {
-        const response = await axios.get(`${baseUrl}${path}`, {
-          params,
-          timeout: METADATA_REQUEST_TIMEOUT_MS,
-          headers: {
-            "User-Agent": getUserAgent(),
-          },
-          signal: sharedSignal,
-        });
+        const response = await providerRequestLimiter.schedule(() =>
+          axios.get(`${baseUrl}${path}`, {
+            params,
+            timeout: METADATA_REQUEST_TIMEOUT_MS,
+            headers: {
+              "User-Agent": getUserAgent(),
+            },
+            signal: sharedSignal,
+          }),
+        );
         providerCache.set(cacheKey, response.data);
         healthState.lastSuccessAt = healthState.lastCheckedAt;
         healthState.lastFailureReason = "";


### PR DESCRIPTION
## What changed

- Added a 100 ms minimum interval between BrainzMASH metadata requests.
- Extended metadata cache entries to 24 hours with a maximum of 20,000 entries.
- Kept existing timeout, retry, caching, and request behavior intact.

## Why

BrainzMASH metadata requests could be sent too quickly and repeated more often than necessary. Throttling requests and extending the metadata cache reduces provider load while preserving current lookup behavior.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

- Not run; this change is limited to provider request throttling and cache configuration.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Metadata provider results are cached for up to 24 hours, improving response speed and reducing repeated lookups.
* **Reliability**
  * Requests are rate-limited to maintain consistent service behavior.
  * Queues now have bounded capacity and safeguards against excessive wait times.
  * Cancelled, timed-out, and rejected requests are handled cleanly without triggering unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->