### PR TITLE
fix(http): honor environment proxies in axios fetch

### DIFF
--- a/.tests/helpers/api-client-utils.test.js
+++ b/.tests/helpers/api-client-utils.test.js
@@ -114,6 +114,71 @@ test("fetch timeouts expose an axios-compatible timeout code", async () => {
   }
 });
 
+test("uses environment proxy settings when NODE_USE_ENV_PROXY is enabled", async () => {
+  let targetHits = 0;
+  let proxyHits = 0;
+  const target = http.createServer((_request, response) => {
+    targetHits += 1;
+    response.end("direct");
+  });
+  const proxy = http.createServer((_request, response) => {
+    proxyHits += 1;
+    response.end("proxied");
+  });
+  await Promise.all([
+    new Promise((resolve) => target.listen(0, "127.0.0.1", resolve)),
+    new Promise((resolve) => proxy.listen(0, "127.0.0.1", resolve)),
+  ]);
+
+  const saved = Object.fromEntries(
+    ["NODE_USE_ENV_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]
+      .map((name) => [name, process.env[name]]),
+  );
+  const restoreEnvironment = () => {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  };
+
+  try {
+    const proxyUrl = `http://127.0.0.1:${proxy.address().port}`;
+    process.env.NODE_USE_ENV_PROXY = "1";
+    process.env.HTTP_PROXY = proxyUrl;
+    process.env.HTTPS_PROXY = proxyUrl;
+    process.env.http_proxy = proxyUrl;
+    process.env.https_proxy = proxyUrl;
+    process.env.NO_PROXY = "";
+    process.env.no_proxy = "";
+
+    const response = await axios.get(`http://127.0.0.1:${target.address().port}`);
+    assert.equal(response.data, "proxied");
+    assert.equal(proxyHits, 1);
+    assert.equal(targetHits, 0);
+
+    process.env.NO_PROXY = "127.0.0.1";
+    process.env.no_proxy = "127.0.0.1";
+    const noProxyResponse = await axios.get(`http://127.0.0.1:${target.address().port}`);
+    assert.equal(noProxyResponse.data, "direct");
+    assert.equal(proxyHits, 1);
+    assert.equal(targetHits, 1);
+
+    delete process.env.NODE_USE_ENV_PROXY;
+    process.env.NO_PROXY = "";
+    process.env.no_proxy = "";
+    const disabledResponse = await axios.get(`http://127.0.0.1:${target.address().port}`);
+    assert.equal(disabledResponse.data, "direct");
+    assert.equal(proxyHits, 1);
+    assert.equal(targetHits, 2);
+  } finally {
+    restoreEnvironment();
+    await Promise.all([
+      new Promise((resolve) => target.close(resolve)),
+      new Promise((resolve) => proxy.close(resolve)),
+    ]);
+  }
+});
+
 test("public-only transport rejects socket failures without an uncaught exception", () => {
   const moduleUrl = new URL("../../lib/axiosFetch.js", import.meta.url).href;
   const result = spawnSync(process.execPath, ["--input-type=module", "--eval", `

--- a/lib/axiosFetch.js
+++ b/lib/axiosFetch.js
@@ -1,5 +1,5 @@
 import { Readable } from "node:stream";
-import { Agent, fetch as undiciFetch } from "undici";
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
 import { resolvePublicUrl } from "./publicUrl.js";
 
 const usesNativeFetch = () => Function.prototype.toString.call(globalThis.fetch).includes("internal/deps/undici");
@@ -39,6 +39,8 @@ const defaultDispatcher = new Agent({
   keepAliveMaxTimeout: 60_000,
 });
 
+let envProxyDispatcher = null;
+
 const insecureDispatcher = new Agent({
   connections: 16,
   keepAliveTimeout: 30_000,
@@ -49,6 +51,10 @@ const insecureDispatcher = new Agent({
 function resolveDispatcher(config) {
   if (config.httpsAgent?.options?.rejectUnauthorized === false) {
     return insecureDispatcher;
+  }
+  if (process.env.NODE_USE_ENV_PROXY === "1") {
+    envProxyDispatcher ||= new EnvHttpProxyAgent();
+    return envProxyDispatcher;
   }
   return defaultDispatcher;
 }


### PR DESCRIPTION
## Problem
`lib/axiosFetch.js` supplied a direct Undici `Agent` for every normal request, bypassing `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` when `NODE_USE_ENV_PROXY=1`.

## Solution
Lazily use Undici's `EnvHttpProxyAgent` when the opt-in environment flag is enabled. The existing direct/insecure dispatchers remain in place otherwise, and `publicOnly` requests still replace the dispatcher with their SSRF-safe DNS-bound agent.

## Verification
- `node --test --import ./.tests/setup-env.js .tests/helpers/api-client-utils.test.js`
- Covers proxy routing, `NO_PROXY`, and disabled-flag direct routing.
- `git diff --check`

Fixes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for routing fetch requests through environment-configured HTTP and HTTPS proxies when enabled.
  - Supports proxy bypass rules for specified hosts through `NO_PROXY`.

- **Bug Fixes**
  - Preserves direct request routing when environment proxy support is disabled or when a host matches the bypass configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->