### PR TITLE
docs(release): add 2.8.0 nightly release notes

### DIFF
--- a/release-notes/2.8.0.md
+++ b/release-notes/2.8.0.md
@@ -1,0 +1,25 @@
+2.8.0 adds a Deezer download path through deemix and makes artwork metadata survive local cache cleanup. It also reduces repeated BrainzMASH requests and handles metadata bursts more predictably.
+
+## What's new
+
+- Configure deemix as a download client for flows and playlists, with bitrate and Deezer plan checks, source priority, path mappings, fallback, queue handling, and quality upgrades.
+- Keep stable provider artwork links and complete artist image metadata in SQLite, even when the local image cache is cleared or evicted.
+- Refresh artist and release-group artwork without reusing a stale browser or provider response.
+- Keep existing playlist artwork when a generated replacement cannot be created.
+
+## Fixes worth noticing
+
+- BrainzMASH metadata requests now wait at least 100 ms between starts and cache results for up to 24 hours, with a limit of 20,000 entries.
+- Metadata requests that are cancelled, time out, or arrive after the queue is full now stop cleanly instead of waiting through an unbounded queue.
+- Legacy image-proxy links continue to work while new artwork responses use stable source links and native image caching.
+
+## Things to try
+
+- Open **Settings > Download clients**, enable deemix, test the connection, and set a bitrate your Deezer plan supports.
+- Run a flow or playlist download through deemix. If Aurral cannot read deemix's download folder directly, add a remote path mapping.
+- Clear the artwork cache, then revisit an artist and a release. Their artwork metadata should remain available.
+- Refresh artwork after an initial lookup and check that the page does not keep showing the old result.
+
+## Full change list
+
+The [full change list from 2.7.0 to this nightly](https://github.com/lklynet/aurral/compare/v2.7.0...HEAD) includes every pull request and fix.


### PR DESCRIPTION
## What changed

Added nightly release notes for version 2.8.0, covering deemix downloads, artwork metadata persistence, metadata request handling, notable fixes, testing suggestions, and the full change list.

## Why

Provides users with a concise summary of the changes included in the 2.8.0 nightly release and guidance for validating the new behavior.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue


## Testing

Reviewed the release notes for accuracy against the included change summary and verified the comparison link format.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Deezer download support for flows and playlists through deemix.
  - Preserved provider artwork links and artist image metadata across cache cleanup.
  - Improved artwork refreshing and retained existing playlist artwork when replacements fail.
- **Bug Fixes**
  - Added safer handling for cancelled, timed-out, or full-queue metadata requests.
- **Performance**
  - Added request throttling and caching for BrainzMASH metadata lookups.
- **Compatibility**
  - Continued support for the legacy image proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->