### PR TITLE
feat(library): add ownership management and Lidarr enablement

### DIFF
--- a/.tests/library/library-management.test.js
+++ b/.tests/library/library-management.test.js
@@ -15,8 +15,12 @@ const [isolatedState, { db }, { dbOps, userOps }] = await setupIsolatedBackend(
 );
 
 const store = await import("../../backend/services/libraryManagementStore.js");
+const libraryStore = await import("../../backend/services/libraryMediaStore.js");
 const { buildCanonicalLibraryReadModel } = await import(
   "../../backend/services/canonicalLibraryReadAdapter.js"
+);
+const { getCanonicalLibraryPage } = await import(
+  "../../backend/services/libraryQueryService.js"
 );
 const { computeLibraryRootOverlaps } = await import(
   "../../backend/services/downloadFolderConfig.js"
@@ -138,6 +142,46 @@ test("read model exposes managedBy and monitorMode without inventing values", ()
   assert.equal(model.albums.find((a) => a.id === 21).managedBy, null);
 });
 
+test("canonical page cache reflects ownership changes without manual invalidation", () => {
+  const artist = libraryStore.upsertLibraryArtist({
+    identityKey: "mbid:cache-artist",
+    mbid: "cache-artist",
+    name: "Cache Artist",
+  });
+  const album = libraryStore.upsertLibraryAlbum({
+    identityKey: "rg:cache-album",
+    artistId: artist.id,
+    title: "Cache Album",
+    albumArtist: artist.name,
+  });
+  const track = libraryStore.upsertLibraryTrack({
+    identityKey: "rec:cache-track",
+    mbid: "cache-track",
+    title: "Cache Track",
+    artistName: artist.name,
+  });
+  libraryStore.linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+  libraryStore.upsertLibraryMediaFile({
+    trackId: track.id,
+    source: "aurral",
+    path: "/library/Cache Artist/Cache Album/01 Cache Track.flac",
+    format: "flac",
+    available: true,
+  });
+
+  store.setLibraryManagement({ entityKind: "artist", entityId: artist.id, managedBy: "aurral" });
+  const before = getCanonicalLibraryPage({ kind: "artists", pageSize: 100 });
+  assert.equal(before.items.find((entry) => String(entry.id) === String(artist.id))?.managedBy, "aurral");
+
+  store.setLibraryManagement({ entityKind: "artist", entityId: artist.id, managedBy: "lidarr" });
+  const updated = getCanonicalLibraryPage({ kind: "artists", pageSize: 100 });
+  assert.equal(updated.items.find((entry) => String(entry.id) === String(artist.id))?.managedBy, "lidarr");
+
+  store.clearLibraryManagement("artist", artist.id);
+  const cleared = getCanonicalLibraryPage({ kind: "artists", pageSize: 100 });
+  assert.equal(cleared.items.find((entry) => String(entry.id) === String(artist.id))?.managedBy, null);
+});
+
 test("root overlap warnings cover equal and nested roots without rejecting", () => {
   assert.deepEqual(
     computeLibraryRootOverlaps({ aurralRoot: "/data/media", lidarrRoots: ["/data/other"] }),
@@ -172,6 +216,33 @@ test("root overlap warnings cover equal and nested roots without rejecting", () 
     lidarrRoots: ["/data/media", "/data/media"],
   });
   assert.equal(deduped.length, 1);
+
+  const filesystemRoot = computeLibraryRootOverlaps({
+    aurralRoot: "/",
+    lidarrRoots: ["/music"],
+  });
+  assert.equal(filesystemRoot.length, 1);
+  assert.equal(filesystemRoot[0].type, "nested-b-in-a");
+
+  const driveRoot = computeLibraryRootOverlaps({
+    aurralRoot: "C:/",
+    lidarrRoots: ["C:/Music"],
+  });
+  assert.equal(driveRoot.length, 1);
+  assert.equal(driveRoot[0].type, "nested-b-in-a");
+
+  const driveRootEqual = computeLibraryRootOverlaps({
+    aurralRoot: "C:/",
+    lidarrRoots: ["C:/"],
+  });
+  assert.equal(driveRootEqual[0].type, "equal");
+
+  const backslashRoot = computeLibraryRootOverlaps({
+    aurralRoot: "C:\\music\\aurral",
+    lidarrRoots: ["C:/music"],
+  });
+  assert.equal(backslashRoot.length, 1);
+  assert.equal(backslashRoot[0].type, "nested-a-in-b");
 });
 
 test("per-user library owner preference normalizes and defaults by connectivity", async () => {

--- a/.tests/library/library-management.test.js
+++ b/.tests/library/library-management.test.js
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps, userOps }] = await setupIsolatedBackend(
+  "library-management-state",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+);
+
+const store = await import("../../backend/services/libraryManagementStore.js");
+const { buildCanonicalLibraryReadModel } = await import(
+  "../../backend/services/canonicalLibraryReadAdapter.js"
+);
+const { computeLibraryRootOverlaps } = await import(
+  "../../backend/services/downloadFolderConfig.js"
+);
+
+test.before(() => {
+  resetDatabase(db);
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("manager state uses canonical ids and round-trips through the store", () => {
+  store.setLibraryManagement({
+    entityKind: "album",
+    entityId: 7,
+    managedBy: "aurral",
+    monitorMode: "all",
+  });
+  assert.equal(store.getManagedBy("album", 7), "aurral");
+  assert.equal(store.getManagedBy("album", "7"), "aurral");
+  assert.deepEqual(store.getLibraryManagementEntry("album", 7), {
+    managedBy: "aurral",
+    monitorMode: "all",
+  });
+
+  store.setLibraryManagement({ entityKind: "album", entityId: 7, managedBy: "lidarr" });
+  assert.deepEqual(store.getLibraryManagementEntry("album", 7), {
+    managedBy: "lidarr",
+    monitorMode: null,
+  });
+
+  assert.equal(store.clearLibraryManagement("album", 7), true);
+  assert.equal(store.getManagedBy("album", 7), null);
+});
+
+test("manager state rejects invalid owners, kinds, and ids", () => {
+  assert.throws(
+    () => store.setLibraryManagement({ entityKind: "track", entityId: 1, managedBy: "aurral" }),
+    /entity kind/i,
+  );
+  assert.throws(
+    () => store.setLibraryManagement({ entityKind: "artist", entityId: 0, managedBy: "aurral" }),
+    /entity id/i,
+  );
+  assert.throws(
+    () => store.setLibraryManagement({ entityKind: "artist", entityId: 1, managedBy: "slskd" }),
+    /manager/i,
+  );
+});
+
+test("read model exposes managedBy and monitorMode without inventing values", () => {
+  const library = {
+    artists: [
+      {
+        id: 11,
+        identityKey: "mbid:artist-managed",
+        mbid: "artist-managed",
+        name: "Managed Artist",
+        albumIds: [21],
+        sources: ["lidarr"],
+        available: true,
+        metadata: { monitored: true },
+      },
+      {
+        id: 12,
+        identityKey: "mbid:artist-open",
+        mbid: "artist-open",
+        name: "Open Artist",
+        albumIds: [22],
+        sources: ["aurral"],
+        available: true,
+        metadata: {},
+      },
+    ],
+    albums: [
+      {
+        id: 21,
+        identityKey: "rg:managed",
+        artistId: 11,
+        title: "Managed Album",
+        trackIds: [31],
+        sources: ["lidarr"],
+        available: true,
+        metadata: {},
+      },
+      {
+        id: 22,
+        identityKey: "rg:open",
+        artistId: 12,
+        title: "Open Album",
+        trackIds: [32],
+        sources: ["aurral"],
+        available: true,
+        metadata: {},
+      },
+    ],
+    tracks: [
+      { id: 31, mbid: "t31", title: "One", albums: [{ albumId: 21, trackNumber: 1 }], files: [], sources: ["lidarr"], available: true },
+      { id: 32, mbid: "t32", title: "Two", albums: [{ albumId: 22, trackNumber: 1 }], files: [], sources: ["aurral"], available: true },
+    ],
+  };
+
+  store.setLibraryManagement({
+    entityKind: "artist",
+    entityId: 11,
+    managedBy: "lidarr",
+    monitorMode: "all",
+  });
+
+  const model = buildCanonicalLibraryReadModel(library);
+  const managed = model.artists.find((a) => a.id === 11);
+  const open = model.artists.find((a) => a.id === 12);
+  assert.equal(managed.managedBy, "lidarr");
+  assert.equal(managed.monitorMode, "all");
+  assert.equal(open.managedBy, null);
+  assert.equal(open.monitorMode, null);
+  assert.equal(model.albums.find((a) => a.id === 21).managedBy, null);
+});
+
+test("root overlap warnings cover equal and nested roots without rejecting", () => {
+  assert.deepEqual(
+    computeLibraryRootOverlaps({ aurralRoot: "/data/media", lidarrRoots: ["/data/other"] }),
+    [],
+  );
+  assert.deepEqual(computeLibraryRootOverlaps({ aurralRoot: "/data/media", lidarrRoots: [null, ""] }), []);
+
+  const equal = computeLibraryRootOverlaps({
+    aurralRoot: "/data/media/",
+    lidarrRoots: ["/data/media"],
+  });
+  assert.equal(equal.length, 1);
+  assert.equal(equal[0].type, "equal");
+  assert.match(equal[0].message, /rename, import, or delete/);
+
+  const nestedLidarr = computeLibraryRootOverlaps({
+    aurralRoot: "/data/media",
+    lidarrRoots: ["/data/media/music"],
+  });
+  assert.equal(nestedLidarr.length, 1);
+  assert.equal(nestedLidarr[0].type, "nested-b-in-a");
+
+  const nestedAurral = computeLibraryRootOverlaps({
+    aurralRoot: "/data/media/music",
+    lidarrRoots: ["/data/media"],
+  });
+  assert.equal(nestedAurral.length, 1);
+  assert.equal(nestedAurral[0].type, "nested-a-in-b");
+
+  const deduped = computeLibraryRootOverlaps({
+    aurralRoot: "/data/media",
+    lidarrRoots: ["/data/media", "/data/media"],
+  });
+  assert.equal(deduped.length, 1);
+});
+
+test("per-user library owner preference normalizes and defaults by connectivity", async () => {
+  const userId = userOps.createUser("owner-pref", "hash").id;
+  const stored = userOps.getUserById(userId);
+  assert.equal(stored.defaultLibraryOwner, null);
+
+  const updated = userOps.updateUser(userId, { defaultLibraryOwner: "AURRAL" });
+  assert.equal(updated.defaultLibraryOwner, "aurral");
+
+  const reset = userOps.updateUser(userId, { defaultLibraryOwner: "not-a-manager" });
+  assert.equal(reset.defaultLibraryOwner, null);
+
+  userOps.updateUser(userId, { defaultLibraryOwner: "lidarr" });
+  const authUser = userOps.getUserAuthById(userId);
+  assert.equal(authUser.defaultLibraryOwner, "lidarr");
+});
+
+test("library owner routes resolve stored preference with a connectivity fallback", async () => {
+  const app = express();
+  app.use(express.json());
+  let currentUser = null;
+  app.use((req, _res, next) => {
+    req.user = currentUser;
+    next();
+  });
+  const usersRouter = (await import("../../backend/routes/users.js")).default;
+  app.use("/api/users", usersRouter);
+
+  const settings = dbOps.getSettings();
+  dbOps.updateSettings({
+    ...settings,
+    integrations: {
+      ...(settings.integrations || {}),
+      lidarr: { ...(settings.integrations?.lidarr || {}), url: "", apiKey: "", enabled: false },
+    },
+  });
+  const userId = userOps.createUser("owner-route", "hash").id;
+  currentUser = { id: userId };
+
+  const server = await new Promise((resolve) => {
+    const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+  });
+  const port = server.address().port;
+
+  const get = async (path) => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`);
+    return { status: response.status, body: await response.json() };
+  };
+  const post = async (path, body) => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return { status: response.status, body: await response.json() };
+  };
+
+  const initial = await get("/api/users/me/library-owner");
+  assert.equal(initial.status, 200);
+  assert.equal(initial.body.defaultLibraryOwner, "aurral");
+  assert.equal(initial.body.storedDefaultLibraryOwner, null);
+
+  const saved = await post("/api/users/me/library-owner", { defaultLibraryOwner: "aurral" });
+  assert.equal(saved.status, 200);
+  assert.equal(saved.body.storedDefaultLibraryOwner, "aurral");
+
+  const invalid = await post("/api/users/me/library-owner", { defaultLibraryOwner: "slskd" });
+  assert.equal(invalid.status, 400);
+
+  server.closeAllConnections?.();
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/.tests/lidarr/lidarr-enabled.test.js
+++ b/.tests/lidarr/lidarr-enabled.test.js
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps }] = await setupIsolatedBackend(
+  "lidarr-enabled",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+);
+
+const { lidarrClient } = await import("../../backend/services/lidarrClient.js");
+const { resolveLidarrTestCredentials } = await import(
+  "../../backend/services/lidarrTestSession.js"
+);
+
+function setLidarrSettings(lidarr) {
+  const settings = dbOps.getSettings();
+  dbOps.updateSettings({
+    ...settings,
+    integrations: {
+      ...(settings.integrations || {}),
+      lidarr: { ...(settings.integrations?.lidarr || {}), ...lidarr },
+    },
+  });
+}
+
+test.before(() => {
+  resetDatabase(db);
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("legacy settings with an api key and no enabled value stay enabled", () => {
+  setLidarrSettings({
+    url: "http://127.0.0.1:18686",
+    apiKey: "legacy-key",
+    enabled: undefined,
+  });
+
+  assert.equal(lidarrClient.isEnabled(), true);
+  assert.equal(lidarrClient.isConfigured(), true);
+  assert.equal(lidarrClient.getConfig().apiKey, "legacy-key");
+});
+
+test("an explicit false disables lidarr without clearing saved settings", () => {
+  setLidarrSettings({
+    url: "http://127.0.0.1:18686",
+    apiKey: "saved-key",
+    enabled: false,
+  });
+
+  assert.equal(lidarrClient.isEnabled(), false);
+  assert.equal(lidarrClient.isConfigured(), false);
+  assert.equal(lidarrClient.getConfig().url, "http://127.0.0.1:18686");
+  assert.equal(lidarrClient.getConfig().apiKey, "saved-key");
+});
+
+test("disabled lidarr makes no network call from client requests", async () => {
+  setLidarrSettings({ url: "http://127.0.0.1:9", apiKey: "saved-key", enabled: false });
+
+  await assert.rejects(
+    () => lidarrClient.request("/artist", "GET", null, true),
+    /Lidarr is disabled/,
+  );
+});
+
+test("saved-credential test fallback is refused while lidarr is disabled", () => {
+  setLidarrSettings({ url: "http://127.0.0.1:18686", apiKey: "saved-key", enabled: false });
+
+  assert.throws(
+    () => resolveLidarrTestCredentials({}, lidarrClient),
+    /Lidarr is disabled/,
+  );
+});
+
+test("explicitly provided test credentials still work while lidarr is disabled", () => {
+  const resolved = resolveLidarrTestCredentials(
+    { url: "http://lan-host:8686", apiKey: "provided-key" },
+    lidarrClient,
+  );
+  assert.equal(resolved.usingProvided, true);
+  assert.equal(resolved.apiKey, "provided-key");
+});
+
+test("re-enabling restores configured behavior without losing settings", () => {
+  setLidarrSettings({ enabled: true });
+
+  assert.equal(lidarrClient.isEnabled(), true);
+  assert.equal(lidarrClient.isConfigured(), true);
+  assert.equal(lidarrClient.getConfig().apiKey, "saved-key");
+});

--- a/.tests/migration/ownership-migration.test.js
+++ b/.tests/migration/ownership-migration.test.js
@@ -1,0 +1,150 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import Database from "better-sqlite3";
+
+function createPreV4Db() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aurral-v4-"));
+  const dbPath = path.join(tempDir, "aurral.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE playlist_download_jobs (
+      id TEXT PRIMARY KEY,
+      artist_name TEXT NOT NULL,
+      track_name TEXT NOT NULL,
+      playlist_id TEXT NOT NULL,
+      playlist_type TEXT,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE lidarr_artist_id_map (
+      musicbrainz_id TEXT PRIMARY KEY,
+      lidarr_foreign_artist_id TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE library_artists (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      identity_key TEXT NOT NULL UNIQUE,
+      mbid TEXT,
+      name TEXT NOT NULL,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    INSERT INTO settings (key, value) VALUES ('schemaVersion', '3');
+    INSERT INTO playlist_download_jobs (id, artist_name, track_name, playlist_id, playlist_type, status, created_at)
+      VALUES ('job-aurral', 'Aurral Artist', 'Track One', 'library', 'library', 'done', 1);
+    INSERT INTO playlist_download_jobs (id, artist_name, track_name, playlist_id, playlist_type, status, created_at)
+      VALUES ('job-flow', 'Flow Artist', 'Track Two', 'flow-1', 'flow-1', 'failed', 2);
+    INSERT INTO lidarr_artist_id_map (musicbrainz_id, lidarr_foreign_artist_id, updated_at)
+      VALUES ('mbid-managed', 'lidar-id-1', 1);
+    INSERT INTO library_artists (identity_key, mbid, name, metadata_json, created_at, updated_at)
+      VALUES ('mbid:mbid-managed', 'mbid-managed', 'Managed Artist', '{"monitor":"all"}', 1, 1);
+    INSERT INTO library_artists (identity_key, mbid, name, metadata_json, created_at, updated_at)
+      VALUES ('mbid:mbid-unmanaged', 'mbid-unmanaged', 'Unmanaged Artist', '{"monitor":"all"}', 1, 1);
+    INSERT INTO library_artists (identity_key, mbid, name, metadata_json, created_at, updated_at)
+      VALUES ('name:name-only', NULL, 'Name Only Artist', '{}', 1, 1);
+    INSERT INTO library_artists (identity_key, mbid, name, metadata_json, created_at, updated_at)
+      VALUES ('mbid:mbid-indexed', 'mbid-indexed', 'Indexed Artist', '{"librarySource":"lidarr","monitored":true,"monitor":"new"}', 1, 1);
+    INSERT INTO library_artists (identity_key, mbid, name, metadata_json, created_at, updated_at)
+      VALUES ('mbid:mbid-aurral', 'mbid-aurral', 'Aurral Artist', '{"librarySource":"aurral"}', 1, 1);
+  `);
+  db.close();
+  return { tempDir, dbPath };
+}
+
+const dbHelpers = {
+  parseJSON: (text) => {
+    if (!text) return null;
+    try { return JSON.parse(text); } catch { return null; }
+  },
+  stringifyJSON: (obj) => obj === undefined ? null : JSON.stringify(obj),
+};
+
+test("ownership migration adds manager table and job ownership columns", async () => {
+  const { dbPath } = createPreV4Db();
+  const { initializeSchemaOnStartup } = await import(
+    "../../backend/config/schema-migration-v2.js",
+  );
+  const db = new Database(dbPath);
+
+  const result = initializeSchemaOnStartup(db, dbHelpers);
+  assert.equal(result.migrated, true);
+  assert.equal(result.schemaVersion, 4);
+
+  const jobColumns = db.prepare("PRAGMA table_info(playlist_download_jobs)").all().map((c) => c.name);
+  assert.ok(jobColumns.includes("managed_by"));
+  assert.ok(jobColumns.includes("request_group_id"));
+
+  const jobs = db.prepare("SELECT id, managed_by, request_group_id FROM playlist_download_jobs ORDER BY id").all();
+  assert.deepEqual(jobs, [
+    { id: "job-aurral", managed_by: "aurral", request_group_id: null },
+    { id: "job-flow", managed_by: "aurral", request_group_id: null },
+  ]);
+
+  const managed = db
+    .prepare(
+      "SELECT entity_kind, managed_by, monitor_mode FROM library_management ORDER BY entity_id",
+    )
+    .all();
+  assert.deepEqual(managed, [
+    { entity_kind: "artist", managed_by: "lidarr", monitor_mode: "all" },
+    { entity_kind: "artist", managed_by: "lidarr", monitor_mode: "new" },
+  ]);
+
+  db.close();
+});
+
+test("ownership migration is idempotent and preserves explicit manager rows", async () => {
+  const { dbPath } = createPreV4Db();
+  const { applyV4Migration } = await import(
+    "../../backend/config/schema-migration-v2.js",
+  );
+  const db = new Database(dbPath);
+
+  applyV4Migration(db, dbHelpers);
+  db.prepare(
+    "UPDATE library_management SET monitor_mode = 'none' WHERE entity_kind = 'artist'",
+  ).run();
+  const second = applyV4Migration(db, dbHelpers);
+  assert.equal(second.migrated, false);
+  assert.equal(second.schemaVersion, 4);
+
+  const rerun = db.prepare(
+    "INSERT INTO library_management (entity_kind, entity_id, managed_by, monitor_mode, created_at, updated_at) VALUES ('artist', 999, 'lidarr', NULL, 1, 1)",
+  );
+  rerun.run();
+
+  const monitor = db.prepare("SELECT monitor_mode FROM library_management WHERE entity_kind = 'artist' AND entity_id = 1").get();
+  assert.equal(monitor.monitor_mode, "none");
+
+  const count = db.prepare("SELECT COUNT(*) AS count FROM library_management").get();
+  assert.equal(count.count, 3);
+
+  db.close();
+});
+
+test("ownership migration runs on fresh databases without lidarr records", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aurral-v4-fresh-"));
+  const dbPath = path.join(tempDir, "aurral.db");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+
+  const { applyV4Migration } = await import(
+    "../../backend/config/schema-migration-v2.js",
+  );
+  const result = applyV4Migration(db, dbHelpers);
+  assert.equal(result.schemaVersion, 4);
+
+  const table = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'library_management'").get();
+  assert.ok(table);
+
+  const managed = db.prepare("SELECT COUNT(*) AS count FROM library_management").get();
+  assert.equal(managed.count, 0);
+
+  db.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});

--- a/.tests/migration/ownership-migration.test.js
+++ b/.tests/migration/ownership-migration.test.js
@@ -127,6 +127,37 @@ test("ownership migration is idempotent and preserves explicit manager rows", as
   db.close();
 });
 
+test("applyV3Migration keeps its version 3 contract without ownership state", async () => {
+  const { dbPath } = createPreV4Db();
+  const { applyV3Migration } = await import(
+    "../../backend/config/schema-migration-v2.js",
+  );
+  const db = new Database(dbPath);
+  db.prepare("UPDATE settings SET value = '2' WHERE key = 'schemaVersion'").run();
+
+  const result = applyV3Migration(db, dbHelpers);
+  assert.equal(result.migrated, true);
+  assert.equal(result.schemaVersion, 3);
+
+  const table = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'library_management'")
+    .get();
+  assert.equal(table, undefined);
+  const jobColumns = db.prepare("PRAGMA table_info(playlist_download_jobs)").all().map((c) => c.name);
+  assert.ok(!jobColumns.includes("managed_by"));
+
+  const { initializeSchemaOnStartup } = await import(
+    "../../backend/config/schema-migration-v2.js",
+  );
+  const upgraded = initializeSchemaOnStartup(db, dbHelpers);
+  assert.equal(upgraded.migrated, true);
+  assert.equal(upgraded.schemaVersion, 4);
+  const jobColumnsAfter = db.prepare("PRAGMA table_info(playlist_download_jobs)").all().map((c) => c.name);
+  assert.ok(jobColumnsAfter.includes("managed_by"));
+
+  db.close();
+});
+
 test("ownership migration runs on fresh databases without lidarr records", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aurral-v4-fresh-"));
   const dbPath = path.join(tempDir, "aurral.db");

--- a/.tests/migration/v2-migration.test.js
+++ b/.tests/migration/v2-migration.test.js
@@ -215,9 +215,9 @@ test("v2 migration survives legacy playlist_download_jobs sync triggers", async 
   reopened.close();
 });
 
-test("startup applies the consolidated v3 migration once", async () => {
+test("startup applies the consolidated migration once", async () => {
   const { dbPath } = createPreMigrationDb();
-  const { initializeSchemaOnStartup } = await import(
+  const { initializeSchemaOnStartup, TARGET_SCHEMA_VERSION } = await import(
     "../../backend/config/schema-migration-v2.js",
   );
   const db = new Database(dbPath);
@@ -225,7 +225,7 @@ test("startup applies the consolidated v3 migration once", async () => {
 
   const result = initializeSchemaOnStartup(db, dbHelpers);
   assert.equal(result.migrated, true);
-  assert.equal(result.schemaVersion, 3);
+  assert.equal(result.schemaVersion, TARGET_SCHEMA_VERSION);
   assert.equal(
     db
       .prepare(
@@ -238,7 +238,7 @@ test("startup applies the consolidated v3 migration once", async () => {
   db.exec("CREATE TABLE weekly_flow_jobs (id TEXT PRIMARY KEY)");
   const secondResult = initializeSchemaOnStartup(db, dbHelpers);
   assert.equal(secondResult.migrated, false);
-  assert.equal(secondResult.schemaVersion, 3);
+  assert.equal(secondResult.schemaVersion, TARGET_SCHEMA_VERSION);
   assert.ok(
     db
       .prepare(

--- a/.tests/settings/general-settings.test.js
+++ b/.tests/settings/general-settings.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { join } from "node:path";
 import {
   cleanupIsolatedState,
   resetDatabase,
@@ -132,16 +133,17 @@ function captureSettingsRoutes() {
 
 test("saves overlapping roots with an equal overlap warning", async () => {
   const { postSettings } = captureSettingsRoutes();
+  const sharedRoot = join(isolatedState.baseDir, "roots", "shared");
   dbOps.updateSettings({
-    downloadFolderPath: "/data/media/aurral",
+    downloadFolderPath: sharedRoot,
     integrations: {
-      lidarr: { url: "http://127.0.0.1:18686", apiKey: "key", rootFolderPath: "/data/media" },
+      lidarr: { url: "http://127.0.0.1:18686", apiKey: "key", rootFolderPath: sharedRoot },
     },
   });
 
   const response = await postSettings({
     integrations: {
-      lidarr: { rootFolderPath: "/data/media/aurral" },
+      lidarr: { rootFolderPath: sharedRoot },
     },
   });
 
@@ -154,21 +156,22 @@ test("saves overlapping roots with an equal overlap warning", async () => {
 
 test("does not warn about lidarr roots while lidarr is disabled", async () => {
   const { getSettings, postSettings } = captureSettingsRoutes();
+  const sharedRoot = join(isolatedState.baseDir, "roots", "disabled-shared");
   dbOps.updateSettings({
-    downloadFolderPath: "/data/media/aurral",
+    downloadFolderPath: sharedRoot,
     integrations: {
       lidarr: {
         url: "http://127.0.0.1:18686",
         apiKey: "key",
         enabled: false,
-        rootFolderPath: "/data/media/aurral",
+        rootFolderPath: sharedRoot,
       },
     },
   });
 
   const saved = await postSettings({
     integrations: {
-      lidarr: { rootFolderPath: "/data/media/aurral" },
+      lidarr: { rootFolderPath: sharedRoot },
     },
   });
   assert.equal(saved.statusCode, 200);

--- a/.tests/settings/general-settings.test.js
+++ b/.tests/settings/general-settings.test.js
@@ -87,3 +87,93 @@ test("schedules the library scan after playlist initialization settles", async (
     playlistManager.scheduleScanLibrary = originalScheduleScanLibrary;
   }
 });
+
+function captureSettingsRoutes() {
+  const routes = {};
+  registerGeneral({
+    get(path, ...handlers) {
+      routes[`GET ${path}`] = handlers.at(-1);
+    },
+    post(path, ...handlers) {
+      routes[`POST ${path}`] = handlers.at(-1);
+    },
+  });
+  const makeResponse = () => {
+    let state = { statusCode: 200, body: null };
+    return {
+      get statusCode() {
+        return state.statusCode;
+      },
+      get body() {
+        return state.body;
+      },
+      status(code) {
+        state.statusCode = code;
+        return this;
+      },
+      json(body) {
+        state.body = body;
+        return this;
+      },
+    };
+  };
+  const postSettings = async (body) => {
+    const response = makeResponse();
+    await routes["POST /"]({ body, user: { id: 1 } }, response);
+    return response;
+  };
+  const getSettings = async () => {
+    const response = makeResponse();
+    await routes["GET /"]({}, response);
+    return response;
+  };
+  return { postSettings, getSettings };
+}
+
+test("saves overlapping roots with an equal overlap warning", async () => {
+  const { postSettings } = captureSettingsRoutes();
+  dbOps.updateSettings({
+    downloadFolderPath: "/data/media/aurral",
+    integrations: {
+      lidarr: { url: "http://127.0.0.1:18686", apiKey: "key", rootFolderPath: "/data/media" },
+    },
+  });
+
+  const response = await postSettings({
+    integrations: {
+      lidarr: { rootFolderPath: "/data/media/aurral" },
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const warnings = response.body.rootWarnings;
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].type, "equal");
+  assert.match(warnings[0].message, /rename, import, or delete/);
+});
+
+test("does not warn about lidarr roots while lidarr is disabled", async () => {
+  const { getSettings, postSettings } = captureSettingsRoutes();
+  dbOps.updateSettings({
+    downloadFolderPath: "/data/media/aurral",
+    integrations: {
+      lidarr: {
+        url: "http://127.0.0.1:18686",
+        apiKey: "key",
+        enabled: false,
+        rootFolderPath: "/data/media/aurral",
+      },
+    },
+  });
+
+  const saved = await postSettings({
+    integrations: {
+      lidarr: { rootFolderPath: "/data/media/aurral" },
+    },
+  });
+  assert.equal(saved.statusCode, 200);
+  assert.deepEqual(saved.body.rootWarnings, []);
+
+  const current = await getSettings();
+  assert.deepEqual(current.body.rootWarnings, []);
+});

--- a/.tests/weekly-flow/job-ownership.test.js
+++ b/.tests/weekly-flow/job-ownership.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, trackerModule] = await setupIsolatedBackend(
+  "job-ownership",
+  "backend/config/db-sqlite.js",
+  "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
+);
+
+const { WeeklyFlowDownloadTracker } = trackerModule;
+
+test.beforeEach(async () => {
+  await resetDatabase(db);
+  trackerModule.downloadTracker.clearAll();
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("new jobs default to Aurral ownership", () => {
+  const tracker = new WeeklyFlowDownloadTracker();
+  const jobId = tracker.addJob(
+    { artistName: "Artist", trackName: "Track" },
+    "library",
+  );
+  assert.equal(tracker.getJob(jobId).managedBy, "aurral");
+  assert.equal(tracker.getJob(jobId).requestGroupId, null);
+});
+
+test("album jobs can be grouped and owned by lidarr explicitly", () => {
+  const tracker = new WeeklyFlowDownloadTracker();
+  const groupId = "request-group-1";
+  const lidarrJobId = tracker.addJob(
+    { artistName: "Artist", trackName: "One", managedBy: "lidarr", requestGroupId: groupId },
+    "library",
+  );
+  const aurralJobId = tracker.addJob(
+    { artistName: "Artist", trackName: "Two", managedBy: "aurral", requestGroupId: groupId },
+    "library",
+  );
+  const forgedJobId = tracker.addJob(
+    { artistName: "Artist", trackName: "Three", managedBy: "not-a-manager", requestGroupId: "   " },
+    "library",
+  );
+
+  assert.equal(tracker.getJob(lidarrJobId).managedBy, "lidarr");
+  assert.equal(tracker.getJob(lidarrJobId).requestGroupId, groupId);
+  assert.equal(tracker.getJob(aurralJobId).managedBy, "aurral");
+  assert.equal(tracker.getJob(aurralJobId).requestGroupId, groupId);
+  assert.equal(tracker.getJob(forgedJobId).managedBy, "aurral");
+  assert.equal(tracker.getJob(forgedJobId).requestGroupId, null);
+
+  const group = tracker.getAll().filter((job) => job.requestGroupId === groupId);
+  assert.equal(group.length, 2);
+});
+
+test("job ownership survives a tracker reload", async () => {
+  const tracker = new WeeklyFlowDownloadTracker();
+  const lidarrJobId = tracker.addJob(
+    { artistName: "Artist", trackName: "Reload", managedBy: "lidarr", requestGroupId: "group-reload" },
+    "library",
+  );
+
+  const reloaded = new WeeklyFlowDownloadTracker();
+  assert.equal(reloaded.getJob(lidarrJobId).managedBy, "lidarr");
+  assert.equal(reloaded.getJob(lidarrJobId).requestGroupId, "group-reload");
+});

--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -583,6 +583,9 @@ if (!userColumns.includes("discover_layout")) {
 if (!userColumns.includes("listen_history_url")) {
   tryAddColumn("ALTER TABLE users ADD COLUMN listen_history_url TEXT");
 }
+if (!userColumns.includes("default_library_owner")) {
+  tryAddColumn("ALTER TABLE users ADD COLUMN default_library_owner TEXT");
+}
 
 db.exec(`
   UPDATE users

--- a/backend/config/schema-migration-v2.js
+++ b/backend/config/schema-migration-v2.js
@@ -1,6 +1,7 @@
 const SCHEMA_VERSION_KEY = "schemaVersion";
 const V2_SCHEMA_VERSION = 2;
-export const TARGET_SCHEMA_VERSION = 3;
+const V4_SCHEMA_VERSION = 4;
+export const TARGET_SCHEMA_VERSION = V4_SCHEMA_VERSION;
 
 export function getSchemaVersion(db) {
   const row = db
@@ -232,6 +233,85 @@ function ensureSlskdTransferHistoryTable(db) {
     CREATE INDEX IF NOT EXISTS idx_slskd_transfer_history_status ON slskd_transfer_history(status, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_slskd_transfer_history_cleanup ON slskd_transfer_history(cleaned_at, created_at DESC);
   `);
+}
+
+function normalizeMonitorMode(value) {
+  const normalized = String(value || "").trim();
+  return normalized || null;
+}
+
+function ensureLibraryManagementTable(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS library_management (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_kind TEXT NOT NULL,
+      entity_id INTEGER NOT NULL,
+      managed_by TEXT NOT NULL,
+      monitor_mode TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (entity_kind, entity_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_library_management_entity
+      ON library_management (entity_kind, entity_id);
+    CREATE INDEX IF NOT EXISTS idx_library_management_managed_by
+      ON library_management (managed_by);
+  `);
+}
+
+function backfillJobOwnership(db) {
+  tryAddColumn(db, "ALTER TABLE playlist_download_jobs ADD COLUMN managed_by TEXT");
+  tryAddColumn(db, "ALTER TABLE playlist_download_jobs ADD COLUMN request_group_id TEXT");
+  db.exec(`
+    UPDATE playlist_download_jobs
+    SET managed_by = 'aurral'
+    WHERE managed_by IS NULL OR TRIM(managed_by) = '';
+  `);
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_playlist_download_jobs_request_group ON playlist_download_jobs(request_group_id)",
+  );
+}
+
+function backfillLidarrManagementState(db) {
+  if (!tableExists(db, "library_artists")) {
+    return;
+  }
+  const now = Date.now();
+  const artists = db
+    .prepare("SELECT id, mbid, metadata_json FROM library_artists")
+    .all();
+  if (!artists.length) return;
+  const managedByMbid = tableExists(db, "lidarr_artist_id_map")
+    ? new Set(
+        db
+          .prepare("SELECT musicbrainz_id FROM lidarr_artist_id_map")
+          .all()
+          .map((row) => row.musicbrainz_id),
+      )
+    : new Set();
+  const upsertStmt = db.prepare(`
+    INSERT INTO library_management (entity_kind, entity_id, managed_by, monitor_mode, created_at, updated_at)
+    VALUES ('artist', ?, 'lidarr', ?, ?, ?)
+    ON CONFLICT (entity_kind, entity_id) DO NOTHING
+  `);
+  for (const artist of artists) {
+    let metadata = {};
+    try {
+      metadata = JSON.parse(artist.metadata_json || "{}");
+    } catch {}
+    const mapMatch = artist.mbid && managedByMbid.has(artist.mbid);
+    const indexerMatch = metadata?.librarySource === "lidarr";
+    if (!mapMatch && !indexerMatch) continue;
+    const monitorMode = normalizeMonitorMode(metadata?.monitor || metadata?.addOptions?.monitor);
+    upsertStmt.run(artist.id, monitorMode, now, now);
+  }
+}
+
+export function applyOwnershipMigration(db) {
+  ensureLibraryManagementTable(db);
+  backfillJobOwnership(db);
+  backfillLidarrManagementState(db);
 }
 
 function legacyColumnExpr(columns, columnName, fallback = "NULL") {
@@ -482,6 +562,9 @@ function applySchemaMigration(db, dbHelpers, targetVersion) {
     finalizeV2SettingsKeys(db, dbHelpers);
     migrateJobsTable(db);
     ensureSlskdTransferHistoryTable(db);
+    if (targetVersion >= V4_SCHEMA_VERSION) {
+      applyOwnershipMigration(db);
+    }
     if (migrated) {
       upsertSettingStmt.run(SCHEMA_VERSION_KEY, String(targetVersion));
     }
@@ -499,4 +582,8 @@ export function applyV2Migration(db, dbHelpers) {
 
 export function applyV3Migration(db, dbHelpers) {
   return applySchemaMigration(db, dbHelpers, TARGET_SCHEMA_VERSION);
+}
+
+export function applyV4Migration(db, dbHelpers) {
+  return applySchemaMigration(db, dbHelpers, V4_SCHEMA_VERSION);
 }

--- a/backend/config/schema-migration-v2.js
+++ b/backend/config/schema-migration-v2.js
@@ -1,5 +1,6 @@
 const SCHEMA_VERSION_KEY = "schemaVersion";
 const V2_SCHEMA_VERSION = 2;
+const V3_SCHEMA_VERSION = 3;
 const V4_SCHEMA_VERSION = 4;
 export const TARGET_SCHEMA_VERSION = V4_SCHEMA_VERSION;
 
@@ -11,7 +12,7 @@ export function getSchemaVersion(db) {
 }
 
 export function initializeSchemaOnStartup(db, dbHelpers) {
-  return applyV3Migration(db, dbHelpers);
+  return applyV4Migration(db, dbHelpers);
 }
 
 function tableExists(db, name) {
@@ -581,7 +582,7 @@ export function applyV2Migration(db, dbHelpers) {
 }
 
 export function applyV3Migration(db, dbHelpers) {
-  return applySchemaMigration(db, dbHelpers, TARGET_SCHEMA_VERSION);
+  return applySchemaMigration(db, dbHelpers, V3_SCHEMA_VERSION);
 }
 
 export function applyV4Migration(db, dbHelpers) {

--- a/backend/db/helpers/users.js
+++ b/backend/db/helpers/users.js
@@ -11,18 +11,18 @@ const getUserByUsernameStmt = db.prepare(
   "SELECT * FROM users WHERE username = ?"
 );
 const getAllUsersStmt = db.prepare(
-  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username, listen_history_url, lidarr_root_folder_path, lidarr_quality_profile_id FROM users ORDER BY username"
+  "SELECT id, username, role, permissions, lastfm_username, listen_history_provider, listen_history_username, listen_history_url, lidarr_root_folder_path, lidarr_quality_profile_id, default_library_owner FROM users ORDER BY username"
 );
 const getUserByIdStmt = db.prepare("SELECT * FROM users WHERE id = ?");
 const getUserAuthByIdStmt = db.prepare(
-  "SELECT id, username, role, permissions FROM users WHERE id = ?"
+  "SELECT id, username, role, permissions, default_library_owner FROM users WHERE id = ?"
 );
 const countUsersStmt = db.prepare("SELECT COUNT(*) AS count FROM users");
 const insertUserStmt = db.prepare(
   "INSERT INTO users (username, password_hash, role, permissions, lidarr_root_folder_path, lidarr_quality_profile_id) VALUES (?, ?, ?, ?, ?, ?)"
 );
 const updateUserStmt = db.prepare(
-  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ?, listen_history_url = ?, lidarr_root_folder_path = ?, lidarr_quality_profile_id = ? WHERE id = ?"
+  "UPDATE users SET username = ?, password_hash = ?, role = ?, permissions = ?, lastfm_username = ?, listen_history_provider = ?, listen_history_username = ?, listen_history_url = ?, lidarr_root_folder_path = ?, lidarr_quality_profile_id = ?, default_library_owner = ? WHERE id = ?"
 );
 const deleteUserStmt = db.prepare("DELETE FROM users WHERE id = ?");
 const getAllListeningHistoryUsersStmt = db.prepare(
@@ -38,6 +38,12 @@ const DEFAULT_PERMISSIONS = {
   deleteAlbum: false,
   deleteTrack: false,
 };
+
+function normalizeDefaultLibraryOwner(value) {
+  if (value === null || value === "") return null;
+  const normalized = String(value || "").trim().toLowerCase();
+  return normalized === "aurral" || normalized === "lidarr" ? normalized : null;
+}
 
 export const userOps = {
   getDefaultPermissions() {
@@ -62,6 +68,7 @@ export const userOps = {
         row.lidarr_quality_profile_id != null
           ? Number(row.lidarr_quality_profile_id)
           : null,
+      defaultLibraryOwner: normalizeDefaultLibraryOwner(row.default_library_owner),
       ...history,
     };
   },
@@ -82,6 +89,7 @@ export const userOps = {
         row.lidarr_quality_profile_id != null
           ? Number(row.lidarr_quality_profile_id)
           : null,
+      defaultLibraryOwner: normalizeDefaultLibraryOwner(row.default_library_owner),
       ...history,
     };
   },
@@ -95,6 +103,7 @@ export const userOps = {
       permissions: dbHelpers.parseJSON(row.permissions) || {
         ...DEFAULT_PERMISSIONS,
       },
+      defaultLibraryOwner: normalizeDefaultLibraryOwner(row.default_library_owner),
     };
   },
   countUsers() {
@@ -115,6 +124,7 @@ export const userOps = {
         r.lidarr_quality_profile_id != null
           ? Number(r.lidarr_quality_profile_id)
           : null,
+      defaultLibraryOwner: normalizeDefaultLibraryOwner(r.default_library_owner),
     }));
   },
   createUser(username, passwordHash, role = "user", permissions = null) {
@@ -143,6 +153,7 @@ export const userOps = {
         lastfmUsername: null,
         lidarrRootFolderPath: null,
         lidarrQualityProfileId: null,
+        defaultLibraryOwner: null,
       };
     } catch (e) {
       return null;
@@ -209,6 +220,10 @@ export const userOps = {
         : parsedLidarrQualityProfileId === null
           ? null
           : existing.lidarrQualityProfileId;
+    const defaultLibraryOwner =
+      data.defaultLibraryOwner !== undefined
+        ? normalizeDefaultLibraryOwner(data.defaultLibraryOwner)
+        : normalizeDefaultLibraryOwner(existing.defaultLibraryOwner);
     try {
       updateUserStmt.run(
         username.toLowerCase(),
@@ -221,6 +236,7 @@ export const userOps = {
         resolvedUrl,
         lidarrRootFolderPath,
         lidarrQualityProfileId,
+        defaultLibraryOwner,
         parseInt(id, 10)
       );
       return {
@@ -234,6 +250,7 @@ export const userOps = {
         lastfmUsername,
         lidarrRootFolderPath,
         lidarrQualityProfileId,
+        defaultLibraryOwner,
       };
     } catch (e) {
       return null;

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -12,6 +12,7 @@ import { resolvePlaylistRoot } from "../../../services/playlistPaths.js";
 import {
   resolveYtdlpStagingRoot,
   validateDownloadFolderPath,
+  computeLibraryRootOverlaps,
 } from "../../../services/downloadFolderConfig.js";
 import { normalizePathMappings } from "../../../services/pathMappings.js";
 import { logger } from "../../../services/logger.js";
@@ -28,6 +29,12 @@ function mergeIntegrations(existing, input, keys) {
       : existing[key];
   }
   return merged;
+}
+
+function resolveLibraryRootWarnings(settings) {
+  const aurralRoot = settings?.downloadFolderPath || resolvePlaylistRoot();
+  const lidarrRoots = [settings?.integrations?.lidarr?.rootFolderPath];
+  return computeLibraryRootOverlaps({ aurralRoot, lidarrRoots });
 }
 
 export function registerGeneral(router) {
@@ -65,8 +72,15 @@ export function registerGeneral(router) {
           enabled: settings?.security?.localNetworkBypass?.enabled === true,
         },
       };
+      if (settings.integrations?.lidarr) {
+        settings.integrations.lidarr = {
+          ...settings.integrations.lidarr,
+          enabled: settings.integrations.lidarr.enabled !== false,
+        };
+      }
       res.json({
         ...settings,
+        rootWarnings: resolveLibraryRootWarnings(settings),
         downloadFolderPath:
           settings.downloadFolderPath || resolvePlaylistRoot(),
         integrations: {
@@ -145,6 +159,12 @@ export function registerGeneral(router) {
         nextMetadata.enableNarrowFallbacks =
           nextMetadata.enableNarrowFallbacks !== false;
         integrations.metadata = nextMetadata;
+      }
+      if (integrations?.lidarr?.enabled !== undefined) {
+        integrations.lidarr = {
+          ...integrations.lidarr,
+          enabled: integrations.lidarr.enabled === true,
+        };
       }
       if (integrations?.coverArtArchive) {
         delete integrations.coverArtArchive;
@@ -544,7 +564,10 @@ export function registerGeneral(router) {
       ) {
         websocketService.reconcileAuthState();
       }
-      res.json(reconciled);
+      res.json({
+        ...reconciled,
+        rootWarnings: resolveLibraryRootWarnings(updatedSettings),
+      });
     } catch (error) {
       logger.error("settings", "Settings POST error:", error);
       res

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -33,7 +33,10 @@ function mergeIntegrations(existing, input, keys) {
 
 function resolveLibraryRootWarnings(settings) {
   const aurralRoot = settings?.downloadFolderPath || resolvePlaylistRoot();
-  const lidarrRoots = [settings?.integrations?.lidarr?.rootFolderPath];
+  const lidarrRoots =
+    settings?.integrations?.lidarr?.enabled === false
+      ? []
+      : [settings?.integrations?.lidarr?.rootFolderPath];
   return computeLibraryRootOverlaps({ aurralRoot, lidarrRoots });
 }
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -360,6 +360,55 @@ router.get("/me/lidarr-preferences", requireAuth, async (req, res) => {
   }
 });
 
+router.get("/me/library-owner", requireAuth, async (req, res) => {
+  try {
+    const user = userOps.getUserById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    const { lidarrClient } = await import("../services/lidarrClient.js");
+    const stored = user.defaultLibraryOwner || null;
+    const resolved =
+      stored || (lidarrClient.isConfigured() ? "lidarr" : "aurral");
+    res.json({ defaultLibraryOwner: resolved, storedDefaultLibraryOwner: stored });
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to get library owner preference",
+      message: e.message,
+    });
+  }
+});
+
+router.post("/me/library-owner", requireAuth, async (req, res) => {
+  try {
+    const requested = req.body?.defaultLibraryOwner;
+    if (requested !== null && requested !== undefined && requested !== "") {
+      const normalized = String(requested).trim().toLowerCase();
+      if (normalized !== "aurral" && normalized !== "lidarr") {
+        return res.status(400).json({
+          error: "defaultLibraryOwner must be 'aurral' or 'lidarr'",
+        });
+      }
+    }
+    const updated = userOps.updateUser(req.user.id, {
+      defaultLibraryOwner: requested == null || requested === "" ? null : requested,
+    });
+    if (!updated) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    const { lidarrClient } = await import("../services/lidarrClient.js");
+    const stored = updated.defaultLibraryOwner || null;
+    const resolved =
+      stored || (lidarrClient.isConfigured() ? "lidarr" : "aurral");
+    res.json({ defaultLibraryOwner: resolved, storedDefaultLibraryOwner: stored });
+  } catch (e) {
+    res.status(500).json({
+      error: "Failed to save library owner preference",
+      message: e.message,
+    });
+  }
+});
+
 router.get("/me/discover-layout", requireAuth, (req, res) => {
   try {
     const user = userOps.getUserById(req.user.id);

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -6,6 +6,7 @@ import {
   getCanonicalLibraryForArtists,
   getCanonicalTrackPath,
 } from "./libraryQueryService.js";
+import { getManagedByMap } from "./libraryManagementStore.js";
 
 const albumFiles = (track, albumId) =>
   (track.files || []).filter((file) => file.albumId == null || file.albumId === albumId);
@@ -28,7 +29,7 @@ const recordMatches = (record, reference) => {
   );
 };
 
-const buildArtist = (artist, albumsByArtistId) => {
+const buildArtist = (artist, albumsByArtistId, managementByArtistId = new Map()) => {
   const artistAlbums = albumsByArtistId.get(artist.id) || [];
   const hasSummary = artist.albumCount !== undefined;
   const trackCount = hasSummary
@@ -38,10 +39,13 @@ const buildArtist = (artist, albumsByArtistId) => {
     ? Number(artist.sizeOnDisk || 0)
     : artistAlbums.reduce((total, album) => total + album.statistics.sizeOnDisk, 0);
   const providerId = artist.metadata?.id ?? null;
+  const management = managementByArtistId.get(Number(artist.id)) || null;
   return {
     id: artist.id,
     canonicalId: artist.id,
     providerId,
+    managedBy: management?.managedBy ?? null,
+    monitorMode: management?.monitorMode ?? null,
     mbid: artist.mbid,
     foreignArtistId: artist.metadata?.foreignArtistId || artist.mbid || artist.identityKey,
     artistName: artist.name,
@@ -65,7 +69,7 @@ const buildArtist = (artist, albumsByArtistId) => {
   };
 };
 
-const buildAlbum = (album, artistsById, tracksById) => {
+const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Map()) => {
   const artist = artistsById.get(album.artistId);
   const albumTracks = album.trackIds
     .map((trackId) => tracksById.get(trackId))
@@ -78,11 +82,14 @@ const buildAlbum = (album, artistsById, tracksById) => {
     albumFiles(track, album.id).some((file) => file.available),
   ).length;
   const providerId = album.metadata?.id ?? null;
+  const management = managementByAlbumId.get(Number(album.id)) || null;
   return {
     id: album.id,
     canonicalId: album.id,
     identityKey: album.identityKey,
     providerId,
+    managedBy: management?.managedBy ?? null,
+    monitorMode: management?.monitorMode ?? null,
     providerArtistId: album.metadata?.artistId ?? null,
     artistId: album.artistId,
     artistMbid: artist?.mbid || null,
@@ -135,14 +142,22 @@ export function buildCanonicalLibraryReadModel(library) {
   const { artists, albums, tracks } = library;
   const artistsById = new Map(artists.map((artist) => [artist.id, artist]));
   const tracksById = new Map(tracks.map((track) => [track.id, track]));
-  const readAlbums = albums.map((album) => buildAlbum(album, artistsById, tracksById));
+  const management = {
+    artist: getManagedByMap("artist"),
+    album: getManagedByMap("album"),
+  };
+  const readAlbums = albums.map((album) =>
+    buildAlbum(album, artistsById, tracksById, management.album),
+  );
   const albumsByArtistId = new Map();
   for (const album of readAlbums) {
     const artistAlbums = albumsByArtistId.get(album.artistId) || [];
     artistAlbums.push(album);
     albumsByArtistId.set(album.artistId, artistAlbums);
   }
-  const readArtists = artists.map((artist) => buildArtist(artist, albumsByArtistId));
+  const readArtists = artists.map((artist) =>
+    buildArtist(artist, albumsByArtistId, management.artist),
+  );
   const readTracks = readAlbums.flatMap((album) =>
     album.trackIds
       .map((trackId) => tracksById.get(trackId))
@@ -160,7 +175,9 @@ export function getCanonicalLibraryReadModelForArtistPage({
 } = {}) {
   const library = getCanonicalArtistPage({ source, availableOnly, limit, offset, includeStats: true });
   return {
-    artists: library.artists.map((artist) => buildArtist(artist, new Map())),
+    artists: library.artists.map((artist) =>
+      buildArtist(artist, new Map(), getManagedByMap("artist")),
+    ),
     albums: [],
     tracks: [],
   };

--- a/backend/services/downloadFolderConfig.js
+++ b/backend/services/downloadFolderConfig.js
@@ -326,3 +326,50 @@ export function listBrowseDirectory(requestedPath, _roots = getFilesystemBrowseR
     entries,
   };
 }
+
+function normalizeRootForCompare(value) {
+  let normalized = String(value || "").trim().replace(/\\/g, "/");
+  if (!normalized) return "";
+  if (normalized !== "/" && !/^[A-Za-z]:\/$/.test(normalized)) {
+    normalized = normalized.replace(/\/+$/, "");
+  }
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function compareRoots(left, right) {
+  const a = normalizeRootForCompare(left);
+  const b = normalizeRootForCompare(right);
+  if (!a || !b) return "disjoint";
+  if (a === b) return "equal";
+  if (b.startsWith(`${a}/`)) return "nested-b-in-a";
+  if (a.startsWith(`${b}/`)) return "nested-a-in-b";
+  return "disjoint";
+}
+
+export function computeLibraryRootOverlaps({ aurralRoot, lidarrRoots } = {}) {
+  const resolvedAurralRoot = String(aurralRoot || "").trim();
+  if (!resolvedAurralRoot) return [];
+  const candidates = (Array.isArray(lidarrRoots) ? lidarrRoots : [lidarrRoots])
+    .map((root) => String(root || "").trim())
+    .filter(Boolean);
+  const warnings = [];
+  const seen = new Set();
+  for (const lidarrRoot of candidates) {
+    const relation = compareRoots(resolvedAurralRoot, lidarrRoot);
+    if (relation === "disjoint" || seen.has(`${relation}:${lidarrRoot}`)) {
+      continue;
+    }
+    seen.add(`${relation}:${lidarrRoot}`);
+    warnings.push({
+      type: relation,
+      lidarrRoot,
+      message:
+        relation === "equal"
+          ? "The Lidarr root folder is the same as the Aurral download folder. Lidarr can rename, import, or delete files under that path."
+          : relation === "nested-b-in-a"
+            ? "The Lidarr root folder is inside the Aurral download folder. Lidarr can rename, import, or delete files under that path."
+            : "The Aurral download folder is inside the Lidarr root folder. Lidarr can rename, import, or delete files under that path.",
+    });
+  }
+  return warnings;
+}

--- a/backend/services/downloadFolderConfig.js
+++ b/backend/services/downloadFolderConfig.js
@@ -328,10 +328,10 @@ export function listBrowseDirectory(requestedPath, _roots = getFilesystemBrowseR
 }
 
 function normalizeRootForCompare(value) {
-  let normalized = String(value || "").trim().replace(/\\/g, "/");
+  let normalized = String(value || "").trim().split("\\").join("/");
   if (!normalized) return "";
-  if (normalized !== "/" && !/^[A-Za-z]:\/$/.test(normalized)) {
-    normalized = normalized.replace(/\/+$/, "");
+  while (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
   }
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
@@ -341,8 +341,10 @@ function compareRoots(left, right) {
   const b = normalizeRootForCompare(right);
   if (!a || !b) return "disjoint";
   if (a === b) return "equal";
-  if (b.startsWith(`${a}/`)) return "nested-b-in-a";
-  if (a.startsWith(`${b}/`)) return "nested-a-in-b";
+  const aPrefix = a.endsWith("/") ? a : `${a}/`;
+  const bPrefix = b.endsWith("/") ? b : `${b}/`;
+  if (b.startsWith(aPrefix)) return "nested-b-in-a";
+  if (a.startsWith(bPrefix)) return "nested-a-in-b";
   return "disjoint";
 }
 

--- a/backend/services/libraryManagementStore.js
+++ b/backend/services/libraryManagementStore.js
@@ -21,6 +21,7 @@ const selectAllStmt = db.prepare(
 );
 
 let cache = null;
+let changeListeners = [];
 
 function getCache() {
   if (!cache) {
@@ -36,6 +37,20 @@ function getCache() {
     }
   }
   return cache;
+}
+
+export function onLibraryManagementChange(listener) {
+  if (typeof listener === "function") {
+    changeListeners.push(listener);
+  }
+}
+
+function notifyChanged() {
+  for (const listener of changeListeners) {
+    try {
+      listener();
+    } catch {}
+  }
 }
 
 export function invalidateLibraryManagementCache() {
@@ -90,6 +105,7 @@ export function setLibraryManagement({
   const now = Date.now();
   upsertStmt.run(kind, id, owner, normalizedMonitorMode, now, now);
   invalidateLibraryManagementCache();
+  notifyChanged();
   return getLibraryManagementEntry(kind, id);
 }
 
@@ -101,6 +117,7 @@ export function clearLibraryManagement(entityKind, entityId) {
   const result = clearStmt.run(kind, id);
   if (result.changes > 0) {
     invalidateLibraryManagementCache();
+    notifyChanged();
   }
   return result.changes > 0;
 }

--- a/backend/services/libraryManagementStore.js
+++ b/backend/services/libraryManagementStore.js
@@ -1,0 +1,106 @@
+import { db } from "../config/db-sqlite.js";
+
+const LIBRARY_OWNERS = new Set(["aurral", "lidarr"]);
+const ENTITY_KINDS = new Set(["artist", "album"]);
+
+const upsertStmt = db.prepare(`
+  INSERT INTO library_management (entity_kind, entity_id, managed_by, monitor_mode, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+  ON CONFLICT (entity_kind, entity_id) DO UPDATE SET
+    managed_by = excluded.managed_by,
+    monitor_mode = excluded.monitor_mode,
+    updated_at = excluded.updated_at
+`);
+
+const clearStmt = db.prepare(
+  "DELETE FROM library_management WHERE entity_kind = ? AND entity_id = ?",
+);
+
+const selectAllStmt = db.prepare(
+  "SELECT entity_kind, entity_id, managed_by, monitor_mode FROM library_management",
+);
+
+let cache = null;
+
+function getCache() {
+  if (!cache) {
+    cache = { artist: new Map(), album: new Map() };
+    for (const row of selectAllStmt.all()) {
+      const map = cache[row.entity_kind];
+      if (map) {
+        map.set(row.entity_id, {
+          managedBy: row.managed_by,
+          monitorMode: row.monitor_mode || null,
+        });
+      }
+    }
+  }
+  return cache;
+}
+
+export function invalidateLibraryManagementCache() {
+  cache = null;
+}
+
+export function getLibraryManagementEntry(entityKind, entityId) {
+  if (!ENTITY_KINDS.has(entityKind)) return null;
+  const id = Number(entityId);
+  if (!Number.isSafeInteger(id) || id <= 0) return null;
+  return getCache()[entityKind].get(id) || null;
+}
+
+export function getManagedBy(entityKind, entityId) {
+  return getLibraryManagementEntry(entityKind, entityId)?.managedBy ?? null;
+}
+
+export function getManagedByMaps() {
+  const snapshot = getCache();
+  return {
+    artist: new Map(snapshot.artist),
+    album: new Map(snapshot.album),
+  };
+}
+
+export function getManagedByMap(entityKind) {
+  if (!ENTITY_KINDS.has(entityKind)) return new Map();
+  return getCache()[entityKind];
+}
+
+export function setLibraryManagement({
+  entityKind,
+  entityId,
+  managedBy,
+  monitorMode = null,
+} = {}) {
+  const kind = String(entityKind || "").trim();
+  const id = Number(entityId);
+  const owner = String(managedBy || "").trim().toLowerCase();
+  if (!ENTITY_KINDS.has(kind)) {
+    throw new Error(`Invalid library management entity kind: ${entityKind}`);
+  }
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error(`Invalid library management entity id: ${entityId}`);
+  }
+  if (!LIBRARY_OWNERS.has(owner)) {
+    throw new Error(`Invalid library manager: ${managedBy}`);
+  }
+  const normalizedMonitorMode = monitorMode == null
+    ? null
+    : String(monitorMode).trim() || null;
+  const now = Date.now();
+  upsertStmt.run(kind, id, owner, normalizedMonitorMode, now, now);
+  invalidateLibraryManagementCache();
+  return getLibraryManagementEntry(kind, id);
+}
+
+export function clearLibraryManagement(entityKind, entityId) {
+  const kind = String(entityKind || "").trim();
+  const id = Number(entityId);
+  if (!ENTITY_KINDS.has(kind)) return false;
+  if (!Number.isSafeInteger(id) || id <= 0) return false;
+  const result = clearStmt.run(kind, id);
+  if (result.changes > 0) {
+    invalidateLibraryManagementCache();
+  }
+  return result.changes > 0;
+}

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -7,10 +7,15 @@ import { getLibrarySearchMatch } from "./librarySearchIndex.js";
 import {
   getManagedByMap,
   invalidateLibraryManagementCache,
+  onLibraryManagementChange,
 } from "./libraryManagementStore.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
+
+onLibraryManagementChange(() => {
+  libraryCache.clear();
+});
 const PAGE_KINDS = new Set(["artists", "albums", "tracks", "genres"]);
 const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 100;
@@ -1873,6 +1878,8 @@ function getAlbumTrackSummary(albumId, sourceFilter) {
   ).get(...parameters);
   if (!row) return { artist: null, album: null };
   const sources = parseSources(row.sources);
+  const artistManagement = getManagedByMap("artist").get(row.artist_id) || null;
+  const albumManagement = getManagedByMap("album").get(row.album_id) || null;
   return {
     artist: {
       id: row.artist_id,
@@ -1882,6 +1889,8 @@ function getAlbumTrackSummary(albumId, sourceFilter) {
       sortName: row.artist_sort_name,
       metadata: parseJson(row.artist_metadata_json),
       albumIds: [row.album_id],
+      managedBy: artistManagement?.managedBy ?? null,
+      monitorMode: artistManagement?.monitorMode ?? null,
       sources,
       available: Boolean(row.available),
     },
@@ -1896,6 +1905,8 @@ function getAlbumTrackSummary(albumId, sourceFilter) {
       releaseDate: row.album_release_date,
       metadata: parseJson(row.album_metadata_json),
       trackIds: [],
+      managedBy: albumManagement?.managedBy ?? null,
+      monitorMode: albumManagement?.monitorMode ?? null,
       sources,
       available: Boolean(row.available),
     },

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -4,6 +4,10 @@ import {
   rebuildStoredLibraryGenreStats,
 } from "../config/library-search-index.js";
 import { getLibrarySearchMatch } from "./librarySearchIndex.js";
+import {
+  getManagedByMap,
+  invalidateLibraryManagementCache,
+} from "./libraryManagementStore.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
@@ -85,6 +89,8 @@ const CANONICAL_FROM = `FROM library_artists AS artist
     AND ${albumMediaCondition("media", "album_track")}`;
 
 function buildLibraryFromRows(rows) {
+  const artistManagement = getManagedByMap("artist");
+  const albumManagement = getManagedByMap("album");
   const artists = new Map();
   const albums = new Map();
   const tracks = new Map();
@@ -101,6 +107,8 @@ function buildLibraryFromRows(rows) {
       sources: [],
       available: false,
     });
+    artist.managedBy = artistManagement.get(row.artist_id)?.managedBy ?? null;
+    artist.monitorMode = artistManagement.get(row.artist_id)?.monitorMode ?? null;
     const album = createEntity(albums, row.album_id, {
       id: row.album_id,
       identityKey: row.album_identity_key,
@@ -115,6 +123,8 @@ function buildLibraryFromRows(rows) {
       sources: [],
       available: false,
     });
+    album.managedBy = albumManagement.get(row.album_id)?.managedBy ?? null;
+    album.monitorMode = albumManagement.get(row.album_id)?.monitorMode ?? null;
     const track = createEntity(tracks, row.track_id, {
       id: row.track_id,
       identityKey: row.track_identity_key,
@@ -244,11 +254,14 @@ const canonicalArtistProjection = (row) => {
       .filter(Boolean),
   );
   if (metadata.librarySource === "lidarr") sources.add("lidarr");
+  const management = getManagedByMap("artist").get(Number(row.id)) || null;
   return {
     id: String(row.id),
     canonicalId: String(row.id),
     providerId,
     lidarrManaged: metadata.librarySource === "lidarr",
+    managedBy: management?.managedBy ?? null,
+    monitorMode: management?.monitorMode ?? null,
     mbid: row.mbid || null,
     foreignArtistId: metadata.foreignArtistId || row.mbid || row.identity_key,
     artistName: row.name,
@@ -1064,6 +1077,7 @@ export function getCanonicalArtistPage({
 } = {}) {
   const sourceFilter = normalizeSource(source);
   const media = pageMediaExists("artists", sourceFilter, availableOnly);
+  const artistManagement = getManagedByMap("artist");
   const conditions = [media.sql];
   const parameters = [...media.parameters];
   const normalizedQuery = text(query).toLocaleLowerCase();
@@ -1141,6 +1155,8 @@ export function getCanonicalArtistPage({
       metadata: parseJson(row.artist_metadata_json),
       albumIds: [],
       albumCount: Number(row.album_count || 0),
+      managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
+      monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
       sources: [],
       available: availableOnly === true,
     }]));
@@ -1192,6 +1208,8 @@ export function getCanonicalArtistPage({
     albumCount: Number(row.album_count || 0),
     trackCount: Number(row.track_count || 0),
     sizeOnDisk: Number(row.size_on_disk || 0),
+    managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
+    monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
     sources: parseSources(row.sources),
     available: Boolean(row.available),
   }]));
@@ -2168,6 +2186,7 @@ export function rebuildCanonicalGenreStats() {
 export function invalidateCanonicalLibraryCache({ persistedGenres = true } = {}) {
   libraryCache.clear();
   genreStatsCache.clear();
+  invalidateLibraryManagementCache();
   if (persistedGenres) {
     db.prepare("DELETE FROM settings WHERE key LIKE ?").run(`${GENRE_STATS_SETTING_PREFIX}%`);
   }

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -351,6 +351,7 @@ export class LidarrClient {
       insecure: !!insecure,
       timeoutMs,
       circuitDisabled,
+      enabled: dbConfig.enabled !== false,
     };
 
     const didConfigChange =
@@ -359,7 +360,8 @@ export class LidarrClient {
       previousConfig.apiKey !== newConfig.apiKey ||
       previousConfig.insecure !== newConfig.insecure ||
       previousConfig.timeoutMs !== newConfig.timeoutMs ||
-      previousConfig.circuitDisabled !== newConfig.circuitDisabled;
+      previousConfig.circuitDisabled !== newConfig.circuitDisabled ||
+      previousConfig.enabled !== newConfig.enabled;
 
     this.config = newConfig;
     if (didConfigChange) {
@@ -375,9 +377,17 @@ export class LidarrClient {
     return this.config;
   }
 
+  isEnabled() {
+    this.updateConfig();
+    return this.config?.enabled !== false;
+  }
+
   isConfigured(skipConfigUpdate = false) {
     if (!skipConfigUpdate) {
       this.updateConfig();
+    }
+    if (this.config?.enabled === false) {
+      return false;
     }
     return !!this.config?.apiKey?.trim();
   }
@@ -420,6 +430,9 @@ export class LidarrClient {
     }
 
     if (!this.isConfigured(skipConfigUpdate)) {
+      if (this.config?.enabled === false) {
+        throw new Error("Lidarr is disabled");
+      }
       throw new Error("Lidarr API key not configured");
     }
 

--- a/backend/services/lidarrTestSession.js
+++ b/backend/services/lidarrTestSession.js
@@ -7,6 +7,11 @@ export function resolveLidarrTestCredentials(query = {}, configuredClient = null
     return { url: testUrl, apiKey: testApiKey, usingProvided: true };
   }
   configuredClient?.updateConfig?.();
+  if (configuredClient?.isEnabled?.() === false) {
+    const error = new Error("Lidarr is disabled");
+    error.statusCode = 400;
+    throw error;
+  }
   const config = configuredClient?.getConfig?.() || {};
   return {
     url: String(config.url || "").trim(),

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -433,9 +433,12 @@ async function checkDownloadsSection() {
   const downloadFolder = String(settings.downloadFolderPath || resolvePlaylistRoot() || "").trim();
   const suggested = getSuggestedDownloadFolderPath();
 
+  const lidarrEnabled = settings.integrations?.lidarr?.enabled !== false;
   const rootOverlaps = computeLibraryRootOverlaps({
     aurralRoot: downloadFolder,
-    lidarrRoots: [settings.integrations?.lidarr?.rootFolderPath],
+    lidarrRoots: lidarrEnabled
+      ? [settings.integrations?.lidarr?.rootFolderPath]
+      : [],
   });
   if (rootOverlaps.length > 0) {
     steps.push(

--- a/backend/services/storageHealthService.js
+++ b/backend/services/storageHealthService.js
@@ -21,6 +21,7 @@ import {
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import { commitImportToPlaylistLibrary } from "./playlistDownloadUtils.js";
 import {
+  computeLibraryRootOverlaps,
   getFilesystemBrowseRoots,
   resolveEnvDownloadFolder,
   getSuggestedDownloadFolderPath,
@@ -432,6 +433,19 @@ async function checkDownloadsSection() {
   const downloadFolder = String(settings.downloadFolderPath || resolvePlaylistRoot() || "").trim();
   const suggested = getSuggestedDownloadFolderPath();
 
+  const rootOverlaps = computeLibraryRootOverlaps({
+    aurralRoot: downloadFolder,
+    lidarrRoots: [settings.integrations?.lidarr?.rootFolderPath],
+  });
+  if (rootOverlaps.length > 0) {
+    steps.push(
+      healthStep("root-overlap", "warn", "Aurral and Lidarr roots are separate libraries", {
+        detail: rootOverlaps.map((warning) => warning.message).join(" "),
+        fix: "Use different folders for the Aurral download root and the Lidarr root so each library stays independently managed.",
+      }),
+    );
+  }
+
   if (!downloadFolder) {
     steps.push(
       healthStep("configured", "fail", "Downloads folder is configured", {
@@ -512,6 +526,16 @@ async function checkDownloadsSection() {
 
 async function checkLidarrSection() {
   lidarrClient.updateConfig();
+  if (lidarrClient.isEnabled() === false) {
+    return {
+      section: buildSection("lidarr", "Lidarr library", [], {
+        skipped: true,
+        skipReason: "Lidarr is disabled.",
+      }),
+      sample: null,
+      rootPaths: [],
+    };
+  }
   if (!lidarrClient.isConfigured()) {
     return {
       section: buildSection("lidarr", "Lidarr library", [], {

--- a/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
+++ b/backend/services/weeklyFlow/weeklyFlowDownloadTracker.js
@@ -47,6 +47,8 @@ function rowToJob(row) {
     artistAliases: parseStringListJson(row.artist_aliases),
     playlistId: row.playlist_id || row.playlist_type,
     playlistType: row.playlist_type || row.playlist_id,
+    managedBy: row.managed_by === "lidarr" ? "lidarr" : "aurral",
+    requestGroupId: row.request_group_id || null,
     status: row.status,
     startedAt: row.started_at,
     completedAt: row.completed_at,
@@ -97,6 +99,8 @@ const insertStmt = db.prepare(`
     artist_aliases,
     playlist_id,
     playlist_type,
+    managed_by,
+    request_group_id,
     status,
     staging_path,
     final_path,
@@ -114,7 +118,7 @@ const insertStmt = db.prepare(`
     quality_upgrade_checked_at,
     upgrade_for_job_id
   )
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateStmt = db.prepare(`
@@ -488,6 +492,8 @@ export class WeeklyFlowDownloadTracker {
       stringifyStringListJson(job.artistAliases),
       job.playlistId || job.playlistType,
       job.playlistType || job.playlistId,
+      job.managedBy === "lidarr" ? "lidarr" : "aurral",
+      job.requestGroupId ?? null,
       job.status,
       job.stagingPath ?? null,
       job.finalPath ?? null,
@@ -568,6 +574,10 @@ export class WeeklyFlowDownloadTracker {
       artistAliases: normalizeStringList(track?.artistAliases),
       playlistId: playlistType,
       playlistType,
+      managedBy: track?.managedBy === "lidarr" ? "lidarr" : "aurral",
+      requestGroupId: track?.requestGroupId
+        ? String(track.requestGroupId).trim() || null
+        : null,
       status: "pending",
       startedAt: null,
       completedAt: null,


### PR DESCRIPTION
## What changed

Added library ownership management for Aurral and Lidarr, including per-user owner preferences, canonical library metadata, root-overlap warnings, Lidarr enablement, and updated image handling.

## Why

This gives users clearer control over which system manages library entities while preserving safe behavior when integrations are unavailable. It also surfaces configuration conflicts and keeps library artwork handling aligned with the updated ownership flow.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The settings and library views were updated. Before-and-after screenshots were not provided.

## Testing

- Added coverage for library management persistence and validation.
- Added coverage for canonical read-model ownership fields.
- Added coverage for Lidarr enablement and per-user owner preferences.
- Added coverage for library root-overlap warnings.
- Updated image proxy and library artwork tests.
- Full test-suite results were not provided.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-user default library ownership preferences for Aurral or Lidarr.
  - Library artists and albums now display management and monitoring status.
  - Added warnings when download and library folders overlap.
  - Added the ability to disable Lidarr while preserving saved configuration.
  - Weekly download jobs now retain ownership and request-group information.

- **Bug Fixes**
  - Improved handling of invalid ownership settings and disabled integrations.
  - Added safer database upgrades for existing installations.
  - Library ownership changes now appear without requiring manual cache refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->