### PR TITLE
fix(activity): reconcile completed tracker job status in history requests

### DIFF
--- a/.tests/history/aurral-history.test.js
+++ b/.tests/history/aurral-history.test.js
@@ -177,6 +177,39 @@ test("getAurralHistoryRequests reconciles completed download jobs", async () => 
   assert.equal(entry?.inQueue, false);
 });
 
+test("getAurralHistoryRequests reconciles pending queued jobs as reused when tracker job is done", async () => {
+  const jobId = downloadTracker.addJob(
+    {
+      artistName: "Artist",
+      trackName: "Reused Song",
+    },
+    "playlist-1",
+  );
+  upsertAurralHistory({
+    referenceId: jobId,
+    kind: "track_download",
+    title: "Queueing Reused Song",
+    subtitle: "Artist · Playlist",
+    status: "pending",
+    statusLabel: "Queued",
+    metadata: {
+      jobId,
+      trackName: "Reused Song",
+      artistName: "Artist",
+      playlistId: "playlist-1",
+    },
+    createdAt: Date.now() - 60 * 1000,
+  });
+  downloadTracker.setDone(jobId, "/tmp/reused-song.flac", "Album");
+
+  const entries = await getAurralHistoryRequests();
+  const entry = entries.find((item) => item.jobId === jobId);
+
+  assert.equal(entry?.status, "completed");
+  assert.equal(entry?.statusLabel, "Reused");
+  assert.equal(entry?.inQueue, false);
+});
+
 test("queued library track jobs appear in activity immediately", async () => {
   const jobId = downloadTracker.addJob(
     {

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -1087,6 +1087,14 @@ export const getAurralHistoryRequests = async (lidarrClient = null, user = null)
       const trackName =
         entry.metadata?.trackName ||
         (entry.status === "blocked" && job?.trackName ? job.trackName : null);
+      if (
+        entry.kind === "track_download" &&
+        job?.status === "done" &&
+        (entry.status === "pending" || entry.status === "processing")
+      ) {
+        entry.status = "completed";
+        entry.statusLabel = entry.statusLabel === "Queued" ? "Reused" : "Downloaded";
+      }
       return toHistoryRequestItem(entry, { sourceFilename, albumName, trackName });
     });
 };

--- a/backend/services/aurralHistoryService.js
+++ b/backend/services/aurralHistoryService.js
@@ -591,7 +591,8 @@ export const syncTrackDownloadHistory = async (historyEntries = null) => {
     }
 
     if (job.status === "done") {
-      recordTrackJobCompleted(job);
+      const isReused = entry.statusLabel === "Queued" || job.sourceType === "aurral" || job.sourceType === "lidarr";
+      recordTrackJobCompleted(job, isReused ? "Reused" : "Downloaded");
       continue;
     }
     if (job.status === "failed") {
@@ -936,11 +937,11 @@ export const recordTrackJobMoving = (job) =>
     title: `Moving ${job?.trackName || "track"} into playlist library`,
   });
 
-export const recordTrackJobCompleted = (job) =>
+export const recordTrackJobCompleted = (job, statusLabel = "Downloaded") =>
   recordTrackJob(job, {
     status: "completed",
-    statusLabel: "Downloaded",
-    title: `Downloaded ${job?.trackName || "track"}`,
+    statusLabel,
+    title: `${statusLabel === "Reused" ? "Reused" : "Downloaded"} ${job?.trackName || "track"}`,
     subtitle: `${job?.artistName || "Artist"} · ${resolvePlaylistName(job?.playlistId || job?.playlistType)}`,
   });
 
@@ -1092,8 +1093,9 @@ export const getAurralHistoryRequests = async (lidarrClient = null, user = null)
         job?.status === "done" &&
         (entry.status === "pending" || entry.status === "processing")
       ) {
+        const isReused = entry.statusLabel === "Queued" || job.sourceType === "aurral" || job.sourceType === "lidarr";
         entry.status = "completed";
-        entry.statusLabel = entry.statusLabel === "Queued" ? "Reused" : "Downloaded";
+        entry.statusLabel = isReused ? "Reused" : "Downloaded";
       }
       return toHistoryRequestItem(entry, { sourceFilename, albumName, trackName });
     });


### PR DESCRIPTION
## What changed

- Updated `getAurralHistoryRequests()` in `backend/services/aurralHistoryService.js` to reconcile `aurral_history` records against `jobsById`. When an underlying tracker job reaches `status === "done"` but history remains in `pending` or `processing`, the history item is updated to `status = "completed"` with `statusLabel = "Reused"` (if previously `"Queued"`) or `"Downloaded"`.
- Added unit test in `.tests/history/aurral-history.test.js` asserting that pending queued jobs reconcile to completed status with label "Reused" once tracker job completes.

## Why

After download jobs finished or were reused from local disk, items often stayed visible in the Activity Feed queue (`/activity/queue`) as "Queued" or "Searching" with stale timestamps (e.g., "8:30 PM Yesterday") because `aurral_history` was never updated to reflect the completed tracker job status.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request

## Linked issue

None.

## UI changes

None (ensures the queue UI accurately clears completed and reused items from the active queue feed).

## Testing

- **Automated**: Added unit test in `.tests/history/aurral-history.test.js` verifying pending queued jobs reconcile to completed/reused status when the underlying job is marked done.
- **Manual**: Verified that completed and reused tracks clear from the active `/activity/queue` feed and display under completed history.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download history now accurately reflects completed tracker jobs.
  * Previously queued items are shown as completed with a **Reused** label and are no longer marked as in queue.
  * Completed items sourced from Aurral or Lidarr are labeled **Reused**; other completed items are labeled **Downloaded**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->