### PR TITLE
fix(library): deduplicate lidarr retry jobs

### DIFF
--- a/.tests/library/lidarr-retry.test.js
+++ b/.tests/library/lidarr-retry.test.js
@@ -45,6 +45,10 @@ test("unavailable Lidarr keeps one retry job and continues its retry chain", asy
     throw new Error("provider unavailable");
   });
   const queue = honkerDb.getSystemTaskQueue();
+  const backlogRunAt = Math.floor(Date.now() / 1000) + 3600;
+  for (let index = 0; index < 101; index += 1) {
+    queue.enqueue({ kind: `older-system-task-${index}` }, { runAt: backlogRunAt });
+  }
 
   await libraryManager.syncLidarrArtists();
   for (let index = 0; index < 5; index += 1) {

--- a/.tests/library/lidarr-retry.test.js
+++ b/.tests/library/lidarr-retry.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanupIsolatedState,
+  setupIsolatedBackend,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, honkerDb, libraryManagerModule, systemTaskWorker] =
+  await setupIsolatedBackend(
+    "lidarr-retry",
+    "backend/config/db-sqlite.js",
+    "backend/services/honkerDb.js",
+    "backend/services/libraryManager.js",
+    "backend/services/systemTaskWorker.js",
+  );
+const { lidarrClient } = await import("../../backend/services/lidarrClient.js");
+const { libraryManager } = libraryManagerModule;
+
+function getPendingRetryJobs() {
+  return db
+    .prepare(
+      `
+        SELECT id, payload
+        FROM _honker_live
+        WHERE queue = 'system-task' AND state = 'pending'
+      `,
+    )
+    .all()
+    .filter((row) => JSON.parse(row.payload)?.kind === "lidarr-retry");
+}
+
+async function settleRetryEnqueues() {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test.after(async () => {
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("unavailable Lidarr keeps one retry job and continues its retry chain", async (t) => {
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("provider unavailable");
+  });
+  const queue = honkerDb.getSystemTaskQueue();
+
+  await libraryManager.syncLidarrArtists();
+  for (let index = 0; index < 5; index += 1) {
+    await libraryManager.syncLidarrArtists();
+    await libraryManager.getRecentArtists();
+  }
+  await settleRetryEnqueues();
+
+  const firstRetryJobs = getPendingRetryJobs();
+  assert.equal(firstRetryJobs.length, 1);
+  assert.equal(request.mock.callCount(), 1);
+
+  await systemTaskWorker.stopSystemTaskWorker();
+  const firstRetryJob = firstRetryJobs[0];
+  db.prepare("UPDATE _honker_live SET run_at = ? WHERE id = ?").run(
+    Math.floor(Date.now() / 1000) - 1,
+    firstRetryJob.id,
+  );
+  const claimedRetry = queue.claimOne(honkerDb.getWorkerId());
+  assert.equal(claimedRetry?.id, firstRetryJob.id);
+
+  await systemTaskWorker.processSystemTask(
+    { kind: "lidarr-retry" },
+    claimedRetry,
+  );
+  await settleRetryEnqueues();
+
+  const successorJobs = getPendingRetryJobs();
+  assert.equal(request.mock.callCount(), 2);
+  assert.equal(successorJobs.length, 1);
+  assert.notEqual(successorJobs[0].id, claimedRetry.id);
+
+  claimedRetry.ack();
+  queue.cancel(successorJobs[0].id);
+  await systemTaskWorker.stopSystemTaskWorker();
+});

--- a/backend/services/honkerDb.js
+++ b/backend/services/honkerDb.js
@@ -441,10 +441,11 @@ export function enqueueHonkerStartupTasks() {
 export function findActiveHonkerJob(
   queueName,
   predicate = () => true,
-  { recoverExpired = false } = {},
+  { recoverExpired = false, payloadKind = "" } = {},
 ) {
   const safeQueue = String(queueName || "").trim();
   if (!safeQueue) return null;
+  const safePayloadKind = String(payloadKind || "").trim();
   const queue = getHonkerQueueByName(safeQueue);
   if (recoverExpired) {
     try {
@@ -452,11 +453,18 @@ export function findActiveHonkerJob(
     } catch {}
   }
   const now = Math.floor(Date.now() / 1000);
+  const payloadKindFilter = safePayloadKind
+    ? "AND json_extract(payload, '$.kind') = ?"
+    : "";
+  const parameters = safePayloadKind
+    ? [safeQueue, safePayloadKind, now]
+    : [safeQueue, now];
   const rows = getHonkerDb().query(
     `
       SELECT id, payload, state, run_at, claim_expires_at, attempts
       FROM _honker_live
       WHERE queue = ?
+        ${payloadKindFilter}
         AND (
           state = 'pending'
           OR (state = 'processing' AND (claim_expires_at IS NULL OR claim_expires_at > ?))
@@ -464,7 +472,7 @@ export function findActiveHonkerJob(
       ORDER BY id ASC
       LIMIT 100
     `,
-    [safeQueue, now],
+    parameters,
   );
   for (const row of rows) {
     const payload = parseHonkerPayload(row.payload);

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -188,7 +188,7 @@ function scheduleLidarrRetry() {
       const existing = findActiveHonkerJob(
         "system-task",
         (payload) => payload?.kind === "lidarr-retry",
-        { recoverExpired: true },
+        { recoverExpired: true, payloadKind: "lidarr-retry" },
       );
       if (existing?.state === "pending") return;
       enqueueSystemTaskJob({ kind: "lidarr-retry" }, { delaySeconds: 60 });

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -184,7 +184,13 @@ async function getLidarrClient() {
 
 function scheduleLidarrRetry() {
   import("./honkerDb.js")
-    .then(({ enqueueSystemTaskJob }) => {
+    .then(({ enqueueSystemTaskJob, findActiveHonkerJob }) => {
+      const existing = findActiveHonkerJob(
+        "system-task",
+        (payload) => payload?.kind === "lidarr-retry",
+        { recoverExpired: true },
+      );
+      if (existing?.state === "pending") return;
       enqueueSystemTaskJob({ kind: "lidarr-retry" }, { delaySeconds: 60 });
     })
     .catch((err) => { logger.warn('library', err); });
@@ -897,8 +903,11 @@ export class LibraryManager {
         if (!lidarr || !lidarr.isConfigured()) {
           return _cachedArtists;
         }
-        if (_lastLidarrFailureAt && Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS) {
-          scheduleLidarrRetry();
+        if (
+          forceRefresh !== true &&
+          _lastLidarrFailureAt &&
+          Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS
+        ) {
           return _cachedArtists;
         }
         try {
@@ -945,7 +954,6 @@ export class LibraryManager {
         return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
       }
       if (_lastLidarrFailureAt && Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS) {
-        scheduleLidarrRetry();
         return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
       }
       const normalizedLimit = Math.max(0, limit);


### PR DESCRIPTION
## What changed

Prevent duplicate Lidarr retry jobs while Lidarr is unavailable, preserve the retry chain, and allow forced refreshes to attempt a request when needed.

## Why

Repeated library refreshes could enqueue multiple identical retry jobs during the retry window. This change keeps one active retry job and adds coverage for retry continuation.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #807

## Testing

- Added an automated test covering duplicate prevention and retry-chain continuation.
- Automated test: `.tests/library/lidarr-retry.test.js`

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Lidarr retry handling to prevent duplicate pending retry tasks.
  - Ensured failed Lidarr requests continue through a single retry chain.
  - Preserved cached artist results without creating redundant retries.
  - Improved retry tracking so only the appropriate Lidarr retry task is considered active.

- **Tests**
  - Added coverage for retry behavior when the Lidarr provider is unavailable, including continued retry processing under a backlog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->