### PR TITLE
fix: stop discovery refresh looping when the library has no seed artists

### DIFF
--- a/.tests/discovery/discovery-refresh-scheduler.test.js
+++ b/.tests/discovery/discovery-refresh-scheduler.test.js
@@ -18,12 +18,25 @@ const {
   discoveryNeedsRefresh,
   bootstrapDiscoveryRefresh,
   enqueueDiscoveryRefresh,
+  enqueueDiscoveryRefreshIfNeeded,
   markDiscoveryRefreshDequeued,
   recoverDeadDiscoveryRefresh,
   scheduleNextDiscoveryRefresh,
 } = refreshScheduler;
 const { getDiscoveryCache } = discoveryIndex;
+const { db } = await importFromRepo("backend/config/db-sqlite.js");
 const originalLastfmApiKey = process.env.LASTFM_API_KEY;
+
+function seedLibraryArtist() {
+  db.prepare(
+    `INSERT INTO library_artists (identity_key, name, created_at, updated_at)
+     VALUES ('test:seed-artist', 'Seed Artist', 1, 1)`,
+  ).run();
+}
+
+function clearLibraryArtists() {
+  db.prepare("DELETE FROM library_artists").run();
+}
 
 let heldGlobalRefreshLock = null;
 
@@ -96,6 +109,7 @@ test.beforeEach(() => {
   markDiscoveryRefreshDequeued();
   setDiscoveryCache();
   releaseHeldGlobalRefreshLock();
+  clearLibraryArtists();
 });
 
 test.after(async () => {
@@ -127,6 +141,47 @@ test("discoveryNeedsRefresh retries a recent empty cache", () => {
     }),
     true,
   );
+});
+
+test("discoveryNeedsRefresh does not retry missing genres when the library has no artists", () => {
+  assert.equal(
+    discoveryNeedsRefresh({
+      recommendations: [],
+      globalTop: [{ id: "trend-1" }],
+      topGenres: [],
+      lastUpdated: new Date().toISOString(),
+    }),
+    false,
+  );
+});
+
+test("discoveryNeedsRefresh retries missing genres when the library has seed artists", () => {
+  seedLibraryArtist();
+  assert.equal(
+    discoveryNeedsRefresh({
+      recommendations: [{ id: "rec-1" }],
+      globalTop: [{ id: "trend-1" }],
+      topGenres: [],
+      lastUpdated: new Date().toISOString(),
+    }),
+    true,
+  );
+});
+
+test("interval check does not queue a refresh after a seedless run left genres empty", async () => {
+  process.env.LASTFM_API_KEY = "test-key";
+  setDiscoveryCache({
+    recommendations: [],
+    globalTop: [{ id: "trend-1" }],
+    topGenres: [],
+    lastUpdated: new Date().toISOString(),
+  });
+
+  const result = await enqueueDiscoveryRefreshIfNeeded({ reason: "interval" });
+
+  assert.equal(result.enqueued, false);
+  assert.equal(result.reason, "fresh");
+  assert.equal(countDiscoveryRefreshJobs(), 0);
 });
 
 test("discoveryNeedsRefresh returns false for fresh populated cache", () => {

--- a/backend/services/discovery/refreshScheduler.js
+++ b/backend/services/discovery/refreshScheduler.js
@@ -146,6 +146,14 @@ export async function isDiscoveryRefreshConfigured() {
   return getCanonicalArtistProjection({ page: 1, pageSize: 1 }).length > 0;
 }
 
+function hasDiscoverySeedArtists() {
+  try {
+    return getCanonicalArtistProjection({ page: 1, pageSize: 1 }).length > 0;
+  } catch {
+    return true;
+  }
+}
+
 export function discoveryNeedsRefresh(cache = getDiscoveryCache()) {
   const lastUpdated = cache?.lastUpdated;
   const hasRecommendations =
@@ -156,12 +164,17 @@ export function discoveryNeedsRefresh(cache = getDiscoveryCache()) {
   const refreshHours = getDiscoveryAutoRefreshHours();
   const staleCutoff = Date.now() - refreshHours * 60 * 60 * 1000;
   const lastUpdatedAt = new Date(lastUpdated || "").getTime();
-  return (
-    !Number.isFinite(lastUpdatedAt) ||
-    lastUpdatedAt < staleCutoff ||
-    (!hasRecommendations && !hasGlobalTop) ||
-    !hasGenres
-  );
+  if (!Number.isFinite(lastUpdatedAt) || lastUpdatedAt < staleCutoff) {
+    return true;
+  }
+  if (!hasRecommendations && !hasGlobalTop) {
+    return true;
+  }
+  // Recommendations and genres are seeded from library artists, so with an
+  // empty library a completed refresh legitimately leaves them empty and
+  // retrying cannot fill them — treating that as stale would re-run the
+  // refresh on every scheduled check (#763).
+  return !hasGenres && hasDiscoverySeedArtists();
 }
 
 function emitDiscoveryQueued(reason) {


### PR DESCRIPTION
Fixes #763.

## What changed

`discoveryNeedsRefresh()` no longer treats empty `topGenres` as "stale" when the library has no artists to seed from.

## Why

The `discovery-refresh-check` system task runs every 15 minutes and refreshes whenever `discoveryNeedsRefresh()` says the cache is stale. With a Last.fm API key configured but an empty library (e.g. a fresh install where Lidarr has no artists yet), the global refresh can only ever produce `globalTop` — recommendations and genres are seeded exclusively from library artists (`historyArtists` is always `[]` in the global path). So every run completes with `topGenres: []`, the `!hasGenres` clause marks the cache stale again, and the full refresh (Last.fm calls included) re-runs on every 15-minute check forever — firing the "Daily Discover recommendations have been updated." notification each time when Gotify's `notifyDiscoveryUpdated` is enabled. Details and evidence in #763.

The fix keeps the existing recovery semantics:

- a completely empty cache (no recommendations **and** no globalTop) still retries — trending is attainable regardless of library state, so emptiness there can indicate a failed run;
- missing genres still retry **when seed artists exist** (the original recovery behavior, now covered by an explicit test);
- missing genres with an empty library no longer count as stale — a retry cannot fill them, so the cache is refreshed on the normal `getDiscoveryAutoRefreshHours()` cadence instead of every check.

## Tests

- New: `discoveryNeedsRefresh does not retry missing genres when the library has no artists`
- New: `discoveryNeedsRefresh retries missing genres when the library has seed artists`
- New: `interval check does not queue a refresh after a seedless run left genres empty` (the exact #763 scenario)
- All existing tests pass unmodified: `npm test` → 905/905, `npm run lint:backend` clean.

## Manual verification

Reproduced on my own instance (v2.8.0, empty Lidarr library + Last.fm key + per-user listening history): Gotify received the Discover notification at :03/:18/:33/:48 every hour, matching a full refresh per 15-minute check.

Note: a related edge remains out of scope — if the library *has* artists but a run legitimately yields no genres (e.g. no Last.fm tags for any seed), the retry-on-empty behavior can still loop. Happy to follow up with a backoff if you want that handled too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery refresh behavior for libraries without artists.
  * Prevented unnecessary refreshes when no discovery seed artists exist.
  * Ensured discovery data refreshes when seed artists are available but genre data is missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->