### PR TITLE
fix(ui): keep playlist menu open while scrolling

### DIFF
--- a/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
+++ b/frontend/src/pages/ArtistDetails/components/TrackPlaylistMenu.jsx
@@ -332,7 +332,8 @@ export const TrackPlaylistMenu = forwardRef(function TrackPlaylistMenu(
       setOpenSubmenu(false);
       onOpenChange?.(false);
     };
-    const handleViewportChange = () => {
+    const handleViewportChange = (event) => {
+      if (event?.type === "scroll" && menuRef.current?.contains(event.target)) return;
       setOpen(false);
       setOpenSubmenu(false);
       onOpenChange?.(false);


### PR DESCRIPTION
## Problem
The playlist picker already had an inner scroll area, but the menu's capture-phase `window` scroll listener closed the whole menu whenever that area was scrolled. Playlists below the visible rows were therefore unreachable.

## Solution
Ignore scroll events originating inside the open menu while continuing to close it when the page or another scroll container moves.

## Verification
- `npm run build --workspace frontend`
- `npm run lint --workspace frontend`
- `git diff --check`

Fixes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scrolling within the track playlist menu no longer closes the menu unexpectedly.
  - The menu continues to close when scrolling occurs outside of it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->