### PR TITLE
fix(playlists): encode preview cover URLs

### DIFF
--- a/frontend/src/components/PlaylistModals.jsx
+++ b/frontend/src/components/PlaylistModals.jsx
@@ -278,7 +278,17 @@ export function RenamePlaylistModal({
       return false;
     }
   };
-  const coverSrc = previewUrl || (!imageFailed && isSafeImageUrl(artworkUrl) ? artworkUrl : null);
+  const encodedPreviewUrl = (() => {
+    if (!previewUrl) return null;
+    try {
+      return encodeURI(String(previewUrl));
+    } catch {
+      return null;
+    }
+  })();
+  const coverSrc =
+    encodedPreviewUrl ||
+    (!imageFailed && isSafeImageUrl(artworkUrl) ? artworkUrl : null);
   const fallbackLabel =
     String(displayName || name || "?")
       .trim()


### PR DESCRIPTION
## What changed

Encode playlist preview cover URLs before rendering them as image sources, while preserving the existing safe artwork fallback.

## Why

Prevent malformed or unsafe preview URL values from being used directly in the playlist rename modal.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

The playlist rename modal’s preview cover URL handling changed. Before-and-after screenshots are not included because the visual appearance is unchanged.

## Testing

Not run; this change is limited to URL encoding in `frontend/src/components/PlaylistModals.jsx`.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist cover image handling when renaming a playlist.
  * Local preview images now display more reliably, with a safe fallback to existing artwork when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->