### PR TITLE
refactor(library): optimize media lookups and recent ordering

### DIFF
--- a/backend/config/db-sqlite.js
+++ b/backend/config/db-sqlite.js
@@ -471,6 +471,8 @@ db.exec(`
     ON library_media_files (album_id, source, available);
   CREATE INDEX IF NOT EXISTS idx_library_media_files_track_album_source_available
     ON library_media_files (track_id, album_id, source, available);
+  CREATE INDEX IF NOT EXISTS idx_library_media_files_track_album_source_available_created
+    ON library_media_files (track_id, album_id, source, available, created_at DESC);
 `);
 
 const duplicateLidarrArtistIds = db

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -35,6 +35,27 @@ const LIDARR_METADATA_KEYS = [
   "statistics",
 ];
 
+const getLibraryMediaFileStmt = db.prepare(
+  "SELECT * FROM library_media_files WHERE source = ? AND path = ?",
+);
+const upsertLibraryMediaFileStmt = db.prepare(
+  `INSERT INTO library_media_files
+    (track_id, album_id, source, path, format, size, mtime_ms, duration_ms, quality_json, available, last_seen_scan_id, created_at, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+   ON CONFLICT(source, path) DO UPDATE SET
+     track_id = excluded.track_id,
+     album_id = COALESCE(excluded.album_id, library_media_files.album_id),
+     source = excluded.source,
+     format = excluded.format,
+     size = excluded.size,
+     mtime_ms = excluded.mtime_ms,
+     duration_ms = excluded.duration_ms,
+     quality_json = COALESCE(excluded.quality_json, library_media_files.quality_json),
+     available = excluded.available,
+     last_seen_scan_id = excluded.last_seen_scan_id,
+     updated_at = excluded.updated_at`,
+);
+
 let libraryScanDepth = 0;
 let libraryCacheInvalidationPending = false;
 const libraryScanContext = new AsyncLocalStorage();
@@ -514,9 +535,7 @@ export function upsertLibraryMediaFile({
   const normalizedDurationMs = Number.isFinite(Number(durationMs)) ? Number(durationMs) : null;
   const qualityText = stringify(quality);
   const normalizedAvailable = available === true ? 1 : 0;
-  const existing = db.prepare(
-    "SELECT * FROM library_media_files WHERE source = ? AND path = ?",
-  ).get(fileSource, filePath);
+  const existing = getLibraryMediaFileStmt.get(fileSource, filePath);
   if (
     existing &&
     Number(trackId) === existing.track_id &&
@@ -531,23 +550,7 @@ export function upsertLibraryMediaFile({
     return existing;
   }
   const timestamp = now();
-  db.prepare(
-    `INSERT INTO library_media_files
-      (track_id, album_id, source, path, format, size, mtime_ms, duration_ms, quality_json, available, last_seen_scan_id, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(source, path) DO UPDATE SET
-       track_id = excluded.track_id,
-       album_id = COALESCE(excluded.album_id, library_media_files.album_id),
-       source = excluded.source,
-       format = excluded.format,
-       size = excluded.size,
-       mtime_ms = excluded.mtime_ms,
-       duration_ms = excluded.duration_ms,
-       quality_json = COALESCE(excluded.quality_json, library_media_files.quality_json),
-       available = excluded.available,
-       last_seen_scan_id = excluded.last_seen_scan_id,
-       updated_at = excluded.updated_at`,
-  ).run(
+  upsertLibraryMediaFileStmt.run(
     Number(trackId),
     normalizedAlbumId,
     fileSource,
@@ -563,8 +566,7 @@ export function upsertLibraryMediaFile({
     timestamp,
   );
   invalidateLibraryCache();
-  return db.prepare("SELECT * FROM library_media_files WHERE source = ? AND path = ?")
-    .get(fileSource, filePath);
+  return getLibraryMediaFileStmt.get(fileSource, filePath);
 }
 
 export function getAvailableLibraryMediaPaths(source) {

--- a/backend/services/libraryMediaStore.js
+++ b/backend/services/libraryMediaStore.js
@@ -630,12 +630,5 @@ export function getLibrarySnapshot() {
 }
 
 export function getLibraryMediaFile({ source, path }) {
-  return db
-    .prepare(
-      `SELECT *
-       FROM library_media_files
-       WHERE source = ? AND path = ?
-       LIMIT 1`,
-    )
-    .get(normalizeText(source), normalizeText(path));
+  return getLibraryMediaFileStmt.get(normalizeText(source), normalizeText(path));
 }

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -965,7 +965,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
     return `COALESCE((
       SELECT MAX(page_media.created_at)
       FROM library_album_tracks AS page_album_track
-      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
+      JOIN library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available_created
         ON page_media.track_id = page_album_track.track_id
       WHERE page_album_track.album_id = album.id
         AND ${albumMediaCondition("page_media", "page_album_track")}${mediaFilter}
@@ -973,7 +973,7 @@ const recentMediaOrder = (kind, sourceFilter, availableOnly, direction) => {
   }
   return `COALESCE((
     SELECT MAX(page_media.created_at)
-    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available
+    FROM library_media_files AS page_media INDEXED BY idx_library_media_files_track_album_source_available_created
     WHERE page_media.track_id = track.id${mediaFilter}
   ), 0) ${orderDirection}, track.title COLLATE NOCASE ${direction === "desc" ? "DESC" : "ASC"}`;
 };


### PR DESCRIPTION
## What changed

- Reuse prepared statements for library media file lookups and upserts.
- Add a covering index including `created_at` for recent media ordering.
- Update recent media queries to use the new index.

## Why

Reduce repeated statement preparation and improve the performance of recent media ordering queries without changing application behavior.

## Scope checklist

- [ ] This pull request has one clear purpose
- [ ] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

None.

## Testing

Not run; no test results were provided.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [ ] Patch: backward-compatible fix
- [x] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved the efficiency of library media-file lookups.
  * Optimized the ordering of recently added albums and tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->