### PR TITLE
fix(auth): honor explicit proxy auth disable setting

### DIFF
--- a/.tests/auth/proxy-auth.test.js
+++ b/.tests/auth/proxy-auth.test.js
@@ -16,7 +16,7 @@ const [isolatedState, { db }, dbHelpers, authModule, sessionModule] = await setu
 );
 
 const { dbOps, userOps } = dbHelpers;
-const { issueProxySession, resolveProxyUser, resolveRequestUser } = authModule;
+const { isProxyAuthEnabled, issueProxySession, resolveProxyUser, resolveRequestUser } = authModule;
 const { getSessionByToken } = sessionModule;
 
 const completeOnboarding = () => dbOps.updateSettings({ onboardingComplete: true });
@@ -104,6 +104,18 @@ test("proxy auth does not create users from untrusted proxy IPs", () => {
   );
 
   assert.equal(resolved, null);
+  assert.equal(userOps.getAllUsers().length, 0);
+});
+
+test("explicitly disabling proxy auth overrides a configured header", () => {
+  process.env.AUTH_PROXY_ENABLED = "false";
+  process.env.AUTH_PROXY_HEADER = "x-authentik-username";
+
+  assert.equal(isProxyAuthEnabled(), false);
+  assert.equal(
+    resolveProxyUser(proxyRequest({ "x-authentik-username": "mallory" })),
+    null,
+  );
   assert.equal(userOps.getAllUsers().length, 0);
 });
 

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -80,7 +80,9 @@ export const rotateApiKey = () => {
 };
 
 export const isProxyAuthEnabled = () => {
-  if (process.env.AUTH_PROXY_ENABLED === "true") return true;
+  if (process.env.AUTH_PROXY_ENABLED !== undefined) {
+    return process.env.AUTH_PROXY_ENABLED === "true";
+  }
   return !!process.env.AUTH_PROXY_HEADER;
 };
 


### PR DESCRIPTION
## Problem
`AUTH_PROXY_HEADER` enabled proxy authentication even when `AUTH_PROXY_ENABLED=false`, so deployments could not explicitly disable proxy auth.

## Solution
Treat an explicitly set `AUTH_PROXY_ENABLED` value as authoritative while preserving header-based legacy enablement when the flag is unset.

## Verification
- `node --test --import ./.tests/setup-env.js .tests/auth/proxy-auth.test.js`
- `node --test --import ./.tests/setup-env.js .tests/auth/*.test.js`
- `git diff --check`

## Scope
This fixes the reproducible proxy-auth configuration bug reported in #618. OIDC provider/deployment-specific configuration is unchanged.

Fixes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Proxy authentication can now be explicitly disabled with `AUTH_PROXY_ENABLED=false`, even when a proxy authentication header is configured.
  - When disabled, proxy headers no longer resolve or create users.
  - Proxy authentication continues to be enabled automatically when the setting is unset and a proxy header is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->