### PR TITLE
fix(tasks): report queue counts beyond display limit

### DIFF
--- a/.tests/honker/honker-worker-runtime.test.js
+++ b/.tests/honker/honker-worker-runtime.test.js
@@ -41,6 +41,22 @@ test("getHonkerQueueNextClaimAt reports delayed queue work", () => {
   assert.equal(nextClaimAt, runAt);
 });
 
+test("task status reports queued jobs beyond the live row display limit", async () => {
+  const queue = honkerDb.getPipelineQueue();
+  const jobIds = [];
+  for (let index = 0; index < 501; index += 1) {
+    jobIds.push(queue.enqueue({ kind: `queue-count-${index}` }));
+  }
+
+  try {
+    const status = await taskStatus.getHonkerTaskStatus();
+    const worker = status.workers.find((entry) => entry.queue === "slskd-pipeline");
+    assert.equal(worker?.queued, 501);
+  } finally {
+    for (const jobId of jobIds) queue.cancel(jobId);
+  }
+});
+
 test("withJobHeartbeat extends job claim while work runs", async () => {
   const queue = honkerDb.getLibraryScanQueue();
   const jobId = queue.enqueue({ kind: "heartbeat-test" });

--- a/backend/services/honkerTaskStatus.js
+++ b/backend/services/honkerTaskStatus.js
@@ -732,6 +732,43 @@ function readLiveJobs() {
   );
 }
 
+function readLiveJobStats() {
+  const currentTime = nowUnix();
+  return safeQuery(
+    `
+      SELECT queue,
+             COUNT(*) AS live_count,
+             SUM(CASE WHEN state = 'processing' THEN 1 ELSE 0 END) AS running_count,
+             SUM(CASE
+                   WHEN state != 'processing' AND COALESCE(run_at, 0) > ? THEN 1
+                   ELSE 0
+                 END) AS scheduled_count,
+             SUM(CASE
+                   WHEN state != 'processing' AND COALESCE(run_at, 0) <= ? THEN 1
+                   ELSE 0
+                 END) AS queued_count,
+             MIN(CASE
+                   WHEN state != 'processing' AND COALESCE(run_at, 0) > ? THEN run_at
+                   ELSE NULL
+                 END) AS next_run_at
+      FROM _honker_live
+      GROUP BY queue
+    `,
+    [currentTime, currentTime, currentTime],
+  );
+}
+
+function readScheduledLiveJobs() {
+  return safeQuery(
+    `
+      SELECT queue, payload, run_at
+      FROM _honker_live
+      WHERE state != 'processing' AND COALESCE(run_at, 0) > ?
+    `,
+    [nowUnix()],
+  );
+}
+
 function readDeadJobs() {
   const cutoff = getRunLedgerCutoffUnix();
   return safeQuery(
@@ -747,7 +784,7 @@ function readDeadJobs() {
   );
 }
 
-function readQueueStats(liveRows = []) {
+function readQueueStats(liveRows = [], liveStats = [], scheduledRows = []) {
   const currentTime = nowUnix();
   const deadStats = safeQuery(
     `
@@ -816,6 +853,22 @@ function readQueueStats(liveRows = []) {
     } else {
       entry.queuedCount += 1;
     }
+  }
+  for (const row of scheduledRows) {
+    const entry = ensure(row.queue);
+    const runAt = Number(row.run_at || 0);
+    entry.scheduledKeys.add(taskMatchKey(row.queue, parsePayload(row.payload)));
+    if (!entry.nextRunAt || runAt < Number(Date.parse(entry.nextRunAt) / 1000)) {
+      entry.nextRunAt = unixToIso(runAt);
+    }
+  }
+  for (const row of liveStats) {
+    const entry = ensure(row.queue);
+    entry.liveCount = Number(row.live_count || 0);
+    entry.runningCount = Number(row.running_count || 0);
+    entry.queuedCount = Number(row.queued_count || 0);
+    entry.scheduledCount = Number(row.scheduled_count || 0);
+    entry.nextRunAt = row.next_run_at ? unixToIso(row.next_run_at) : null;
   }
   for (const row of deadStats) {
     ensure(row.queue).failedCount = Number(row.failed_count || 0);
@@ -1142,10 +1195,12 @@ export async function getHonkerTaskStatus() {
   const scheduledRows = readScheduledRows();
   const latestRunsByTask = readLatestRunsByTask();
   const liveRows = readLiveJobs();
+  const liveStats = readLiveJobStats();
+  const scheduledLiveRows = readScheduledLiveJobs();
   const deadRows = readDeadJobs();
   const runRows = readRecentRuns();
   const runningStartsByJobId = readRunningStartsByJobId();
-  const queueStats = readQueueStats(liveRows);
+  const queueStats = readQueueStats(liveRows, liveStats, scheduledLiveRows);
   const workerStatuses = await readWorkerStatuses();
   const workers = normalizeWorkerRows(workerStatuses, queueStats);
   const queue = normalizeQueueRows(liveRows, deadRows, runRows, runningStartsByJobId);


### PR DESCRIPTION
## Problem
The Tasks page counted live jobs from the same 500-row result used for the queue display, so the Download Pipeline worker stayed pinned at 500 for larger imports.

## Solution
Keep the queue display bounded, but calculate live worker counts and next-run data with aggregate queries over the full live-job table. Scheduled task identity grouping remains preserved.

## Verification
- `node --test --import ./.tests/setup-env.js .tests/honker/honker-worker-runtime.test.js`
- `git diff --check`

Fixes #749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected worker status reporting so queued jobs are counted accurately, including queues with more than 500 jobs.
  * Improved visibility of running, queued, and scheduled jobs, including their next scheduled run times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->