### PR TITLE
fix(subsonic): mark album directory entries correctly

### DIFF
--- a/.tests/subsonic/subsonic-library.test.js
+++ b/.tests/subsonic/subsonic-library.test.js
@@ -15,7 +15,7 @@ const [isolatedState, { db }, subsonic, libraryStore] =
     "backend/services/libraryMediaStore.js",
   );
 
-const { getAlbumList, getTopSongs, starMany } = subsonic;
+const { getAlbumList, getMusicDirectory, getTopSongs, starMany } = subsonic;
 
 const {
   linkLibraryAlbumTrack,
@@ -125,4 +125,12 @@ test("returns top songs only for the requested artist", () => {
     getTopSongs("  test-artist:artist-a  ", { count: 10 }).map((song) => song.title),
     ["New Song", "Old Song"],
   );
+});
+
+test("marks album entries as directories in artist music directories", () => {
+  const directory = getMusicDirectory(`artist:${encodeURIComponent("test-artist:artist-a")}`);
+
+  assert.ok(directory);
+  assert.equal(directory.child.length, 2);
+  assert.equal(directory.child.every((album) => album.isDir === true), true);
 });

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -175,7 +175,7 @@ const albumData = (library, album) => {
     artistId: artistValue.id,
     artists: [artistValue],
     parent: artistValue.id,
-    isDir: false,
+    isDir: true,
     isVideo: false,
     created: PROTOCOL_DATE,
     coverArt: coverArtForAlbum(album),


### PR DESCRIPTION
Symfonium treats album entries from `getMusicDirectory` as playable songs because Aurral marks them with `isDir: false`. The response now marks albums as directories while leaving song entries unchanged.

Verification:
- `node --test --import ./.tests/setup-env.js .tests/subsonic/subsonic-library.test.js`

Fixes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Albums in an artist’s music directory are now correctly identified as navigable directories.
  * Album directories now display their available child items correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->