### PR TITLE
fix(ci): ignore unrelated Chrome APT source

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,17 +29,32 @@ jobs:
             exit 0
           fi
 
-          if [ "$(id -u)" -eq 0 ]; then
-            apt-get update
-            apt-get install -y ffmpeg fontconfig fonts-dejavu-core fonts-noto-color-emoji
-          elif command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y ffmpeg fontconfig fonts-dejavu-core fonts-noto-color-emoji
-          else
-            echo "ffmpeg and fontconfig are required for validation."
-            echo "Install ffmpeg, fontconfig, fonts-dejavu-core, and fonts-noto-color-emoji on the runner."
-            exit 1
+          apt_prefix=()
+          if [ "$(id -u)" -ne 0 ]; then
+            if command -v sudo >/dev/null 2>&1; then
+              apt_prefix=(sudo)
+            else
+              echo "ffmpeg and fontconfig are required for validation."
+              echo "Install ffmpeg, fontconfig, fonts-dejavu-core, and fonts-noto-color-emoji on the runner."
+              exit 1
+            fi
           fi
+
+          chrome_sources=()
+          restore_chrome_sources() {
+            for source in "${chrome_sources[@]}"; do
+              "${apt_prefix[@]}" mv "$source.disabled" "$source"
+            done
+          }
+          trap restore_chrome_sources EXIT
+
+          while IFS= read -r source; do
+            "${apt_prefix[@]}" mv "$source" "$source.disabled"
+            chrome_sources+=("$source")
+          done < <(grep -ril 'dl.google.com/linux/chrome' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true)
+
+          "${apt_prefix[@]}" apt-get update
+          "${apt_prefix[@]}" apt-get install -y ffmpeg fontconfig fonts-dejavu-core fonts-noto-color-emoji
 
       - run: npm ci
 


### PR DESCRIPTION
## Problem

Nightly validation failed before `npm ci` because the unrelated Google Chrome APT repository on the runner returned a stale `Hash Sum mismatch`.

## Solution

Temporarily disable only the Chrome APT source while installing the required runtime packages, then restore it on exit.

## Verification

- Extracted validation Bash block passes `bash -n`.
- `git diff --check` passes.
- Required GitHub CI validates the workflow on this PR.

## Limitation

Genuine failures from the Ubuntu package repositories still fail validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved validation environment setup for both root and non-root execution.
  * Temporarily disables incompatible Chrome package sources during dependency installation and restores them afterward.
  * Ensures required media and font packages are installed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->