### PR TITLE
fix(lidarr): prevent large library scans from getting stuck

### DIFF
--- a/.tests/library/library-refresh.test.js
+++ b/.tests/library/library-refresh.test.js
@@ -143,6 +143,35 @@ test("library scan scheduling keeps one live job and recovers stale registry ent
   }
 });
 
+test("library refresh replaces a scan whose processing claim expired", () => {
+  const queue = getLibraryScanQueue();
+  clearScheduledLibraryScan();
+  let staleJobId;
+  let replacementJobId;
+  try {
+    staleJobId = scheduleLibraryScan();
+    const claimed = queue.claimOne("stale-library-scan-test");
+    assert.equal(claimed?.id, staleJobId);
+    db.prepare("UPDATE _honker_live SET claim_expires_at = ? WHERE id = ?").run(
+      Math.floor(Date.now() / 1000) - 1,
+      staleJobId,
+    );
+
+    replacementJobId = scheduleLibraryScan({ force: true });
+
+    assert.notEqual(replacementJobId, staleJobId);
+    assert.equal(queue.getJob(staleJobId), null);
+    assert.deepEqual(JSON.parse(queue.getJob(replacementJobId).payload), {
+      force: true,
+      includeLidarr: true,
+    });
+  } finally {
+    if (staleJobId) queue.cancel(staleJobId);
+    if (replacementJobId) queue.cancel(replacementJobId);
+    clearScheduledLibraryScan();
+  }
+});
+
 test("a full refresh upgrades a pending local-only scan", () => {
   const queue = getLibraryScanQueue();
   clearScheduledLibraryScan();

--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -59,6 +59,40 @@ test("bulk track reads use Lidarr artist selectors", async (t) => {
   client._httpsInsecureAgent.destroy();
 });
 
+test("bulk album reads use Lidarr artist selectors when requested", async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("[]");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+
+  await client.getAllAlbums({ artistIds: [7, 8], forceRefresh: true });
+
+  assert.deepEqual(requests.sort(), [
+    "/api/v1/album?artistId=7",
+    "/api/v1/album?artistId=8",
+  ]);
+  client._httpAgent.destroy();
+  client._httpsAgent.destroy();
+  client._httpsInsecureAgent.destroy();
+});
+
 test("bulk reads wait for active requests before failing", async () => {
   const client = new LidarrClient();
   const artistIds = Array.from({ length: 14 }, (_, index) => index + 1);

--- a/backend/services/libraryLidarrIndexer.js
+++ b/backend/services/libraryLidarrIndexer.js
@@ -161,9 +161,12 @@ export async function indexLidarrLibrary({ client, syncSearch = true } = {}) {
     return { skipped: true, filesSeen: 0, filesIndexed: 0, filesFailed: 0 };
   }
 
-  const [artists, albums, rootFolders] = await Promise.all([
-    client.request("/artist", "GET", null, false, { forceRefresh: true }),
-    client.getAllAlbums({ forceRefresh: true }),
+  const artists = await client.request("/artist", "GET", null, false, { forceRefresh: true });
+  const [albums, rootFolders] = await Promise.all([
+    client.getAllAlbums({
+      artistIds: (Array.isArray(artists) ? artists : []).map((artist) => artist?.id),
+      forceRefresh: true,
+    }),
     client.getRootFolders(),
   ]);
   if (

--- a/backend/services/libraryScanWorker.js
+++ b/backend/services/libraryScanWorker.js
@@ -23,7 +23,16 @@ function normalizeJobId(value) {
 }
 
 function hasLiveScanJob(jobId) {
-  return Boolean(getLibraryScanQueue().getJob(jobId));
+  const queue = getLibraryScanQueue();
+  const job = queue.getJob(jobId);
+  if (!job) return false;
+  if (job.state !== "processing") return true;
+  const claimExpiresAt = Number(job.claim_expires_at ?? job.claimExpiresAt);
+  if (!Number.isFinite(claimExpiresAt) || claimExpiresAt > Math.floor(Date.now() / 1000)) {
+    return true;
+  }
+  queue.cancel(jobId);
+  return false;
 }
 
 export function getScheduledLibraryScanJobId() {

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -1419,7 +1419,30 @@ export class LidarrClient {
   }
 
   async getAllAlbums(options = {}) {
-    const albums = await this.request("/album", "GET", null, false, options);
+    const { artistIds, ...requestOptions } = options;
+    if (Array.isArray(artistIds)) {
+      const normalizedArtistIds = normalizeLidarrArtistIds(artistIds);
+      if (normalizedArtistIds.length === 0) return [];
+      const results = await mapWithConcurrency(
+        normalizedArtistIds,
+        LIDARR_MAX_CONCURRENT,
+        async (artistId) => {
+          const albums = await this.request(
+            `/album?artistId=${artistId}`,
+            "GET",
+            null,
+            false,
+            requestOptions,
+          );
+          if (Array.isArray(albums)) return albums;
+          if (albums?.records && Array.isArray(albums.records)) return albums.records;
+          return [];
+        },
+        { stopOnError: true },
+      );
+      return results.flat();
+    }
+    const albums = await this.request("/album", "GET", null, false, requestOptions);
     return Array.isArray(albums) ? albums : [];
   }
 


### PR DESCRIPTION
Lidarr libraries with thousands of albums can make Aurral's startup scan abort before the library becomes browsable. A scan whose processing claim expires can also leave refreshes reusing the stuck job.

The scan now loads artists first and requests albums per artist with bounded concurrency. Refresh scheduling drops an expired processing claim so it can enqueue a new scan.

Verification:
- Reproduced the unfiltered album request and stale job reuse before the fix.
- Shared testing stack: 11 artist-scoped album requests, 0 unfiltered album requests; authenticated refresh completed.
- `npm test` (952 passed)
- `npm run lint:backend -- --quiet`
- `npm run build`
- `git diff --check`

The shared test fixture contains no available Lidarr track files, so native playback availability could not be verified there.

Closes #762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved library scan scheduling by replacing jobs whose processing claims have expired.
  - Prevented stale scan jobs from remaining active in the queue.
  - Improved Lidarr library indexing by limiting album retrieval to the currently discovered artists.
  - Added support for more reliable artist-specific album retrieval while preserving full-library album scans when no filter is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->