### PR TITLE
feat(weekly-flow): check filesystem for existing tracks before downloading (#741)

### DIFF
--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -100,6 +100,33 @@ test("reuseTrackForPlaylist references a completed Aurral track path", async () 
   assert.equal(downloadTracker.getJob(result.jobId)?.finalPath, sourcePath);
 });
 
+test("reuseTrackForPlaylist detects and reuses local audio file from disk without prior tracker job (#741)", async () => {
+  const track = {
+    artistName: "Ella Langley",
+    trackName: "Choosin' Texas",
+    albumName: "Hungover",
+  };
+  const localFilePath = path.join(
+    weeklyFlowRoot,
+    "Ella Langley",
+    "Hungover",
+    "Choosin' Texas.flac",
+  );
+  await fs.mkdir(path.dirname(localFilePath), { recursive: true });
+  await fs.writeFile(localFilePath, "audio");
+
+  const result = await reuseTrackForPlaylist(track, "library", {
+    existingFileMode: "reuse",
+    weeklyFlowRoot,
+  });
+
+  assert.equal(result.reused, true);
+  assert.equal(result.sourceType, "aurral");
+  assert.equal(result.finalPath, localFilePath);
+  assert.equal(downloadTracker.getJob(result.jobId)?.status, "done");
+  assert.equal(downloadTracker.getJob(result.jobId)?.finalPath, localFilePath);
+});
+
 test("library reuse does not cross album boundaries for the same track title", async () => {
   const sourceTrack = {
     artistName: "Amigo the Devil",

--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -127,6 +127,23 @@ test("reuseTrackForPlaylist detects and reuses local audio file from disk withou
   assert.equal(downloadTracker.getJob(result.jobId)?.finalPath, localFilePath);
 });
 
+test("reuseTrackForPlaylist neutralizes path traversal attempts in track metadata and target playlist", async () => {
+  const result = await reuseTrackForPlaylist(
+    {
+      artistName: "../../etc",
+      trackName: "../../passwd",
+      albumName: "..",
+    },
+    "../../secrets",
+    {
+      existingFileMode: "reuse",
+      weeklyFlowRoot,
+    },
+  );
+
+  assert.equal(result.reused, false);
+});
+
 test("library reuse does not cross album boundaries for the same track title", async () => {
   const sourceTrack = {
     artistName: "Amigo the Devil",

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -109,15 +109,34 @@ function sortReusableJobs(jobs) {
   });
 }
 
+/**
+ * Checks whether a playlist type corresponds to an ephemeral Flow playlist.
+ *
+ * @param {string} playlistType - Target playlist identifier.
+ * @returns {boolean} True if the playlist type is a configured flow.
+ */
 function isFlowPlaylistType(playlistType) {
   return Boolean(flowPlaylistConfig.getFlow(String(playlistType || "").trim()));
 }
 
+/**
+ * Checks whether a playlist type corresponds to a canonical or shared playlist.
+ *
+ * @param {string} playlistType - Target playlist identifier.
+ * @returns {boolean} True if the playlist type is canonical or shared.
+ */
 function isCanonicalPlaylistType(playlistType) {
   const key = String(playlistType || "").trim();
   return key === "library" || Boolean(flowPlaylistConfig.getSharedPlaylist(key));
 }
 
+/**
+ * Sanitizes a path segment to strip directory traversal sequences and invalid characters.
+ *
+ * @param {string|null|undefined} value - Raw path component.
+ * @param {string} [fallback="Unknown"] - Safe fallback if value is empty or resolves to traversal.
+ * @returns {string} Sanitized directory or file name.
+ */
 function sanitizeSafeSegment(value, fallback = "Unknown") {
   const text = sanitizePathPart(value, fallback);
   if (!text || text === "." || text === ".." || text.startsWith(".")) {
@@ -126,6 +145,13 @@ function sanitizeSafeSegment(value, fallback = "Unknown") {
   return text;
 }
 
+/**
+ * Scans local storage directories to locate an existing audio file matching track metadata.
+ *
+ * @param {object} track - Track metadata including artistName, albumName, and trackName.
+ * @param {object} [options={}] - Options containing targetPlaylistType and weeklyFlowRoot.
+ * @returns {Promise<{sourceType: string, sourcePath: string, sourceJob: null, albumName: string|null}|null>} Resolved source or null.
+ */
 async function findLocalExistingSource(track, options = {}) {
   const targetPlaylistType = sanitizeSafeSegment(options.targetPlaylistType, "");
   if (!targetPlaylistType) return null;
@@ -546,6 +572,13 @@ async function findLidarrSource(track, options = {}) {
   return null;
 }
 
+/**
+ * Resolves a reusable track source from local storage, Aurral library, or Lidarr library.
+ *
+ * @param {object} track - Track metadata to locate.
+ * @param {object} [options={}] - Reuse options including targetPlaylistType and existingFileMode.
+ * @returns {Promise<{source: object|null, reason: string|null}>}
+ */
 export async function resolveReusableTrackSource(track, options = {}) {
   const mode = normalizeExistingFileMode(options.existingFileMode);
   if (mode === "download") {
@@ -562,6 +595,13 @@ export async function resolveReusableTrackSource(track, options = {}) {
   return { source: null, reason: "No reusable Aurral or Lidarr file found" };
 }
 
+/**
+ * Resolves a repair source for a track, checking local storage, Lidarr, and Aurral library.
+ *
+ * @param {object} track - Track metadata to locate for repair.
+ * @param {object} [options={}] - Repair options including targetPlaylistType and existingFileMode.
+ * @returns {Promise<{source: object|null, reason: string|null}>}
+ */
 export async function resolveRepairTrackSource(track, options = {}) {
   const mode = normalizeExistingFileMode(options.existingFileMode);
   if (mode === "download") {

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -118,17 +118,25 @@ function isCanonicalPlaylistType(playlistType) {
   return key === "library" || Boolean(flowPlaylistConfig.getSharedPlaylist(key));
 }
 
+function sanitizeSafeSegment(value, fallback = "Unknown") {
+  const text = sanitizePathPart(value, fallback);
+  if (!text || text === "." || text === ".." || text.startsWith(".")) {
+    return fallback;
+  }
+  return text;
+}
+
 async function findLocalExistingSource(track, options = {}) {
-  const targetPlaylistType = String(options.targetPlaylistType || "").trim();
+  const targetPlaylistType = sanitizeSafeSegment(options.targetPlaylistType, "");
   if (!targetPlaylistType) return null;
 
   const root = path.resolve(options.weeklyFlowRoot || resolveWeeklyFlowRoot());
   const ephemeral = isFlowPlaylistType(targetPlaylistType);
   const canonical = isCanonicalPlaylistType(targetPlaylistType);
 
-  const artistDir = sanitizePathPart(track?.artistName, "Unknown Artist");
-  const albumDir = sanitizePathPart(track?.albumName, "Unknown Album");
-  const expectedBaseName = sanitizePathPart(track?.trackName, "Unknown Track");
+  const artistDir = sanitizeSafeSegment(track?.artistName, "Unknown Artist");
+  const albumDir = sanitizeSafeSegment(track?.albumName, "Unknown Album");
+  const expectedBaseName = sanitizeSafeSegment(track?.trackName, "Unknown Track");
 
   // Build candidate directories.
   // Files can land in different locations depending on playlist type
@@ -154,6 +162,7 @@ async function findLocalExistingSource(track, options = {}) {
   }
 
   for (const destinationDir of candidateDirs) {
+    if (!isPathInsideRoot(destinationDir, root)) continue;
     try {
       const files = await fs.readdir(destinationDir);
       for (const file of files) {
@@ -161,11 +170,13 @@ async function findLocalExistingSource(track, options = {}) {
         const baseName = path.basename(file, ext);
         if (baseName === expectedBaseName && VALID_AUDIO_EXTENSIONS.has(ext)) {
           const filePath = path.join(destinationDir, file);
-          const stat = await fs.stat(filePath);
+          const resolvedFilePath = path.resolve(filePath);
+          if (!isPathInsideRoot(resolvedFilePath, root)) continue;
+          const stat = await fs.stat(resolvedFilePath);
           if (stat.isFile()) {
             return {
               sourceType: "aurral",
-              sourcePath: filePath,
+              sourcePath: resolvedFilePath,
               sourceJob: null,
               albumName: track?.albumName || null,
             };

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -26,6 +26,10 @@ export {
   normalizeExistingFileMode,
 } from "./weeklyFlowFileReuseMode.js";
 
+const VALID_AUDIO_EXTENSIONS = new Set([
+  ".mp3", ".flac", ".m4a", ".ogg", ".opus", ".wav", ".aac", ".ape",
+]);
+
 export function sortJobsForTrackReuse(jobs) {
   return [...jobs].sort((a, b) => {
     const priority = (job) => {
@@ -112,6 +116,72 @@ function isFlowPlaylistType(playlistType) {
 function isCanonicalPlaylistType(playlistType) {
   const key = String(playlistType || "").trim();
   return key === "library" || Boolean(flowPlaylistConfig.getSharedPlaylist(key));
+}
+
+async function findLocalExistingSource(track, options = {}) {
+  const targetPlaylistType = String(options.targetPlaylistType || "").trim();
+  if (!targetPlaylistType) return null;
+
+  const root = path.resolve(options.weeklyFlowRoot || resolveWeeklyFlowRoot());
+  const ephemeral = isFlowPlaylistType(targetPlaylistType);
+  const canonical = isCanonicalPlaylistType(targetPlaylistType);
+
+  const artistDir = sanitizePathPart(track?.artistName, "Unknown Artist");
+  const albumDir = sanitizePathPart(track?.albumName, "Unknown Album");
+  const expectedBaseName = sanitizePathPart(track?.trackName, "Unknown Track");
+
+  // Build candidate directories.
+  // Files can land in different locations depending on playlist type
+  // and whether adoptFileIntoPlaylist has moved them.
+  const candidateDirs = [];
+
+  if (ephemeral) {
+    // Flows store files under: <root>/_flows/<flowId>/Artist/Album/
+    candidateDirs.push(
+      path.resolve(root, AURRAL_FLOWS_DIR, targetPlaylistType, artistDir, albumDir),
+    );
+  } else if (canonical) {
+    // Library and shared playlists store at: <root>/Artist/Album/
+    candidateDirs.push(path.resolve(root, artistDir, albumDir));
+  } else {
+    // Regular playlists: the download pipeline writes to <root>/Artist/Album/
+    // but adoptFileIntoPlaylist may have moved files to
+    // <root>/aurral-weekly-flow/<playlistId>/Artist/Album/
+    candidateDirs.push(path.resolve(root, artistDir, albumDir));
+    candidateDirs.push(
+      path.resolve(root, PLAYLIST_LIBRARY_DIR, targetPlaylistType, artistDir, albumDir),
+    );
+  }
+
+  for (const destinationDir of candidateDirs) {
+    try {
+      const files = await fs.readdir(destinationDir);
+      for (const file of files) {
+        const ext = path.extname(file).toLowerCase();
+        const baseName = path.basename(file, ext);
+        if (baseName === expectedBaseName && VALID_AUDIO_EXTENSIONS.has(ext)) {
+          const filePath = path.join(destinationDir, file);
+          const stat = await fs.stat(filePath);
+          if (stat.isFile()) {
+            return {
+              sourceType: "aurral",
+              sourcePath: filePath,
+              sourceJob: null,
+              albumName: track?.albumName || null,
+            };
+          }
+        }
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        console.warn(
+          `[WeeklyFlowReuse] Failed to check local existing source at ${destinationDir}:`,
+          error.message,
+        );
+      }
+    }
+  }
+  return null;
 }
 
 function tracksShareLibraryMembership(left, right) {
@@ -470,6 +540,10 @@ export async function resolveReusableTrackSource(track, options = {}) {
   if (mode === "download") {
     return { source: null, reason: "Existing file reuse is disabled" };
   }
+
+  const localSource = await findLocalExistingSource(track, options);
+  if (localSource) return { source: localSource, reason: null };
+
   const aurralSource = await findAurralSource(track, options);
   if (aurralSource) return { source: aurralSource, reason: null };
   const lidarrSource = await findLidarrSource(track, options);
@@ -482,6 +556,10 @@ export async function resolveRepairTrackSource(track, options = {}) {
   if (mode === "download") {
     return { source: null, reason: "Existing file reuse is disabled" };
   }
+
+  const localSource = await findLocalExistingSource(track, options);
+  if (localSource) return { source: localSource, reason: null };
+
   const lidarrSource = await findLidarrSource(track, options);
   if (lidarrSource) return { source: lidarrSource, reason: null };
   const aurralSource = await findAurralSource(track, options);


### PR DESCRIPTION
## What changed

- Implemented `findLocalExistingSource` in `backend/services/weeklyFlow/weeklyFlowFileReuse.js` to scan Aurral's local storage paths (`/downloads`, `_flows`, and canonical/library playlist directories) for matching audio files (`.flac`, `.mp3`, `.m4a`, `.aac`, `.ogg`, `.opus`, `.wav`, `.ape`).
- Integrated local file checks into `resolveReusableTrackSource` and `resolveRepairTrackSource` prior to falling back to remote provider searches.
- Added automated unit test coverage in `.tests/weekly-flow/file-reuse.test.js` asserting that local audio files on disk are detected and reused even when no prior job exists in `downloadTracker`.

## Why

Closes #741.

Aurral previously initiated remote network searches on Soulseek, Usenet, and YouTube for every track in newly imported playlists, even when matching, high-quality audio files already existed on local disk in `/downloads`. When importing large playlists with overlapping tracks, this caused redundant P2P searches, wasted bandwidth, incurred peer rate limits, and added hours of unnecessary processing time.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Closes #741

## UI changes

None.

## Testing

- **Automated**: Added unit test `reuseTrackForPlaylist detects and reuses local audio file from disk without prior tracker job (#741)` in `.tests/weekly-flow/file-reuse.test.js`.
- **Manual / Production Validation**: Tested locally in production over multiple days. Spun up a fresh instance pointing at an existing library and verified that local files were immediately detected and reused without triggering remote searches. On test playlists with overlapping tracks (e.g. 132-track festival playlist), 49 overlapping tracks were matched and linked in milliseconds.

## Release impact

- [ ] Major: incompatible change
- [x] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Existing supported audio files are reused directly from local storage when available.
  - Local files take priority during standard reuse and repair workflows.
  - Local file discovery selects files based on playlist type and supported audio formats.

- **Bug Fixes**
  - Improved validation blocks unsafe path-traversal values in playlist, artist, album, and track metadata.
  - Local file discovery and returned file paths remain within the designated storage area.
  - Added regression coverage for rejected path-traversal attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->