### PR TITLE
fix(ytdlp): validate channels and review identity mismatches

### DIFF
--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -218,6 +218,51 @@ test("yt-dlp sends weak title matches to review", async () => {
   await access(filePath);
 });
 
+test("yt-dlp sends other identity mismatches to review", async () => {
+  const jobId = downloadTracker.addJob(
+    {
+      artistName: "Artist Name",
+      trackName: "Correct Track",
+      albumName: "",
+      durationMs: 1000,
+    },
+    "ytdlp-weak-artist-review",
+  );
+  downloadTracker.setDownloading(jobId);
+  const filePath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    ".ytdlp-staging",
+    jobId,
+    "Correct.mp3",
+  );
+  await writeOneSecondMp3(filePath);
+
+  const result = await processYtdlpPipelinePayload(
+    {
+      phase: "finalize",
+      source: "ytdlp",
+      jobId,
+      downloadedPath: filePath,
+      destination: "ytdlp-weak-artist-review/Artist Name",
+      candidate: {
+        raw: {
+          id: "video-weak-artist",
+          title: "Correct",
+        },
+      },
+      candidateIndex: 0,
+    },
+    { failOrTryNextSource: failIfPipelineFallsThrough },
+  );
+
+  assert.equal(result, null);
+  const job = downloadTracker.getJob(jobId);
+  assert.equal(job.status, "blocked");
+  assert.match(job.error, /^weak-artist-match:/);
+  assert.equal(job.stagingPath, filePath);
+  await access(filePath);
+});
+
 test("Usenet sends its best plausible duration mismatch to review", async () => {
   const server = await createMockHttpServer((req, res) => {
     req.resume();

--- a/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
+++ b/.tests/weekly-flow/weekly-flow-soulseek-matcher.test.js
@@ -952,6 +952,25 @@ test("validateDownloadedTrack scores identity before final quality admission", a
   assert.ok(accepted.scores.title >= 82);
 });
 
+test("validateDownloadedTrack uses yt-dlp channel metadata as an artist signal", async () => {
+  const validated = await validateDownloadedTrack(
+    "/tmp/does-not-exist.mp3",
+    {
+      raw: {
+        channel: "Drake",
+        file: "0 to 100 The Catch Up.mp3",
+      },
+    },
+    {
+      artistName: "Drake",
+      trackName: "0 to 100 / The Catch Up",
+    },
+  );
+
+  assert.equal(validated.scores.artist, 100);
+  assert.match(validated.reason, /^quality-unknown:/);
+});
+
 test("validateDownloadedTrack accepts a remote filename that omits the requested version suffix", async () => {
   const validated = await validateDownloadedTrack(
     "/tmp/does-not-exist.mp3",

--- a/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
+++ b/backend/services/weeklyFlow/weeklyFlowSoulseekMatcher.js
@@ -649,11 +649,13 @@ function readFileNameArtistTitle(context, filePath) {
   }, null);
 }
 
-function collectArtistTags(common) {
+function collectArtistTags(common, candidate) {
   return [
     common?.artist,
     ...(Array.isArray(common?.artists) ? common.artists : []),
     common?.albumartist,
+    candidate?.raw?.channel,
+    candidate?.raw?.uploader,
   ].filter(Boolean);
 }
 
@@ -1160,7 +1162,7 @@ export async function validateDownloadedTrack(filePath, candidate, context) {
   );
   const artistScore = Math.max(
     0,
-    ...collectArtistTags(metadata).map((tag) => pickBestArtistScore(context, tag)),
+    ...collectArtistTags(metadata, candidate).map((tag) => pickBestArtistScore(context, tag)),
     pickBestArtistScore(context, remoteFilename),
   );
   const albumScore = albumName

--- a/backend/services/ytdlpOrchestrator.js
+++ b/backend/services/ytdlpOrchestrator.js
@@ -183,8 +183,7 @@ async function handleYtdlpFinalize(payload, helpers) {
     resolvedTrack,
   );
   if (!validation.valid) {
-    const reviewable =
-      validation.blocked || validation.scores?.matchReason === "weak-title-match";
+    const reviewable = validation.blocked || Boolean(validation.scores?.matchReason);
     if (reviewable && blockPipelineJobForReview({
       downloadTracker,
       job,


### PR DESCRIPTION
## Problem
Post-download yt-dlp validation ignored the candidate uploader/channel, so title-only official uploads could be rejected with `weak-artist-match`. Other identity mismatch reasons were then deleted as hard failures instead of being available for review.

## Solution
- Include yt-dlp channel/uploader metadata in the shared artist score.
- Route any identity match rejection to the existing review path while leaving quality-only failures on the existing hard-fail path.

## Verification
- `node --test --import ./.tests/setup-env.js .tests/weekly-flow/weekly-flow-soulseek-matcher.test.js .tests/weekly-flow/download-review-routing.test.js`
- `git diff --check`

Fixes #786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artist matching for downloaded tracks by considering additional uploader and channel metadata.
  - More identity-mismatch cases are now routed for manual review instead of being incorrectly finalized.
  - Downloaded files associated with review-required mismatches remain available for follow-up and inspection.
  - Validation outcomes now provide more consistent handling when artist information is incomplete or uncertain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->