### PR TITLE
test(e2e): add Playwright smoke coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist/
 
 # Test output
 coverage/
+test-results/
+playwright-report/
 
 # Private maintainer instructions
 /.maintainer/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,13 @@ Large changes are not automatically wrong, but they need a clear reason and a na
 Keep UI changes focused and explain any new interaction in the pull request.
 
 Before opening the pull request, run the checks that apply to your change and describe any manual testing in the pull request. Maintainers may ask for a smaller diff, more context, or a separate pull request.
+
+## Run browser smoke tests
+
+Start the candidate application before running the browser suite. Set `AURRAL_BASE_URL` to its URL, and set `AUTH_USER` and `AUTH_PASSWORD` to disposable test credentials.
+
+```sh
+AURRAL_BASE_URL=http://127.0.0.1:3017 AUTH_USER=... AUTH_PASSWORD=... npm run test:e2e
+```
+
+The command installs Chromium before running Playwright. Non-loopback URLs must use HTTPS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "backend",
         "frontend"
       ],
+      "devDependencies": {
+        "@playwright/test": "^1.63.0"
+      },
       "engines": {
         "node": "22.23.x"
       }
@@ -2506,9 +2509,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2524,9 +2524,6 @@
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2544,9 +2541,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2562,9 +2556,6 @@
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2582,9 +2573,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2600,9 +2588,6 @@
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2620,9 +2605,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2639,9 +2621,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2657,9 +2636,6 @@
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2683,9 +2659,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2707,9 +2680,6 @@
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2733,9 +2703,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2757,9 +2724,6 @@
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2783,9 +2747,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2808,9 +2769,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2832,9 +2790,6 @@
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3031,6 +2986,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -3141,9 +3112,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3161,9 +3129,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3181,9 +3146,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3201,9 +3163,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,9 +3180,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,9 +3197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3836,9 +3789,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3851,9 +3801,6 @@
       "integrity": "sha512-cqD9kAn01tTNdIM+DxJ1ZlNuCan7PM2hO1ZXxSmPkR5SZ93APz+4SKLvmnBkWtVKz4Z95W0yzUY6Lmag6uCG+g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -3919,9 +3866,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3937,9 +3881,6 @@
       "integrity": "sha512-IGo/hSI7bqJdrjAQXkvzhmuJ+UPMj/D4w+afKW7Ro9Hfj5AEUKPAf7184FlnNWlRyLIw0H6ZmXTAwxKOcOfb/A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -7857,6 +7798,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:backend": "eslint backend lib --no-config-lookup --rule 'no-unused-vars:[error,{\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"varsIgnorePattern\":\"^_\"}]'",
     "test": "node --test --import ./.tests/setup-env.js --test-concurrency=4 $(find .tests -name '*.test.js' -not -name '*.int.test.js' -print)",
     "test:integration": "node --test --import ./.tests/setup-env.js --test-concurrency=1 $(find .tests -name '*.int.test.js' -print)",
+    "test:e2e": "playwright test",
     "perf:library": "node scripts/benchmark-library.mjs",
     "dev": "node scripts/dev.mjs",
     "wait-and-dev:frontend": "while ! curl -s http://localhost:3001/api/health; do sleep 1; done && npm run dev --workspace frontend",
@@ -49,5 +50,8 @@
     "better-sqlite3@12.10.0": true,
     "fsevents@2.3.3": true,
     "sharp@0.34.5": true
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.63.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:backend": "eslint backend lib --no-config-lookup --rule 'no-unused-vars:[error,{\"argsIgnorePattern\":\"^_\",\"caughtErrors\":\"none\",\"varsIgnorePattern\":\"^_\"}]'",
     "test": "node --test --import ./.tests/setup-env.js --test-concurrency=4 $(find .tests -name '*.test.js' -not -name '*.int.test.js' -print)",
     "test:integration": "node --test --import ./.tests/setup-env.js --test-concurrency=1 $(find .tests -name '*.int.test.js' -print)",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright install chromium && playwright test",
     "perf:library": "node scripts/benchmark-library.mjs",
     "dev": "node scripts/dev.mjs",
     "wait-and-dev:frontend": "while ! curl -s http://localhost:3001/api/health; do sleep 1; done && npm run dev --workspace frontend",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const outputDir = process.env.PLAYWRIGHT_OUTPUT_DIR || "test-results";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [
+    ["line"],
+    [
+      "html",
+      {
+        outputFolder: process.env.PLAYWRIGHT_HTML_OUTPUT_DIR || "playwright-report",
+        open: "never",
+      },
+    ],
+    ["json", { outputFile: process.env.PLAYWRIGHT_JSON_OUTPUT_FILE || `${outputDir}/results.json` }],
+  ],
+  use: {
+    baseURL: process.env.AURRAL_BASE_URL || "http://127.0.0.1:3017",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    navigationTimeout: 30_000,
+    actionTimeout: 10_000,
+    ...devices["Desktop Chrome"],
+  },
+  outputDir,
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { expect, test } from "@playwright/test";
 
 const username = String(process.env.AUTH_USER || "").trim();
@@ -14,6 +15,15 @@ test("health, login, and authenticated navigation work", async ({ page }) => {
   expect(health.ok()).toBe(true);
 
   await page.goto("/");
+  const signInUrl = new URL(page.url());
+  const hostname = signInUrl.hostname.replace(/^\[|\]$/g, "");
+  const isLoopback =
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    (isIP(hostname) === 4 && hostname.startsWith("127."));
+  if (signInUrl.protocol !== "https:" && !isLoopback) {
+    throw new Error("Refusing to submit test credentials over insecure transport");
+  }
   await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
   await page.getByLabel("Username").fill(username);
   await page.getByLabel("Password").fill(password);

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+const username = String(process.env.AUTH_USER || "").trim();
+const password = String(process.env.AUTH_PASSWORD || "");
+
+test.beforeAll(() => {
+  if (!username || !password) {
+    throw new Error("AUTH_USER and AUTH_PASSWORD are required for the full browser suite");
+  }
+});
+
+test("health, login, and authenticated navigation work", async ({ page }) => {
+  const health = await page.request.get("/api/health/live");
+  expect(health.ok()).toBe(true);
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+  await expect(page.getByLabel("Primary navigation")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Discover", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Library", exact: true })).toBeVisible();
+
+  await page.goto("/settings");
+  await expect(page).toHaveURL(/\/settings/);
+  await expect(page).toHaveTitle(/Settings/);
+});


### PR DESCRIPTION
Aurral had no committed browser smoke coverage, so a change could pass unit-level checks while basic health, sign-in, or authenticated navigation was broken.

This adds Playwright configuration and a focused smoke test covering the live health endpoint, sign-in, primary navigation, and settings navigation. It also adds the package script and dependency and ignores generated Playwright output.

Verification:
- Lint passed
- Unit tests passed
- Integration tests passed
- Frontend and documentation builds passed
- Application startup passed
- Playwright browser smoke passed
- Production container build and smoke checks passed

Known limitation: the browser suite requires a running Aurral instance and AUTH_USER/AUTH_PASSWORD test credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end smoke testing for health checks, sign-in, authenticated navigation, and Settings page access.
  - Added Playwright configuration with browser-based test reporting and failure diagnostics.
  - Prevented smoke tests from submitting credentials over insecure, non-local connections.

- **Documentation**
  - Documented how to start the application, configure required environment variables, install Chromium, and run browser smoke tests.

- **Chores**
  - Added a command for running end-to-end tests.
  - Excluded generated test reports and results from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->