### PR TITLE
fix(library): retry failed Lidarr scans

### DIFF
--- a/.tests/lidarr/lidarr-circuit.test.js
+++ b/.tests/lidarr/lidarr-circuit.test.js
@@ -93,6 +93,42 @@ test("bulk album reads use Lidarr artist selectors when requested", async (t) =>
   client._httpsInsecureAgent.destroy();
 });
 
+test("no-response Lidarr errors identify the endpoint and timeout", async (t) => {
+  const server = http.createServer((request) => request.destroy());
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const address = server.address();
+  const client = new LidarrClient();
+  client._holdConfig = true;
+  client.config = {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey: "test",
+    timeoutMs: 2000,
+    circuitDisabled: true,
+  };
+  const originalConsoleError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args);
+  t.after(() => {
+    console.error = originalConsoleError;
+    client._httpAgent.destroy();
+    client._httpsAgent.destroy();
+    client._httpsInsecureAgent.destroy();
+  });
+
+  await assert.rejects(
+    client.request("/album?artistId=7"),
+    /GET \/album: This operation was aborted|GET \/album: fetch failed/,
+  );
+  assert.match(JSON.stringify(errors), /Lidarr API request failed with no response/);
+  assert.match(JSON.stringify(errors), /timeoutMs/);
+  assert.match(JSON.stringify(errors), /\/album/);
+});
+
 test("bulk reads wait for active requests before failing", async () => {
   const client = new LidarrClient();
   const artistIds = Array.from({ length: 14 }, (_, index) => index + 1);

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -7,6 +7,7 @@ import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
 import { rebuildLibrarySearchIndex } from "./librarySearchIndex.js";
 import { rebuildCanonicalGenreStats } from "./libraryQueryService.js";
 import { musicbrainzGetArtistNameByMbid } from "./apiClients/index.js";
+import { logger } from "./logger.js";
 
 function getAurralJobMetadataByPath() {
   const rows = db
@@ -80,9 +81,12 @@ export async function scanConfiguredLibrary({
         lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });
       } catch (error) {
         scanFailed = true;
+        logger.error("library", "Lidarr library indexing failed", {
+          message: error?.message || String(error),
+        });
         lidarr = {
           skipped: false,
-          error: error.message,
+          error: error?.message || String(error),
           filesSeen: 0,
           filesIndexed: 0,
           filesFailed: 0,

--- a/backend/services/libraryScanWorker.js
+++ b/backend/services/libraryScanWorker.js
@@ -150,7 +150,10 @@ const {
     const includeLidarr =
       payload?.includeLidarr === true ||
       (Number(registry.jobId) === Number(job.id) && registry.includeLidarr === true);
-    await scanConfiguredLibrary({ lidarrClient, includeLidarr });
+    const scanResult = await scanConfiguredLibrary({ lidarrClient, includeLidarr });
+    if (scanResult?.lidarr?.error) {
+      throw new Error(`Lidarr library indexing failed: ${scanResult.lidarr.error}`);
+    }
     const { playlistManager } = await import("./weeklyFlow/weeklyFlowPlaylistManager.js");
     await playlistManager.scanLibrary();
     websocketService.broadcast("library", { type: "library_scan_completed" });

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -684,9 +684,15 @@ export class LidarrClient {
           userError.response = raw.response;
           throw userError;
         } else if (error.request) {
-          console.error("Lidarr API request failed - no response:", msg);
+          logger.error("library", "Lidarr API request failed with no response", {
+            endpoint: endpoint.split("?")[0],
+            method,
+            message: msg,
+            code: error.code || null,
+            timeoutMs: this.config.timeoutMs,
+          });
           throw new Error(
-            `Cannot connect to Lidarr at ${this.config.url}. Check if Lidarr is running and the URL is correct.`,
+            `Lidarr request failed with no response: ${method} ${endpoint.split("?")[0]}: ${msg}`,
           );
         } else {
           console.error("Lidarr API error:", msg);

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -78,7 +78,10 @@ which notifications are sent.
 If the file does not appear in **Library**, use the **Refresh** button there.
 Refresh waits for the canonical scan to finish. If it still does not appear,
 run **Test library access** and check [Filesystem and mounts](/getting-started/storage/)
-for a path mismatch.
+for a path mismatch. If Lidarr fails during refresh, Aurral retries the scan
+instead of reporting it complete and writes the provider error to the server
+log. No-response errors include the request method, endpoint, and configured
+timeout.
 
 See [Library access fails on a folder that is not your root folder](/admin/troubleshooting/#library-access-fails-on-a-folder-that-is-not-your-root-folder).
 


### PR DESCRIPTION
A failed Lidarr library request was reported as a completed scan. The error was swallowed, and no-response logs did not identify the request that failed.

The scan worker now retries failed Lidarr indexing instead of acknowledging the job as complete. Library indexing and no-response requests log the provider error, request endpoint, and configured timeout. The Lidarr integration guide also explains the retry behavior.

Verification:

- `npm test` (953 passed)
- `npm run lint:backend -- --quiet`
- `npm run build`
- `git diff --check`
- Deployed the patched image against the local test stack with a disposable Lidarr stub. A synthetic album request failure changed the refresh from `completed` to `running`, then `queued` for retry, and the logs identified the failing request.

The shared Lidarr fixture has logical tracks but no track files, so readable-file import remains unverified there.

Fixes #762
