### PR TITLE
docs: add Easypanel deployment option

### DIFF
--- a/docs/src/content/docs/getting-started/docker.mdx
+++ b/docs/src/content/docs/getting-started/docker.mdx
@@ -46,6 +46,10 @@ docker compose up -d
 
 Continue with [First run](/getting-started/first-run/).
 
+## Deploy with Easypanel
+
+[Easypanel](https://easypanel.io/) can deploy Aurral with one click using its [official template](https://easypanel.io/templates/aurral), without needing to manually write a Compose file.
+
 ## Which image tag to use
 
 | Tag | Contents | Use it when |


### PR DESCRIPTION
Adds a short Easypanel section to the Docker setup guide. Aurral has an official one-click template on Easypanel (https://easypanel.io/templates/aurral).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for deploying Aurral with Easypanel using its official one-click template.
  - Included links to Easypanel and the deployment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->