### PR TITLE
fix(auth): reject API-key-only user mutations

### DIFF
--- a/.tests/scrobbling/lastfm-link.int.test.js
+++ b/.tests/scrobbling/lastfm-link.int.test.js
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setupIsolatedBackend,
+  cleanupIsolatedState,
+  resetDatabase,
+  startServerProcess,
+} from "../helpers/backendTestHarness.js";
+
+const [isolatedState, { db }, { userOps, dbOps }, { getApiKey }, { createSession }] =
+  await setupIsolatedBackend(
+    "lastfm-link-api-key",
+    "backend/config/db-sqlite.js",
+    "backend/db/helpers/index.js",
+    "backend/middleware/auth.js",
+    "backend/config/session-helpers.js",
+  );
+
+let server = null;
+let apiKey = "";
+let sessionToken = "";
+let userId = null;
+
+test.before(async () => {
+  resetDatabase(db);
+  dbOps.updateSettings({
+    integrations: {
+      lastfm: { apiKey: "test-lastfm-key", apiSecret: "test-lastfm-secret" },
+    },
+    onboardingComplete: true,
+  });
+  const user = userOps.createUser("lastfm-user", "test-password-hash", "user");
+  userId = Number(user.id);
+  apiKey = getApiKey();
+  sessionToken = createSession(userId).token;
+  server = await startServerProcess();
+});
+
+test.after(async () => {
+  await server?.stop();
+  await cleanupIsolatedState(isolatedState);
+});
+
+test("Last.fm link requires a real user identity", async () => {
+  const apiKeyResponse = await fetch(
+    `http://127.0.0.1:${server.port}/api/scrobbling/lastfm/link`,
+    { headers: { "X-Api-Key": apiKey } },
+  );
+  const apiKeyPayload = await apiKeyResponse.json();
+
+  assert.equal(apiKeyResponse.status, 403);
+  assert.deepEqual(apiKeyPayload, {
+    error: "User account required",
+    message: "Authenticate as a user account before using this endpoint.",
+  });
+  assert.equal(
+    db.prepare("SELECT COUNT(*) AS count FROM lastfm_link_states").get().count,
+    0,
+  );
+
+  for (const [path, body] of [
+    [
+      "/api/play-events",
+      { trackId: "track-1", title: "Track", artist: "Artist" },
+    ],
+    ["/api/library/favorites", { ids: ["artist:missing"], starred: true }],
+  ]) {
+    const response = await fetch(`http://127.0.0.1:${server.port}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Api-Key": apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 403, `${path}: ${JSON.stringify(payload)}`);
+    assert.deepEqual(payload, {
+      error: "User account required",
+      message: "Authenticate as a user account before using this endpoint.",
+    });
+  }
+
+  const sessionResponse = await fetch(
+    `http://127.0.0.1:${server.port}/api/scrobbling/lastfm/link`,
+    { headers: { Authorization: `Bearer ${sessionToken}` } },
+  );
+  const sessionPayload = await sessionResponse.json();
+
+  assert.equal(sessionResponse.status, 200, JSON.stringify(sessionPayload));
+  assert.equal(sessionPayload.configured, true);
+  assert.equal(sessionPayload.connected, false);
+  assert.match(sessionPayload.authorizeUrl, /^https:\/\/www\.last\.fm\/api\/auth\//);
+  assert.equal(
+    db.prepare("SELECT user_id FROM lastfm_link_states").get().user_id,
+    userId,
+  );
+});

--- a/.tests/scrobbling/lastfm-link.int.test.js
+++ b/.tests/scrobbling/lastfm-link.int.test.js
@@ -42,7 +42,7 @@ test.after(async () => {
   await cleanupIsolatedState(isolatedState);
 });
 
-test("Last.fm link requires a real user identity", async () => {
+test("user-owned mutations require a real user identity", async () => {
   const apiKeyResponse = await fetch(
     `http://127.0.0.1:${server.port}/api/scrobbling/lastfm/link`,
     { headers: { "X-Api-Key": apiKey } },
@@ -59,15 +59,18 @@ test("Last.fm link requires a real user identity", async () => {
     0,
   );
 
-  for (const [path, body] of [
+  for (const [method, path, body] of [
     [
+      "POST",
       "/api/play-events",
       { trackId: "track-1", title: "Track", artist: "Artist" },
     ],
-    ["/api/library/favorites", { ids: ["artist:missing"], starred: true }],
+    ["POST", "/api/library/favorites", { ids: ["artist:missing"], starred: true }],
+    ["PUT", "/api/scrobbling/listenbrainz/link", {}],
+    ["PUT", "/api/scrobbling/koito/link", {}],
   ]) {
     const response = await fetch(`http://127.0.0.1:${server.port}${path}`, {
-      method: "POST",
+      method,
       headers: {
         "Content-Type": "application/json",
         "X-Api-Key": apiKey,

--- a/backend/middleware/requirePermission.js
+++ b/backend/middleware/requirePermission.js
@@ -7,6 +7,17 @@ export function requireAuth(req, res, next) {
   next();
 }
 
+export function requireUserAccount(req, res, next) {
+  const userId = Number(req.user?.id);
+  if (!Number.isSafeInteger(userId) || userId <= 0) {
+    return res.status(403).json({
+      error: "User account required",
+      message: "Authenticate as a user account before using this endpoint.",
+    });
+  }
+  next();
+}
+
 export function requireAdmin(req, res, next) {
   if (!req.user || req.user.role !== "admin") {
     return res.status(403).json({ error: "Forbidden", message: "Admin access required" });

--- a/backend/routes/library/handlers/canonical.js
+++ b/backend/routes/library/handlers/canonical.js
@@ -1,5 +1,8 @@
 import { noCache } from "../../../middleware/cache.js";
-import { requireAuth } from "../../../middleware/requirePermission.js";
+import {
+  requireAuth,
+  requireUserAccount,
+} from "../../../middleware/requirePermission.js";
 import { dbOps } from "../../../db/helpers/index.js";
 import { buildImageProxyUrl } from "../../../services/imageProxyService.js";
 import {
@@ -169,7 +172,7 @@ export function registerCanonical(router) {
     res.json({ ...starred, library: toPublicLibrary(library) });
   });
 
-  router.post("/favorites", requireAuth, noCache, (req, res) => {
+  router.post("/favorites", requireAuth, requireUserAccount, noCache, (req, res) => {
     const ids = Array.isArray(req.body?.ids)
       ? req.body.ids.map((id) => String(id || "").trim()).filter(Boolean)
       : [];

--- a/backend/routes/playEvents.js
+++ b/backend/routes/playEvents.js
@@ -1,5 +1,8 @@
 import express from "express";
-import { requireAuth } from "../middleware/requirePermission.js";
+import {
+  requireAuth,
+  requireUserAccount,
+} from "../middleware/requirePermission.js";
 import { getPlayHistory, recordPlayEvent } from "../services/playEventService.js";
 
 const router = express.Router();
@@ -9,7 +12,7 @@ router.get("/", (req, res) => {
   res.json({ events: getPlayHistory(req.user.id, req.query) });
 });
 
-router.post("/", (req, res) => {
+router.post("/", requireUserAccount, (req, res) => {
   try {
     res.status(201).json({ event: recordPlayEvent(req.user.id, req.body) });
   } catch (error) {

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -210,7 +210,7 @@ router.get("/listenbrainz/link", requireAuth, (req, res) => {
   res.json({ connected: Boolean(connection), displayName: connection?.displayName || null });
 });
 
-router.put("/listenbrainz/link", requireAuth, async (req, res) => {
+router.put("/listenbrainz/link", requireAuth, requireUserAccount, async (req, res) => {
   const token = String(req.body?.token || "").trim();
   if (!token) return res.status(400).json({ error: "Token is required" });
   let validation;
@@ -245,7 +245,7 @@ router.delete("/listenbrainz/link", requireAuth, (req, res) => {
   res.status(204).end();
 });
 
-router.put("/koito/link", requirePermission("accessSettings"), async (req, res) => {
+router.put("/koito/link", requirePermission("accessSettings"), requireUserAccount, async (req, res) => {
   const rawUrl = String(req.body?.url || userOps.getUserById(req.user.id)?.listenHistoryUrl || "").trim();
   const validation = validateExternalUrl(rawUrl);
   const token = String(req.body?.token || "").trim();

--- a/backend/routes/scrobbling.js
+++ b/backend/routes/scrobbling.js
@@ -3,7 +3,11 @@ import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypt
 import { db } from "../config/db-sqlite.js";
 import { getLastfmApiKey, getLastfmApiSecret, lastfmGetSession, listenbrainzValidateToken } from "../services/apiClients/index.js";
 import { userOps } from "../db/helpers/index.js";
-import { requireAuth, requirePermission } from "../middleware/requirePermission.js";
+import {
+  requireAuth,
+  requirePermission,
+  requireUserAccount,
+} from "../middleware/requirePermission.js";
 import { validateExternalUrl } from "../middleware/urlValidator.js";
 import { getKoitoListenBrainzBaseUrl, normalizeKoitoBaseUrl } from "../services/koitoClient.js";
 import { getScrobbleEncryptionKey, scrobbleConnectionStore } from "../services/scrobbleConnectionStore.js";
@@ -124,7 +128,7 @@ router.get("/status", requireAuth, (req, res) => {
   res.json(status);
 });
 
-router.get("/lastfm/link", requireAuth, (req, res) => {
+router.get("/lastfm/link", requireAuth, requireUserAccount, (req, res) => {
   const configured = Boolean(getLastfmApiKey() && getLastfmApiSecret());
   if (!configured) {
     return res.status(400).json({ error: "Last.fm API key and secret are required first." });

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -86,7 +86,7 @@ instance API key for WebSocket connections.
 | `GET` | `/api/library/refresh/:jobId` | Read canonical library scan status |
 | `GET` | `/api/library/canonical` | Read a bounded canonical page; provide a supported `kind` and `pageSize` (1-100) |
 | `GET` | `/api/library/favorites` | Read the current user's library favorites |
-| `POST` | `/api/library/favorites` | Add or remove a library favorite |
+| `POST` | `/api/library/favorites` | Add or remove a library favorite; requires a user session |
 | `GET` | `/api/library/playback-queue` | Build a bounded playback queue page; optional `page` and `pageSize` (1-100) |
 | `GET` | `/api/library/stream/:songId` | Stream a library song |
 | `GET` | `/api/library/canonical-stream/:trackId` | Stream a canonical library track |
@@ -344,10 +344,13 @@ Every route in this section requires an administrator.
 
 ## Scrobbling and play events
 
+The instance API key has no user identity. Last.fm linking and local play-event
+recording require a user's login session.
+
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/scrobbling/status` | Read scrobbling provider status |
-| `GET` | `/api/scrobbling/lastfm/link` | Start or read Last.fm linking |
+| `GET` | `/api/scrobbling/lastfm/link` | Start or read Last.fm linking; requires a user session |
 | `GET` | `/api/scrobbling/lastfm/link/callback` | Complete Last.fm linking |
 | `DELETE` | `/api/scrobbling/lastfm/link` | Unlink Last.fm |
 | `GET` | `/api/scrobbling/listenbrainz/link` | Read ListenBrainz linking |
@@ -356,7 +359,7 @@ Every route in this section requires an administrator.
 | `PUT` | `/api/scrobbling/koito/link` | Configure Koito |
 | `DELETE` | `/api/scrobbling/koito/link` | Unlink Koito |
 | `GET` | `/api/play-events` | Read local play history |
-| `POST` | `/api/play-events` | Record a local play event |
+| `POST` | `/api/play-events` | Record a local play event; requires a user session |
 
 ## Onboarding
 

--- a/docs/src/content/docs/api/endpoints.mdx
+++ b/docs/src/content/docs/api/endpoints.mdx
@@ -344,7 +344,7 @@ Every route in this section requires an administrator.
 
 ## Scrobbling and play events
 
-The instance API key has no user identity. Last.fm linking and local play-event
+The instance API key has no user identity. Account linking and local play-event
 recording require a user's login session.
 
 | Method | Path | Purpose |
@@ -354,9 +354,9 @@ recording require a user's login session.
 | `GET` | `/api/scrobbling/lastfm/link/callback` | Complete Last.fm linking |
 | `DELETE` | `/api/scrobbling/lastfm/link` | Unlink Last.fm |
 | `GET` | `/api/scrobbling/listenbrainz/link` | Read ListenBrainz linking |
-| `PUT` | `/api/scrobbling/listenbrainz/link` | Link ListenBrainz |
+| `PUT` | `/api/scrobbling/listenbrainz/link` | Link ListenBrainz; requires a user session |
 | `DELETE` | `/api/scrobbling/listenbrainz/link` | Unlink ListenBrainz |
-| `PUT` | `/api/scrobbling/koito/link` | Configure Koito |
+| `PUT` | `/api/scrobbling/koito/link` | Configure Koito; requires a user session |
 | `DELETE` | `/api/scrobbling/koito/link` | Unlink Koito |
 | `GET` | `/api/play-events` | Read local play history |
 | `POST` | `/api/play-events` | Record a local play event; requires a user session |

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -44,8 +44,9 @@ have read-only access.
 
 The API key identifies the Aurral installation, not a user account. Use a
 user's login session for operations that create or update user-owned data, such
-as Last.fm account linking, local play events, and library favorites. Aurral
-returns `403` when an API key calls one of these operations.
+as Last.fm, ListenBrainz, or Koito account linking, local play events, and
+library favorites. Aurral returns `403` when an API key calls one of these
+operations.
 
 Keep the key in a secret store. If your integration needs read access, make
 only `GET` requests. After you rotate the key, the old key does not operate.

--- a/docs/src/content/docs/api/overview.mdx
+++ b/docs/src/content/docs/api/overview.mdx
@@ -42,6 +42,11 @@ The API key replaces a login session token. You do not need to call the login
 endpoint first. The key currently gives administrator access. It does **not**
 have read-only access.
 
+The API key identifies the Aurral installation, not a user account. Use a
+user's login session for operations that create or update user-owned data, such
+as Last.fm account linking, local play events, and library favorites. Aurral
+returns `403` when an API key calls one of these operations.
+
 Keep the key in a secret store. If your integration needs read access, make
 only `GET` requests. After you rotate the key, the old key does not operate.
 
@@ -108,6 +113,8 @@ the key.
 - If authentication is invalid or not present, Aurral returns `401`.
 - If a valid account does not have the necessary permission, Aurral returns
   `403`.
+- If an instance API key calls an operation that needs a user account, Aurral
+  returns `403`.
 - Aurral limits each client to 5,000 API requests in each 15-minute period.
 - The API key does not have a separate permission or read-only scope.
 

--- a/docs/src/content/docs/integrations/lastfm.mdx
+++ b/docs/src/content/docs/integrations/lastfm.mdx
@@ -17,6 +17,8 @@ and complete the authorization in the Last.fm window.
 
 Aurral copies Navidrome's Last.fm flow directly: it uses the API key and API secret from
 **Settings > Connect**, then stores each user's Last.fm session key. Navidrome is not required.
+Account linking requires a user's login session. The instance API key cannot identify which
+user should own the Last.fm connection.
 
 ## Per-user listening history
 


### PR DESCRIPTION
API-key authentication uses the synthetic user ID `-1`. `GET /api/scrobbling/lastfm/link` tried to insert a foreign-key row for that ID and returned `500`.

Add a shared `requireUserAccount` middleware. Last.fm, ListenBrainz, and Koito account linking, local play-event recording, and library favorite writes now return `403` unless the request has a real user session. API-key reads remain available.

Add an integration regression test for the API-key and user-session paths, and document the authentication rule in the API and Last.fm guides.

Verification:
- Focused scrobbling integration test passes.
- Backend lint passes.
- The full validator passes unit tests, integration tests, frontend and docs builds, startup, Docker checks, and production smoke.
- The full validator still reports one unrelated browser smoke failure because the Settings page title is empty while the smoke test expects `/Settings/`.

Closes #813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - User-specific actions now require a valid user login session, including Last.fm, ListenBrainz, and Koito linking, saving favorites, and recording play events.
  - API-key-only requests to these actions now return a clear `403` error.
  - Last.fm linking now creates link state only for authenticated user sessions.

- **Documentation**
  - Clarified API authentication requirements and the distinction between instance API keys and user sessions.
  - Updated Last.fm, ListenBrainz, and Koito integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->