### PR TITLE
fix(weekly-flow): avoid unnecessary library scans

### DIFF
--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -49,9 +49,13 @@ test.after(async () => {
 
 test("pipeline completion leaves the library scan to playlist completion", async (t) => {
   const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
-  t.mock.method(playlistManager, "refreshPlaylist", async () => null);
-  t.mock.method(weeklyFlowWorker, "wake", () => {});
-  t.mock.method(weeklyFlowWorker, "checkPlaylistComplete", async () => {});
+  const refreshPlaylist = t.mock.method(playlistManager, "refreshPlaylist", async () => null);
+  const wake = t.mock.method(weeklyFlowWorker, "wake", () => {});
+  const checkPlaylistComplete = t.mock.method(
+    weeklyFlowWorker,
+    "checkPlaylistComplete",
+    async () => {},
+  );
 
   await finalizePipelineJobSuccess({
     downloadTracker: {
@@ -67,6 +71,12 @@ test("pipeline completion leaves the library scan to playlist completion", async
   });
 
   assert.equal(scheduleScanLibrary.mock.callCount(), 0);
+  assert.deepEqual(refreshPlaylist.mock.calls.map((call) => call.arguments), [["flow-playlist"]]);
+  assert.deepEqual(wake.mock.calls.map((call) => call.arguments), [[0]]);
+  assert.deepEqual(
+    checkPlaylistComplete.mock.calls.map((call) => call.arguments),
+    [["flow-playlist"]],
+  );
 });
 
 async function writeOneSecondMp3(filePath) {

--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -19,7 +19,9 @@ const [
   { processDeemixPipelinePayload },
   { dbOps },
   { db },
-  { blockPipelineJobForReview },
+  pipelineHelpersModule,
+  playlistManagerModule,
+  weeklyFlowWorkerModule,
 ] = await setupIsolatedBackend(
   "download-review-routing",
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
@@ -29,7 +31,13 @@ const [
   "backend/db/helpers/index.js",
   "backend/config/db-sqlite.js",
   "backend/services/pipelineHelpers.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
+  "backend/services/weeklyFlow/weeklyFlowWorker.js",
 );
+
+const { blockPipelineJobForReview, finalizePipelineJobSuccess } = pipelineHelpersModule;
+const { playlistManager } = playlistManagerModule;
+const { weeklyFlowWorker } = weeklyFlowWorkerModule;
 
 test.beforeEach(() => {
   resetDatabase(db);
@@ -37,6 +45,28 @@ test.beforeEach(() => {
 
 test.after(async () => {
   await cleanupIsolatedState(isolatedState);
+});
+
+test("pipeline completion leaves the library scan to playlist completion", async (t) => {
+  const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
+  t.mock.method(playlistManager, "refreshPlaylist", async () => null);
+  t.mock.method(weeklyFlowWorker, "wake", () => {});
+  t.mock.method(weeklyFlowWorker, "checkPlaylistComplete", async () => {});
+
+  await finalizePipelineJobSuccess({
+    downloadTracker: {
+      setDone() {},
+    },
+    job: {
+      id: "pipeline-job",
+      playlistType: "flow-playlist",
+      artistName: "Artist",
+      trackName: "Track",
+    },
+    committedFinalPath: "/library/Artist/Track.flac",
+  });
+
+  assert.equal(scheduleScanLibrary.mock.callCount(), 0);
 });
 
 async function writeOneSecondMp3(filePath) {

--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -104,6 +104,7 @@ test("reuseTrackForPlaylist references a completed Aurral track path", async () 
 });
 
 test("reusing an existing track for a flow does not schedule a full library scan", async (t) => {
+  const flow = flowPlaylistConfig.createFlow({ name: "Reuse Flow", size: 10 });
   const track = {
     artistName: "System of a Down",
     trackName: "Chop Suey",
@@ -111,6 +112,8 @@ test("reusing an existing track for a flow does not schedule a full library scan
   };
   const sourcePath = path.join(
     weeklyFlowRoot,
+    "_flows",
+    flow.id,
     "System of a Down",
     "Toxicity",
     "Chop Suey.flac",
@@ -120,7 +123,7 @@ test("reusing an existing track for a flow does not schedule a full library scan
   const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
   t.mock.method(playlistManager, "refreshPlaylist", async () => null);
 
-  const result = await reuseTrackForPlaylist(track, "flow-playlist", {
+  const result = await reuseTrackForPlaylist(track, flow.id, {
     existingFileMode: "reuse",
     weeklyFlowRoot,
   });
@@ -278,7 +281,7 @@ test("restoreCompletedTrack requeues done jobs when the file and reuse source ar
   assert.equal(downloadTracker.getJob(jobId)?.finalPath, null);
 });
 
-test("repairJobsUnderRemovedPlaylistDir requeues other playlists that reused a deleted flow folder", async () => {
+test("repairJobsUnderRemovedPlaylistDir requeues other playlists that reused a deleted flow folder", async (t) => {
   const track = {
     artistName: "Metric",
     trackName: "Victim of Luck",
@@ -295,6 +298,7 @@ test("repairJobsUnderRemovedPlaylistDir requeues other playlists that reused a d
   );
   const jobId = downloadTracker.addJob(track, "active-playlist");
   downloadTracker.setDone(jobId, reusedPath, track.albumName);
+  const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
 
   const result = await repairJobsUnderRemovedPlaylistDir(deletedFlowId, {
     existingFileMode: "reuse",
@@ -305,6 +309,7 @@ test("repairJobsUnderRemovedPlaylistDir requeues other playlists that reused a d
   assert.equal(result.requeued, 1);
   assert.equal(downloadTracker.getJob(jobId)?.status, "pending");
   assert.equal(downloadTracker.getJob(jobId)?.finalPath, null);
+  assert.equal(scheduleScanLibrary.mock.callCount(), 0);
 });
 
 test("repairOrphanedPlaylistTrackPaths finds removed playlist ids from missing file paths", async () => {
@@ -336,7 +341,7 @@ test("repairOrphanedPlaylistTrackPaths finds removed playlist ids from missing f
   assert.equal(downloadTracker.getJob(jobId)?.status, "pending");
 });
 
-test("repairReusableTrackLinks requeues missing completed tracks and refreshes playlists", async () => {
+test("repairReusableTrackLinks requeues missing completed tracks and refreshes playlists", async (t) => {
   const track = {
     artistName: "Portishead",
     trackName: "Glory Box",
@@ -350,6 +355,7 @@ test("repairReusableTrackLinks requeues missing completed tracks and refreshes p
   );
   const jobId = downloadTracker.addJob(track, "flow-playlist");
   downloadTracker.setDone(jobId, missingPath, track.albumName);
+  const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
 
   const result = await repairReusableTrackLinks({
     existingFileMode: "reuse",
@@ -359,6 +365,34 @@ test("repairReusableTrackLinks requeues missing completed tracks and refreshes p
 
   assert.equal(result.requeued, 1);
   assert.equal(downloadTracker.getJob(jobId)?.status, "pending");
+  assert.equal(scheduleScanLibrary.mock.callCount(), 0);
+});
+
+test("repairReusableTrackLinks scans after repairing a library track", async (t) => {
+  const track = {
+    artistName: "Portishead",
+    trackName: "Glory Box",
+    albumName: "Dummy",
+  };
+  const sourcePath = path.join(isolatedState.baseDir, "library-source.flac");
+  await fs.writeFile(sourcePath, "audio");
+  const missingPath = path.join(weeklyFlowRoot, "Portishead", "Dummy", "Glory Box.flac");
+  const jobId = downloadTracker.addJob(track, "library");
+  downloadTracker.setDone(jobId, missingPath, track.albumName);
+  const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
+
+  const result = await repairReusableTrackLinks({
+    existingFileMode: "reuse",
+    weeklyFlowRoot,
+    resolveSource: async () => ({
+      source: { sourceType: "aurral", sourcePath, albumName: track.albumName },
+      reason: null,
+    }),
+  });
+
+  assert.equal(result.repaired, 1);
+  assert.equal(downloadTracker.getJob(jobId)?.finalPath, sourcePath);
+  assert.equal(scheduleScanLibrary.mock.callCount(), 1);
 });
 
 test("reuseTrackForPlaylist path-shares flow files until refresh relocates them", async () => {

--- a/.tests/weekly-flow/file-reuse.test.js
+++ b/.tests/weekly-flow/file-reuse.test.js
@@ -16,6 +16,7 @@ const [
   trackerModule,
   reuseModule,
   playlistConfigModule,
+  playlistManagerModule,
 ] = await setupIsolatedBackend(
   "weekly-flow-file-reuse",
   "backend/config/db-sqlite.js",
@@ -23,10 +24,12 @@ const [
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
   "backend/services/weeklyFlow/weeklyFlowFileReuse.js",
   "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
+  "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
 );
 
 const { downloadTracker } = trackerModule;
 const { flowPlaylistConfig } = playlistConfigModule;
+const { playlistManager } = playlistManagerModule;
 const {
   pathsShareDevice,
   reuseTrackForPlaylist,
@@ -98,6 +101,33 @@ test("reuseTrackForPlaylist references a completed Aurral track path", async () 
   assert.equal(result.finalPath, sourcePath);
   assert.equal(downloadTracker.getJob(result.jobId)?.status, "done");
   assert.equal(downloadTracker.getJob(result.jobId)?.finalPath, sourcePath);
+});
+
+test("reusing an existing track for a flow does not schedule a full library scan", async (t) => {
+  const track = {
+    artistName: "System of a Down",
+    trackName: "Chop Suey",
+    albumName: "Toxicity",
+  };
+  const sourcePath = path.join(
+    weeklyFlowRoot,
+    "System of a Down",
+    "Toxicity",
+    "Chop Suey.flac",
+  );
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.writeFile(sourcePath, "audio");
+  const scheduleScanLibrary = t.mock.method(playlistManager, "scheduleScanLibrary", () => 1);
+  t.mock.method(playlistManager, "refreshPlaylist", async () => null);
+
+  const result = await reuseTrackForPlaylist(track, "flow-playlist", {
+    existingFileMode: "reuse",
+    weeklyFlowRoot,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(result.reused, true);
+  assert.equal(scheduleScanLibrary.mock.callCount(), 0);
 });
 
 test("reuseTrackForPlaylist detects and reuses local audio file from disk without prior tracker job (#741)", async () => {

--- a/backend/services/pipelineHelpers.js
+++ b/backend/services/pipelineHelpers.js
@@ -76,7 +76,6 @@ export async function finalizePipelineJobSuccess({
   const playlistType = job.playlistId || job.playlistType;
   const { playlistManager } = await import("./weeklyFlow/weeklyFlowPlaylistManager.js");
   await playlistManager.refreshPlaylist(playlistType);
-  playlistManager.scheduleScanLibrary();
   const { weeklyFlowWorker } = await import("./weeklyFlow/weeklyFlowWorker.js");
   weeklyFlowWorker.wake(0);
   await weeklyFlowWorker.checkPlaylistComplete(playlistType);

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -885,10 +885,10 @@ export async function repairReusableTrackLinks(options = {}) {
   };
 }
 
-async function refreshPlaylistAfterReuse(playlistType) {
+async function refreshPlaylistAfterReuse(playlistType, scheduleLibraryScan = false) {
   const { playlistManager } = await import("./weeklyFlowPlaylistManager.js");
   await playlistManager.refreshPlaylist(playlistType);
-  playlistManager.scheduleScanLibrary();
+  if (scheduleLibraryScan) playlistManager.scheduleScanLibrary();
 }
 
 export async function reuseTrackForPlaylist(track, playlistType, options = {}) {
@@ -961,7 +961,7 @@ export async function reuseTrackForPlaylist(track, playlistType, options = {}) {
       )
       .catch(() => {});
   }
-  refreshPlaylistAfterReuse(playlistType).catch((error) => {
+  refreshPlaylistAfterReuse(playlistType, targetPlaylistType === "library").catch((error) => {
     console.warn(
       `[WeeklyFlowReuse] Failed to refresh playlist ${playlistType}: ${error?.message || error}`,
     );

--- a/backend/services/weeklyFlow/weeklyFlowFileReuse.js
+++ b/backend/services/weeklyFlow/weeklyFlowFileReuse.js
@@ -730,7 +730,7 @@ export async function repairJobsUnderRemovedPlaylistDir(playlistType, options = 
     for (const changedPlaylistType of changedPlaylistTypes) {
       await playlistManager.refreshPlaylist(changedPlaylistType).catch(() => {});
     }
-    playlistManager.scheduleScanLibrary();
+    if (changedPlaylistTypes.has("library")) playlistManager.scheduleScanLibrary();
   }
 
   return {
@@ -862,7 +862,7 @@ export async function repairReusableTrackLinks(options = {}) {
     for (const playlistType of changedPlaylistTypes) {
       await playlistManager.refreshPlaylist(playlistType).catch(() => {});
     }
-    playlistManager.scheduleScanLibrary();
+    if (changedPlaylistTypes.has("library")) playlistManager.scheduleScanLibrary();
     if (requeued > 0) {
       const [{ weeklyFlowWorker }, { restartWorkerIfPending }] = await Promise.all([
         import("./weeklyFlowWorker.js"),


### PR DESCRIPTION
## What changed

Stopped scheduling full library scans when completing pipeline jobs or reusing tracks for flow playlists. Library scans remain enabled for library playlist reuse.

## Why

Flow playlist updates only require playlist refreshes, so triggering a full library scan adds unnecessary work. This change reduces redundant scans while preserving library playlist behavior.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## UI changes

Not applicable.

## Testing

- Added coverage confirming pipeline completion does not schedule a library scan.
- Added coverage confirming flow playlist track reuse does not schedule a library scan.
- Existing library playlist scan behavior remains covered by the implementation path.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary full library scans when completing flow-playlist pipeline jobs.
  - Reusing tracks in flow playlists now refreshes the playlist without triggering a library scan.
  - Library playlist track reuse continues to schedule the required library scan.
  - Repairs now schedule library scans only when library playlist tracks are affected.
- **Tests**
  - Added regression coverage for pipeline completion, playlist refresh behavior, and track reuse to verify scan scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->