### PR TITLE
fix(library): keep local library available without lidarr

### DIFF
--- a/.tests/history/aurral-history.test.js
+++ b/.tests/history/aurral-history.test.js
@@ -24,6 +24,7 @@ const { downloadTracker } = await importFromRepo(
   "backend/services/weeklyFlow/weeklyFlowDownloadTracker.js",
 );
 const { getHonkerDb } = await importFromRepo("backend/services/honkerDb.js");
+const { lidarrClient } = await importFromRepo("backend/services/lidarrClient.js");
 
 test.beforeEach(() => {
   resetDatabase(db);
@@ -31,6 +32,16 @@ test.beforeEach(() => {
   transaction.execute("DELETE FROM _honker_live WHERE queue = ?", ["weekly-flow-operation"]);
   transaction.commit();
   downloadTracker.clearAll();
+});
+
+test("activity reads stay local when Lidarr is disabled", async (t) => {
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("disabled activity reads must not call Lidarr");
+  });
+
+  assert.deepEqual(await getAurralHistoryRequests(lidarrClient), []);
+  assert.equal(request.mock.callCount(), 0);
 });
 
 test.after(async () => {

--- a/.tests/library/canonical-favorites-routes.test.js
+++ b/.tests/library/canonical-favorites-routes.test.js
@@ -197,6 +197,15 @@ test("canonical library pages return bounded collection responses", () => {
   assert.equal(response.body.total, 3);
   assert.equal(response.body.items.length, 1);
   assert.equal(response.body.items[0].artistName, "Favorite Artist");
+  assert.equal(
+    String(response.body.items[0].canonicalId),
+    String(response.body.items[0].id),
+  );
+  assert.equal(response.body.items[0].providerId, null);
+  assert.equal(response.body.items[0].source, "aurral");
+  assert.equal(response.body.items[0].available, true);
+  assert.equal(response.body.items[0].managedBy, null);
+  assert.equal(response.body.items[0].monitorMode, null);
   assert.equal(response.body.albums[0].trackCount, 2);
   assert.equal(response.body.albums[0].availableTrackCount, 1);
   assert.equal(response.body.hasMore, true);
@@ -209,6 +218,12 @@ test("canonical library pages return bounded collection responses", () => {
   );
   assert.equal(availableResponse.body.items[0].trackCount, 2);
   assert.equal(availableResponse.body.items[0].availableTrackCount, 1);
+  assert.equal(
+    String(availableResponse.body.items[0].canonicalId),
+    String(availableResponse.body.items[0].id),
+  );
+  assert.equal(availableResponse.body.items[0].source, "aurral");
+  assert.equal(availableResponse.body.items[0].available, true);
 
   const artistResponse = responseFor();
   getRoute("GET /canonical")(
@@ -216,6 +231,22 @@ test("canonical library pages return bounded collection responses", () => {
     artistResponse,
   );
   assert.equal(artistResponse.body.items[0].userFavorite, true);
+});
+
+test("canonical track responses expose additive ownership fields", () => {
+  const response = responseFor();
+  getRoute("GET /canonical")(
+    { user, query: { kind: "tracks", page: "1", pageSize: "1", availableOnly: "false" } },
+    response,
+  );
+
+  const track = response.body.items[0];
+  assert.equal(String(track.canonicalId), String(track.id));
+  assert.equal(track.providerId, null);
+  assert.equal(track.source, "aurral");
+  assert.equal(track.available, true);
+  assert.equal(track.managedBy, null);
+  assert.equal(track.monitorMode, null);
 });
 
 test("canonical library rejects unbounded requests", () => {

--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -76,6 +76,22 @@ test("canonical read model maps the existing root to Library-shaped records", ()
   assert.equal(result.tracks[0].path, "/music/Root Artist/Root Album/01 Root Track.flac");
 });
 
+test("canonical album statistics exclude unavailable file sizes", () => {
+  const result = buildCanonicalLibraryReadModel({
+    artists: [{ id: 11, name: "Unavailable Artist", albumIds: [12] }],
+    albums: [{ id: 12, artistId: 11, title: "Unavailable Album", trackIds: [13] }],
+    tracks: [{
+      id: 13,
+      title: "Unavailable Track",
+      albums: [{ albumId: 12 }],
+      files: [{ path: "/music/unavailable.flac", size: 456, available: false }],
+    }],
+  });
+
+  assert.equal(result.albums[0].statistics.trackFileCount, 0);
+  assert.equal(result.albums[0].statistics.sizeOnDisk, 0);
+});
+
 test("canonical read model preserves non-MBID provider artist identity", () => {
   const result = buildCanonicalLibraryReadModel({
     artists: [

--- a/.tests/library/canonical-read-adapter.test.js
+++ b/.tests/library/canonical-read-adapter.test.js
@@ -7,6 +7,7 @@ import {
   findCanonicalArtist,
   findCanonicalTracksForAlbum,
 } from "../../backend/services/canonicalLibraryReadAdapter.js";
+import { selectCanonicalFile } from "../../backend/services/canonicalFileSelector.js";
 
 const library = {
   artists: [
@@ -111,4 +112,13 @@ test("canonical read model keeps flow-like records out when the index excludes t
   });
 
   assert.deepEqual(result, { artists: [], albums: [], tracks: [] });
+});
+
+test("canonical file reads prefer the album manager before Lidarr", () => {
+  const file = selectCanonicalFile([
+    { albumId: 2, source: "lidarr", path: "/music/lidarr.flac", available: true },
+    { albumId: 2, source: "aurral", path: "/music/aurral.flac", available: true },
+  ], 2, "aurral");
+
+  assert.equal(file.path, "/music/aurral.flac");
 });

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -65,6 +65,82 @@ test("stable artist and discovery reads do not call Lidarr", async (t) => {
   }
 });
 
+test("optional Lidarr reads use indexed Aurral media without provider calls", async (t) => {
+  const key = `optional-lidarr-read-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}-artist-mbid`,
+    name: "Optional Read Artist",
+    metadata: { id: 9911, monitored: true },
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: artist.id,
+    title: "Optional Read Album",
+    metadata: { id: 9922, foreignAlbumId: `${key}-album`, monitored: true },
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${key}:track`,
+    title: "Optional Read Track",
+    artistName: artist.name,
+    metadata: { id: 9933, foreignRecordingId: `${key}-track` },
+  });
+  const filePath = `/tmp/${key}.flac`;
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id, trackNumber: 1 });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "aurral",
+    path: filePath,
+    available: true,
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("optional reads must not call Lidarr");
+  });
+  for (const method of [
+    "getArtistByMbid",
+    "getArtist",
+    "getAlbum",
+    "getTracksByAlbumId",
+    "getTrackFilesByAlbumId",
+  ]) {
+    t.mock.method(lidarrClient, method, async () => {
+      throw new Error("optional reads must not call Lidarr");
+    });
+  }
+
+  try {
+    const [byMbid, byId, albums, byAlbumId, tracks, queue] = await Promise.all([
+      libraryManager.getArtist(artist.mbid),
+      libraryManager.getArtistById(9911),
+      libraryManager.getAlbums(9911),
+      libraryManager.getAlbumById(9922),
+      libraryManager.getTracks(9922),
+      libraryManager.getPlaybackQueue({ pageSize: 10 }),
+    ]);
+    assert.equal(byMbid.canonicalId, String(artist.id));
+    assert.equal(byId.canonicalId, String(artist.id));
+    assert.equal(albums[0].canonicalId, String(album.id));
+    assert.equal(albums[0].providerId, 9922);
+    assert.equal(byAlbumId.canonicalId, String(album.id));
+    assert.equal(byAlbumId.providerId, 9922);
+    assert.equal(tracks[0].canonicalId, String(track.id));
+    assert.equal(tracks[0].providerId, 9933);
+    assert.equal(
+      queue.find((entry) => entry.id === `lib-${artist.id}-${album.id}-${track.id}`)?.streamPath,
+      `/library/canonical-stream/${album.id}/${track.id}`,
+    );
+    assert.equal(request.mock.callCount(), 0);
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(filePath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("artist key reads use identity columns and preserve metadata foreign IDs", (t) => {
   const identityKey = `artist-key-read:${Date.now()}`;
   const foreignArtistId = "artist-key-foreign-id";

--- a/.tests/library/canonical-stable-reads.test.js
+++ b/.tests/library/canonical-stable-reads.test.js
@@ -141,6 +141,72 @@ test("optional Lidarr reads use indexed Aurral media without provider calls", as
   }
 });
 
+test("configured Lidarr read failures fall back to the canonical index", async (t) => {
+  const key = `fallback-lidarr-read-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    mbid: `${key}-artist-mbid`,
+    name: "Fallback Read Artist",
+    metadata: { id: 9941 },
+  });
+  const album = upsertLibraryAlbum({
+    identityKey: `${key}:album`,
+    artistId: artist.id,
+    title: "Fallback Read Album",
+    metadata: { id: 9942 },
+  });
+  const track = upsertLibraryTrack({
+    identityKey: `${key}:track`,
+    title: "Fallback Read Track",
+    metadata: { id: 9943 },
+  });
+  const filePath = `/tmp/${key}.flac`;
+  linkLibraryAlbumTrack({ albumId: album.id, trackId: track.id });
+  upsertLibraryMediaFile({
+    trackId: track.id,
+    albumId: album.id,
+    source: "aurral",
+    path: filePath,
+    available: true,
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getArtistByMbid", async () => {
+    throw new Error("Lidarr connection refused");
+  });
+  t.mock.method(lidarrClient, "getArtist", async () => {
+    throw new Error("Lidarr connection refused");
+  });
+  t.mock.method(lidarrClient, "getHistory", async () => {
+    throw new Error("Lidarr connection refused");
+  });
+  t.mock.method(lidarrClient, "getAlbum", async () => {
+    throw new Error("Lidarr connection refused");
+  });
+
+  try {
+    const [byMbid, byId, recent, albums, byAlbumId, tracks] = await Promise.all([
+      libraryManager.getArtist(artist.mbid),
+      libraryManager.getArtistById(9941),
+      libraryManager.getRecentArtists(10),
+      libraryManager.getAlbums(9941),
+      libraryManager.getAlbumById(9942),
+      libraryManager.getTracks(9942),
+    ]);
+    assert.equal(byMbid?.canonicalId, String(artist.id));
+    assert.equal(byId?.canonicalId, String(artist.id));
+    assert.ok(recent.some((entry) => entry.id === String(artist.id)));
+    assert.equal(albums[0]?.canonicalId, String(album.id));
+    assert.equal(byAlbumId?.canonicalId, String(album.id));
+    assert.equal(tracks[0]?.canonicalId, String(track.id));
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(filePath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ?").run(album.id);
+    db.prepare("DELETE FROM library_tracks WHERE id = ?").run(track.id);
+    db.prepare("DELETE FROM library_albums WHERE id = ?").run(album.id);
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+  }
+});
+
 test("artist key reads use identity columns and preserve metadata foreign IDs", (t) => {
   const identityKey = `artist-key-read:${Date.now()}`;
   const foreignArtistId = "artist-key-foreign-id";

--- a/.tests/library/library-refresh.test.js
+++ b/.tests/library/library-refresh.test.js
@@ -25,9 +25,10 @@ const {
   getLibraryScanQueue,
   SCHEDULED_SYSTEM_TASKS,
 } = await import("../../backend/services/honkerDb.js");
-const { createLibraryFileWatcher } = await import(
+const { createLibraryFileWatcher, resolveLibraryWatchRoots } = await import(
   "../../backend/services/libraryFileWatcher.js"
 );
+const { lidarrClient } = await import("../../backend/services/lidarrClient.js");
 
 test("library scans are not scheduled as a recurring background task", () => {
   assert.equal(
@@ -256,4 +257,16 @@ test("library file watcher debounces library changes and ignores generated folde
   assert.equal(scheduled, 1);
 
   watcher.close();
+});
+
+test("library watcher reuses configured roots without querying Lidarr", (t) => {
+  const rootPath = "/data/music";
+  t.mock.method(lidarrClient, "isEnabled", () => true);
+  t.mock.method(lidarrClient, "getConfiguredRootFolderPaths", () => [rootPath]);
+  const rootRequest = t.mock.method(lidarrClient, "getRootFolders", async () => {
+    throw new Error("watcher should not discover roots");
+  });
+
+  assert.equal(resolveLibraryWatchRoots().includes(rootPath), true);
+  assert.equal(rootRequest.mock.callCount(), 0);
 });

--- a/.tests/library/lidarr-status-snapshot.test.js
+++ b/.tests/library/lidarr-status-snapshot.test.js
@@ -11,6 +11,25 @@ import {
 import { LidarrClient, lidarrClient } from "../../backend/services/lidarrClient.js";
 import { buildLidarrRequests } from "../../backend/services/lidarrRequestBuilder.js";
 
+test("disabled status reads stay local", async (t) => {
+  t.mock.method(lidarrClient, "isConfigured", () => false);
+  t.mock.method(lidarrClient, "isCircuitOpen", () => false);
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("disabled status reads must not call Lidarr");
+  });
+  invalidateAllDownloadStatusesCache();
+
+  assert.deepEqual(await getDownloadStatusesForAlbumIds([10]), {});
+  const snapshot = await getLidarrStatusSnapshot({ force: true });
+  assert.deepEqual(snapshot.provider, {
+    queue: [],
+    history: { records: [] },
+    commands: [],
+  });
+  assert.deepEqual(snapshot.statuses, {});
+  assert.equal(request.mock.callCount(), 0);
+});
+
 test("Lidarr status consumers share refreshes, idle, failure, and recovery state", async (t) => {
   let active = false;
   let fail = false;

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -144,6 +144,25 @@ test("a local-only configured scan does not contact Lidarr", async () => {
   }
 });
 
+test("root scans ignore empty root values instead of scanning the process directory", async () => {
+  const source = `empty-root-scan-${process.pid}-${Date.now()}`;
+  try {
+    const result = await scanMusicRoots({
+      rootPaths: ["", "  ", null],
+      source,
+      syncSearch: false,
+    });
+
+    assert.deepEqual(result, { filesSeen: 0, filesIndexed: 0, filesFailed: 0, changed: false });
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS count FROM library_scan_runs WHERE source = ?").get(source).count,
+      0,
+    );
+  } finally {
+    db.prepare("DELETE FROM library_scan_runs WHERE source = ?").run(source);
+  }
+});
+
 test("a configured scan does not contact Lidarr without discovered roots", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-failed-index-repair-"));
   const identityKey = `name:failed-index-repair-${process.pid}`;

--- a/.tests/library/media-index.test.js
+++ b/.tests/library/media-index.test.js
@@ -21,7 +21,7 @@ import {
   upsertLibraryTrack,
   withLibraryScan,
 } from "../../backend/services/libraryMediaStore.js";
-import { scanMusicRoot } from "../../backend/services/libraryFileScanner.js";
+import { scanMusicRoot, scanMusicRoots } from "../../backend/services/libraryFileScanner.js";
 import { indexLidarrLibrary } from "../../backend/services/libraryLidarrIndexer.js";
 import { scanConfiguredLibrary } from "../../backend/services/libraryIndexService.js";
 
@@ -144,7 +144,7 @@ test("a local-only configured scan does not contact Lidarr", async () => {
   }
 });
 
-test("a failed provider scan repairs derived library indexes", async () => {
+test("a configured scan does not contact Lidarr without discovered roots", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "aurral-failed-index-repair-"));
   const identityKey = `name:failed-index-repair-${process.pid}`;
   const artist = upsertLibraryArtist({
@@ -160,22 +160,115 @@ test("a failed provider scan repairs derived library indexes", async () => {
       musicRoot: root,
       lidarrClient: {
         isConfigured: () => true,
+        isEnabled: () => true,
         request: async () => {
-          throw new Error("Lidarr unavailable");
+          throw new Error("unexpected Lidarr request");
         },
-        getAllAlbums: async () => [],
-        getRootFolders: async () => [],
       },
     });
-    const indexed = db.prepare(
-      "SELECT 1 FROM library_search_documents WHERE entity_kind = 'artist' AND entity_id = ?",
-    ).get(artist.id);
 
-    assert.equal(result.lidarr.error, "Lidarr unavailable");
-    assert.equal(Boolean(indexed), true);
+    assert.equal(result.lidarr.skipped, true);
   } finally {
     db.prepare("DELETE FROM library_artists WHERE identity_key = ?").run(identityKey);
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("configured Lidarr roots scan locally and reconcile only those roots", async () => {
+  const roots = await Promise.all([
+    mkdtemp(path.join(tmpdir(), "aurral-local-lidarr-root-one-")),
+    mkdtemp(path.join(tmpdir(), "aurral-local-lidarr-root-two-")),
+  ]);
+  const aurralRoot = path.join(tmpdir(), `aurral-disabled-lidarr-${process.pid}`);
+  const paths = await Promise.all([
+    createAudioFile(roots[0], "Local Artist/Local Album/01 Local Track.flac"),
+    createAudioFile(roots[1], "Local Artist/Local Album/02 Local Track.flac"),
+  ]);
+  const outsidePath = path.join(tmpdir(), `aurral-local-lidarr-outside-${process.pid}.flac`);
+  const scanMetadata = {
+    ...metadata,
+    common: {
+      ...metadata.common,
+      albumartist: `Local Artist ${process.pid}`,
+      artist: `Local Artist ${process.pid}`,
+      album: `Local Album ${process.pid}`,
+      title: `Local Track ${process.pid}`,
+      musicbrainz_albumartistid: `11111111-1111-4111-8111-${String(process.pid).padStart(12, "0")}`,
+      musicbrainz_releasegroupid: `22222222-2222-4222-8222-${String(process.pid).padStart(12, "0")}`,
+      musicbrainz_recordingid: `33333333-3333-4333-8333-${String(process.pid).padStart(12, "0")}`,
+    },
+  };
+  let trackId;
+  try {
+    const result = await scanMusicRoots({
+      rootPaths: roots,
+      source: "lidarr",
+      metadataReader: async () => scanMetadata,
+      syncSearch: false,
+    });
+    assert.equal(result.filesIndexed, 2);
+    trackId = getLibrarySnapshot().tracks.find((track) => track.title === scanMetadata.common.title)?.id;
+    upsertLibraryMediaFile({
+      trackId,
+      source: "lidarr",
+      path: outsidePath,
+      available: true,
+    });
+
+    await rm(paths[0]);
+    const rescanned = await scanMusicRoots({
+      rootPaths: roots,
+      source: "lidarr",
+      metadataReader: async () => scanMetadata,
+      syncSearch: false,
+    });
+    const snapshot = getLibrarySnapshot();
+    assert.equal(rescanned.filesIndexed, 1);
+    assert.equal(snapshot.files.find((file) => file.path === paths[0])?.available, 0);
+    assert.equal(snapshot.files.find((file) => file.path === outsidePath)?.available, 1);
+
+    let disabledCalls = 0;
+    const disabled = await scanConfiguredLibrary({
+      musicRoot: aurralRoot,
+      includeLidarr: true,
+      lidarrRoots: roots,
+      lidarrClient: {
+        isEnabled: () => false,
+        request: async () => {
+          disabledCalls += 1;
+          throw new Error("unexpected disabled Lidarr request");
+        },
+      },
+    });
+    assert.equal(disabled.lidarr.skipped, true);
+    assert.equal(disabledCalls, 0);
+    assert.equal(snapshot.files.find((file) => file.path === outsidePath)?.available, 1);
+  } finally {
+    const albumIds = trackId
+      ? db.prepare("SELECT album_id FROM library_album_tracks WHERE track_id = ?").all(trackId)
+        .map((row) => row.album_id)
+      : [];
+    const artistIds = albumIds.length
+      ? db.prepare(`SELECT artist_id FROM library_albums WHERE id IN (${albumIds.map(() => "?").join(",")})`)
+        .all(...albumIds)
+        .map((row) => row.artist_id)
+      : [];
+    db.prepare("DELETE FROM library_media_files WHERE path IN (?, ?, ?)").run(
+      ...paths,
+      outsidePath,
+    );
+    if (trackId) {
+      db.prepare("DELETE FROM library_album_tracks WHERE track_id = ?").run(trackId);
+      db.prepare("DELETE FROM library_tracks WHERE id = ?").run(trackId);
+    }
+    if (albumIds.length) {
+      db.prepare(`DELETE FROM library_albums WHERE id IN (${albumIds.map(() => "?").join(",")})`).run(...albumIds);
+    }
+    if (artistIds.length) {
+      db.prepare(`DELETE FROM library_artists WHERE id IN (${artistIds.map(() => "?").join(",")})`).run(...artistIds);
+    }
+    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+    await rm(aurralRoot, { recursive: true, force: true });
   }
 });
 
@@ -669,16 +762,6 @@ test("an unchanged Lidarr rescan does not rewrite library rows", async () => {
     }, { artist: 1, album: 1, track: 1, media: 1 });
 
     db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(genreStatsKey, "preserved");
-    const configuredChangesBefore = db.prepare("SELECT total_changes() AS count").get().count;
-    const configured = await scanConfiguredLibrary({
-      musicRoot: path.join(root, "empty-aurral-root"),
-      lidarrClient: client,
-    });
-    const configuredChangesAfter = db.prepare("SELECT total_changes() AS count").get().count;
-
-    assert.equal(configured.local.changed, false);
-    assert.equal(configured.lidarr.changed, false);
-    assert.equal(configuredChangesAfter - configuredChangesBefore, 4);
     assert.equal(db.prepare("SELECT value FROM settings WHERE key = ?").get(genreStatsKey)?.value, "preserved");
   } finally {
     db.prepare("DELETE FROM settings WHERE key = ?").run(genreStatsKey);
@@ -1299,16 +1382,17 @@ test("a Lidarr outage leaves the last indexed library available", async () => {
       musicRoot: path.join(root, "empty-aurral-root"),
       lidarrClient: {
         isConfigured: () => true,
+        isEnabled: () => true,
         request: async () => {
           throw new Error("Lidarr unavailable");
         },
-        getAllAlbums: async () => [],
-        getRootFolders: async () => [],
       },
+      lidarrRoots: [root],
     });
     const file = getLibrarySnapshot().files.find((entry) => entry.path === filePath);
 
-    assert.equal(result.lidarr.error, "Lidarr unavailable");
+    assert.equal(result.lidarr.error, undefined);
+    assert.equal(result.lidarr.filesIndexed, 1);
     assert.equal(file?.available, 1);
   } finally {
     if (filePath) deleteIndexedFile("lidarr", filePath);

--- a/.tests/library/media-query.test.js
+++ b/.tests/library/media-query.test.js
@@ -118,6 +118,74 @@ test("getCanonicalTrackPath keeps shared tracks scoped to the requested album", 
   }
 });
 
+test("canonical references prefer the canonical ID over a provider ID collision", () => {
+  const key = `query-reference-collision-${process.pid}-${Date.now()}`;
+  const artist = upsertLibraryArtist({
+    identityKey: `${key}:artist`,
+    name: "Reference Collision Artist",
+  });
+  const providerAlbum = upsertLibraryAlbum({
+    identityKey: `${key}:provider-album`,
+    artistId: artist.id,
+    title: "Provider Album",
+    metadata: { id: 999001 },
+  });
+  const targetAlbum = upsertLibraryAlbum({
+    identityKey: `${key}:target-album`,
+    artistId: artist.id,
+    title: "Target Album",
+  });
+  const providerTrack = upsertLibraryTrack({
+    identityKey: `${key}:provider-track`,
+    title: "Provider Track",
+    metadata: { id: 999002 },
+  });
+  const targetTrack = upsertLibraryTrack({
+    identityKey: `${key}:target-track`,
+    title: "Target Track",
+  });
+  const targetPath = `/tmp/${key}.flac`;
+  db.prepare("UPDATE library_albums SET metadata_json = ? WHERE id = ?")
+    .run(JSON.stringify({ id: targetAlbum.id }), providerAlbum.id);
+  db.prepare("UPDATE library_tracks SET metadata_json = ? WHERE id = ?")
+    .run(JSON.stringify({ id: targetTrack.id }), providerTrack.id);
+  linkLibraryAlbumTrack({ albumId: targetAlbum.id, trackId: targetTrack.id });
+  upsertLibraryMediaFile({
+    trackId: targetTrack.id,
+    albumId: targetAlbum.id,
+    source: "aurral",
+    path: targetPath,
+    available: true,
+  });
+
+  try {
+    assert.equal(getCanonicalTrackPath(targetAlbum.id, targetTrack.id), targetPath);
+    assert.deepEqual(
+      getCanonicalTrack({ trackId: targetTrack.id }).tracks.map((track) => track.id),
+      [targetTrack.id],
+    );
+    assert.deepEqual(
+      getCanonicalLibraryForAlbumReferences({ references: [targetAlbum.id] }).albums
+        .map((album) => album.id),
+      [targetAlbum.id],
+    );
+  } finally {
+    db.prepare("DELETE FROM library_media_files WHERE path = ?").run(targetPath);
+    db.prepare("DELETE FROM library_album_tracks WHERE album_id = ? OR track_id = ?")
+      .run(targetAlbum.id, targetTrack.id);
+    db.prepare("DELETE FROM library_tracks WHERE id IN (?, ?)").run(
+      providerTrack.id,
+      targetTrack.id,
+    );
+    db.prepare("DELETE FROM library_albums WHERE id IN (?, ?)").run(
+      providerAlbum.id,
+      targetAlbum.id,
+    );
+    db.prepare("DELETE FROM library_artists WHERE id = ?").run(artist.id);
+    invalidateCanonicalLibraryCache();
+  }
+});
+
 test("focused track, ownership, count, and sample queries stay bounded", () => {
   const key = `query-focused-${process.pid}-${Date.now()}`;
   const artist = upsertLibraryArtist({

--- a/.tests/lidarr/lidarr-enabled.test.js
+++ b/.tests/lidarr/lidarr-enabled.test.js
@@ -14,6 +14,7 @@ const [isolatedState, { db }, { dbOps }] = await setupIsolatedBackend(
 );
 
 const { lidarrClient } = await import("../../backend/services/lidarrClient.js");
+const { registerMisc } = await import("../../backend/routes/library/handlers/misc.js");
 const { resolveLidarrTestCredentials } = await import(
   "../../backend/services/lidarrTestSession.js"
 );
@@ -62,6 +63,39 @@ test("an explicit false disables lidarr without clearing saved settings", () => 
   assert.equal(lidarrClient.getConfig().apiKey, "saved-key");
 });
 
+test("root folder reads retain saved paths while lidarr is disabled", async (t) => {
+  const rootPath = "/data/music";
+  setLidarrSettings({
+    url: "http://127.0.0.1:18686",
+    apiKey: "saved-key",
+    enabled: false,
+    rootFolderPath: null,
+    rootFolderPaths: [rootPath],
+  });
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("disabled root-folder reads must stay local");
+  });
+  const routes = new Map();
+  registerMisc({
+    get(routePath, ...handlers) {
+      routes.set(routePath, handlers.at(-1));
+    },
+    post() {},
+    put() {},
+    delete() {},
+  });
+  let body;
+  await routes.get("/rootfolder")({}, {
+    json(value) {
+      body = value;
+      return this;
+    },
+  });
+
+  assert.deepEqual(body, [{ path: rootPath }]);
+  assert.equal(request.mock.callCount(), 0);
+});
+
 test("disabled lidarr makes no network call from client requests", async () => {
   setLidarrSettings({ url: "http://127.0.0.1:9", apiKey: "saved-key", enabled: false });
 
@@ -69,6 +103,23 @@ test("disabled lidarr makes no network call from client requests", async () => {
     () => lidarrClient.request("/artist", "GET", null, true),
     /Lidarr is disabled/,
   );
+});
+
+test("discovered root paths are reused without another root-folder request", async (t) => {
+  const rootPath = "/data/music";
+  setLidarrSettings({
+    url: "http://127.0.0.1:18686",
+    apiKey: "saved-key",
+    enabled: true,
+    rootFolderPath: null,
+    rootFolderPaths: [rootPath],
+  });
+  const request = t.mock.method(lidarrClient, "request", async () => {
+    throw new Error("root-folder discovery should be cached");
+  });
+
+  assert.deepEqual(await lidarrClient.getRootFolders(), [{ path: rootPath }]);
+  assert.equal(request.mock.callCount(), 0);
 });
 
 test("saved-credential test fallback is refused while lidarr is disabled", () => {

--- a/.tests/search/unified-search.test.js
+++ b/.tests/search/unified-search.test.js
@@ -44,6 +44,22 @@ test("searchLocalFromData returns library artist and track matches", () => {
   assert.equal(result.tracks[0].inLibrary, true);
 });
 
+test("searchLocalFromData does not let duplicate artist projections consume result slots", () => {
+  const result = searchLocalFromData(
+    "artist",
+    {
+      artists: [
+        { canonicalId: "1", id: "provider-1", artistName: "Artist One" },
+        { canonicalId: "1", id: "provider-1", artistName: "Artist One" },
+        { canonicalId: "2", id: "provider-2", artistName: "Artist Two" },
+      ],
+    },
+    2,
+  );
+
+  assert.deepEqual(result.artists.map((artist) => artist.name), ["Artist One", "Artist Two"]);
+});
+
 test("searchLocalFromData ignores library artists that only share article words", () => {
   const result = searchLocalFromData(
     "the used",
@@ -287,5 +303,4 @@ test("applyCatalogSearchContext preserves artist bucket order", () => {
   assert.equal(catalog.artists[0].name, "The Used");
   assert.equal(catalog.tracks[0].title, "The Band the Used");
 });
-
 

--- a/.tests/settings/general-settings.test.js
+++ b/.tests/settings/general-settings.test.js
@@ -7,13 +7,14 @@ import {
   setupIsolatedBackend,
 } from "../helpers/backendTestHarness.js";
 
-const [isolatedState, { db }, { dbOps }, { registerGeneral }, { playlistManager }] =
+const [isolatedState, { db }, { dbOps }, { registerGeneral }, { playlistManager }, { lidarrClient }] =
   await setupIsolatedBackend(
     "general-settings",
     "backend/config/db-sqlite.js",
     "backend/db/helpers/index.js",
     "backend/routes/settings/handlers/general.js",
     "backend/services/weeklyFlow/weeklyFlowPlaylistManager.js",
+    "backend/services/lidarrClient.js",
   );
 
 test.beforeEach(() => {
@@ -179,4 +180,61 @@ test("does not warn about lidarr roots while lidarr is disabled", async () => {
 
   const current = await getSettings();
   assert.deepEqual(current.body.rootWarnings, []);
+});
+
+test("clears saved Lidarr roots when the connection identity changes", async (t) => {
+  const { postSettings } = captureSettingsRoutes();
+  dbOps.updateSettings({
+    integrations: {
+      lidarr: {
+        url: "http://old-lidarr:8686",
+        apiKey: "old-key",
+        rootFolderPath: "/old/music",
+        rootFolderPaths: ["/old/music", "/old/other"],
+      },
+    },
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  const refresh = t.mock.method(lidarrClient, "getRootFolders", async () => {
+    throw new Error("new Lidarr is unavailable");
+  });
+
+  const response = await postSettings({
+    integrations: {
+      lidarr: { url: "http://new-lidarr:8686", apiKey: "new-key" },
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(refresh.mock.callCount(), 1);
+  assert.deepEqual(dbOps.getSettings().integrations.lidarr.rootFolderPaths, []);
+  assert.equal(dbOps.getSettings().integrations.lidarr.rootFolderPath, null);
+});
+
+test("preserves saved Lidarr roots when discovery fails for the same connection", async (t) => {
+  const { postSettings } = captureSettingsRoutes();
+  dbOps.updateSettings({
+    integrations: {
+      lidarr: {
+        url: "http://lidarr:8686",
+        apiKey: "key",
+        rootFolderPath: "/old/music",
+        rootFolderPaths: ["/old/music"],
+      },
+    },
+  });
+  t.mock.method(lidarrClient, "isConfigured", () => true);
+  t.mock.method(lidarrClient, "getRootFolders", async () => {
+    throw new Error("Lidarr is temporarily unavailable");
+  });
+
+  const response = await postSettings({
+    integrations: {
+      lidarr: { rootFolderPath: "/new/default" },
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(dbOps.getSettings().integrations.lidarr.rootFolderPaths, ["/old/music"]);
+  assert.equal(dbOps.getSettings().integrations.lidarr.rootFolderPath, "/new/default");
 });

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Set `MEDIA_ROOT` to the **same host media path that Lidarr already mounts**. Kee
 docker compose up -d
 ```
 
-Open `http://localhost:3001`, create your admin account, and connect Lidarr.
+Open `http://localhost:3001` and create your admin account. Connect Lidarr if you want managed library changes and provider status.
 
 Want the latest merged changes? Use `ghcr.io/lklynet/aurral:nightly`. Nightly
 builds may be less stable than releases; see the [Docker image channels](https://docs.aurral.org/getting-started/docker/#which-image-tag-to-use).

--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -115,6 +115,8 @@ export const defaultData = {
         url: "",
         externalUrl: "",
         apiKey: "",
+        rootFolderPath: null,
+        rootFolderPaths: [],
         qualityProfileId: null,
         metadataProfileId: null,
         tagId: null,

--- a/backend/db/helpers/settings.js
+++ b/backend/db/helpers/settings.js
@@ -78,6 +78,12 @@ let settingsCache = null;
 let settingsCacheTime = 0;
 const SETTINGS_CACHE_TTL = 60000;
 
+const normalizeLidarrRootFolderPaths = (paths) => [...new Set(
+  (Array.isArray(paths) ? paths : [])
+    .map((value) => String(value || "").trim())
+    .filter(Boolean),
+)];
+
 export const dbOps = {
   getJSONSetting(key) {
     return dbHelpers.parseJSON(getSettingStmt.get(key)?.value) || null;
@@ -96,6 +102,26 @@ export const dbOps = {
       `user:${parseInt(userId, 10)}:discoverLayout`,
       layout,
     );
+  },
+
+  setLidarrRootFolderPaths(paths) {
+    const settings = dbOps.getSettings();
+    const normalized = normalizeLidarrRootFolderPaths(paths);
+    const currentIntegrations = settings.integrations || {};
+    const currentLidarr = currentIntegrations.lidarr || {};
+    if (JSON.stringify(currentLidarr.rootFolderPaths || []) === JSON.stringify(normalized)) {
+      return normalized;
+    }
+    dbOps.updateSettings({
+      integrations: {
+        ...currentIntegrations,
+        lidarr: {
+          ...currentLidarr,
+          rootFolderPaths: normalized,
+        },
+      },
+    });
+    return normalized;
   },
 
   getSettings() {

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -13,12 +13,15 @@ import { getCanonicalArtistMbids } from "../../../services/libraryQueryService.j
 
 const ARTIST_LOOKUP_BATCH_MAX = 100;
 
-const canonicalAlbumLookup = (albums, reference) =>
-  albums.find((album) =>
-    [album.id, album.providerId, album.mbid, album.releaseGroupMbid, album.foreignAlbumId, album.identityKey].some(
-      (value) => String(value || "").trim() === String(reference || "").trim(),
+const canonicalAlbumLookup = (albums, reference) => {
+  const value = String(reference || "").trim();
+  if (!value) return undefined;
+  return albums.find((album) =>
+    [album.foreignAlbumId, album.mbid, album.releaseGroupMbid, album.identityKey].some(
+      (candidate) => String(candidate || "").trim() === value,
     ),
   );
+};
 
 const canonicalAlbumResult = (album, ownedTrackMbids = []) => ({
   inLibrary: true,

--- a/backend/routes/library/handlers/misc.js
+++ b/backend/routes/library/handlers/misc.js
@@ -15,7 +15,7 @@ const ARTIST_LOOKUP_BATCH_MAX = 100;
 
 const canonicalAlbumLookup = (albums, reference) =>
   albums.find((album) =>
-    [album.mbid, album.releaseGroupMbid, album.identityKey].some(
+    [album.id, album.providerId, album.mbid, album.releaseGroupMbid, album.foreignAlbumId, album.identityKey].some(
       (value) => String(value || "").trim() === String(reference || "").trim(),
     ),
   );
@@ -127,7 +127,11 @@ export function registerMisc(router) {
   router.get("/rootfolder", async (req, res) => {
     try {
       const { lidarrClient } = await import("../../../services/lidarrClient.js");
-      if (!lidarrClient.isConfigured()) {
+      const configured = lidarrClient.getConfiguredRootFolderPaths();
+      if (!lidarrClient.isEnabled()) {
+        return res.json(configured.map((path) => ({ path })));
+      }
+      if (!lidarrClient.isConfigured() && configured.length === 0) {
         return res.json([]);
       }
       const rootFolders = await lidarrClient.getRootFolders();

--- a/backend/routes/library/handlers/tracks.js
+++ b/backend/routes/library/handlers/tracks.js
@@ -10,7 +10,6 @@ import path from "path";
 import { logger } from "../../../services/logger.js";
 import {
   findCanonicalTracksForAlbum,
-  getCanonicalLibraryReadModelForAlbumIds,
   getCanonicalLibraryReadModelForAlbumReferences,
   resolveCanonicalTrackPath,
 } from "../../../services/canonicalLibraryReadAdapter.js";
@@ -96,10 +95,10 @@ export function registerTracks(router) {
 
       if (req.query.readPath === "canonical") {
         let canonical = albumId
-          ? getCanonicalLibraryReadModelForAlbumIds({
+          ? getCanonicalLibraryReadModelForAlbumReferences({
               source: req.query.source || "all",
               availableOnly: true,
-              ids: [albumId],
+              references: [albumId],
             })
           : getCanonicalLibraryReadModelForAlbumReferences({
               source: req.query.source || "all",
@@ -118,7 +117,7 @@ export function registerTracks(router) {
           .filter(Boolean)
           .map((reference) =>
             albums.find((candidate) =>
-              [candidate.id, candidate.mbid, candidate.foreignAlbumId].some(
+              [candidate.id, candidate.providerId, candidate.mbid, candidate.foreignAlbumId].some(
                 (value) => String(value ?? "") === String(reference),
               ),
             ),

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -53,6 +53,14 @@ function didLidarrRootDiscoveryChange(previousSettings, nextSettings) {
     .some((key) => JSON.stringify(previous[key]) !== JSON.stringify(next[key]));
 }
 
+function didLidarrConnectionChange(previousSettings, nextSettings) {
+  const previous = previousSettings?.integrations?.lidarr || {};
+  const next = nextSettings?.integrations?.lidarr || {};
+  return ["url", "apiKey"].some(
+    (key) => JSON.stringify(previous[key]) !== JSON.stringify(next[key]),
+  );
+}
+
 export function registerGeneral(router) {
   router.post("/navidrome/test", testNavidromeConnection);
 
@@ -529,6 +537,17 @@ export function registerGeneral(router) {
       }
       if (updatedSettings?.integrations?.musicbrainz) {
         delete updatedSettings.integrations.musicbrainz;
+      }
+
+      if (didLidarrConnectionChange(currentSettings, updatedSettings)) {
+        updatedSettings.integrations = {
+          ...updatedSettings.integrations,
+          lidarr: {
+            ...(updatedSettings.integrations?.lidarr || {}),
+            rootFolderPath: null,
+            rootFolderPaths: [],
+          },
+        };
       }
 
       dbOps.updateSettings(updatedSettings);

--- a/backend/routes/settings/handlers/general.js
+++ b/backend/routes/settings/handlers/general.js
@@ -33,11 +33,24 @@ function mergeIntegrations(existing, input, keys) {
 
 function resolveLibraryRootWarnings(settings) {
   const aurralRoot = settings?.downloadFolderPath || resolvePlaylistRoot();
+  const configuredLidarr = settings?.integrations?.lidarr || {};
   const lidarrRoots =
-    settings?.integrations?.lidarr?.enabled === false
+    configuredLidarr.enabled === false
       ? []
-      : [settings?.integrations?.lidarr?.rootFolderPath];
+      : [
+          ...(Array.isArray(configuredLidarr.rootFolderPaths)
+            ? configuredLidarr.rootFolderPaths
+            : []),
+          configuredLidarr.rootFolderPath,
+        ];
   return computeLibraryRootOverlaps({ aurralRoot, lidarrRoots });
+}
+
+function didLidarrRootDiscoveryChange(previousSettings, nextSettings) {
+  const previous = previousSettings?.integrations?.lidarr || {};
+  const next = nextSettings?.integrations?.lidarr || {};
+  return ["url", "apiKey", "enabled", "insecure", "rootFolderPath", "rootFolderPaths"]
+    .some((key) => JSON.stringify(previous[key]) !== JSON.stringify(next[key]));
 }
 
 export function registerGeneral(router) {
@@ -519,6 +532,17 @@ export function registerGeneral(router) {
       }
 
       dbOps.updateSettings(updatedSettings);
+      const { lidarrClient } = await import("../../../services/lidarrClient.js");
+      lidarrClient.updateConfig();
+      if (didLidarrRootDiscoveryChange(currentSettings, updatedSettings) && lidarrClient.isConfigured()) {
+        try {
+          await lidarrClient.getRootFolders({ forceRefresh: true });
+        } catch (error) {
+          logger.warn("settings", "Failed to refresh Lidarr root folders:", {
+            message: error.message,
+          });
+        }
+      }
       const { downloadClientRegistry } = await import(
         "../../../services/download/downloadClientSettings.js"
       );

--- a/backend/services/canonicalFileSelector.js
+++ b/backend/services/canonicalFileSelector.js
@@ -1,0 +1,22 @@
+const sourceRank = (source, managedBy) => {
+  if (managedBy && source === managedBy) return 0;
+  if (source === "lidarr") return 1;
+  return 2;
+};
+
+export function selectCanonicalFile(files, albumId = null, managedBy = null) {
+  const candidates = (Array.isArray(files) ? files : [])
+    .filter((file) => file?.albumId == null || albumId == null || file.albumId == albumId)
+    .map((file) => ({ file }))
+    .sort((left, right) => {
+      const available = Number(Boolean(right.file.available)) - Number(Boolean(left.file.available));
+      if (available) return available;
+      const scoped = Number(left.file.albumId != null) - Number(right.file.albumId != null);
+      if (scoped) return -scoped;
+      const source = sourceRank(left.file.source, managedBy) - sourceRank(right.file.source, managedBy);
+      if (source) return source;
+      return String(left.file.path || "").localeCompare(String(right.file.path || ""));
+    });
+
+  return candidates[0]?.file || null;
+}

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -68,7 +68,7 @@ const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Ma
     .filter(Boolean);
   const sizeOnDisk = albumTracks.reduce((total, track) => {
     const file = selectCanonicalFile(track.files, album.id, album.managedBy);
-    return total + Number(file?.size || 0);
+    return total + (file?.available ? Number(file.size || 0) : 0);
   }, 0);
   const trackFileCount = albumTracks.filter((track) =>
     albumFiles(track, album.id).some((file) => file.available),

--- a/backend/services/canonicalLibraryReadAdapter.js
+++ b/backend/services/canonicalLibraryReadAdapter.js
@@ -7,24 +7,15 @@ import {
   getCanonicalTrackPath,
 } from "./libraryQueryService.js";
 import { getManagedByMap } from "./libraryManagementStore.js";
+import { selectCanonicalFile } from "./canonicalFileSelector.js";
 
 const albumFiles = (track, albumId) =>
   (track.files || []).filter((file) => file.albumId == null || file.albumId === albumId);
 
-const firstAvailableFile = (track, albumId) => {
-  const albumSpecific = (track.files || []).filter((file) => file.albumId === albumId);
-  const unscoped = (track.files || []).filter((file) => file.albumId == null);
-  return albumSpecific.find((file) => file.available)
-    || unscoped.find((file) => file.available)
-    || albumSpecific[0]
-    || unscoped[0]
-    || null;
-};
-
 const recordMatches = (record, reference) => {
   const value = String(reference ?? "").trim();
   if (!value) return false;
-  return [record.id, record.mbid, record.identityKey].some(
+  return [record.id, record.canonicalId, record.providerId, record.mbid, record.identityKey].some(
     (candidate) => String(candidate ?? "").trim() === value,
   );
 };
@@ -44,6 +35,7 @@ const buildArtist = (artist, albumsByArtistId, managementByArtistId = new Map())
     id: artist.id,
     canonicalId: artist.id,
     providerId,
+    source: artist.source || (artist.sources?.length === 1 ? artist.sources[0] : null),
     managedBy: management?.managedBy ?? null,
     monitorMode: management?.monitorMode ?? null,
     mbid: artist.mbid,
@@ -75,7 +67,7 @@ const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Ma
     .map((trackId) => tracksById.get(trackId))
     .filter(Boolean);
   const sizeOnDisk = albumTracks.reduce((total, track) => {
-    const file = firstAvailableFile(track, album.id);
+    const file = selectCanonicalFile(track.files, album.id, album.managedBy);
     return total + Number(file?.size || 0);
   }, 0);
   const trackFileCount = albumTracks.filter((track) =>
@@ -88,6 +80,7 @@ const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Ma
     canonicalId: album.id,
     identityKey: album.identityKey,
     providerId,
+    source: album.source || (album.sources?.length === 1 ? album.sources[0] : null),
     managedBy: management?.managedBy ?? null,
     monitorMode: management?.monitorMode ?? null,
     providerArtistId: album.metadata?.artistId ?? null,
@@ -96,7 +89,8 @@ const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Ma
     artistName: artist?.name || album.albumArtist,
     mbid: album.mbid || album.releaseGroupMbid,
     releaseGroupMbid: album.releaseGroupMbid || null,
-    foreignAlbumId: album.mbid || album.releaseGroupMbid || album.identityKey,
+    foreignAlbumId:
+      album.metadata?.foreignAlbumId || album.mbid || album.releaseGroupMbid || album.identityKey,
     albumName: album.title,
     title: album.title,
     releaseDate: album.releaseDate,
@@ -116,13 +110,17 @@ const buildAlbum = (album, artistsById, tracksById, managementByAlbumId = new Ma
 };
 
 const buildTrack = (track, album) => {
-  const file = firstAvailableFile(track, album.id);
+  const file = selectCanonicalFile(track.files, album.id, album.managedBy);
   const relation = track.albums.find((entry) => entry.albumId === album.id);
   return {
     id: track.id,
+    canonicalId: track.id,
+    providerId: track.metadata?.id ?? null,
     albumId: album.id,
     artistId: album.artistId,
     mbid: track.mbid,
+    foreignTrackId:
+      track.metadata?.foreignRecordingId || track.metadata?.foreignTrackId || track.mbid || track.identityKey,
     trackName: track.title,
     title: track.title,
     trackNumber: relation?.trackNumber || 0,
@@ -133,6 +131,9 @@ const buildTrack = (track, album) => {
     streamFormat: file?.format || null,
     addedAt: null,
     source: file?.source || null,
+    managedBy: album.managedBy ?? null,
+    monitorMode: album.monitorMode ?? null,
+    monitored: Boolean(album.metadata?.monitored),
     available: Boolean(file?.available),
     sources: track.sources,
   };
@@ -236,7 +237,7 @@ export function findCanonicalAlbumsForArtist(albums, reference) {
 
   return albums.filter(
     (album) =>
-      [album.artistId, album.artistMbid].some(
+      [album.artistId, album.providerArtistId, album.artistMbid].some(
         (candidate) => String(candidate ?? "").trim() === normalizedReference,
       ),
   );

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -276,8 +276,9 @@ export async function scanMusicRoot({
 export async function scanMusicRoots({ rootPaths = [], ...options } = {}) {
   const roots = [...new Set(
     (Array.isArray(rootPaths) ? rootPaths : [])
-      .map((rootPath) => path.resolve(String(rootPath || "")))
-      .filter(Boolean),
+      .map((rootPath) => String(rootPath ?? "").trim())
+      .filter(Boolean)
+      .map((rootPath) => path.resolve(rootPath)),
   )];
   const unseenPaths = getAvailableLibraryMediaPaths(options.source || "aurral");
   const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0, changed: false };

--- a/backend/services/libraryFileScanner.js
+++ b/backend/services/libraryFileScanner.js
@@ -273,4 +273,57 @@ export async function scanMusicRoot({
   return scanResult;
 }
 
+export async function scanMusicRoots({ rootPaths = [], ...options } = {}) {
+  const roots = [...new Set(
+    (Array.isArray(rootPaths) ? rootPaths : [])
+      .map((rootPath) => path.resolve(String(rootPath || "")))
+      .filter(Boolean),
+  )];
+  const unseenPaths = getAvailableLibraryMediaPaths(options.source || "aurral");
+  const result = { filesSeen: 0, filesIndexed: 0, filesFailed: 0, changed: false };
+  const scannedRoots = [];
+
+  for (const rootPath of roots) {
+    let rootStat;
+    try {
+      rootStat = await fs.stat(rootPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      result.filesFailed += 1;
+      continue;
+    }
+    if (!rootStat.isDirectory()) {
+      result.filesFailed += 1;
+      continue;
+    }
+
+    try {
+      const filePaths = [];
+      for await (const filePath of walkAudioFiles(rootPath)) filePaths.push(filePath);
+      const scan = await scanMusicRoot({ ...options, rootPath, filePaths });
+      result.filesSeen += scan.filesSeen;
+      result.filesIndexed += scan.filesIndexed;
+      result.filesFailed += scan.filesFailed;
+      result.changed ||= scan.changed;
+      for (const filePath of filePaths) unseenPaths.delete(filePath);
+      if (scan.filesFailed === 0) scannedRoots.push(rootPath);
+    } catch {
+      result.filesFailed += 1;
+    }
+  }
+
+  if (scannedRoots.length > 0) {
+    const missingPaths = [...unseenPaths].filter((filePath) =>
+      scannedRoots.some((rootPath) => {
+        const relative = path.relative(rootPath, filePath);
+        return relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+      }),
+    );
+    result.changed = markLibraryMediaFilesUnavailable(options.source || "aurral", missingPaths) > 0
+      || result.changed;
+  }
+
+  return result;
+}
+
 export { buildMetadataRecord, readPathFallback, AUDIO_EXTENSIONS };

--- a/backend/services/libraryFileWatcher.js
+++ b/backend/services/libraryFileWatcher.js
@@ -64,17 +64,14 @@ export function createLibraryFileWatcher({
   };
 }
 
-async function resolveLibraryWatchRoots() {
+export function resolveLibraryWatchRoots() {
   const roots = [resolvePlaylistRoot()];
-  if (lidarrClient.isConfigured()) {
-    try {
-      const rootFolders = await lidarrClient.getRootFolders();
-      roots.push(
-        ...(Array.isArray(rootFolders)
-          ? rootFolders.map((folder) => resolveLocalPath(folder?.path, getPathMappings("lidarr")))
-          : []),
-      );
-    } catch {}
+  if (lidarrClient.isEnabled()) {
+    roots.push(
+      ...lidarrClient
+        .getConfiguredRootFolderPaths()
+        .map((root) => resolveLocalPath(root, getPathMappings("lidarr"))),
+    );
   }
   return roots.filter(Boolean);
 }
@@ -87,7 +84,7 @@ export async function refreshLibraryFileWatcher({ logger = console } = {}) {
   activeWatcher?.close();
   const playlistRoot = path.resolve(resolvePlaylistRoot());
   activeWatcher = createLibraryFileWatcher({
-    roots: await resolveLibraryWatchRoots(),
+    roots: resolveLibraryWatchRoots(),
     onChange: (changedRoots) => scheduleLibraryScan({
       includeLidarr: changedRoots.some((root) => path.resolve(root) !== playlistRoot),
     }),

--- a/backend/services/libraryIndexService.js
+++ b/backend/services/libraryIndexService.js
@@ -1,13 +1,14 @@
 import path from "node:path";
 import { db } from "../config/db-sqlite.js";
+import { dbOps } from "../db/helpers/index.js";
 import { resolvePlaylistRoot } from "./playlistPaths.js";
-import { scanMusicRoot } from "./libraryFileScanner.js";
+import { scanMusicRoot, scanMusicRoots } from "./libraryFileScanner.js";
 import { upsertLibraryArtist } from "./libraryMediaStore.js";
-import { indexLidarrLibrary } from "./libraryLidarrIndexer.js";
 import { rebuildLibrarySearchIndex } from "./librarySearchIndex.js";
 import { rebuildCanonicalGenreStats } from "./libraryQueryService.js";
 import { musicbrainzGetArtistNameByMbid } from "./apiClients/index.js";
 import { logger } from "./logger.js";
+import { getPathMappings, resolveLocalPath } from "./pathMappings.js";
 
 function getAurralJobMetadataByPath() {
   const rows = db
@@ -59,10 +60,28 @@ async function canonicalizeAurralArtistNames(jobMetadataByPath) {
   }
 }
 
+function configuredLidarrRoots(lidarrClient, override) {
+  if (Array.isArray(override)) return override;
+  const fromClient = lidarrClient?.getConfiguredRootFolderPaths?.();
+  if (Array.isArray(fromClient) && fromClient.length > 0) return fromClient;
+  const settings = dbOps.getSettings();
+  const lidarr = settings.integrations?.lidarr || {};
+  return [
+    ...(Array.isArray(lidarr.rootFolderPaths) ? lidarr.rootFolderPaths : []),
+    lidarr.rootFolderPath,
+  ].filter(Boolean);
+}
+
+function isLidarrScanEnabled(lidarrClient) {
+  if (typeof lidarrClient?.isEnabled === "function") return lidarrClient.isEnabled();
+  return dbOps.getSettings().integrations?.lidarr?.enabled !== false;
+}
+
 export async function scanConfiguredLibrary({
   musicRoot = resolvePlaylistRoot(),
   lidarrClient,
   includeLidarr = true,
+  lidarrRoots = null,
 } = {}) {
   const jobMetadataByPath = getAurralJobMetadataByPath();
   let local;
@@ -76,12 +95,18 @@ export async function scanConfiguredLibrary({
       syncSearch: false,
     });
     await canonicalizeAurralArtistNames(jobMetadataByPath);
-    if (includeLidarr) {
+    const configuredRoots = configuredLidarrRoots(lidarrClient, lidarrRoots)
+      .map((root) => resolveLocalPath(root, getPathMappings("lidarr")));
+    if (includeLidarr && isLidarrScanEnabled(lidarrClient) && configuredRoots.length > 0) {
       try {
-        lidarr = await indexLidarrLibrary({ client: lidarrClient, syncSearch: false });
+        lidarr = await scanMusicRoots({
+          rootPaths: configuredRoots,
+          source: "lidarr",
+          syncSearch: false,
+        });
       } catch (error) {
         scanFailed = true;
-        logger.error("library", "Lidarr library indexing failed", {
+        logger.error("library", "Lidarr root scan failed", {
           message: error?.message || String(error),
         });
         lidarr = {

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -5,10 +5,14 @@ import { dbOps, userOps } from "../db/helpers/index.js";
 import { hasPermission } from "../middleware/auth.js";
 import {
   iterateCanonicalArtistProjection,
+  getCanonicalArtistProjection,
+  getCanonicalLibraryForAlbumReferences,
+  getCanonicalLibraryForArtistReferences,
   getCanonicalLibraryPage,
   getCanonicalTrack,
   invalidateCanonicalLibraryCache,
 } from "./libraryQueryService.js";
+import { selectCanonicalFile } from "./canonicalFileSelector.js";
 import { scheduleLibraryScan } from "./libraryScanWorker.js";
 import { downloadTracker } from "./weeklyFlow/weeklyFlowDownloadTracker.js";
 import {
@@ -62,6 +66,100 @@ const ALBUM_OWNED_BY_DIFFERENT_ARTIST_ERROR =
 function scheduleCanonicalLibraryReconciliation() {
   invalidateCanonicalLibraryCache();
   return scheduleLibraryScan({ includeLidarr: true });
+}
+
+function mapCanonicalAlbum(album, artist, tracks = []) {
+  const albumTrackIds = Array.isArray(album.trackIds) ? album.trackIds : [];
+  const albumTracks = tracks.filter((track) => albumTrackIds.includes(track.id));
+  const files = albumTracks.map((track) =>
+    selectCanonicalFile(track.files, album.id, album.managedBy),
+  );
+  const availableFiles = files.filter((file) => file?.available);
+  const trackCount = albumTracks.length;
+  return {
+    id: String(album.id),
+    canonicalId: String(album.id),
+    providerId: album.metadata?.id ?? null,
+    artistId: String(album.artistId),
+    artistName: artist?.name || album.albumArtist || null,
+    artistMbid: artist?.mbid || null,
+    mbid: album.mbid || album.releaseGroupMbid || null,
+    releaseGroupMbid: album.releaseGroupMbid || null,
+    foreignAlbumId:
+      album.metadata?.foreignAlbumId || album.mbid || album.releaseGroupMbid || album.identityKey,
+    albumName: album.title,
+    title: album.title,
+    path: album.metadata?.path || null,
+    addedAt: album.metadata?.added || null,
+    releaseDate: album.releaseDate || null,
+    monitored: album.metadata?.monitored === true,
+    managedBy: album.managedBy || null,
+    monitorMode: album.monitorMode || null,
+    sources: album.sources,
+    available: Boolean(album.available),
+    statistics: {
+      trackCount,
+      trackFileCount: availableFiles.length,
+      sizeOnDisk: availableFiles.reduce((total, file) => total + Number(file.size || 0), 0),
+      percentOfTracks: trackCount > 0
+        ? Math.round((availableFiles.length / trackCount) * 100)
+        : 0,
+    },
+  };
+}
+
+function mapCanonicalTrack(track, album) {
+  const file = selectCanonicalFile(track.files, album?.id, album?.managedBy);
+  const relation = (track.albums || []).find((entry) => entry.albumId === album?.id);
+  return {
+    id: String(track.id),
+    canonicalId: String(track.id),
+    providerId: track.metadata?.id ?? null,
+    albumId: album ? String(album.id) : null,
+    artistId: album ? String(album.artistId) : null,
+    mbid: track.mbid || null,
+    foreignTrackId:
+      track.metadata?.foreignRecordingId || track.metadata?.foreignTrackId || track.mbid || track.identityKey,
+    trackName: track.title,
+    title: track.title,
+    trackNumber: relation?.trackNumber || 0,
+    discNumber: relation?.discNumber || 1,
+    path: file?.path || null,
+    hasFile: Boolean(file?.available),
+    available: Boolean(file?.available),
+    source: file?.source || null,
+    managedBy: album?.managedBy || null,
+    monitorMode: album?.monitorMode || null,
+    monitored: album?.metadata?.monitored === true,
+    sources: track.sources,
+    size: Number(file?.size || 0),
+    quality:
+      file?.quality?.audioFormat ||
+      file?.quality?.quality?.name ||
+      file?.quality?.format ||
+      null,
+    addedAt: track.metadata?.added || null,
+  };
+}
+
+function canonicalArtistFallback(reference) {
+  return getCanonicalArtistProjection({ reference })[0] || null;
+}
+
+function canonicalLibraryForArtist(reference) {
+  return getCanonicalLibraryForArtistReferences({
+    source: "all",
+    availableOnly: false,
+    references: [reference],
+  });
+}
+
+function canonicalLibraryForAlbum(reference) {
+  return getCanonicalLibraryForAlbumReferences({
+    source: "all",
+    availableOnly: false,
+    references: [reference],
+  });
 }
 
 function removeLibraryDownloadJobs(track) {
@@ -197,11 +295,12 @@ function scheduleLidarrRetry() {
 }
 
 export function getCachedArtistCount() {
-  return Array.isArray(_cachedArtists) ? _cachedArtists.length : 0;
+  return getCachedArtists().length;
 }
 
 export function getCachedArtists() {
-  return Array.isArray(_cachedArtists) ? _cachedArtists : [];
+  const canonical = getCanonicalArtistProjection({ pageSize: 10000 });
+  return canonical.length > 0 ? canonical : (Array.isArray(_cachedArtists) ? _cachedArtists : []);
 }
 
 function getSettings() {
@@ -306,13 +405,8 @@ export function buildPlaybackQueueFromCanonicalLibrary({ artists = [], albums = 
     for (const trackId of album.trackIds || []) {
       const track = tracksById.get(trackId);
       if (!track) continue;
-      const file = (track.files || []).find(
-        (entry) =>
-          entry.available &&
-          entry.source === "lidarr" &&
-          (entry.albumId == null || entry.albumId === album.id),
-      );
-      if (!file) continue;
+      const file = selectCanonicalFile(track.files, album.id, album.managedBy);
+      if (!file?.available) continue;
       const relation = (track.albums || []).find((entry) => entry.albumId === album.id);
       queue.push({
         id: `lib-${album.artistId}-${album.id}-${track.id}`,
@@ -779,9 +873,7 @@ export class LibraryManager {
 
   async getArtist(mbid, { forceRefresh = false } = {}) {
     const lidarr = await getLidarrClient();
-    if (!lidarr || !lidarr.isConfigured()) {
-      return null;
-    }
+    if (!lidarr || !lidarr.isConfigured()) return canonicalArtistFallback(mbid);
     if (!forceRefresh) {
       const cachedArtist = findCachedArtistByMbid(mbid);
       if (cachedArtist) {
@@ -801,9 +893,7 @@ export class LibraryManager {
 
   async getArtistById(id) {
     const lidarr = await getLidarrClient();
-    if (!lidarr || !lidarr.isConfigured()) {
-      return null;
-    }
+    if (!lidarr || !lidarr.isConfigured()) return canonicalArtistFallback(id);
     try {
       const lidarrArtist = await lidarr.getArtist(id);
       await this.backfillLidarrArtistMappings([lidarrArtist]);
@@ -951,7 +1041,10 @@ export class LibraryManager {
     try {
       const lidarr = await getLidarrClient();
       if (!lidarr || !lidarr.isConfigured()) {
-        return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
+        const normalizedLimit = Math.max(0, Number(limit) || 0);
+        return normalizedLimit === 0
+          ? []
+          : getCanonicalArtistProjection({ pageSize: normalizedLimit });
       }
       if (_lastLidarrFailureAt && Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS) {
         return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
@@ -1472,7 +1565,9 @@ export class LibraryManager {
   async getAlbums(artistId, lidarrArtist = null, options = {}) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      return [];
+      const library = canonicalLibraryForArtist(artistId);
+      const artist = library.artists.find((entry) => entry.id === library.albums[0]?.artistId);
+      return library.albums.map((album) => mapCanonicalAlbum(album, artist, library.tracks));
     }
     try {
       const resolvedArtist = lidarrArtist || (await lidarr.getArtist(artistId));
@@ -1498,7 +1593,11 @@ export class LibraryManager {
   async getAlbumById(id) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      return null;
+      const library = canonicalLibraryForAlbum(id);
+      const album = library.albums[0];
+      if (!album) return null;
+      const artist = library.artists.find((entry) => entry.id === album.artistId);
+      return mapCanonicalAlbum(album, artist, library.tracks);
     }
     if (!id || id === "undefined" || id === "null") {
       return null;
@@ -1748,15 +1847,20 @@ export class LibraryManager {
       return [];
     }
 
+    const lidarr = await getLidarrClient();
+    if (!lidarr || !lidarr.isConfigured()) {
+      const library = canonicalLibraryForAlbum(albumId);
+      const album = library.albums[0];
+      if (!album) return [];
+      return library.tracks
+        .filter((track) => track.albums.some((entry) => entry.albumId === album.id))
+        .map((track) => mapCanonicalTrack(track, album));
+    }
+
     const key = String(albumId);
     const cached = _tracksCache.get(key);
     if (cached && cached.expires > Date.now()) {
       return cached.tracks;
-    }
-
-    const lidarr = await getLidarrClient();
-    if (!lidarr || !lidarr.isConfigured()) {
-      return [];
     }
     try {
       const lidarrAlbum = await lidarr.getAlbum(albumId);
@@ -1860,7 +1964,7 @@ export class LibraryManager {
   async getPlaybackQueue({ page = 1, pageSize = 100 } = {}) {
     return buildPlaybackQueueFromCanonicalLibrary(
       getCanonicalLibraryPage({
-        source: "lidarr",
+        source: "all",
         availableOnly: true,
         kind: "tracks",
         page,

--- a/backend/services/libraryManager.js
+++ b/backend/services/libraryManager.js
@@ -162,6 +162,52 @@ function canonicalLibraryForAlbum(reference) {
   });
 }
 
+function canonicalAlbumsForArtist(reference) {
+  const library = canonicalLibraryForArtist(reference);
+  const artistId = library.albums[0]?.artistId;
+  const artist = library.artists.find((entry) => entry.id === artistId);
+  return library.albums.map((album) => mapCanonicalAlbum(album, artist, library.tracks));
+}
+
+function canonicalAlbumForReference(reference) {
+  const library = canonicalLibraryForAlbum(reference);
+  const album = library.albums[0];
+  if (!album) return null;
+  const artist = library.artists.find((entry) => entry.id === album.artistId);
+  return mapCanonicalAlbum(album, artist, library.tracks);
+}
+
+function canonicalTracksForAlbum(reference) {
+  const library = canonicalLibraryForAlbum(reference);
+  const album = library.albums[0];
+  if (!album) return [];
+  return library.tracks
+    .filter((track) => track.albums.some((entry) => entry.albumId === album.id))
+    .map((track) => mapCanonicalTrack(track, album));
+}
+
+function canonicalRecentArtists(limit) {
+  const normalizedLimit = Math.max(0, Number(limit) || 0);
+  return normalizedLimit === 0
+    ? []
+    : getCanonicalArtistProjection({ pageSize: normalizedLimit });
+}
+
+function cachedOrCanonicalRecentArtists(limit) {
+  const normalizedLimit = Math.max(0, Number(limit) || 0);
+  if (normalizedLimit === 0) return [];
+  if (Array.isArray(_cachedArtists) && _cachedArtists.length > 0) {
+    return _cachedArtists.slice(0, normalizedLimit);
+  }
+  return canonicalRecentArtists(normalizedLimit);
+}
+
+function isLidarrNotFoundError(error) {
+  return error?.response?.status === 404 ||
+    error?.status === 404 ||
+    /\b404\b|not found in lidarr/i.test(String(error?.message || ""));
+}
+
 function removeLibraryDownloadJobs(track) {
   const normalize = (value) => String(value || "").trim().toLocaleLowerCase();
   const trackMbid = normalize(track?.mbid);
@@ -241,6 +287,18 @@ function findCachedArtistByMbid(mbid) {
     _cachedArtists.find((artist) => artist?.mbid === mbid || artist?.foreignArtistId === mbid) ||
     null
   );
+}
+
+function findCachedArtistById(id) {
+  const value = String(id ?? "").trim();
+  if (!value || !Array.isArray(_cachedArtists) || _cachedArtists.length === 0) {
+    return null;
+  }
+  return _cachedArtists.find((artist) =>
+    [artist?.id, artist?.canonicalId, artist?.providerId].some(
+      (candidate) => String(candidate ?? "").trim() === value,
+    ),
+  ) || null;
 }
 
 function upsertCachedArtist(mappedArtist) {
@@ -886,7 +944,10 @@ export class LibraryManager {
       const mappedArtist = this.mapLidarrArtist(lidarrArtist);
       upsertCachedArtist(mappedArtist);
       return mappedArtist;
-    } catch {
+    } catch (error) {
+      if (!isLidarrNotFoundError(error)) {
+        return findCachedArtistByMbid(mbid) || canonicalArtistFallback(mbid);
+      }
       return null;
     }
   }
@@ -899,6 +960,9 @@ export class LibraryManager {
       await this.backfillLidarrArtistMappings([lidarrArtist]);
       return this.mapLidarrArtist(lidarrArtist);
     } catch (error) {
+      if (!isLidarrNotFoundError(error)) {
+        return findCachedArtistById(id) || canonicalArtistFallback(id);
+      }
       return null;
     }
   }
@@ -1041,13 +1105,10 @@ export class LibraryManager {
     try {
       const lidarr = await getLidarrClient();
       if (!lidarr || !lidarr.isConfigured()) {
-        const normalizedLimit = Math.max(0, Number(limit) || 0);
-        return normalizedLimit === 0
-          ? []
-          : getCanonicalArtistProjection({ pageSize: normalizedLimit });
+        return canonicalRecentArtists(limit);
       }
       if (_lastLidarrFailureAt && Date.now() - _lastLidarrFailureAt < LIDARR_RETRY_MS) {
-        return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
+        return cachedOrCanonicalRecentArtists(limit);
       }
       const normalizedLimit = Math.max(0, limit);
       const normalizedPool = Math.max(normalizedLimit, poolSize);
@@ -1079,7 +1140,7 @@ export class LibraryManager {
             }
           } catch {}
         }
-        return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, normalizedLimit) : [];
+        return cachedOrCanonicalRecentArtists(normalizedLimit);
       }
       const picked = artistIds.sort(() => 0.5 - Math.random()).slice(0, normalizedLimit);
       const artists = await Promise.all(picked.map((id) => lidarr.getArtist(id).catch(() => null)));
@@ -1098,9 +1159,9 @@ export class LibraryManager {
           .slice(0, Math.max(0, normalizedLimit - mapped.length));
         return [...mapped, ...extra];
       }
-      return mapped;
+      return mapped.length > 0 ? mapped : canonicalRecentArtists(normalizedLimit);
     } catch (_) {
-      return Array.isArray(_cachedArtists) ? _cachedArtists.slice(0, limit) : [];
+      return cachedOrCanonicalRecentArtists(limit);
     }
   }
 
@@ -1565,9 +1626,7 @@ export class LibraryManager {
   async getAlbums(artistId, lidarrArtist = null, options = {}) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      const library = canonicalLibraryForArtist(artistId);
-      const artist = library.artists.find((entry) => entry.id === library.albums[0]?.artistId);
-      return library.albums.map((album) => mapCanonicalAlbum(album, artist, library.tracks));
+      return canonicalAlbumsForArtist(artistId);
     }
     try {
       const resolvedArtist = lidarrArtist || (await lidarr.getArtist(artistId));
@@ -1586,18 +1645,16 @@ export class LibraryManager {
         : [];
       return artistAlbums.map((a) => this.mapLidarrAlbum(a, resolvedArtist));
     } catch (error) {
-      logger.error('library', `[LibraryManager] Failed to fetch albums from Lidarr: ${error.message}`);      return [];
+      if (isLidarrNotFoundError(error)) return [];
+      logger.error('library', `[LibraryManager] Failed to fetch albums from Lidarr: ${error.message}`);
+      return canonicalAlbumsForArtist(artistId);
     }
   }
 
   async getAlbumById(id) {
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      const library = canonicalLibraryForAlbum(id);
-      const album = library.albums[0];
-      if (!album) return null;
-      const artist = library.artists.find((entry) => entry.id === album.artistId);
-      return mapCanonicalAlbum(album, artist, library.tracks);
+      return canonicalAlbumForReference(id);
     }
     if (!id || id === "undefined" || id === "null") {
       return null;
@@ -1610,10 +1667,8 @@ export class LibraryManager {
       const lidarrArtist = await lidarr.getArtist(lidarrAlbum.artistId);
       return this.mapLidarrAlbum(lidarrAlbum, lidarrArtist);
     } catch (error) {
-      if (error.response?.status === 404 || error.message?.includes("404")) {
-        return null;
-      }
-      return null;
+      if (isLidarrNotFoundError(error)) return null;
+      return canonicalAlbumForReference(id);
     }
   }
 
@@ -1849,12 +1904,7 @@ export class LibraryManager {
 
     const lidarr = await getLidarrClient();
     if (!lidarr || !lidarr.isConfigured()) {
-      const library = canonicalLibraryForAlbum(albumId);
-      const album = library.albums[0];
-      if (!album) return [];
-      return library.tracks
-        .filter((track) => track.albums.some((entry) => entry.albumId === album.id))
-        .map((track) => mapCanonicalTrack(track, album));
+      return canonicalTracksForAlbum(albumId);
     }
 
     const key = String(albumId);
@@ -1954,10 +2004,9 @@ export class LibraryManager {
       if (cached) {
         return cached.tracks;
       }
-      if (error.message && error.message.includes("404")) {
-        return [];
-      }
-      logger.error('library', `[LibraryManager] Failed to fetch tracks from Lidarr: ${error.message}`);      return [];
+      if (isLidarrNotFoundError(error)) return [];
+      logger.error('library', `[LibraryManager] Failed to fetch tracks from Lidarr: ${error.message}`);
+      return canonicalTracksForAlbum(albumId);
     }
   }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -9,6 +9,7 @@ import {
   invalidateLibraryManagementCache,
   onLibraryManagementChange,
 } from "./libraryManagementStore.js";
+import { selectCanonicalFile } from "./canonicalFileSelector.js";
 
 const SOURCES = new Set(["aurral", "lidarr"]);
 const libraryCache = new Map();
@@ -101,13 +102,23 @@ function buildLibraryFromRows(rows) {
   const tracks = new Map();
 
   for (const row of rows) {
+    const artistMetadata = parseJson(row.artist_metadata_json);
+    const albumMetadata = parseJson(row.album_metadata_json);
+    const trackMetadata = parseJson(row.track_metadata_json);
     const artist = createEntity(artists, row.artist_id, {
       id: row.artist_id,
+      canonicalId: String(row.artist_id),
       identityKey: row.artist_identity_key,
       mbid: row.artist_mbid,
       name: row.artist_name,
       sortName: row.artist_sort_name,
-      metadata: parseJson(row.artist_metadata_json),
+      metadata: artistMetadata,
+      providerId: artistMetadata?.id ?? null,
+      monitored: artistMetadata?.monitored === true,
+      monitorOption:
+        artistMetadata?.monitor ||
+        artistMetadata?.addOptions?.monitor ||
+        "none",
       albumIds: [],
       sources: [],
       available: false,
@@ -116,6 +127,7 @@ function buildLibraryFromRows(rows) {
     artist.monitorMode = artistManagement.get(row.artist_id)?.monitorMode ?? null;
     const album = createEntity(albums, row.album_id, {
       id: row.album_id,
+      canonicalId: String(row.album_id),
       identityKey: row.album_identity_key,
       mbid: row.album_mbid,
       releaseGroupMbid: row.album_release_group_mbid,
@@ -123,7 +135,13 @@ function buildLibraryFromRows(rows) {
       title: row.album_title,
       albumArtist: row.album_artist,
       releaseDate: row.album_release_date,
-      metadata: parseJson(row.album_metadata_json),
+      metadata: albumMetadata,
+      providerId: albumMetadata?.id ?? null,
+      monitored: albumMetadata?.monitored === true,
+      monitorOption:
+        albumMetadata?.monitor ||
+        albumMetadata?.addOptions?.monitor ||
+        "none",
       trackIds: [],
       sources: [],
       available: false,
@@ -132,16 +150,21 @@ function buildLibraryFromRows(rows) {
     album.monitorMode = albumManagement.get(row.album_id)?.monitorMode ?? null;
     const track = createEntity(tracks, row.track_id, {
       id: row.track_id,
+      canonicalId: String(row.track_id),
       identityKey: row.track_identity_key,
       mbid: row.track_mbid,
       title: row.track_title,
       artistName: row.track_artist_name,
-      metadata: parseJson(row.track_metadata_json),
+      metadata: trackMetadata,
+      providerId: trackMetadata?.id ?? null,
       albums: [],
       files: [],
       sources: [],
       available: false,
     });
+    track.managedBy = album.managedBy ?? null;
+    track.monitorMode = album.monitorMode ?? null;
+    track.monitored = album.monitored;
 
     if (!artist.albumIds.includes(album.id)) artist.albumIds.push(album.id);
     if (!album.trackIds.includes(track.id)) album.trackIds.push(track.id);
@@ -187,9 +210,12 @@ function buildLibraryFromRows(rows) {
 
   for (const entity of [...artists.values(), ...albums.values(), ...tracks.values()]) {
     entity.sources.sort();
+    entity.source = entity.sources.length === 1 ? entity.sources[0] : null;
   }
   for (const track of tracks.values()) {
-    track.files.sort((left, right) => left.path.localeCompare(right.path));
+    track.files.sort((left, right) =>
+      String(left.path || "").localeCompare(String(right.path || "")),
+    );
   }
 
   return {
@@ -426,6 +452,8 @@ export function* iterateCanonicalArtistProjection({ pageSize = 100 } = {}) {
 const canonicalDateAlbumProjection = (row) => {
   const metadata = parseJson(row.metadata_json) || {};
   const artistMetadata = parseJson(row.artist_metadata_json) || {};
+  const sources = parseSources(row.sources);
+  const management = getManagedByMap("album").get(Number(row.id)) || null;
   const trackCount = Number(row.track_count || 0);
   const availableTrackCount = Number(row.available_track_count || 0);
   return {
@@ -440,11 +468,17 @@ const canonicalDateAlbumProjection = (row) => {
       artistMetadata.foreignArtistId || row.artist_mbid || row.artist_identity_key,
     mbid: row.mbid || row.release_group_mbid || null,
     releaseGroupMbid: row.release_group_mbid || null,
-    foreignAlbumId: row.mbid || row.release_group_mbid || row.identity_key,
+    foreignAlbumId:
+      metadata.foreignAlbumId || row.mbid || row.release_group_mbid || row.identity_key,
     albumName: row.title,
     title: row.title,
     releaseDate: row.release_date,
     monitored: metadata.monitored === true,
+    managedBy: management?.managedBy ?? null,
+    monitorMode: management?.monitorMode ?? null,
+    source: sources.length === 1 ? sources[0] : null,
+    sources,
+    available: Boolean(row.available),
     albumType: metadata.albumType || metadata.releaseType || null,
     trackCount,
     availableTrackCount,
@@ -524,7 +558,9 @@ export function getCanonicalAlbumsByReleaseDate({
       album.*,
       COUNT(DISTINCT album_track.track_id) AS track_count,
       COUNT(DISTINCT CASE WHEN media.available = 1 THEN album_track.track_id END) AS available_track_count,
-      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk
+      COALESCE(SUM(CASE WHEN media.available = 1 THEN media.size ELSE 0 END), 0) AS size_on_disk,
+      GROUP_CONCAT(DISTINCT media.source) AS sources,
+      MAX(media.available) AS available
     FROM date_albums AS album
     LEFT JOIN library_album_tracks AS album_track ON album_track.album_id = album.id
     LEFT JOIN library_media_files AS media
@@ -541,35 +577,36 @@ export function getCanonicalTrackPath(albumReference, trackReference) {
   const trackValue = String(trackReference ?? "").trim();
   if (!albumValue || !trackValue) return null;
 
-  const album = /^[1-9]\d*$/.test(albumValue)
-    ? db.prepare("SELECT id FROM library_albums WHERE id = ?").get(albumValue)
-    : db.prepare(
-      `SELECT id FROM library_albums
-       WHERE identity_key = ? OR mbid = ? OR release_group_mbid = ?
+  const album = db.prepare(
+    `SELECT id FROM library_albums
+       WHERE id = ? OR identity_key = ? OR mbid = ? OR release_group_mbid = ? OR
+         (json_valid(metadata_json) AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?)
        LIMIT 1`,
-    ).get(albumValue, albumValue, albumValue);
-  const track = /^[1-9]\d*$/.test(trackValue)
-    ? db.prepare("SELECT id FROM library_tracks WHERE id = ?").get(trackValue)
-    : db.prepare(
-      `SELECT id FROM library_tracks
-       WHERE identity_key = ? OR mbid = ?
+  ).get(albumValue, albumValue, albumValue, albumValue, albumValue);
+  const track = db.prepare(
+    `SELECT id FROM library_tracks
+       WHERE id = ? OR identity_key = ? OR mbid = ? OR
+         (json_valid(metadata_json) AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?)
        LIMIT 1`,
-    ).get(trackValue, trackValue);
+  ).get(trackValue, trackValue, trackValue, trackValue);
   if (!album || !track) return null;
 
-  return db.prepare(
-    `SELECT media.path
+  const files = db.prepare(
+    `SELECT media.id,
+            media.album_id AS albumId,
+            media.source,
+            media.path,
+            media.available
      FROM library_media_files AS media
      JOIN library_album_tracks AS album_track
        ON album_track.album_id = ? AND album_track.track_id = media.track_id
      WHERE media.track_id = ?
        AND media.available = 1
        AND (media.album_id = ? OR media.album_id IS NULL)
-     ORDER BY media.album_id = ? DESC,
-              media.source = 'lidarr' DESC,
-              media.path COLLATE NOCASE
-     LIMIT 1`,
-  ).get(album.id, track.id, album.id, album.id)?.path || null;
+     ORDER BY media.path COLLATE NOCASE`,
+  ).all(album.id, track.id, album.id);
+  const managedBy = getManagedByMap("album").get(Number(album.id))?.managedBy || null;
+  return selectCanonicalFile(files, album.id, managedBy)?.path || null;
 }
 
 export function getCanonicalTrack({
@@ -585,11 +622,17 @@ export function getCanonicalTrack({
   const conditions = [];
   const parameters = [];
   if (Number.isSafeInteger(numericId) && numericId > 0) {
-    conditions.push("track.id = ?");
-    parameters.push(numericId);
+    conditions.push(`(
+      track.id = ? OR
+      (json_valid(track.metadata_json) AND CAST(json_extract(track.metadata_json, '$.id') AS TEXT) = ?)
+    )`);
+    parameters.push(numericId, reference);
   } else {
-    conditions.push("(track.identity_key = ? OR track.mbid = ?)");
-    parameters.push(reference, reference);
+    conditions.push(`(
+      track.identity_key = ? OR track.mbid = ? OR
+      (json_valid(track.metadata_json) AND CAST(json_extract(track.metadata_json, '$.id') AS TEXT) = ?)
+    )`);
+    parameters.push(reference, reference, reference);
   }
   if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
     conditions.push("album.id = ?");
@@ -832,10 +875,16 @@ export function getCanonicalLibraryForAlbumReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
+  const columns = ["identity_key", "mbid", "release_group_mbid"];
+  if (references.some((reference) => /^\d+$/.test(reference))) {
+    columns.push(
+      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+    );
+  }
   const ids = resolveCanonicalReferenceIds(
     "library_albums",
     references,
-    ["identity_key", "mbid", "release_group_mbid"],
+    columns,
   );
   if (!ids.length) return { artists: [], albums: [], tracks: [] };
   const sourceFilter = normalizeSource(source);
@@ -1151,20 +1200,27 @@ export function getCanonicalArtistPage({
          ${albumFilter}
        GROUP BY artist.id`,
     ).all(...ids, ...(sourceFilter ? [sourceFilter] : []));
-    const byId = new Map(rows.map((row) => [row.artist_id, {
-      id: row.artist_id,
-      identityKey: row.artist_identity_key,
-      mbid: row.artist_mbid,
-      name: row.artist_name,
-      sortName: row.artist_sort_name,
-      metadata: parseJson(row.artist_metadata_json),
-      albumIds: [],
-      albumCount: Number(row.album_count || 0),
-      managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
-      monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
-      sources: [],
-      available: availableOnly === true,
-    }]));
+    const byId = new Map(rows.map((row) => {
+      const metadata = parseJson(row.artist_metadata_json);
+      return [row.artist_id, {
+        id: row.artist_id,
+        canonicalId: String(row.artist_id),
+        identityKey: row.artist_identity_key,
+        mbid: row.artist_mbid,
+        name: row.artist_name,
+        sortName: row.artist_sort_name,
+        metadata,
+        providerId: metadata?.id ?? null,
+        albumIds: [],
+        albumCount: Number(row.album_count || 0),
+        managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
+        monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
+        sources: [],
+        source: null,
+        monitored: metadata?.monitored === true,
+        available: availableOnly === true,
+      }];
+    }));
     return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
   }
 
@@ -1202,22 +1258,30 @@ export function getCanonicalArtistPage({
      ORDER BY coalesce(artist.sort_name, artist.name) COLLATE NOCASE,
        artist.name COLLATE NOCASE`,
   ).all(...aggregateParameters);
-  const byId = new Map(rows.map((row) => [row.artist_id, {
-    id: row.artist_id,
-    identityKey: row.artist_identity_key,
-    mbid: row.artist_mbid,
-    name: row.artist_name,
-    sortName: row.artist_sort_name,
-    metadata: parseJson(row.artist_metadata_json),
-    albumIds: [],
-    albumCount: Number(row.album_count || 0),
-    trackCount: Number(row.track_count || 0),
-    sizeOnDisk: Number(row.size_on_disk || 0),
-    managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
-    monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
-    sources: parseSources(row.sources),
-    available: Boolean(row.available),
-  }]));
+  const byId = new Map(rows.map((row) => {
+    const metadata = parseJson(row.artist_metadata_json);
+    const sources = parseSources(row.sources);
+    return [row.artist_id, {
+      id: row.artist_id,
+      canonicalId: String(row.artist_id),
+      identityKey: row.artist_identity_key,
+      mbid: row.artist_mbid,
+      name: row.artist_name,
+      sortName: row.artist_sort_name,
+      metadata,
+      providerId: metadata?.id ?? null,
+      albumIds: [],
+      albumCount: Number(row.album_count || 0),
+      trackCount: Number(row.track_count || 0),
+      sizeOnDisk: Number(row.size_on_disk || 0),
+      managedBy: artistManagement.get(row.artist_id)?.managedBy ?? null,
+      monitorMode: artistManagement.get(row.artist_id)?.monitorMode ?? null,
+      sources,
+      source: sources.length === 1 ? sources[0] : null,
+      monitored: metadata?.monitored === true,
+      available: Boolean(row.available),
+    }];
+  }));
   return { artists: ids.map((id) => byId.get(id)).filter(Boolean), albums: [], tracks: [] };
 }
 

--- a/backend/services/libraryQueryService.js
+++ b/backend/services/libraryQueryService.js
@@ -577,18 +577,19 @@ export function getCanonicalTrackPath(albumReference, trackReference) {
   const trackValue = String(trackReference ?? "").trim();
   if (!albumValue || !trackValue) return null;
 
-  const album = db.prepare(
-    `SELECT id FROM library_albums
-       WHERE id = ? OR identity_key = ? OR mbid = ? OR release_group_mbid = ? OR
-         (json_valid(metadata_json) AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?)
-       LIMIT 1`,
-  ).get(albumValue, albumValue, albumValue, albumValue, albumValue);
-  const track = db.prepare(
-    `SELECT id FROM library_tracks
-       WHERE id = ? OR identity_key = ? OR mbid = ? OR
-         (json_valid(metadata_json) AND CAST(json_extract(metadata_json, '$.id') AS TEXT) = ?)
-       LIMIT 1`,
-  ).get(trackValue, trackValue, trackValue, trackValue);
+  const [albumId] = resolveCanonicalReferenceIds("library_albums", [albumValue], [
+    "identity_key",
+    "mbid",
+    "release_group_mbid",
+    "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+  ]);
+  const [trackId] = resolveCanonicalReferenceIds("library_tracks", [trackValue], [
+    "identity_key",
+    "mbid",
+    "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+  ]);
+  const album = albumId ? { id: albumId } : null;
+  const track = trackId ? { id: trackId } : null;
   if (!album || !track) return null;
 
   const files = db.prepare(
@@ -618,22 +619,14 @@ export function getCanonicalTrack({
   const reference = String(trackId ?? "").trim();
   if (!reference) return { artists: [], albums: [], tracks: [] };
 
-  const numericId = /^\d+$/.test(reference) ? Number(reference) : null;
-  const conditions = [];
-  const parameters = [];
-  if (Number.isSafeInteger(numericId) && numericId > 0) {
-    conditions.push(`(
-      track.id = ? OR
-      (json_valid(track.metadata_json) AND CAST(json_extract(track.metadata_json, '$.id') AS TEXT) = ?)
-    )`);
-    parameters.push(numericId, reference);
-  } else {
-    conditions.push(`(
-      track.identity_key = ? OR track.mbid = ? OR
-      (json_valid(track.metadata_json) AND CAST(json_extract(track.metadata_json, '$.id') AS TEXT) = ?)
-    )`);
-    parameters.push(reference, reference, reference);
-  }
+  const [resolvedTrackId] = resolveCanonicalReferenceIds("library_tracks", [reference], [
+    "identity_key",
+    "mbid",
+    "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+  ]);
+  if (!resolvedTrackId) return { artists: [], albums: [], tracks: [] };
+  const conditions = ["track.id = ?"];
+  const parameters = [resolvedTrackId];
   if (albumId !== null && albumId !== undefined && String(albumId).trim()) {
     conditions.push("album.id = ?");
     parameters.push(Number(albumId));
@@ -802,22 +795,32 @@ function getCanonicalLibraryForIds(kind, ids, source, availableOnly) {
 }
 
 function resolveCanonicalReferenceIds(table, references, columns) {
-  const numericIds = references
-    .filter((reference) => /^\d+$/.test(reference))
-    .map(Number);
-  const queries = [];
-  const parameters = [];
-  if (numericIds.length) {
-    queries.push(`SELECT id FROM ${table} WHERE id IN (${numericIds.map(() => "?").join(",")})`);
-    parameters.push(...numericIds);
-  }
-  for (const column of columns) {
-    queries.push(
-      `SELECT id FROM ${table} WHERE ${column} IN (${references.map(() => "?").join(",")})`,
-    );
-    parameters.push(...references);
-  }
-  return db.prepare(queries.join(" UNION ")).all(...parameters).map((row) => row.id);
+  const requested = references.map(() => "(?, ?)").join(", ");
+  const canonicalCandidates = `(
+    SELECT canonical.id
+    FROM ${table} AS canonical
+    WHERE canonical.id = requested.canonical_id
+    LIMIT 1
+  )`;
+  const aliasCandidates = columns.map((column) => `(
+    SELECT alias.id
+    FROM ${table} AS alias
+    WHERE ${column} = requested.reference
+    ORDER BY alias.id
+    LIMIT 1
+  )`);
+  const sql = `
+    SELECT id FROM ${table}
+    WHERE id IN (
+      WITH requested(reference, canonical_id) AS (VALUES ${requested})
+      SELECT COALESCE(${[canonicalCandidates, ...aliasCandidates].join(",")})
+      FROM requested
+    )`;
+  const parameters = references.flatMap((reference) => {
+    const numericId = /^\d+$/.test(reference) ? Number(reference) : null;
+    return [reference, Number.isSafeInteger(numericId) && numericId > 0 ? numericId : null];
+  });
+  return db.prepare(sql).all(...parameters).map((row) => row.id);
 }
 
 export function getCanonicalLibraryForArtistReferences({
@@ -875,12 +878,12 @@ export function getCanonicalLibraryForAlbumReferences({
 } = {}) {
   const references = normalizeLookupValues(requestedReferences);
   if (!references.length) return { artists: [], albums: [], tracks: [] };
-  const columns = ["identity_key", "mbid", "release_group_mbid"];
-  if (references.some((reference) => /^\d+$/.test(reference))) {
-    columns.push(
-      "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
-    );
-  }
+  const columns = [
+    "identity_key",
+    "mbid",
+    "release_group_mbid",
+    "CAST(CASE WHEN json_valid(metadata_json) THEN json_extract(metadata_json, '$.id') END AS TEXT)",
+  ];
   const ids = resolveCanonicalReferenceIds(
     "library_albums",
     references,

--- a/backend/services/lidarrClient.js
+++ b/backend/services/lidarrClient.js
@@ -36,6 +36,14 @@ function normalizeRootFolderPath(value) {
   return normalized || null;
 }
 
+function normalizeRootFolderPaths(values) {
+  return [...new Set(
+    (Array.isArray(values) ? values : [])
+      .map(normalizeRootFolderPath)
+      .filter(Boolean),
+  )];
+}
+
 function normalizeProfileId(value) {
   if (value === null || value === undefined || value === "") {
     return null;
@@ -178,6 +186,7 @@ export class LidarrClient {
     this._albumCache = new BoundedMap(LIDARR_ARTIST_ALBUM_CACHE_MAX);
     this._albumMbidIndex = null;
     this._statusCache = new BoundedMap(LIDARR_STATUS_CACHE_MAX);
+    this._rootFoldersCache = null;
     this._inflightGets = new Map();
     this._httpAgent = new http.Agent({
       keepAlive: true,
@@ -312,6 +321,9 @@ export class LidarrClient {
     if (endpoint === "/artist" && this._artistListCache) {
       return this._artistListCache.data;
     }
+    if (endpoint === "/rootFolder" && this._rootFoldersCache) {
+      return this._rootFoldersCache.data;
+    }
     if (endpoint === "/album" || endpoint.startsWith("/album?")) {
       const cached = this._albumCache.get(endpoint);
       if (cached) return cached.data;
@@ -348,6 +360,8 @@ export class LidarrClient {
     const newConfig = {
       url: url,
       apiKey: (dbConfig.apiKey || process.env.LIDARR_API_KEY || "").trim(),
+      rootFolderPath: normalizeRootFolderPath(dbConfig.rootFolderPath),
+      rootFolderPaths: normalizeRootFolderPaths(dbConfig.rootFolderPaths),
       insecure: !!insecure,
       timeoutMs,
       circuitDisabled,
@@ -358,6 +372,8 @@ export class LidarrClient {
       !previousConfig ||
       previousConfig.url !== newConfig.url ||
       previousConfig.apiKey !== newConfig.apiKey ||
+      previousConfig.rootFolderPath !== newConfig.rootFolderPath ||
+      JSON.stringify(previousConfig.rootFolderPaths) !== JSON.stringify(newConfig.rootFolderPaths) ||
       previousConfig.insecure !== newConfig.insecure ||
       previousConfig.timeoutMs !== newConfig.timeoutMs ||
       previousConfig.circuitDisabled !== newConfig.circuitDisabled ||
@@ -369,6 +385,7 @@ export class LidarrClient {
       this._invalidateArtistIndexes();
       this._albumCache = new BoundedMap(LIDARR_ARTIST_ALBUM_CACHE_MAX);
       this._statusCache.clear();
+      this._rootFoldersCache = null;
     }
   }
 
@@ -404,6 +421,7 @@ export class LidarrClient {
   async request(endpoint, method = "GET", data = null, skipConfigUpdate = false, options = {}) {
     const shouldDedupeGet =
       endpoint === "/artist" ||
+      endpoint === "/rootFolder" ||
       endpoint.startsWith("/album") ||
       endpoint === "/queue" ||
       endpoint.startsWith("/history?") ||
@@ -744,8 +762,34 @@ export class LidarrClient {
     }
   }
 
-  async getRootFolders() {
-    return this.request("/rootFolder");
+  getConfiguredRootFolderPaths() {
+    this.updateConfig();
+    return normalizeRootFolderPaths([
+      ...this.config.rootFolderPaths,
+      this.config.rootFolderPath,
+    ]);
+  }
+
+  async getRootFolders({ forceRefresh = false } = {}) {
+    this.updateConfig();
+    if (!forceRefresh && this._rootFoldersCache) return this._rootFoldersCache.data;
+    const configured = this.getConfiguredRootFolderPaths();
+    if (!forceRefresh && configured.length > 0) {
+      const folders = configured.map((path) => ({ path }));
+      this._rootFoldersCache = { data: folders, at: Date.now() };
+      return folders;
+    }
+    const folders = mapRootFolders(await this.request(
+      "/rootFolder",
+      "GET",
+      null,
+      false,
+      { forceRefresh },
+    ));
+    this._rootFoldersCache = { data: folders, at: Date.now() };
+    const paths = folders.map((folder) => folder.path);
+    this.config.rootFolderPaths = dbOps.setLidarrRootFolderPaths(paths);
+    return folders;
   }
 
   async getTags(skipConfigUpdate = false) {

--- a/backend/services/subsonicLibraryService.js
+++ b/backend/services/subsonicLibraryService.js
@@ -29,6 +29,7 @@ import { playlistManager } from "./weeklyFlow/weeklyFlowPlaylistManager.js";
 import { weeklyFlowWorker } from "./weeklyFlow/weeklyFlowWorker.js";
 import { hasPermission } from "../middleware/auth.js";
 import { recordTrackJobQueued } from "./aurralHistoryService.js";
+import { selectCanonicalFile } from "./canonicalFileSelector.js";
 
 const idFor = (kind, key) => `${kind}:${encodeURIComponent(String(key))}`;
 const LIBRARY_IMAGE_PROFILE = "library";
@@ -43,8 +44,8 @@ const parseId = (value) => {
   }
 };
 
-const firstFile = (track) =>
-  (track?.files || []).find((file) => file.available) || (track?.files || [])[0] || null;
+const firstFile = (track, albumId = null, managedBy = null) =>
+  selectCanonicalFile(track?.files, albumId, managedBy);
 
 const seconds = (durationMs) => {
   const value = Number(durationMs);
@@ -115,7 +116,7 @@ const coverArtForAlbum = (album) => idFor("album", album.identityKey);
 
 const toSong = (library, track, album = findAlbumForTrack(library, track)) => {
   const artist = findArtistForAlbum(library, album);
-  const file = firstFile(track);
+  const file = firstFile(track, album?.id, album?.managedBy);
   const genres = [...new Set([
     ...entityGenres(artist),
     ...entityGenres(album),
@@ -180,7 +181,10 @@ const albumData = (library, album) => {
     created: PROTOCOL_DATE,
     coverArt: coverArtForAlbum(album),
     songCount: tracks.length,
-    duration: tracks.reduce((total, track) => total + seconds(firstFile(track)?.durationMs), 0),
+    duration: tracks.reduce(
+      (total, track) => total + seconds(firstFile(track, album.id, album.managedBy)?.durationMs),
+      0,
+    ),
     song: [],
   };
   const releaseYear = year(album.releaseDate);
@@ -496,7 +500,7 @@ const trackFromCanonical = (library, track) => {
     albumMbid: album?.mbid || album?.releaseGroupMbid,
     trackMbid: track?.mbid,
     releaseYear: year(album?.releaseDate),
-    durationMs: firstFile(track)?.durationMs,
+    durationMs: firstFile(track, album?.id, album?.managedBy)?.durationMs,
     trackNumber: track?.albums?.[0]?.trackNumber,
   });
 };
@@ -579,9 +583,10 @@ const findAvailableCanonicalFile = (track) => {
     }));
     candidate = library.tracks.find((entry) => isSameTrack(track, trackFromCanonical(library, entry)));
   }
-  const file = firstFile(candidate);
+  const album = findAlbumForTrack(library, candidate);
+  const file = firstFile(candidate, album?.id, album?.managedBy);
   return file?.available && file.path
-    ? { file, track: candidate, albumName: findAlbumForTrack(library, candidate)?.title }
+    ? { file, track: candidate, albumName: album?.title }
     : null;
 };
 
@@ -960,7 +965,8 @@ export function resolveStreamPath(value, user) {
     availableOnly: false,
   }));
   const track = findCanonical(library, parsed);
-  const file = firstFile(track);
+  const album = findAlbumForTrack(library, track);
+  const file = firstFile(track, album?.id, album?.managedBy);
   return file?.available && file.path ? file.path : null;
 }
 

--- a/backend/services/unifiedSearchService.js
+++ b/backend/services/unifiedSearchService.js
@@ -5,7 +5,9 @@ import {
 } from "./providers/brainzmashRanking.js";
 import { getMetadataBaseUrl } from "./providers/brainzmashProvider.js";
 import { searchAlbums, searchArtists } from "./providers/brainzmashProvider.js";
-import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";import { getCachedArtists } from "./libraryManager.js";
+import { flowPlaylistConfig } from "./weeklyFlow/weeklyFlowPlaylistConfig.js";
+import { getCachedArtists } from "./libraryManager.js";
+import { getCanonicalSearchPage } from "./libraryQueryService.js";
 import { getDiscoveryCache } from "./discovery/index.js";
 import { compareSearchResults, getLocalMatchThreshold } from "./searchRanking.js";
 import { parsePositiveInt } from "./searchService.js";
@@ -631,13 +633,47 @@ export function searchLocalFromData(
 async function searchLocalLibrary(query, limit, user) {
   try {
     const context = getSearchContext(user);
+    const canonical = getCanonicalSearchPage({
+      source: "all",
+      availableOnly: true,
+      query,
+      artistLimit: limit,
+      albumLimit: 0,
+      songLimit: limit,
+    });
+    const albums = new Map(
+      [
+        ...(canonical.albums?.albums || []),
+        ...(canonical.tracks?.albums || []),
+      ].map((album) => [album.id, album]),
+    );
+    const artists = [
+      ...context.artists,
+      ...(canonical.artists || []),
+      ...(canonical.tracks?.artists || []),
+    ];
+    const tracks = (canonical.tracks?.tracks || []).map((track) => {
+      const album = track.albums
+        ?.map((entry) => albums.get(entry.albumId))
+        .find(Boolean);
+      const artist = artists.find((entry) => entry.id === album?.artistId);
+      return {
+        id: track.id,
+        title: track.title,
+        artistName: artist?.name || track.artistName,
+        albumTitle: album?.title || null,
+        streamPath: album
+          ? `/library/canonical-stream/${encodeURIComponent(album.id)}/${encodeURIComponent(track.id)}`
+          : null,
+      };
+    });
     return {
       context,
       library: searchLocalFromData(
         query,
         {
-          artists: context.artists,
-          tracks: context.tracks,
+          artists,
+          tracks: [...context.tracks, ...tracks],
         },
         limit,
       ),

--- a/backend/services/unifiedSearchService.js
+++ b/backend/services/unifiedSearchService.js
@@ -120,6 +120,19 @@ function addArtistToIndex(index, artist, target = "library") {
   addCount(index.playlistArtistNames, normalizeKey(name));
 }
 
+function dedupeSearchArtists(artists) {
+  const seen = new Set();
+  return (Array.isArray(artists) ? artists : []).filter((artist) => {
+    const stableField = ["canonicalId", "id", "mbid", "foreignArtistId", "artistMbid", "identityKey"]
+      .find((field) => String(artist?.[field] ?? "").trim());
+    if (!stableField) return true;
+    const key = `${stableField}:${String(artist[stableField]).trim()}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function addPlaylistTrackToIndex(index, track) {
   const artistName = String(track?.artistName || track?.artist || "").trim();
   const title = String(track?.trackName || track?.title || track?.name || "").trim();
@@ -572,7 +585,7 @@ export function searchLocalFromData(
     return { artists: [], tracks: [] };
   }
 
-  const artistResults = artists
+  const artistResults = dedupeSearchArtists(artists)
     .map((artist) => {
       const name = String(artist?.artistName || artist?.name || "").trim();
       const mbid = artist?.mbid || artist?.foreignArtistId || artist?.artistMbid || artist?.id || null;
@@ -647,11 +660,11 @@ async function searchLocalLibrary(query, limit, user) {
         ...(canonical.tracks?.albums || []),
       ].map((album) => [album.id, album]),
     );
-    const artists = [
+    const artists = dedupeSearchArtists([
       ...context.artists,
       ...(canonical.artists || []),
       ...(canonical.tracks?.artists || []),
-    ];
+    ]);
     const tracks = (canonical.tracks?.tracks || []).map((track) => {
       const album = track.albums
         ?.map((entry) => albums.get(entry.albumId))

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -1,9 +1,9 @@
 ---
 title: First run
-description: Create your admin account, connect Lidarr, and verify the filesystem before playback setup.
+description: Create your admin account, configure the filesystem, and optionally connect Lidarr before playback setup.
 ---
 
-First, create the admin account and connect Lidarr. Then configure the filesystem before you connect a download client or playback server.
+First, create the admin account and configure the filesystem. Connect Lidarr if you want managed library changes, requests, or provider status.
 
 ![Aurral Lidarr connection settings](../../../assets/screenshots/settings-lidarr.webp)
 
@@ -11,25 +11,27 @@ First, create the admin account and connect Lidarr. Then configure the filesyste
 
 Complete [Filesystem and mounts](/getting-started/storage/) first. The short version is:
 
-- Mount the same host media root in Aurral, Lidarr, and the services you use.
+- Mount the same host media root in Aurral and the services you use.
+- If you use Lidarr, mount its library root in Aurral at the same container path.
 - Use the same container path, normally `/data`.
 - Keep Aurral's `/config` mount separate.
 
 ## First-run steps
 
 1. Open Aurral and create your admin account.
-2. Open **Settings > Lidarr**.
-3. Enter the Lidarr URL that Aurral can reach. In one Docker Compose network this is often `http://lidarr:8686`.
-4. Enter the Lidarr API key and select **Test connection**.
-5. Open **Settings > Download clients**.
-6. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
-7. Open **Settings > Storage health**, select **Run Checks**, and fix failed checks.
-8. Open **Settings > Lidarr** and select **Test library access**.
+2. Open **Settings > Download clients**.
+3. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
+4. Open **Settings > Storage health**, select **Run Checks**, and fix failed checks.
+5. If you use Lidarr, open **Settings > Lidarr**.
+6. Enter the Lidarr URL that Aurral can reach. In one Docker Compose network this is often `http://lidarr:8686`.
+7. Enter the Lidarr API key and select **Test connection**.
+8. Select **Test library access** after the connection test passes.
 9. Connect the download clients and playback server that you use. Navidrome and Plex are optional
    destinations. Aurral can play indexed media in the built-in player when the canonical file is readable.
 
 The Lidarr connection test checks the API. The library-access and storage checks verify that Aurral
-can read the files and write the Downloads Folder. The **Aurral-native playback** check reports
+can read the files and write the Downloads Folder. Aurral can run these filesystem checks without
+Lidarr. The **Aurral-native playback** check reports
 whether indexed media is ready to play. The built-in Subsonic service is available at `/rest` for
 compatible external players.
 

--- a/docs/src/content/docs/getting-started/first-run.mdx
+++ b/docs/src/content/docs/getting-started/first-run.mdx
@@ -23,7 +23,7 @@ Complete [Filesystem and mounts](/getting-started/storage/) first. The short ver
 3. Set **Downloads Folder > Path** to a writable path inside Aurral, such as `/data/downloads/aurral`.
 4. Open **Settings > Storage health**, select **Run Checks**, and fix failed checks.
 5. If you use Lidarr, open **Settings > Lidarr**.
-6. Enter the Lidarr URL that Aurral can reach. In one Docker Compose network this is often `http://lidarr:8686`.
+6. Prefer an HTTPS Lidarr URL. In a trusted, isolated Docker Compose network, `http://lidarr:8686` is also acceptable because Aurral sends the Lidarr API key to this URL.
 7. Enter the Lidarr API key and select **Test connection**.
 8. Select **Test library access** after the connection test passes.
 9. Connect the download clients and playback server that you use. Navidrome and Plex are optional

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: Install, configure, and use Aurral.
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Aurral is a self-hosted companion for music discovery and playback. It connects to Lidarr for library management, adds recommendations and requests, and downloads tracks for flows and imported playlists.
+Aurral is a self-hosted app for music discovery and playback. It keeps a canonical index of Aurral-owned files and optional Lidarr library files, adds recommendations and requests, and downloads tracks for flows and imported playlists.
 
 ![Aurral Discover page](../../assets/screenshots/discover.webp)
 
@@ -17,14 +17,14 @@ Aurral is a self-hosted companion for music discovery and playback. It connects 
 4. Connect the services that you use.
 
 :::note
-This release documents the Lidarr-connected workflow. Separate Aurral-only and split-root ownership modes are planned for a later release.
+Lidarr is optional for browsing, searching, playback, streaming, activity, and library scans. Connect Lidarr when you want Lidarr-managed library changes, requests, or provider status.
 :::
 
 ## How Aurral fits
 
 **Discover. Download. Listen.**
 
-Aurral reads your Lidarr library and keeps a canonical index of readable music. It manages flows and static playlists, and it can play canonical tracks in its built-in player. Navidrome, Jellyfin, Plex, and Subsonic clients are optional playback destinations.
+Aurral reads configured Aurral and Lidarr roots and keeps a canonical index of readable music. It manages flows and static playlists, and it can play canonical tracks in its built-in player. Navidrome, Jellyfin, Plex, and Subsonic clients are optional playback destinations.
 
 ## Essential guides
 

--- a/docs/src/content/docs/integrations/lidarr.mdx
+++ b/docs/src/content/docs/integrations/lidarr.mdx
@@ -3,7 +3,9 @@ title: Lidarr
 description: Connect Lidarr for library management, requests, and library file access.
 ---
 
-Aurral requires Lidarr in this release. Aurral adds artists and albums, reads library state, and shows queue and history status through Lidarr. Separate Aurral-only and split-root ownership modes are not part of this release.
+Lidarr is optional. Connect it when you want Lidarr to manage artists and
+albums, or when you want Aurral to show Lidarr queue and history status. Aurral
+can browse, search, play, stream, and scan indexed files without Lidarr.
 
 The Lidarr integration has two parts:
 
@@ -26,9 +28,9 @@ Enter these values in first-run setup or in **Settings > Lidarr**:
 
 ## Library display
 
-Lidarr reports an artist's full discography, including albums you have not
-downloaded. **Show available music only** (in **Settings > Lidarr**) keeps the
-Library focused on music you actually have:
+When Lidarr is configured, it reports an artist's full discography, including
+albums you have not downloaded. **Show available music only** (in **Settings >
+Lidarr**) keeps the Library focused on music you actually have:
 
 - When **on** (the default), the Library — the Albums list, Album artists list,
   and the home **Recently added** shelf — shows only albums with downloaded
@@ -42,6 +44,9 @@ This setting only changes what the Library **lists**. You can still search for
 and request unmonitored or undownloaded albums from the artist's discography,
 and the request and monitor workflows are unchanged.
 
+Without Lidarr, the Library lists the artists, albums, and tracks that Aurral
+has indexed from its configured roots.
+
 ## Metadata providers
 
 Aurral keeps the MusicBrainz UUID for artist routes and stores Lidarr's provider ID separately. If Lidarr uses a provider such as Tubifarry Deezer or Discogs, Aurral verifies the submitted MusicBrainz artist, accepts names recorded as MusicBrainz aliases, uses Lidarr's lookup to identify the active provider, and retries a provider-ID format error with the canonical provider ID. Existing provider-ID artists are verified and backfilled when Aurral reads the library. If the identities do not match, search for the artist in Lidarr first or use MusicBrainz metadata.
@@ -52,11 +57,16 @@ Aurral tests file access at paths that Lidarr reports. If the test fails, mount 
 
 The check samples a track from an artist inside a root folder. It falls back to an artist outside them and then reports that the artist was left behind by a root folder change.
 
-After Lidarr imports a file, Aurral watches the configured Lidarr root folders
-and queues a canonical library scan. Aurral does not need a second import step
-in Lidarr. The file must still be readable at the path Lidarr reports. The
-canonical Library uses the MusicBrainz and provider identities that Aurral reads
-from the file and from Lidarr.
+After a file changes in a configured Lidarr root, Aurral watches the root and
+queues a local canonical library scan. Aurral does not request Lidarr artist,
+album, track, or track-file data during that scan. The file must be readable at
+the saved root path. The canonical Library uses the MusicBrainz and provider
+identities that Aurral reads from the file and from Lidarr.
+
+Aurral stores discovered Lidarr root paths locally. It refreshes the Lidarr
+`/rootFolder` endpoint when it connects, reconnects, or the root configuration
+changes. If you disable Lidarr, Aurral keeps indexed Lidarr media visible and
+does not scan those roots until you enable Lidarr again.
 
 ## Request availability notifications
 
@@ -91,7 +101,8 @@ This mapping only helps Aurral read Lidarr files. Navidrome must scan the corres
 
 ## Safety
 
-Artist and album changes go through Lidarr. Aurral does not write directly into your root music library.
+When Lidarr is configured, artist and album changes go through Lidarr. Aurral
+does not write directly into a Lidarr root music library.
 
 ## Import list feeds
 

--- a/docs/src/content/docs/using/library.mdx
+++ b/docs/src/content/docs/using/library.mdx
@@ -31,8 +31,8 @@ media for the track is available, it also removes the canonical track and any
 empty album or artist record. If one of several files cannot be deleted, Aurral
 keeps the track until a later deletion succeeds.
 
-Navidrome remains optional. Lidarr remains the library provider when it is
-configured.
+Navidrome remains optional. Lidarr is optional. When it is configured, Aurral
+uses it for managed library changes and explicit provider actions.
 
 ## Aurral-owned storage
 
@@ -46,14 +46,15 @@ promote a Flow track when **Favorite Flow tracks** is enabled in **Settings > Sy
 ## When new files appear
 
 Aurral keeps the canonical library in its own database. It scans the Aurral
-root and the root folders reported by Lidarr. The scan records the provider
+root and the saved Lidarr root folders locally. The scan records provider
 identities, album and track metadata, and the readable media files that belong
-to them.
+to them. A manual or watcher scan does not request Lidarr artist, album, track,
+or track-file data.
 
-When Lidarr imports a download, or a file changes in the Aurral root, Aurral's
-filesystem watcher queues a scan. The watcher waits briefly for a file move or
-rename to finish and ignores `_playlists`, `_staging`, `_fallback`, hidden
-folders, `_flows`, and `aurral-weekly-flow`.
+When a file changes in a watched Aurral or Lidarr root, Aurral's filesystem
+watcher queues a local scan. The watcher waits briefly for a file move or rename
+to finish and ignores `_playlists`, `_staging`, `_fallback`, hidden folders,
+`_flows`, and `aurral-weekly-flow`.
 
 When the scan completes, an open Library page reloads its canonical records
 automatically. The home page and **Newest** album or track sorting use the time
@@ -67,10 +68,13 @@ scans. When files change, the filesystem watcher queues a scan; use the
 starts a scan, waits for it to finish, and reloads the page from the updated
 canonical records.
 
-If Discover says an album is in Lidarr but Library does not show it, check the
-Lidarr path mapping first. Aurral must be able to read the path Lidarr reports.
-Then use **Refresh** in Library. See [Filesystem and mounts](/getting-started/storage/)
+When Lidarr is configured, check the Lidarr path mapping if Discover says an
+album is in Lidarr but Library does not show it. Aurral must be able to read the
+saved root path. Then use **Refresh** in Library. See [Filesystem and mounts](/getting-started/storage/)
 and [Lidarr library access](/integrations/lidarr/#library-access-check).
+
+When you disable Lidarr, Aurral keeps indexed Lidarr media visible and stops
+watching and scanning those roots until you enable Lidarr again.
 
 Use the search field in the toolbar to filter the current section.
 

--- a/docs/src/content/docs/using/overview.mdx
+++ b/docs/src/content/docs/using/overview.mdx
@@ -3,7 +3,7 @@ title: App overview
 description: Main sections of the Aurral interface.
 ---
 
-Aurral is a Lidarr companion for music discovery and playback. It connects to your existing library and keeps a canonical index of readable music.
+Aurral is a self-hosted app for music discovery and playback. It keeps a canonical index of readable Aurral and optional Lidarr library files.
 
 ## Main sections
 
@@ -42,7 +42,7 @@ Flows regenerate on a schedule. Static playlists keep fixed tracklists or synchr
 
 ![Aurral activity timeline](../../../assets/screenshots/history.webp)
 
-Activity shows active Lidarr requests, download client activity, and Aurral playlist jobs.
+When Lidarr is configured, Activity shows its requests alongside download client activity and Aurral playlist jobs.
 
 Queue combines active work with tracks waiting for review. History shows completed and failed events. Wanted shows Aurral-owned tracks that need another search or a quality upgrade.
 


### PR DESCRIPTION
## What changed

- Keep local library reads, playback, and canonical streams available when Lidarr is disabled or unavailable.
- Persist configured Lidarr root folders and scan them locally without repeated provider requests.
- Add canonical source, ownership, availability, and provider fields to library responses.
- Update documentation and add regression coverage for disabled Lidarr, local scans, cached roots, and provider outages.

## Why

Aurral’s local library should remain usable without an active Lidarr connection. Previously, some library reads and root-folder handling depended on Lidarr, which made local media unavailable when the integration was disabled or offline. Lidarr remains available for managed library changes and provider status.

## Scope checklist

- [x] This pull request has one clear purpose
- [x] I kept unrelated fixes, refactors, formatting changes, dependency updates, and features out of this pull request
- [ ] If this adds a feature, I linked the approved feature request or included the Discord context in the Why section

## Linked issue

Not linked.

## Testing

- Added and updated Node test coverage for local-only reads, disabled Lidarr behavior, cached root folders, local scans, canonical responses, and Lidarr outages.
- Manual validation was not run.

## Release impact

- [ ] Major: incompatible change
- [ ] Minor: backward-compatible feature
- [x] Patch: backward-compatible fix
- [ ] None: documentation, CI, tests, or internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lidarr is optional for browsing, searching, playback, streaming, activity, and library scans.
  * Library scans support multiple configured root folders and preserve locally stored paths.
  * Library items show canonical IDs, provider details, source, availability, and management status.
  * File selection prioritizes available, managed media.

* **Bug Fixes**
  * Indexed media remains available during Lidarr outages or disconnection.
  * Empty scan paths are ignored safely, and duplicate search results are removed.
  * Root folders refresh when Lidarr connection settings change.

* **Documentation**
  * Updated setup and integration guidance for optional Lidarr connectivity and local library workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->