### PR TITLE
fix(deemix): reuse existing playlist files

### DIFF
--- a/.tests/weekly-flow/download-review-routing.test.js
+++ b/.tests/weekly-flow/download-review-routing.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { access, mkdir } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 
 import {
@@ -381,5 +381,88 @@ test("deemix drops its queue entry before a track goes to review", async () => {
     assert.deepEqual(removed, ["track_1_1"]);
   } finally {
     await server.close();
+  }
+});
+
+test("deemix reuses an existing final path instead of creating a duplicate", async () => {
+  const sourcePath = path.join(
+    process.env.DOWNLOAD_FOLDER,
+    "deemix-duplicate-source",
+    "Artist Name - Correct Track.mp3",
+  );
+  const destination = "deemix-duplicate/Artist Name/Album Name";
+  const targetPath = path.join(
+    process.env.WEEKLY_FLOW_FOLDER,
+    destination,
+    "Correct Track.mp3",
+  );
+  await writeOneSecondMp3(sourcePath);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, "existing-audio", "utf8");
+  const server = await createMockHttpServer((req, res) => {
+    req.resume();
+    const url = new URL(req.url, "http://deemix.test");
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify(
+        url.pathname === "/api/getQueue"
+          ? { queue: { track_1_1: { status: "completed", files: [{ path: sourcePath }] } } }
+          : { result: true },
+      ),
+    );
+  });
+
+  let jobId;
+  try {
+    dbOps.updateSettings({
+      integrations: { deemix: { enabled: true, url: server.url, bitrate: 1 } },
+    });
+    jobId = downloadTracker.addJob(
+      {
+        artistName: "Artist Name",
+        trackName: "Correct Track",
+        albumName: "Album Name",
+        durationMs: 1000,
+      },
+      "deemix-duplicate",
+    );
+    downloadTracker.setDownloading(jobId);
+
+    const polled = await processDeemixPipelinePayload(
+      {
+        phase: "poll",
+        source: "deemix",
+        jobId,
+        queueUuid: "track_1_1",
+        destination,
+        candidate: {
+          raw: {
+            id: "1",
+            title: "Correct Track",
+            artist: "Artist Name",
+            album: "Album Name",
+            file: "Artist Name - Correct Track",
+          },
+        },
+        candidateIndex: 0,
+      },
+      { failOrTryNextSource: failIfPipelineFallsThrough },
+    );
+
+    const result = await processDeemixPipelinePayload(polled, {
+      failOrTryNextSource: failIfPipelineFallsThrough,
+    });
+
+    assert.equal(result, null);
+    assert.equal(downloadTracker.getJob(jobId)?.status, "done");
+    assert.equal(downloadTracker.getJob(jobId)?.finalPath, targetPath);
+    assert.equal(await readFile(targetPath, "utf8"), "existing-audio");
+    await assert.rejects(() => access(sourcePath));
+    await assert.rejects(() => access(path.join(path.dirname(targetPath), "Correct Track (2).mp3")));
+  } finally {
+    if (jobId) downloadTracker.removeJob(jobId);
+    await server.close();
+    await rm(path.dirname(targetPath), { recursive: true, force: true });
+    await rm(path.dirname(sourcePath), { recursive: true, force: true });
   }
 });

--- a/.tests/weekly-flow/slskd-download-locate.test.js
+++ b/.tests/weekly-flow/slskd-download-locate.test.js
@@ -105,3 +105,23 @@ test("commitImportToPlaylistLibrary moves without overwriting existing targets",
   await assert.rejects(() => fs.stat(source), /ENOENT/);
   await fs.rm(root, { recursive: true, force: true });
 });
+
+test("commitImportToPlaylistLibrary can reuse an existing target", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "aurral-import-reuse-"));
+  const source = path.join(root, "deemix", "Track.flac");
+  const target = path.join(root, "aurral", "Track.flac");
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(source, "duplicate-audio", "utf8");
+  await fs.writeFile(target, "existing-audio", "utf8");
+
+  const finalPath = await commitImportToPlaylistLibrary(source, target, {
+    reuseExisting: true,
+  });
+
+  assert.equal(finalPath, target);
+  assert.equal(await fs.readFile(target, "utf8"), "existing-audio");
+  await assert.rejects(() => fs.stat(source), /ENOENT/);
+  await assert.rejects(() => fs.stat(path.join(root, "aurral", "Track (2).flac")));
+  await fs.rm(root, { recursive: true, force: true });
+});

--- a/backend/services/deemixOrchestrator.js
+++ b/backend/services/deemixOrchestrator.js
@@ -306,7 +306,9 @@ async function handleDeemixFinalize(payload, helpers) {
   const finalDir = joinUnderRoot(playlistRoot, destination);
   const finalName = `${sanitizePathPart(job.trackName, "Unknown Track")}${ext || ".flac"}`;
   const finalPath = path.join(finalDir, finalName);
-  const committedFinalPath = await commitImportToPlaylistLibrary(filePath, finalPath);
+  const committedFinalPath = await commitImportToPlaylistLibrary(filePath, finalPath, {
+    reuseExisting: true,
+  });
   return finalizePipelineJobSuccess({
     downloadTracker,
     job,

--- a/backend/services/playlistDownloadUtils.js
+++ b/backend/services/playlistDownloadUtils.js
@@ -127,10 +127,21 @@ async function resolveAvailableTargetPath(targetPath) {
   return path.join(dir, `${base} (${Date.now()})${ext}`);
 }
 
-export async function commitImportToPlaylistLibrary(sourcePath, targetPath) {
+export async function commitImportToPlaylistLibrary(
+  sourcePath,
+  targetPath,
+  { reuseExisting = false } = {},
+) {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
   if (path.resolve(sourcePath) === path.resolve(targetPath)) {
     return targetPath;
+  }
+  if (reuseExisting) {
+    const existing = await fs.stat(targetPath).catch(() => null);
+    if (existing?.isFile()) {
+      await fs.rm(sourcePath, { force: true });
+      return targetPath;
+    }
   }
   const resolvedTarget = await resolveAvailableTargetPath(targetPath);
   try {

--- a/docs/src/content/docs/integrations/deemix.mdx
+++ b/docs/src/content/docs/integrations/deemix.mdx
@@ -42,6 +42,8 @@ When a downloaded file matches the requested track but its duration differs sign
 
 Aurral removes its own queue entry from deemix before it imports the file, including for a track it retains for review, so a repeated request downloads again instead of matching a finished queue item.
 
+If a repeated deemix completion targets a file that is already in the playlist library, Aurral keeps the existing file instead of creating a numbered duplicate.
+
 deemix can also serve quality upgrades. Its bitrate setting fixes the tier it delivers, so Aurral compares that tier against the tier of the file you already have and skips deemix when it cannot improve on it. A deemix set to FLAC upgrades an MP3, and a deemix set to MP3 128 is not asked to upgrade anything better. Downloaded files are checked against the quality profile as well, so a track is never replaced by a worse one.
 
 ## Download source priority


### PR DESCRIPTION
## Problem
When repeated or concurrent deemix completions targeted the same playlist path, the import helper preserved both files by creating `Track (2).flac`, `Track (3).flac`, and so on.

## Solution
Deemix imports now reuse an existing file at the exact requested destination and remove the duplicate source instead of allocating a numbered sibling. Other download sources retain the existing no-overwrite behavior.

## Verification
- `node --test .tests/weekly-flow/slskd-download-locate.test.js`
- `node --test --import ./.tests/setup-env.js .tests/weekly-flow/download-review-routing.test.js`
- `git diff --check`

Fixes #776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate audio files from being created when a completed download matches a file already in the playlist library.
  * Existing files are now preserved while the redundant source file is cleaned up.
  * Repeated deemix completions now finish successfully without generating numbered copies.

* **Documentation**
  * Clarified deemix behavior when a downloaded track already exists in the playlist library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->