### PR TITLE
feat(lidarr): show only available music in the Library by default

### DIFF
--- a/.tests/frontend/library-query-invalidation.test.js
+++ b/.tests/frontend/library-query-invalidation.test.js
@@ -112,7 +112,6 @@ test("library requests forward caller cancellation", async (t) => {
       page: 1,
       pageSize: 100,
       source: "all",
-      availableOnly: "false",
     }),
   );
   await assertQueryCancellation(() => getLibraryFavorites(), queryKeys.libraryFavorites);

--- a/.tests/library/canonical-available-only-route.test.js
+++ b/.tests/library/canonical-available-only-route.test.js
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  resetDatabase,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { dbOps }, libraryStore] = await setupIsolatedBackend(
+  "canonical-available-only-route",
+  "backend/config/db-sqlite.js",
+  "backend/db/helpers/index.js",
+  "backend/services/libraryMediaStore.js",
+);
+
+const { registerCanonical } = await import(
+  "../../backend/routes/library/handlers/canonical.js"
+);
+const {
+  linkLibraryAlbumTrack,
+  upsertLibraryAlbum,
+  upsertLibraryArtist,
+  upsertLibraryMediaFile,
+  upsertLibraryTrack,
+} = libraryStore;
+
+function getRoute(path) {
+  const routes = new Map();
+  registerCanonical({
+    get(routePath, ...handlers) {
+      routes.set(`GET ${routePath}`, handlers.at(-1));
+    },
+    post(routePath, ...handlers) {
+      routes.set(`POST ${routePath}`, handlers.at(-1));
+    },
+  });
+  return routes.get(path);
+}
+
+function callCanonical(query) {
+  let body;
+  getRoute("GET /canonical")(
+    { query },
+    {
+      status() {
+        return this;
+      },
+      json(value) {
+        body = value;
+        return this;
+      },
+    },
+  );
+  return body;
+}
+
+function setAvailableOnly(value) {
+  dbOps.updateSettings({ integrations: { lidarr: { availableOnly: value } } });
+}
+
+test.before(() => {
+  resetDatabase(db);
+
+  // Artist who owns some but not all of their discography (the issue's "Muse" case).
+  const partialArtist = upsertLibraryArtist({
+    identityKey: "partial-artist",
+    name: "Owns Some",
+  });
+  const ownedAlbum = upsertLibraryAlbum({
+    identityKey: "owned-album",
+    artistId: partialArtist.id,
+    title: "Owned Album",
+  });
+  const ownedTrack = upsertLibraryTrack({
+    identityKey: "owned-track",
+    title: "Owned Track",
+    artistName: partialArtist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: ownedAlbum.id, trackId: ownedTrack.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: ownedTrack.id,
+    albumId: ownedAlbum.id,
+    source: "lidarr",
+    path: "/library/Owns Some/Owned Album/01 Owned Track.flac",
+    available: true,
+  });
+
+  const catalogAlbum = upsertLibraryAlbum({
+    identityKey: "catalog-album",
+    artistId: partialArtist.id,
+    title: "Catalog Album",
+  });
+  const catalogTrack = upsertLibraryTrack({
+    identityKey: "catalog-track",
+    title: "Catalog Track",
+    artistName: partialArtist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: catalogAlbum.id, trackId: catalogTrack.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: catalogTrack.id,
+    albumId: catalogAlbum.id,
+    source: "lidarr",
+    path: "/library/Owns Some/Catalog Album/01 Catalog Track.flac",
+    available: false,
+  });
+
+  // Artist who owns nothing (e.g. deleted in Lidarr but lingering) — issue #750.
+  const emptyArtist = upsertLibraryArtist({
+    identityKey: "empty-artist",
+    name: "Owns Nothing",
+  });
+  const emptyAlbum = upsertLibraryAlbum({
+    identityKey: "empty-album",
+    artistId: emptyArtist.id,
+    title: "Unowned Album",
+  });
+  const emptyTrack = upsertLibraryTrack({
+    identityKey: "empty-track",
+    title: "Unowned Track",
+    artistName: emptyArtist.name,
+  });
+  linkLibraryAlbumTrack({ albumId: emptyAlbum.id, trackId: emptyTrack.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: emptyTrack.id,
+    albumId: emptyAlbum.id,
+    source: "lidarr",
+    path: "/library/Owns Nothing/Unowned Album/01 Unowned Track.flac",
+    available: false,
+  });
+});
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("albums list hides unavailable albums when the setting is on (default)", () => {
+  setAvailableOnly(true);
+  const page = callCanonical({ kind: "albums", page: "1", pageSize: "50" });
+  assert.deepEqual(page.items.map((album) => album.title), ["Owned Album"]);
+  assert.equal(page.total, 1);
+});
+
+test("albums list shows the full catalog when the setting is off", () => {
+  setAvailableOnly(false);
+  const page = callCanonical({ kind: "albums", page: "1", pageSize: "50" });
+  assert.deepEqual(
+    page.items.map((album) => album.title).sort(),
+    ["Catalog Album", "Owned Album", "Unowned Album"],
+  );
+  assert.equal(page.total, 3);
+});
+
+test("artists with zero available albums disappear when the setting is on (#750)", () => {
+  setAvailableOnly(true);
+  const page = callCanonical({ kind: "artists", page: "1", pageSize: "50" });
+  assert.deepEqual(page.items.map((entry) => entry.name), ["Owns Some"]);
+  assert.equal(page.total, 1);
+});
+
+test("artists with zero available albums remain when the setting is off", () => {
+  setAvailableOnly(false);
+  const page = callCanonical({ kind: "artists", page: "1", pageSize: "50" });
+  assert.deepEqual(
+    page.items.map((entry) => entry.name).sort(),
+    ["Owns Nothing", "Owns Some"],
+  );
+  assert.equal(page.total, 2);
+});
+
+test("an explicit availableOnly query param overrides the setting", () => {
+  setAvailableOnly(false);
+  const filtered = callCanonical({
+    kind: "albums",
+    page: "1",
+    pageSize: "50",
+    availableOnly: "true",
+  });
+  assert.deepEqual(filtered.items.map((album) => album.title), ["Owned Album"]);
+
+  setAvailableOnly(true);
+  const unfiltered = callCanonical({
+    kind: "albums",
+    page: "1",
+    pageSize: "50",
+    availableOnly: "false",
+  });
+  assert.equal(unfiltered.total, 3);
+});

--- a/.tests/library/canonical-available-only-setting.test.js
+++ b/.tests/library/canonical-available-only-setting.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveCanonicalAvailableOnly } from "../../backend/routes/library/handlers/canonical.js";
+
+test("explicit availableOnly query param overrides the configured default", () => {
+  const settingsOn = { integrations: { lidarr: { availableOnly: true } } };
+  const settingsOff = { integrations: { lidarr: { availableOnly: false } } };
+
+  assert.equal(resolveCanonicalAvailableOnly("true", settingsOff), true);
+  assert.equal(resolveCanonicalAvailableOnly("false", settingsOn), false);
+});
+
+test("absent availableOnly query param follows the lidarr setting", () => {
+  assert.equal(
+    resolveCanonicalAvailableOnly(undefined, { integrations: { lidarr: { availableOnly: true } } }),
+    true,
+  );
+  assert.equal(
+    resolveCanonicalAvailableOnly(undefined, { integrations: { lidarr: { availableOnly: false } } }),
+    false,
+  );
+});
+
+test("absent query param and unset setting defaults to available-only (on)", () => {
+  assert.equal(resolveCanonicalAvailableOnly(undefined, undefined), true);
+  assert.equal(resolveCanonicalAvailableOnly(undefined, {}), true);
+  assert.equal(resolveCanonicalAvailableOnly(undefined, { integrations: {} }), true);
+  assert.equal(
+    resolveCanonicalAvailableOnly(undefined, { integrations: { lidarr: {} } }),
+    true,
+  );
+});

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -186,7 +186,7 @@ test("native favorites include the canonical favorite subset", () => {
 test("canonical library pages return bounded collection responses", () => {
   const response = responseFor();
   getRoute("GET /canonical")(
-    { user, query: { kind: "tracks", page: "1", pageSize: "1" } },
+    { user, query: { kind: "tracks", page: "1", pageSize: "1", availableOnly: "false" } },
     response,
   );
 

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -120,6 +120,7 @@ export const defaultData = {
         tagId: null,
         defaultMonitorOption: "none",
         searchOnAdd: false,
+        availableOnly: true,
       },
       metadata: {
         provider: "brainzmash",

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,5 +1,6 @@
 import { noCache } from "../../../middleware/cache.js";
 import { requireAuth } from "../../../middleware/requirePermission.js";
+import { dbOps } from "../../../db/helpers/index.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import {
   getCanonicalFavoriteTargetKeys,
@@ -27,6 +28,16 @@ export function stripFilesystemPaths(value) {
       .filter(([key]) => !isFilesystemPathKey(key))
       .map(([key, entry]) => [key, stripFilesystemPaths(entry)]),
   );
+}
+
+// Resolves the effective availableOnly flag for a canonical library read.
+// An explicit query param always wins so detail/track views can force a value;
+// otherwise the Lidarr "show available music only" setting decides, defaulting
+// to on so the Library shows owned music rather than the full discography.
+export function resolveCanonicalAvailableOnly(queryValue, settings) {
+  if (queryValue === "true") return true;
+  if (queryValue === "false") return false;
+  return settings?.integrations?.lidarr?.availableOnly !== false;
 }
 
 function getAlbumCoverUrl(album) {
@@ -125,7 +136,10 @@ export function registerCanonical(router) {
       }
       return res.json(toPublicLibraryPage(getCanonicalLibraryPage({
         source: req.query.source,
-        availableOnly: req.query.availableOnly === "true",
+        availableOnly: resolveCanonicalAvailableOnly(
+          req.query.availableOnly,
+          dbOps.getSettings(),
+        ),
         kind,
         page: req.query.page,
         pageSize: requestedPageSize,

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -21,7 +21,26 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 - The URL Aurral can reach (often `http://lidarr:8686` in Docker). Aurral supports both HTTP and HTTPS. Use HTTPS when the connection leaves your trusted network.
 - Your Lidarr API key
 - Default quality profile, metadata profile, tag, monitoring option, and search-on-add behavior
+- **Show available music only**, which controls whether the Library lists your whole Lidarr catalog or only downloaded music
 - Optional **Davo's Community Lidarr Guide** for quality profiles and file names
+
+## Library display
+
+Lidarr reports an artist's full discography, including albums you have not
+downloaded. **Show available music only** (in **Settings > Lidarr**) keeps the
+Library focused on music you actually have:
+
+- When **on** (the default), the Library — the Albums list, Album artists list,
+  and the home **Recently added** shelf — shows only albums with downloaded
+  files, and the library counts reflect that. Artists with no downloaded music
+  drop off the list, so an artist you remove in Lidarr disappears from the
+  Library on the next scan.
+- When **off**, the Library shows each artist's full Lidarr discography,
+  including albums with no files (labelled `0/10 available`).
+
+This setting only changes what the Library **lists**. You can still search for
+and request unmonitored or undownloaded albums from the artist's discography,
+and the request and monitor workflows are unchanged.
 
 ## Metadata providers
 

--- a/frontend/src/pages/FlowPage.jsx
+++ b/frontend/src/pages/FlowPage.jsx
@@ -1192,6 +1192,8 @@ function FlowPage({ mode = "all" }) {
           page: 1,
           pageSize: 100,
           query: track.artistName,
+          // Resolve for navigation even if nothing is available yet.
+          availableOnly: false,
         });
         canonicalId = canonicalLibraryId(
           findCanonicalArtistByName(page?.items, track.artistName),
@@ -1228,6 +1230,8 @@ function FlowPage({ mode = "all" }) {
           page: 1,
           pageSize: 100,
           query: track.albumName,
+          // Resolve for navigation even if nothing is available yet.
+          availableOnly: false,
         });
         canonicalId = canonicalLibraryId(
           findCanonicalAlbumByName(page?.items, track.albumName, track.artistName),

--- a/frontend/src/pages/LibraryPage.jsx
+++ b/frontend/src/pages/LibraryPage.jsx
@@ -595,6 +595,9 @@ function LibraryPage() {
               albumId: routeAlbumId,
               page: 1,
               pageSize,
+              // An album detail view shows the full tracklist regardless of the
+              // library-wide availability setting; owned/missing is shown per row.
+              availableOnly: false,
             }, { signal })
           : await Promise.all([
               fetchCanonicalLibraryPage({
@@ -621,6 +624,8 @@ function LibraryPage() {
                   page: 1,
                   pageSize,
                   sort: "newest",
+                  // "Recently added" defers to the Lidarr "available only"
+                  // setting (omitted param) like the Albums/Artists tabs.
                 }, { signal }),
                 fetchCanonicalLibraryPage({
                   kind: "tracks",
@@ -638,7 +643,9 @@ function LibraryPage() {
                 genre: selectedGenre,
                 sort: sortMode,
                 direction: sortDirection,
-                availableOnly: tab === "tracks",
+                // Albums/artists defer to the Lidarr "available only" setting
+                // (omitted param); tracks always filter to playable files.
+                availableOnly: tab === "tracks" ? true : undefined,
               }, { signal });
       const pageResults = section === "favorites"
         ? [nextData?.library || EMPTY_LIBRARY]
@@ -747,6 +754,9 @@ function LibraryPage() {
           albumId: album.id,
           page: 1,
           pageSize,
+          // Full tracklist regardless of the library-wide availability setting;
+          // availability is surfaced per-track via badges after merging metadata.
+          availableOnly: false,
         }, { signal });
         const ownedTracks = Array.isArray(page?.items) ? page.items : [];
         const pageArtist = page?.artists?.[0] || null;

--- a/frontend/src/pages/Settings/components/LidarrSettingsModalContent.jsx
+++ b/frontend/src/pages/Settings/components/LidarrSettingsModalContent.jsx
@@ -410,6 +410,18 @@ export function LidarrSettingsSection({
             aria-label="Search for missing albums when artists are added"
           />
         </SettingsArrFormGroup>
+
+        <SettingsArrFormGroup
+          label="Show available music only"
+          help="Hide albums and artists with no downloaded files from the Library. You can still search for and request unmonitored albums. Turn off to browse each artist's full Lidarr discography."
+        >
+          <PillToggle
+            className="settings-toggle"
+            checked={settings.integrations?.lidarr?.availableOnly !== false}
+            onChange={(e) => updateLidarr({ availableOnly: e.target.checked })}
+            aria-label="Show only albums with downloaded files in the Library"
+          />
+        </SettingsArrFormGroup>
       </SettingsArrFieldSet>
 
       <SettingsArrFieldSet legend="Community guide">

--- a/frontend/src/pages/Settings/hooks/useSettingsData.js
+++ b/frontend/src/pages/Settings/hooks/useSettingsData.js
@@ -302,6 +302,11 @@ export function useSettingsData(showSuccess, showError, showInfo, activeTab) {
     mutationFn: updateAppSettings,
     onSuccess: (savedSettings) => {
       queryClient.setQueryData(queryKeys.appSettings, savedSettings);
+      // Settings such as the Lidarr "available only" toggle change what the
+      // Library endpoints return without changing the query key, so mark the
+      // Library views stale on save to pick up the new filtering on next view.
+      queryClient.invalidateQueries({ queryKey: queryKeys.libraryViewPrefix });
+      queryClient.invalidateQueries({ queryKey: queryKeys.libraryCanonicalPrefix });
     },
   });
   const lidarrQueries = useQueries({

--- a/frontend/src/pages/Settings/settingsTabsConfig.js
+++ b/frontend/src/pages/Settings/settingsTabsConfig.js
@@ -94,6 +94,7 @@ const SETTINGS_SEARCH_METADATA = {
       Tag: "lidarr tag",
       "Default monitoring option": "albums existing future missing latest first",
       "Search on add": "missing albums artists",
+      "Show available music only": "available downloaded files discography hide unmonitored library owned",
       "Community guide": "Davo recommended settings custom formats naming scheme",
     },
   },

--- a/frontend/src/pages/Settings/utils.js
+++ b/frontend/src/pages/Settings/utils.js
@@ -69,6 +69,7 @@ export const normalizeSettings = (savedSettings) => {
         externalUrl: "",
         apiKey: "",
         searchOnAdd: false,
+        availableOnly: true,
         defaultMonitorOption: "none",
         ...lidarr,
         qualityProfileId:

--- a/frontend/src/utils/api/endpoints/library.js
+++ b/frontend/src/utils/api/endpoints/library.js
@@ -34,7 +34,11 @@ const canonicalLibraryPageParams = (options = {}) => Object.fromEntries(
     artistId: options.artistId,
     albumId: options.albumId,
     source: options.source || "all",
-    availableOnly: options.availableOnly === true ? "true" : "false",
+    // Tri-state: an explicit boolean forces the filter, while `undefined` omits
+    // the param so the backend applies the Lidarr "available only" setting.
+    availableOnly: options.availableOnly === undefined || options.availableOnly === null
+      ? undefined
+      : options.availableOnly === true ? "true" : "false",
   }).filter(([, value]) => value !== undefined && value !== null && value !== ""),
 );
 


### PR DESCRIPTION
## What changed

Adds a **Show available music only** setting to **Settings > Lidarr** (default **on**) that keeps the Library focused on music you have actually downloaded, instead of every album in each artist's Lidarr discography.

When the setting is **on** (default), the Library list views only show albums that have downloaded files, and the counts reflect that:

- **Albums** tab and **Album artists** tab
- The home **Recently added** albums shelf
- Artists with zero downloaded albums drop off the **Album artists** list and its count, so an artist you delete in Lidarr disappears from the Library on the next scan.

When the setting is **off**, the Library lists each artist's full Lidarr discography (including albums with no files, labelled `0/10 available`) — the previous behavior.

The filter applies to the Library **list** views only. Album and artist **detail** pages still show full tracklists, and the **search / request / monitor** workflows are unchanged, so you can still find and request unmonitored or undownloaded albums.

### Implementation

The backend already supported an `availableOnly` filter on `GET /library/canonical` (it maps to a `media.available = 1` predicate and is reflected in the page `total`). The bug was that the Library list views hardcoded the filter **off**. This PR makes the filter setting-driven and backend-authoritative:

- **`backend/routes/library/handlers/canonical.js`** — new exported `resolveCanonicalAvailableOnly(queryValue, settings)`: an explicit `availableOnly` query param still wins (so detail/track views can force a value); otherwise the endpoint falls back to `integrations.lidarr.availableOnly`, defaulting to **on** when unset. Reads settings via the existing 60s-cached `dbOps.getSettings()`.
- **`backend/config/constants.js`** — adds `availableOnly: true` to the Lidarr integration defaults.
- **`frontend/src/utils/api/endpoints/library.js`** — the canonical page-params builder is now tri-state: an explicit boolean serializes to `"true"`/`"false"`, while `undefined` omits the param so the backend applies the setting.
- **`frontend/src/pages/LibraryPage.jsx`** — the Albums/Artists tabs and the home "Recently added" albums shelf omit `availableOnly` (defer to the setting); the Tracks list, album/artist detail views, and the album-tracklist helper keep their explicit values so tracklists and detail pages are unaffected.
- **`frontend/src/pages/FlowPage.jsx`** — the two by-name library lookups used for navigation pass an explicit `availableOnly: false` (they must resolve regardless of availability); no behavior change.
- **Settings UI** — a `PillToggle` in `LidarrSettingsModalContent.jsx`, its default in `Settings/utils.js` (`normalizeSettings`), and a matching entry in the settings search index (`settingsTabsConfig.js`, required by the existing `settings-search` test).
- **`frontend/src/pages/Settings/hooks/useSettingsData.js`** — invalidates the Library query caches on settings save, so toggling the setting takes effect on the next Library view instead of serving a stale page (the Library query key does not include this setting).
- **Docs** — `docs/src/content/docs/integrations/lidarr.mdx` documents the toggle and its effect.
- **Tests** — see Testing.

## Why

With Lidarr connected, the Library listed each artist's entire Lidarr discography, including albums with no files, and the library counts reflected the whole catalog — so a user who owns a few albums by an artist saw the full 10+ album discography sitting in their Library as "0/10 available," and deleted-in-Lidarr artists lingered. There was no way to filter to owned music, even though the backend already supported it.

This is exactly the feature requested in **#766** ("a 'show available only' toggle on the Library, ideally defaulting to on"). Because artists with zero available albums also drop out of the list and its count, it resolves the confusing album-artist count in **#750** as well.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #766
Fixes #750

(#766 is the feature request that describes this exact toggle. Per the template, linked issues stay open until a stable release includes the change.)

## UI changes

Adds one toggle to **Settings > Lidarr**, directly below **Search on add**:

> **Show available music only** &nbsp; `[ ●]` (on by default)
> *Hide albums and artists with no downloaded files from the Library. You can still search for and request unmonitored albums. Turn off to browse each artist's full Lidarr discography.*

<!-- TODO(maintainer): attach before/after screenshots — Settings > Lidarr toggle, and the Albums list before/after with a partially-owned artist. I could not capture these without a running instance connected to Lidarr. -->

## Testing

Ran on the available toolchain (Node 25; CI uses Node 22.23.2):

- `npm test` — backend **library** suite (131/131) and **settings/subsonic/lidarr** suites (39/39) pass, including two new tests:
  - `.tests/library/canonical-available-only-setting.test.js` — `resolveCanonicalAvailableOnly` tri-state logic (param override, setting fallback, default-on for missing/partial settings).
  - `.tests/library/canonical-available-only-route.test.js` — route-level, end-to-end: a partially-owned artist lists only owned albums (and count) when on / the full catalog when off; artists with zero available albums disappear when on (**#750**); an explicit query param overrides the setting.
  - Updated `.tests/library/canonical-favorites-routes.test.js` and `.tests/frontend/library-query-invalidation.test.js` to reflect the new setting-driven default and tri-state query key.
- `npm run lint` — clean (backend + frontend).
- `npm run build` (frontend) — succeeds.
- `cd docs && npm run build` — succeeds (docs are a CI gate).

Note: a handful of pre-existing `.tests/frontend/*` tests fail locally with `storage.getItem is not a function` under Node 25; they fail identically on `main` without this change (an environment issue with the non-pinned Node version), so they are unrelated. CI on Node 22.23.2 should be green.

### QA notes for reviewers

- **No regression for non-Lidarr users.** Only the `lidarr` and `aurral` (local scan) sources ever write `library_media_files` rows, and neither marks *existing* music `available = 0` (a row only goes unavailable when the file is genuinely gone). Navidrome/Plex/Subsonic/Jellyfin write no media rows. So defaulting `availableOnly` on hides nothing for local-scan-only or other-source-only libraries; it is only meaningful where Lidarr reports undownloaded albums.
- **Request workflow intact.** An artist's full discography for requesting comes from MusicBrainz metadata (`GET /artists/:mbid`), and requests/monitoring go through `POST /library/albums/request` and `PUT /library/albums/:id` — none of which are touched by the canonical availability filter.
- **Upgrade note.** The default is **on** (as requested in #766), so after upgrading, existing users' Libraries will hide undownloaded albums. Turning the setting off restores the previous behavior.

### Considered but intentionally out of scope

To keep the change focused, these related surfaces were left alone (happy to split follow-ups if wanted):

- The Discover page's "Recently Added" rail (`GET /library/recent`) is a separate, non-canonical discovery endpoint that can still list a lingering artist. Neither linked issue names it, and filtering it would pull in the discovery subsystem.
- The per-artist library shelf on the standalone artist page (`GET /library/albums?artistId=…`) intentionally shows album completion/download status for managing that artist.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

---

AI disclosure: this PR was investigated and fixed by Claude. I tested the resulting fix in my environment and it worked as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Lidarr setting to show only music with downloaded files in Library views.
  - Library albums, artists, counts, and recently added content now follow this setting by default.
  - When disabled, unavailable albums remain visible with their availability status.
  - Album details and tracklists continue to show complete information, including missing tracks.
  - Library results refresh automatically after changing the setting.
- **Documentation**
  - Updated Lidarr integration documentation with the new setting and Library behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->