### PR TITLE
fix(navidrome): invalidate song cache on publish and prevent dropped playlist tracks

### DIFF
--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -138,10 +138,26 @@ export class NavidromeClient {
     if (relativeMatches.length === 1) return relativeMatches[0];
 
     const mbid = String(track.mbid || "").trim().toLowerCase();
-    if (!mbid) return null;
-    return indexedSongs.find(
-      (song) => String(song.musicBrainzId || "").trim().toLowerCase() === mbid,
-    ) || null;
+    if (mbid) {
+      const mbidMatch = indexedSongs.find(
+        (song) => String(song.musicBrainzId || "").trim().toLowerCase() === mbid,
+      );
+      if (mbidMatch) return mbidMatch;
+    }
+
+    const cleanTitle = String(_title || track.title || track.trackName || "").trim().toLowerCase();
+    const cleanArtist = String(_artist || track.artist || track.artistName || "").trim().toLowerCase();
+    if (cleanTitle && cleanArtist) {
+      return (
+        indexedSongs.find(
+          (song) =>
+            String(song.title || "").trim().toLowerCase() === cleanTitle &&
+            String(song.artist || "").trim().toLowerCase() === cleanArtist,
+        ) || null
+      );
+    }
+
+    return null;
   }
 
   async searchSongsByArtist(artistName, limit = 5) {
@@ -365,8 +381,15 @@ export class NavidromeClient {
     }
   }
 
-  async _getIndexedSongs() {
-    if (!this._indexedSongsPromise) {
+  invalidateIndexedSongsCache() {
+    this._indexedSongsPromise = null;
+    this._indexedSongsAt = 0;
+  }
+
+  async _getIndexedSongs(force = false) {
+    const now = Date.now();
+    if (force || !this._indexedSongsPromise || now - (this._indexedSongsAt || 0) > 30000) {
+      this._indexedSongsAt = now;
       this._indexedSongsPromise = (async () => {
         const songs = [];
         for (let start = 0; ; ) {

--- a/backend/services/navidrome.js
+++ b/backend/services/navidrome.js
@@ -148,13 +148,21 @@ export class NavidromeClient {
     const cleanTitle = String(_title || track.title || track.trackName || "").trim().toLowerCase();
     const cleanArtist = String(_artist || track.artist || track.artistName || "").trim().toLowerCase();
     if (cleanTitle && cleanArtist) {
-      return (
-        indexedSongs.find(
-          (song) =>
-            String(song.title || "").trim().toLowerCase() === cleanTitle &&
-            String(song.artist || "").trim().toLowerCase() === cleanArtist,
-        ) || null
+      const candidateMatches = indexedSongs.filter(
+        (song) =>
+          String(song.title || "").trim().toLowerCase() === cleanTitle &&
+          String(song.artist || "").trim().toLowerCase() === cleanArtist,
       );
+      if (candidateMatches.length === 1) return candidateMatches[0];
+      if (candidateMatches.length > 1) {
+        const cleanAlbum = String(track.album || track.albumName || "").trim().toLowerCase();
+        if (cleanAlbum) {
+          const albumMatches = candidateMatches.filter(
+            (song) => String(song.album || "").trim().toLowerCase() === cleanAlbum,
+          );
+          if (albumMatches.length === 1) return albumMatches[0];
+        }
+      }
     }
 
     return null;

--- a/backend/services/playback/navidromePlaybackDestination.js
+++ b/backend/services/playback/navidromePlaybackDestination.js
@@ -424,6 +424,9 @@ export class NavidromePlaybackDestination {
       pointer = { ...pointer, title: current };
       navidromePlaylistPointerStore.setPointer(snapshot.entityId, targetKey, pointer);
     }
+    if (typeof this.client?.invalidateIndexedSongsCache === "function") {
+      this.client.invalidateIndexedSongsCache();
+    }
     const songs = [];
     for (let index = 0; index < snapshot.tracks.length; index += SONG_LOOKUP_BATCH_SIZE) {
       const batch = snapshot.tracks.slice(index, index + SONG_LOOKUP_BATCH_SIZE);


### PR DESCRIPTION
## What changed

- In `backend/services/navidrome.js`:
  - Added a 30-second TTL to `_getIndexedSongs()` in `NavidromeClient`.
  - Added a public `invalidateIndexedSongsCache()` method to clear the cached song index.
  - Added clean Artist + Title string fallback matching in `findSong()` when exact path and MBID matching fail.
- In `backend/services/playback/navidromePlaybackDestination.js`:
  - Calls `this.client.invalidateIndexedSongsCache()` prior to resolving playlist tracks during playlist publishing.

## Why

When Aurral syncs playlists with Navidrome, `updatePlaylist()` removes all existing playlist entries (`songIndexToRemove: entries.map((_, i) => i)`) and replaces them with resolved `songIds`. Any track for which `findSong()` returns `null` is permanently omitted.

Previously:
1. `_getIndexedSongs()` cached Navidrome songs indefinitely in memory without a TTL or cache invalidation hook, causing newly downloaded or newly indexed tracks to be missed.
2. `findSong()` strictly required an exact filesystem path match or a MusicBrainz ID (`mbid`) and had no fallback matching. Untagged tracks or tracks with minor path differences failed to resolve.

Together, these caused playlists to lose songs or be overwritten with only a fraction of their tracks (e.g. a 10-song playlist shrinking to 3 songs on the next sync).

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request

## Linked issue

None.

## UI changes

None.

## Testing

- **Manual**: Tested against a live Navidrome instance. Verified that newly downloaded and untagged tracks resolve properly via artist/title fallback, and playlists retain all tracks across multiple synchronization cycles without dropping songs.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved song matching when a MusicBrainz ID is unavailable by falling back to title and artist details.
  * Refreshed indexed-song data automatically when the cache becomes stale.
  * Ensured song lookups use updated index data after playlist changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->