### PR TITLE
fix(discovery): annotate adopted discover playlists for plain user ids

### DIFF
--- a/.tests/discovery/discover-playlist-adoption-annotation.test.js
+++ b/.tests/discovery/discover-playlist-adoption-annotation.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, playlistBuilder, weeklyFlowPlaylistConfig] =
+  await setupIsolatedBackend(
+    "discover-playlist-adoption-annotation",
+    "backend/services/discovery/playlistBuilder.js",
+    "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
+  );
+
+const { annotateDiscoverPlaylistsForUser } = playlistBuilder;
+const { flowPlaylistConfig } = weeklyFlowPlaylistConfig;
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+const OWNER_USER_ID = 7;
+
+const flow = flowPlaylistConfig.createFlow({
+  name: "Today's Top Rock",
+  mix: { discover: 34, mix: 33, trending: 33, focus: 0 },
+  size: 20,
+  scheduleDays: [5],
+  scheduleTime: "00:00",
+  ownerUserId: OWNER_USER_ID,
+  discoverPresetId: "top-rock",
+  type: "editorial",
+  tag: "rock",
+});
+
+const discoverPlaylists = [
+  { presetId: "top-rock", name: "Today's Top Rock", tracks: [] },
+  { presetId: "top-metal", name: "Metal Mayhem", tracks: [] },
+];
+
+test("annotates adopted flows when given a plain user id", () => {
+  const annotated = annotateDiscoverPlaylistsForUser(
+    discoverPlaylists,
+    OWNER_USER_ID,
+  );
+  assert.equal(annotated[0].adoptedFlowId, flow.id);
+  assert.equal(annotated[1].adoptedFlowId, null);
+});
+
+test("annotates adopted flows when given a user object", () => {
+  const annotated = annotateDiscoverPlaylistsForUser(discoverPlaylists, {
+    id: OWNER_USER_ID,
+  });
+  assert.equal(annotated[0].adoptedFlowId, flow.id);
+});
+
+test("does not annotate flows owned by another user", () => {
+  const annotated = annotateDiscoverPlaylistsForUser(
+    discoverPlaylists,
+    OWNER_USER_ID + 1,
+  );
+  assert.equal(annotated[0].adoptedFlowId, null);
+});

--- a/backend/services/discovery/playlistBuilder.js
+++ b/backend/services/discovery/playlistBuilder.js
@@ -242,7 +242,8 @@ export async function generateDiscoverPlaylists({
 }
 
 export function annotateDiscoverPlaylistsForUser(playlists, user) {
-  const flows = flowPlaylistConfig.getFlowsOwnedByUser(user?.id);
+  const userId = user && typeof user === "object" ? user.id : user;
+  const flows = flowPlaylistConfig.getFlowsOwnedByUser(userId);
   const adoptedFlowByPresetId = new Map();
   for (const flow of flows) {
     const presetId = String(flow?.discoverPresetId || "").trim();
@@ -250,7 +251,7 @@ export function annotateDiscoverPlaylistsForUser(playlists, user) {
     adoptedFlowByPresetId.set(presetId, flow.id);
   }
   const adoptedPlaylistByPresetId = new Map();
-  for (const playlist of flowPlaylistConfig.getSharedPlaylistsOwnedByUser(user?.id)) {
+  for (const playlist of flowPlaylistConfig.getSharedPlaylistsOwnedByUser(userId)) {
     const presetId = String(playlist?.discoverPresetId || "").trim();
     if (!presetId) continue;
     adoptedPlaylistByPresetId.set(presetId, playlist.id);


### PR DESCRIPTION
## What changed

`annotateDiscoverPlaylistsForUser` now accepts either a user object or a plain user id: it normalizes its second parameter (`user && typeof user === "object" ? user.id : user`) before looking up the user's flows and shared playlists. Added a regression test covering both call shapes plus the other-owner case.

## Why

`getUserDiscovery` calls `annotateDiscoverPlaylistsForUser(discoverPlaylists, userId)` with a plain numeric id, but the function read `user?.id`, which is `undefined` for a number. The ownership check then compared `Number(ownerUserId) === Number(undefined)` (`NaN`), which never matches, so `GET /api/discover` always returned `adoptedFlowId: null` / `adoptedPlaylistId: null` for every playlist.

The visible symptom: the Discover playlist context menu never flips to "Open rotating flow" after adopting — clicking "Add as rotating flow" creates the flow but the card never reflects it, and repeat clicks are silent `alreadyAdopted` no-ops, so adopting looks broken to users.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #777

## Testing

- New `.tests/discovery/discover-playlist-adoption-annotation.test.js`: fails on `main` (plain-id case), passes with the fix.
- `npm test`: 905/905 pass.
- `npm run lint:backend`: clean.
- Verified against a live v2.8.0 instance: adopted flows exist in settings while `GET /api/discover` reports `adoptedFlowId: null` for their presets.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discover playlist annotations when identifying users by either a user ID or a user object.
  * Ensured playlists are correctly annotated for the specified user, including users who own flows or shared playlists.

* **Tests**
  * Added coverage for user IDs, user objects, and cases where the flow belongs to another user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->