### PR TITLE
fix(flows): reject ownerless API-key flow creation

### DIFF
--- a/.tests/weekly-flow/playlist-config.test.js
+++ b/.tests/weekly-flow/playlist-config.test.js
@@ -7,16 +7,25 @@ import {
   resetDatabase,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps }, playlistConfigModule, flowHandlerUtils] =
+const [
+  isolatedState,
+  { db },
+  { dbOps },
+  playlistConfigModule,
+  flowHandlerUtils,
+  flowHandlersModule,
+] =
   await setupIsolatedBackend(
     "playlist-config",
     "backend/config/db-sqlite.js",
     "backend/db/helpers/index.js",
     "backend/services/weeklyFlow/weeklyFlowPlaylistConfig.js",
     "backend/routes/weeklyFlow/handlers/utils.js",
+    "backend/routes/weeklyFlow/handlers/flows.js",
   );
 const { flowPlaylistConfig, normalizeImportSource, tracksShareMembership } = playlistConfigModule;
 const { validateFlowPayload } = flowHandlerUtils;
+const { registerFlows } = flowHandlersModule;
 
 test.beforeEach(() => {
   resetDatabase(db);
@@ -107,6 +116,42 @@ test("normalizes invalid playlist owners to null", () => {
   flowPlaylistConfig.deleteFlow(unowned.id);
   flowPlaylistConfig.deleteSharedPlaylist(unownedPlaylist.id);
   flowPlaylistConfig.deleteFlow(owned.id);
+});
+
+test("rejects flow creation without a real user owner", async () => {
+  const beforeFlowIds = flowPlaylistConfig.getFlows().map((flow) => flow.id);
+  let createHandler;
+  const router = {
+    post(path, ...handlers) {
+      if (path === "/flows") createHandler = handlers.at(-1);
+    },
+    put() {},
+    delete() {},
+    get() {},
+  };
+  registerFlows(router);
+
+  const response = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+
+  await createHandler({ body: {}, user: { id: -1, role: "admin" } }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error, "Flow ownership requires a real user");
+  assert.deepEqual(
+    flowPlaylistConfig.getFlows().map((flow) => flow.id),
+    beforeFlowIds,
+  );
 });
 
 test("defaults listening history on and persists a flow opt-out", () => {

--- a/backend/routes/weeklyFlow/handlers/flows.js
+++ b/backend/routes/weeklyFlow/handlers/flows.js
@@ -76,6 +76,13 @@ export function registerFlows(router) {
 
   router.post("/flows", async (req, res) => {
     try {
+      const ownerUserId = Number(req.user?.id);
+      if (!Number.isSafeInteger(ownerUserId) || ownerUserId <= 0) {
+        return res.status(400).json({
+          error: "Flow ownership requires a real user",
+          message: "Authenticate as a user account before creating a flow.",
+        });
+      }
       const {
         name,
         mix,
@@ -105,7 +112,7 @@ export function registerFlows(router) {
         relatedArtists,
         scheduleDays,
         scheduleTime,
-        ownerUserId: req.user.id,
+        ownerUserId,
       });
       await playlistManager.ensureSmartPlaylists();
       res.json({ success: true, flow });


### PR DESCRIPTION
## Problem
The instance-wide API key resolves to a synthetic user with no real database owner. `POST /flows` passed that identity through, normalized it to `null`, and returned 200 for a flow invisible to every real user.

## Solution
Reject flow creation when the authenticated identity does not have a positive, real user ID. This makes the ownership limitation explicit and prevents silent orphaned flows.

## Verification
- `node --test --import ./.tests/setup-env.js .tests/weekly-flow/playlist-config.test.js`
- `git diff --check`

## Scope
This deliberately chooses the safe error path from the issue rather than introducing an API for impersonating another user. A future owner-selection API would need its own authorization and validation contract.

Fixes #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented playlist flow creation when the requesting account does not have a valid user identity.
  * Added clear validation feedback with a 400 error response instead of creating an unowned flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->