### PR TITLE
fix(library): read AURRAL_IDS from native ID3 comments

### DIFF
--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -506,6 +506,60 @@ test("scanMusicRoot reads Aurral identity markers from portable comments", async
   }
 });
 
+test("scanMusicRoot reads Aurral identity markers from native ID3 comments", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "aurral-library-native-comment-metadata-"));
+  const source = `test-native-comment-metadata-${process.pid}`;
+  let filePath;
+
+  try {
+    filePath = await createAudioFile(root, "Aurral Artist/Aurral Album/01 Track.mp3");
+
+    await scanMusicRoot({
+      rootPath: root,
+      source,
+      metadataReader: async () => ({
+        common: {
+          albumartist: "Aurral Artist",
+          artist: "Aurral Artist",
+          album: "Aurral Album",
+          title: "Track",
+          musicbrainz_trackid: "44444444-4444-4444-8444-444444444444",
+        },
+        native: {
+          "ID3v2.4": [
+            {
+              id: "TXXX:comment",
+              value:
+                'AURRAL_IDS={"artistMbid":"11111111-1111-4111-8111-111111111111","albumMbid":"22222222-2222-4222-8222-222222222222","trackMbid":"33333333-3333-4333-8333-333333333333"}',
+            },
+          ],
+        },
+        format: {},
+      }),
+    });
+
+    const indexed = db.prepare(
+      `SELECT artist.mbid AS artistMbid, album.release_group_mbid AS releaseGroupMbid,
+        track.mbid AS trackMbid
+       FROM library_media_files AS media
+       JOIN library_tracks AS track ON track.id = media.track_id
+       JOIN library_album_tracks AS album_track ON album_track.track_id = track.id
+       JOIN library_albums AS album ON album.id = album_track.album_id
+       JOIN library_artists AS artist ON artist.id = album.artist_id
+       WHERE media.source = ? AND media.path = ?`,
+    ).get(source, filePath);
+
+    assert.deepEqual(indexed, {
+      artistMbid: "11111111-1111-4111-8111-111111111111",
+      releaseGroupMbid: "22222222-2222-4222-8222-222222222222",
+      trackMbid: "33333333-3333-4333-8333-333333333333",
+    });
+  } finally {
+    if (filePath) deleteIndexedFile(source, filePath);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a successful rescan marks removed files unavailable without removing media records", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-library-reconcile-"));
   const source = `test-reconcile-${process.pid}`;

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -56,9 +56,27 @@ const normalizeMbid = (value) => text(first(value)) || null;
 
 const normalizeMetadata = (metadata) => metadata?.common || {};
 
+const parseNativeAurralIdentityComment = (metadata) => {
+  for (const tags of Object.values(metadata?.native || {})) {
+    if (!Array.isArray(tags)) continue;
+
+    for (const tag of tags) {
+      const id = String(tag?.id || "").toLowerCase();
+      if (id !== "txxx:comment" && id !== "comm") continue;
+
+      const embedded = parseAurralIdentityComment(tag?.value);
+      if (embedded) return embedded;
+    }
+  }
+
+  return null;
+};
+
 const applyMetadataEnrichment = (metadata, enrichment = null) => {
   const common = { ...normalizeMetadata(metadata) };
-  const embedded = parseAurralIdentityComment(common.comment);
+  const embedded =
+    parseAurralIdentityComment(common.comment) ||
+    parseNativeAurralIdentityComment(metadata);
   if ((!enrichment || typeof enrichment !== "object") && !embedded) return metadata;
   const trusted = { ...(embedded || {}), ...(enrichment || {}) };
   const fallbackFields = {


### PR DESCRIPTION
## What changed

Library scans now fall back to native ID3 comment tags when an Aurral identity marker is not available through `common.comment`.

The scanner checks native `TXXX:comment` and `COMM` tags and passes their values through the existing `parseAurralIdentityComment()` parser.

A regression test was added for the `ID3v2.4 -> TXXX:comment` case.

## Why

For some MP3 files, `music-metadata` exposes Aurral's embedded `AURRAL_IDS` marker only through the native ID3 tags rather than `common.comment`.

When the marker is missed, the scanner can fall back to `musicbrainz_trackid`, which may represent a MusicBrainz Release Track ID rather than the Recording MBID stored in `AURRAL_IDS.trackMbid`.

This can produce a different canonical track identity for an already downloaded file and prevent existing-file reuse during later playlist syncs.

The native-comment fallback preserves the existing `common.comment` behavior while allowing the embedded Aurral identity to be recovered in this case.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [x] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Fixes #818

## Testing

Automated checks:

- `npm run lint:backend`
- `npm test` — 978 passed, 0 failed
- `npm run build`
- `git diff --check`

Manual validation:

- Confirmed an affected MP3 exposed `AURRAL_IDS` as an ID3v2.4 `TXXX:comment` while `common.comment` was undefined.
- Confirmed the native-comment fallback recovered the embedded `trackMbid` and used it as the canonical recording identity instead of the MusicBrainz Release Track ID.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved music library scanning to recognize Aurral identity metadata stored in native ID3 comments.
  - Artist, album release-group, and track identifiers are now correctly preserved when importing supported audio files.
  - Added coverage to verify metadata enrichment from embedded ID3 comment fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->